### PR TITLE
refactor(template): move variantId rewrite to next.config.ts

### DIFF
--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -16,6 +16,13 @@ const nextConfig: NextConfig = {
     ],
     unoptimized: !!process.env.V0_CALLBACK_URL,
   },
+  rewrites: async () => [
+    {
+      source: "/products/:handle",
+      has: [{ type: "query", key: "variantId", value: "(?<variantId>.+)" }],
+      destination: "/products/:handle/:variantId",
+    },
+  ],
   // Better Auth pulls some adapter modules via internal imports that Turbopack may split
   // into runtime chunks. Keep these packages external and explicitly traced for Vercel.
   serverExternalPackages: ["better-auth"],

--- a/apps/template/proxy.ts
+++ b/apps/template/proxy.ts
@@ -61,26 +61,5 @@ export default async function middleware(request: NextRequest) {
     }
   }
 
-  // Rewrite /products/[handle]?variantId=X → /products/[handle]/[variantId]
-  const url = new URL(request.url);
-  const variantId = url.searchParams.get("variantId");
-
-  if (variantId) {
-    const segments = url.pathname.split("/").filter(Boolean);
-
-    if (segments.length === 2 && segments[0] === "products") {
-      const handle = segments[1];
-      const rewriteUrl = new URL(
-        `/products/${handle}/${variantId}`,
-        request.url,
-      );
-      // Preserve other query params but remove variantId
-      const params = new URLSearchParams(url.searchParams);
-      params.delete("variantId");
-      rewriteUrl.search = params.toString();
-      return NextResponse.rewrite(rewriteUrl);
-    }
-  }
-
   return NextResponse.next();
 }


### PR DESCRIPTION
## Summary
- Moved the `/products/[handle]?variantId=X → /products/[handle]/[variantId]` rewrite from `proxy.ts` to a declarative `rewrites` rule in `next.config.ts`
- `proxy.ts` now only handles markdown content-negotiation (Accept header inspection), which can't be expressed as a config rewrite

## Test plan
- [ ] Visit `/products/<handle>?variantId=<id>` and verify it renders the correct variant
- [ ] Verify markdown content negotiation still works (`Accept: text/markdown`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)