### PR TITLE
Add Pages docs section

### DIFF
--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Docs",
-  "pages": ["index", "getting-started", "---Pages---", "pages", "---Extend---", "skills", "---API Reference---", "env-vars"]
+  "pages": ["index", "getting-started", "pages", "skills", "---API Reference---", "env-vars"]
 }

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Docs",
-  "pages": ["index", "getting-started", "---Extend---", "skills", "---API Reference---", "env-vars"]
+  "pages": ["index", "getting-started", "---Pages---", "pages", "---Extend---", "skills", "---API Reference---", "env-vars"]
 }

--- a/apps/docs/content/docs/pages/cart.mdx
+++ b/apps/docs/content/docs/pages/cart.mdx
@@ -1,0 +1,7 @@
+---
+title: Cart
+description: The shopping cart page — line items, quantity updates, and checkout.
+type: guide
+---
+
+Coming soon.

--- a/apps/docs/content/docs/pages/content.mdx
+++ b/apps/docs/content/docs/pages/content.mdx
@@ -1,0 +1,7 @@
+---
+title: Content
+description: CMS-driven marketing and informational pages.
+type: guide
+---
+
+Coming soon.

--- a/apps/docs/content/docs/pages/home.mdx
+++ b/apps/docs/content/docs/pages/home.mdx
@@ -1,0 +1,7 @@
+---
+title: Home
+description: The storefront landing page — hero, featured collections, and promotional content.
+type: guide
+---
+
+Coming soon.

--- a/apps/docs/content/docs/pages/index.mdx
+++ b/apps/docs/content/docs/pages/index.mdx
@@ -12,14 +12,14 @@ Each storefront is built from a small set of core page types. These guides cover
   <Card title="Home" href="/docs/pages/home">
     The storefront landing page — hero, featured collections, and promotional content.
   </Card>
+  <Card title="Product Detail Page (PDP)" href="/docs/pages/pdp">
+    Individual product pages with variants, media, and add-to-cart.
+  </Card>
   <Card title="Product Listing Page (PLP)" href="/docs/pages/plp">
     Collection and search results pages with filtering, sorting, and pagination.
   </Card>
   <Card title="Cart" href="/docs/pages/cart">
     The shopping cart page — line items, quantity updates, and checkout.
-  </Card>
-  <Card title="Product Detail Page (PDP)" href="/docs/pages/pdp">
-    Individual product pages with variants, media, and add-to-cart.
   </Card>
   <Card title="Content" href="/docs/pages/content">
     CMS-driven marketing and informational pages.

--- a/apps/docs/content/docs/pages/index.mdx
+++ b/apps/docs/content/docs/pages/index.mdx
@@ -1,0 +1,27 @@
+---
+title: Pages
+description: The core pages that make up your Shopify storefront.
+type: overview
+prerequisites:
+  - /docs/getting-started
+---
+
+Each storefront is built from a small set of core page types. These guides cover the architecture, data fetching, and customization patterns for each.
+
+<Cards>
+  <Card title="Home" href="/docs/pages/home">
+    The storefront landing page — hero, featured collections, and promotional content.
+  </Card>
+  <Card title="Product Listing Page (PLP)" href="/docs/pages/plp">
+    Collection and search results pages with filtering, sorting, and pagination.
+  </Card>
+  <Card title="Cart" href="/docs/pages/cart">
+    The shopping cart page — line items, quantity updates, and checkout.
+  </Card>
+  <Card title="Product Detail Page (PDP)" href="/docs/pages/pdp">
+    Individual product pages with variants, media, and add-to-cart.
+  </Card>
+  <Card title="Content" href="/docs/pages/content">
+    CMS-driven marketing and informational pages.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/pages/meta.json
+++ b/apps/docs/content/docs/pages/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Pages",
+  "pages": ["home", "plp", "cart", "pdp", "content"]
+}

--- a/apps/docs/content/docs/pages/meta.json
+++ b/apps/docs/content/docs/pages/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Pages",
-  "pages": ["home", "plp", "cart", "pdp", "content"]
+  "pages": ["home", "pdp", "plp", "cart", "content"]
 }

--- a/apps/docs/content/docs/pages/pdp.mdx
+++ b/apps/docs/content/docs/pages/pdp.mdx
@@ -1,0 +1,7 @@
+---
+title: Product Detail Page (PDP)
+description: Individual product pages with variants, media, and add-to-cart.
+type: guide
+---
+
+Coming soon.

--- a/apps/docs/content/docs/pages/plp.mdx
+++ b/apps/docs/content/docs/pages/plp.mdx
@@ -1,0 +1,7 @@
+---
+title: Product Listing Page (PLP)
+description: Collection and search results pages with filtering, sorting, and pagination.
+type: guide
+---
+
+Coming soon.

--- a/apps/docs/content/docs/skills/index.mdx
+++ b/apps/docs/content/docs/skills/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Extending with agent skills
+title: Extending with Skills
 description: Agent-ready skills for extending your Shopify storefront.
 type: overview
 prerequisites:

--- a/apps/docs/content/docs/skills/meta.json
+++ b/apps/docs/content/docs/skills/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Extending with agent skills",
+  "title": "Extending with Skills",
   "pages": ["enable-shopify-markets", "enable-shopify-cms", "enable-shopify-auth", "enable-content-negotiation"]
 }


### PR DESCRIPTION
## Summary
- Adds a **Pages** section to the docs sidebar (between Getting Started and Extend)
- Stubs out pages for Home, PLP, Cart, PDP, and Content
- Includes an overview page with card links to each sub-page

## Test plan
- [ ] Verify the docs sidebar renders the Pages section with all five sub-pages
- [ ] Confirm each stub page loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)