### PR TITLE
Document PDP page features

### DIFF
--- a/apps/docs/content/docs/pages/home.mdx
+++ b/apps/docs/content/docs/pages/home.mdx
@@ -1,7 +1,43 @@
 ---
 title: Home
-description: The storefront landing page — hero, featured collections, and promotional content.
+description: The storefront landing page — hero, featured products, and promotional content.
 type: guide
 ---
 
-Coming soon.
+The home page is a server component that renders a hero banner, a featured products carousel, and an informational section. Product data is fetched server-side from Shopify.
+
+## Hero section
+
+A full-width banner with a background image, gradient overlay, headline, subheadline, and a CTA link. The hero scales responsively — 300px tall on mobile, 400px on small screens, and 500px on medium and up.
+
+The headline and CTA are configurable through the `HeroSection` type. By default the CTA links to `/search` to browse the catalog.
+
+On mobile, the subheadline and CTA text are hidden to keep the banner compact.
+
+## Featured products carousel
+
+A horizontally scrollable carousel showing up to 10 products fetched via `getProducts()`. Each item is a product card with:
+
+- Featured image (with out-of-stock overlay when unavailable)
+- Title and price (with compare-at price for discounts)
+- Quick-add button for in-stock items
+
+The carousel uses CSS snap scrolling with chevron navigation arrows that appear based on scroll position. Items per view scale with screen size: 2 on mobile, 3 on tablet, 4 on desktop, 5+ on wide screens.
+
+## Information section
+
+A two-column grid (stacked on mobile) with a heading and descriptive prose. This is static content explaining the template's capabilities.
+
+## Data fetching
+
+Products are fetched server-side with `getProducts({ limit: 10, locale })`, which queries the Shopify Storefront API and caches the result with `cacheLife("max")` and product-level cache tags for granular revalidation.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `app/page.tsx` | Root page, metadata generation, product fetch |
+| `components/cms/hero-section.tsx` | Full-width hero banner with image, headline, CTA |
+| `components/cms/blocks/top-products-carousel.tsx` | Horizontally scrollable product carousel |
+| `components/product-card.tsx` | Product card with image, price, quick-add |
+| `lib/shopify/operations/products.ts` | Shopify product fetching with caching |

--- a/apps/docs/content/docs/pages/pdp.mdx
+++ b/apps/docs/content/docs/pages/pdp.mdx
@@ -4,4 +4,111 @@ description: Individual product pages with variants, media, and add-to-cart.
 type: guide
 ---
 
-Coming soon.
+The Product Detail Page renders a single product with variant selection, an image gallery, buy actions, and recommendations. It is entirely server-rendered — variant selection happens through navigation, not client-side state.
+
+## Variant selection
+
+Variants are selected via URL. Each option (color, size, etc.) renders as a `<Link>` pointing to the same product with a `?variantId` query parameter:
+
+```
+/products/classic-tee?variantId=123456
+```
+
+A rewrite rule in `next.config.ts` maps this to the `/products/[handle]/[variantId]` route segment so the server can resolve the variant before rendering:
+
+```ts
+rewrites: async () => [
+  {
+    source: "/products/:handle",
+    has: [{ type: "query", key: "variantId", value: "(?<variantId>.+)" }],
+    destination: "/products/:handle/:variantId",
+  },
+],
+```
+
+On the server, `computeInitialSelectedOptions()` matches the numeric variant ID to the full variant object and extracts its selected options. These are threaded down as props — no client-side variant context or `useState` is involved. This means:
+
+- Every variant selection is a navigation, giving you browser back/forward for free
+- URLs are shareable — opening a link loads the exact variant
+- The page is fully server-rendered with zero layout shift
+
+The `getVariantUrl()` helper in `variants.ts` computes the target URL for each option. When a user selects a new option value, it finds the matching variant (or falls back to the first variant with that option) and returns the URL with the correct `variantId`.
+
+Unavailable options render as inert `<span>` elements instead of links.
+
+## Image gallery
+
+The gallery adapts to screen size with two distinct components.
+
+**Desktop** — `ImageGrid` displays a thumbnail sidebar (80px wide, vertically scrollable) alongside a main image. Hovering or clicking a thumbnail selects it. Videos are supported inline with autoplay.
+
+**Mobile** — `MobileCarousel` is a horizontal snap-scroll carousel with dot indicators below. Swiping or tapping a dot navigates between images.
+
+Both components receive pre-filtered images as props from the server.
+
+### Color-based image filtering
+
+When a product has color variants, the gallery shows only images relevant to the selected color. The `getImagesForSelectedColor()` function in `variants.ts`:
+
+1. Identifies the color option via swatch data or option name
+2. Collects variant images assigned to each color
+3. Excludes images belonging to other colors
+4. Preserves shared/unassigned images
+5. Moves the selected variant's image to the front
+
+If a product has only one color or no color option, all images are shown.
+
+## Buy section
+
+The buy section includes stock status, a quantity selector, and two action buttons:
+
+- **Buy Now** — creates a Shopify checkout and redirects to it
+- **Add to Cart** — adds the item optimistically to the cart drawer
+
+On desktop, the full buy section includes a quantity selector (1–99). On mobile, a simplified two-button row adds a quantity of 1.
+
+Both components receive the `selectedVariant` as a prop and remain client components for cart interactivity.
+
+## Recommendations
+
+Below the product details, a `Recommendations` component fetches related products from Shopify's recommendation API. It renders inside a `Suspense` boundary with a skeleton grid fallback.
+
+Recommendations display as a horizontally scrollable carousel of product cards — 2 columns on mobile, 3 on tablet, 4 on desktop.
+
+## Layout
+
+The page uses two responsive layouts wrapped in a shared `Container`:
+
+**Desktop** (`lg:` breakpoint and up):
+- Breadcrumbs spanning full width
+- Two-column grid: image gallery on the left, product info on the right
+- Right column stacks: title/price, option pickers, buy buttons, description
+
+**Mobile** (below `lg:`):
+- Breadcrumbs, then full-width carousel
+- Buy buttons immediately below the gallery
+- Compact product info (title, options, description) at the bottom
+
+## Structured data
+
+The page emits two JSON-LD schemas:
+
+- **Product schema** — name, description, images, brand, price range, availability, and variant count
+- **Breadcrumb schema** — Home → Product Title
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `components/product/pdp/product-detail-page.tsx` | Server component entry point, computes variant state and threads props |
+| `components/product/pdp/variants.ts` | Variant resolution, URL generation, image filtering |
+| `components/product/pdp/color-picker.tsx` | Color swatch Links with variant images |
+| `components/product/pdp/option-picker.tsx` | Text option Links (size, material, etc.) |
+| `components/product/pdp/product-info.tsx` | Header, options, and description composition |
+| `components/product/pdp/image-grid.tsx` | Desktop thumbnail + main image gallery |
+| `components/product/pdp/mobile-carousel.tsx` | Mobile horizontal snap-scroll carousel |
+| `components/product/pdp/buy-section-client.tsx` | Quantity selector, buy now, add to cart |
+| `components/product/pdp/mobile-buy-buttons.tsx` | Simplified mobile buy buttons |
+| `app/products/[handle]/page.tsx` | Base product route |
+| `app/products/[handle]/[variantId]/page.tsx` | Variant-specific route |
+| `next.config.ts` | `?variantId` → route segment rewrite |

