### PR TITLE
fix(template): upgrade streamdown to 2.4.0

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -41,7 +41,7 @@
     "react-player": "^3.4.0",
     "shiki": "^3.22.0",
     "sonner": "^2.0.7",
-    "streamdown": "^2.1.0",
+    "streamdown": "^2.4.0",
     "tailwind-merge": "^3.4.0",
     "use-stick-to-bottom": "^1.1.1",
     "vaul": "^1.1.2",

--- a/apps/template/components/ai-elements/reasoning.tsx
+++ b/apps/template/components/ai-elements/reasoning.tsx
@@ -177,7 +177,7 @@ export const ReasoningContent = memo(
       )}
       {...props}
     >
-      <Streamdown {...props}>{children}</Streamdown>
+      <Streamdown>{children}</Streamdown>
     </CollapsibleContent>
   ),
 );

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -39,7 +39,7 @@
     "react-remove-scroll": "2.7.2",
     "server-only": "0.0.1",
     "shadcn": "4.0.6",
-    "streamdown": "2.3.0",
+    "streamdown": "2.4.0",
     "tailwind-merge": "3.5.0",
     "tailwindcss": "4.2.1",
     "tw-animate-css": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       streamdown:
-        specifier: ^2.1.0
-        version: 2.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^2.4.0
+        version: 2.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0
@@ -238,8 +238,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6(@types/node@25.5.0)(typescript@5.9.3)
       streamdown:
-        specifier: 2.3.0
-        version: 2.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 2.4.0
+        version: 2.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: 3.5.0
         version: 3.5.0
@@ -6957,8 +6957,8 @@ packages:
   remeda@2.33.4:
     resolution: {integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==}
 
-  remend@1.2.1:
-    resolution: {integrity: sha512-4wC12bgXsfKAjF1ewwkNIQz5sqewz/z1xgIgjEMb3r1pEytQ37F0Cm6i+OhbTWEvguJD7lhOUJhK5fSasw9f0w==}
+  remend@1.2.2:
+    resolution: {integrity: sha512-4ZJgIB9EG9fQE41mOJCRHMmnxDTKHWawQoJWZyUbZuj680wVyogu2ihnj8Edqm7vh2mo/TWHyEZpn2kqeDvS7w==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -7227,8 +7227,8 @@ packages:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
 
-  streamdown@2.3.0:
-    resolution: {integrity: sha512-OqS3by/lt91lSicE8RQP2nTsYI6Q/dQgGP2vcyn9YesCmRHhNjswAuBAZA1z0F4+oBU3II/eV51LqjCqwTb1lw==}
+  streamdown@2.4.0:
+    resolution: {integrity: sha512-fRk4HEYNznRLmxoVeT8wsGBwHF6/Yrdey6k+ZrE1Qtp4NyKwm7G/6e2Iw8penY4yLx31TlAHWT5Bsg1weZ9FZg==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -15602,7 +15602,7 @@ snapshots:
   remeda@2.33.4:
     optional: true
 
-  remend@1.2.1: {}
+  remend@1.2.2: {}
 
   require-directory@2.1.1: {}
 
@@ -15986,7 +15986,7 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  streamdown@2.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  streamdown@2.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       clsx: 2.1.1
       hast-util-to-jsx-runtime: 2.3.6
@@ -16000,7 +16000,7 @@ snapshots:
       remark-gfm: 4.0.1
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
-      remend: 1.2.1
+      remend: 1.2.2
       tailwind-merge: 3.5.0
       unified: 11.0.5
       unist-util-visit: 5.1.0


### PR DESCRIPTION
## Summary
- Upgrades `streamdown` from 2.3.0 to 2.4.0 in the template app (and from ^2.1.0 to ^2.4.0 in docs)
- Fixes type error in `ReasoningContent`: Streamdown 2.4.0 no longer extends `HTMLAttributes<HTMLDivElement>`, so CollapsibleContent rest-props can no longer be spread onto `<Streamdown>`

## Test plan
- [ ] `pnpm tsc --noEmit` passes with no new errors
- [ ] Reasoning collapsible still renders and animates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)