### PR TITLE
Add /about page

### DIFF
--- a/apps/template/app/about/page.tsx
+++ b/apps/template/app/about/page.tsx
@@ -4,7 +4,7 @@ import { Container } from "@/components/layout/container";
 
 export const metadata: Metadata = {
   title: "About",
-  description: "Learn about Vercel Shop — a Next.js storefront template for Shopify.",
+  description: "Learn about Vercel Shop, a Next.js storefront template for Shopify.",
 };
 
 export default function AboutPage() {
@@ -13,25 +13,22 @@ export default function AboutPage() {
       <article className="prose prose-neutral prose-headings:font-semibold prose-headings:tracking-tight">
         <h1>About Vercel Shop</h1>
         <p>
-          Vercel Shop is a production-ready Shopify storefront built with Next.js. It connects to
-          your Shopify store out of the box, giving you product pages, collections, cart
-          functionality, and search — everything you need to start selling.
+          Vercel Shop is a Next.js storefront that connects to Shopify. You get product pages,
+          collections, a cart, and search out of the box. Point it at your store and you're selling.
         </p>
         <p>
-          The template is designed for agentic development. It ships with context, feedback loops,
-          and skills that let coding agents understand and extend your store. Recipes describe common
-          tasks — from enabling Shopify Markets to swapping your CMS — so an agent can execute them
-          in a single command.
+          The template is built for agents. It includes context files, structured skills, and
+          recipes that describe common tasks so a coding agent can pick them up and run. Enable
+          Shopify Markets, swap your CMS, add customer accounts: each one is a single command.
         </p>
         <p>
-          Performance is a first-class concern. Pages use Server Components and streaming by default,
-          the cart is fully optimistic, and collection filters update without waiting for a round-trip.
-          Cache Components keep static shells instant while dynamic content streams in behind them.
+          Pages render on the server and stream by default. The cart is optimistic. Collection
+          filters update instantly, without a round-trip. Static shells are cached and dynamic
+          content streams in behind them.
         </p>
         <p>
-          Every part of the codebase is yours to change. Update the layout, swap components, adjust
-          the styling, or wire in a different CMS — the code is designed to be read and modified, not
-          worked around.
+          The code is yours. Change the layout, pull out components, restyle things, wire in a
+          different CMS. It's written to be read and modified, not worked around.
         </p>
       </article>
     </Container>

--- a/apps/template/app/about/page.tsx
+++ b/apps/template/app/about/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+
+import { Container } from "@/components/layout/container";
+
+export const metadata: Metadata = {
+  title: "About",
+  description: "Learn about Vercel Shop — a Next.js storefront template for Shopify.",
+};
+
+export default function AboutPage() {
+  return (
+    <Container className="max-w-2xl">
+      <article className="prose prose-neutral prose-headings:font-semibold prose-headings:tracking-tight">
+        <h1>About Vercel Shop</h1>
+        <p>
+          Vercel Shop is a production-ready Shopify storefront built with Next.js. It connects to
+          your Shopify store out of the box, giving you product pages, collections, cart
+          functionality, and search — everything you need to start selling.
+        </p>
+        <p>
+          The template is designed for agentic development. It ships with context, feedback loops,
+          and skills that let coding agents understand and extend your store. Recipes describe common
+          tasks — from enabling Shopify Markets to swapping your CMS — so an agent can execute them
+          in a single command.
+        </p>
+        <p>
+          Performance is a first-class concern. Pages use Server Components and streaming by default,
+          the cart is fully optimistic, and collection filters update without waiting for a round-trip.
+          Cache Components keep static shells instant while dynamic content streams in behind them.
+        </p>
+        <p>
+          Every part of the codebase is yours to change. Update the layout, swap components, adjust
+          the styling, or wire in a different CMS — the code is designed to be read and modified, not
+          worked around.
+        </p>
+      </article>
+    </Container>
+  );
+}

--- a/apps/template/app/globals.css
+++ b/apps/template/app/globals.css
@@ -94,6 +94,13 @@
   --sidebar-ring: #5a5a5a;
 }
 
+@layer components {
+  .prose :where(h1, h2, h3, h4):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+    letter-spacing: -0.025em; /* tracking-tight */
+    font-weight: 600; /* font-semibold */
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -69,14 +69,13 @@ export default async function HomePage() {
             <h2 className="text-3xl font-semibold tracking-tight">Built to launch first, customize later</h2>
             <div className="prose prose-neutral max-w-2xl">
               <p>
-                This is a production-ready Shopify storefront built with Next.js. It connects to
-                your Shopify store out of the box, giving you product pages, collections, cart
-                functionality, and search — everything you need to start selling.
+                A Shopify storefront built with Next.js. Connect your store and you get product
+                pages, collections, a cart, and search. It works out of the box, and every part
+                of it is yours to change.
               </p>
               <p>
-                Every part of this template is yours to change. Update the layout, swap components,
-                adjust the styling, or wire in a CMS — the code is designed to be read and modified,
-                not worked around.
+                Swap components, restyle things, wire in a CMS. The code is written to be read
+                and modified, not worked around.
               </p>
             </div>
           </div>

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -65,7 +65,7 @@ export default async function HomePage() {
         />
 
         <section>
-          <div className="grid items-start gap-6 md:grid-cols-2 lg:gap-12">
+          <div className="grid items-start gap-4 md:grid-cols-2">
             <h2 className="text-3xl font-semibold tracking-tight">Built to launch first, customize later</h2>
             <div className="prose prose-neutral max-w-2xl">
               <p>

--- a/apps/template/components/layout/nav/index.tsx
+++ b/apps/template/components/layout/nav/index.tsx
@@ -30,6 +30,13 @@ export function Nav({ locale }: { locale: string }) {
           <QuickLinks locale={locale} />
         </Suspense>
 
+        <Link
+          href="/about"
+          className="hidden md:flex items-center gap-1 text-sm hover:opacity-70 transition-opacity"
+        >
+          About
+        </Link>
+
         <div className="flex items-center gap-4 ml-auto">
           <Suspense fallback={<CartIconFallback />}>
             <CartIcon />

--- a/apps/template/components/product/pdp/product-detail-page.tsx
+++ b/apps/template/components/product/pdp/product-detail-page.tsx
@@ -77,7 +77,7 @@ export async function ProductDetailPage({
         {/* Desktop Layout — breadcrumbs span full width, then 2-column (50/50 images + info) */}
         <div className="hidden lg:block space-y-8">
           <Breadcrumb title={title} handle={handle} />
-          <div className="grid grid-cols-2 items-start gap-8">
+          <div className="grid grid-cols-2 items-start gap-4">
             <div>
               <ImageGrid {...imageProps} />
             </div>


### PR DESCRIPTION
## Summary
- Adds a static `/about` page with prose content describing the template's features
- Updates prose heading styles in globals.css to match site-wide `font-semibold tracking-tight` pattern
- Adds "About" link to the desktop nav

## Test plan
- [ ] Visit `/about` and verify heading and paragraph styles match the rest of the site
- [ ] Check the nav bar shows the "About" link on desktop and hides it on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)