--- a/apps/docs/content/docs/pages/plp.mdx
+++ b/apps/docs/content/docs/pages/plp.mdx
@@ -4,4 +4,66 @@ description: Collection and search results pages with filtering, sorting, and pa
 type: guide
 ---
 
-Coming soon.
+The PLP covers two routes — `/collections/[handle]` for browsing a collection and `/search` for query-based product search. Both share the same grid, filtering, sorting, and pagination components.
+
+## Product grid
+
+Products display in a responsive grid: 2 columns on mobile, 3 on tablet, 4 on desktop. Each page shows up to 50 products. During filter or sort transitions, a `ProductGridPendingOverlay` dims the grid to signal loading.
+
+Each product renders as a card with the featured image, title, price, compare-at price, availability status, and a quick-add button for in-stock items.
+
+## Filtering
+
+A sidebar provides multi-select faceted filters for:
+
+- **Size, Color, Vendor, Product Type, Tags** — checkbox-based multi-select
+- **Price range** — slider with 4 presets (Under \$50, \$50–\$100, \$100–\$200, Over \$200)
+
+Active filters appear as badges with remove buttons. Filter state is encoded in URL search params (`?color=red&price_min=10&price_max=100`) so filtered views are shareable.
+
+Filters use `useOptimistic` for instant UI feedback while the server request is in flight, coordinated through a `FilterTransitionProvider` context.
+
+On mobile, filters are accessible through a sheet overlay rather than a persistent sidebar.
+
+## Sorting
+
+A select dropdown offers five sort options:
+
+- Best Matches (default)
+- Price: Low to High
+- Price: High to Low
+- Name: A to Z
+- Name: Z to A
+
+Sort changes use `useTransition` for non-blocking navigation. On mobile, the sort control renders as a bottom sheet.
+
+## Pagination
+
+Pagination is cursor-based using Shopify's `endCursor` rather than page numbers. A First/Next button pair navigates between pages, with loading indicators and disabled states at boundaries. The cursor resets automatically when filters or sort change.
+
+## Collection pages
+
+The `/collections/[handle]` route fetches collection metadata (title, description, image, SEO) and its products in parallel. Collection data is cached with `cacheLife("max")` and tagged for granular revalidation (`collection-{handle}`).
+
+Products within a collection are fetched via `getCollectionProducts()`, which accepts Shopify `ProductFilter[]` for server-side filtering by variant options, price, vendor, type, tags, and metafields.
+
+## Search page
+
+The `/search` route accepts a `q` query parameter and combines it with the same filter and sort controls. `getProducts()` builds a Shopify search query from the text input and active filters, mapping UI sort keys to Shopify's `RELEVANCE` and `PRICE` sort keys.
+
+The search page displays a custom header with the query and result count, and shows a "no results" message with i18n support when the query returns empty.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `app/collections/[handle]/page.tsx` | Collection route with parallel data fetching |
+| `app/search/page.tsx` | Search route with query param handling |
+| `components/collections/results-grid.tsx` | Responsive product grid with loading overlay |
+| `components/filters/collection-filter-sidebar.tsx` | Faceted filter sidebar with optimistic UI |
+| `components/collections/sort-select.tsx` | Sort dropdown (desktop) / bottom sheet (mobile) |
+| `components/collections/pagination.tsx` | Cursor-based pagination controls |
+| `components/product-card.tsx` | Product card with image, price, quick-add |
+| `components/search/results.tsx` | Search results layout with no-results state |
+| `lib/shopify/operations/products.ts` | Product search with caching and filter mapping |
+| `lib/shopify/operations/collections.ts` | Collection metadata fetching |


### PR DESCRIPTION
## Summary
- Fill in the PDP docs page with comprehensive documentation
- Covers variant selection (Link-based + rewrite rule), image gallery, color filtering, buy section, recommendations, layout, structured data
- Includes key files reference table

## Test plan
- [ ] Verify the docs page renders correctly at `/docs/pages/pdp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)