### PR TITLE
docs: add Shopify CMS skill page

### DIFF
--- a/apps/docs/content/docs/env-vars.mdx
+++ b/apps/docs/content/docs/env-vars.mdx
@@ -17,6 +17,6 @@ type: reference
 | Variable | Description |
 |----------|-------------|
 | `SHOPIFY_STOREFRONT_PRIVATE_TOKEN` | Private Storefront API token for server-side requests. Enables higher rate limits and access to draft content. |
-| `SHOPIFY_CUSTOMER_ACCOUNT_URL` | Customer Account API URL. Required when using the enable-auth skill. |
-| `SHOPIFY_CUSTOMER_CLIENT_ID` | Customer Account API client ID. Required when using the enable-auth skill. |
-| `SHOPIFY_CUSTOMER_CLIENT_SECRET` | Customer Account API client secret. Required when using the enable-auth skill. |
+| `SHOPIFY_CUSTOMER_ACCOUNT_URL` | Customer Account API URL. Required when using the enable-shopify-auth skill. |
+| `SHOPIFY_CUSTOMER_CLIENT_ID` | Customer Account API client ID. Required when using the enable-shopify-auth skill. |
+| `SHOPIFY_CUSTOMER_CLIENT_SECRET` | Customer Account API client secret. Required when using the enable-shopify-auth skill. |

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -28,7 +28,7 @@ Skills are agent-ready guides that transform your storefront. Browse the availab
   <Card title="Enable Markets" href="/docs/skills/enable-shopify-markets">
     Multi-locale and multi-currency support with Shopify Markets.
   </Card>
-  <Card title="Enable auth" href="/docs/skills/enable-auth">
+  <Card title="Enable Shopify Auth" href="/docs/skills/enable-shopify-auth">
     Customer authentication with login, account pages, and nav integration.
   </Card>
   <Card title="Shopify CMS" href="/docs/skills/enable-shopify-cms">

--- a/apps/docs/content/docs/skills/enable-auth.mdx
+++ b/apps/docs/content/docs/skills/enable-auth.mdx
@@ -1,0 +1,15 @@
+---
+title: Enable auth
+description: Add customer authentication with login, account pages, and nav integration.
+type: guide
+---
+
+## How to use
+
+```bash
+/enable-auth
+```
+
+<div className="pb-6" />
+
+<SkillContent skill="enable-auth" />

--- a/apps/docs/content/docs/skills/enable-shopify-auth.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-auth.mdx
@@ -1,5 +1,5 @@
 ---
-title: Enable auth
+title: Enable Shopify Auth
 description: Add customer authentication with login, account pages, and nav integration.
 type: guide
 ---
@@ -7,9 +7,9 @@ type: guide
 ## How to use
 
 ```bash
-/enable-auth
+/enable-shopify-auth
 ```
 
 <div className="pb-6" />
 
-<SkillContent skill="enable-auth" />
+<SkillContent skill="enable-shopify-auth" />

--- a/apps/docs/content/docs/skills/enable-shopify-cms.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-cms.mdx
@@ -1,0 +1,15 @@
+---
+title: Enable Shopify CMS
+description: Wire Shopify metaobjects as the CMS for homepage and marketing page content.
+type: guide
+---
+
+## How to use
+
+```bash
+/enable-shopify-cms
+```
+
+<div className="pb-6" />
+
+<SkillContent skill="enable-shopify-cms" />

--- a/apps/docs/content/docs/skills/index.mdx
+++ b/apps/docs/content/docs/skills/index.mdx
@@ -12,7 +12,7 @@ Skills are agent-ready guides that transform your storefront. Run them with Clau
   <Card title="Enable Shopify Markets" href="/docs/skills/enable-shopify-markets">
     Add multi-locale and multi-currency support with Shopify Markets.
   </Card>
-  <Card title="Enable auth" href="/docs/skills/enable-auth">
+  <Card title="Enable Shopify Auth" href="/docs/skills/enable-shopify-auth">
     Add customer authentication with login, account pages, and nav integration.
   </Card>
   <Card title="Shopify CMS" href="/docs/skills/enable-shopify-cms">

--- a/apps/docs/content/docs/skills/meta.json
+++ b/apps/docs/content/docs/skills/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Extending with agent skills",
-  "pages": ["enable-shopify-markets", "enable-shopify-cms", "enable-auth"]
+  "pages": ["enable-shopify-markets", "enable-shopify-cms", "enable-shopify-auth"]
 }

--- a/apps/docs/content/docs/skills/meta.json
+++ b/apps/docs/content/docs/skills/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Extending with agent skills",
-  "pages": ["enable-shopify-markets"]
+  "pages": ["enable-shopify-markets", "enable-shopify-cms"]
 }

--- a/apps/docs/content/docs/skills/meta.json
+++ b/apps/docs/content/docs/skills/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Extending with agent skills",
-  "pages": ["enable-shopify-markets", "enable-shopify-cms"]
+  "pages": ["enable-shopify-markets", "enable-shopify-cms", "enable-auth"]
 }

--- a/apps/template/.agents/skills/enable-shopify-auth/SKILL.md
+++ b/apps/template/.agents/skills/enable-shopify-auth/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: enable-auth
+name: enable-shopify-auth
 description: Add customer authentication to the shop template using better-auth with Shopify OIDC. Includes login flow, account pages (profile, orders, addresses), and nav integration.
 ---
 


### PR DESCRIPTION
## Summary
- Adds a new doc page at `/docs/skills/enable-shopify-cms` describing the Shopify metaobject CMS skill
- Uses `<SkillContent>` to pull content from the template app's `SKILL.md`
- Adds the page to the skills nav in `meta.json`

## Test plan
- [ ] Verify the page renders at `/docs/skills/enable-shopify-cms`
- [ ] Verify the skills index card links to the new page
- [ ] Verify `<SkillContent>` renders the SKILL.md content correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)