### PR TITLE
Use connection() in PDP recommendations

### DIFF
--- a/apps/template/components/product/recommendations.tsx
+++ b/apps/template/components/product/recommendations.tsx
@@ -1,4 +1,5 @@
 import { getTranslations } from "next-intl/server";
+import { connection } from "next/server";
 import { Suspense } from "react";
 
 import { Skeleton } from "@/components/ui/skeleton";
@@ -32,6 +33,7 @@ function Fallback() {
 }
 
 async function Render({ handle, locale }: { handle: string; locale: Locale }) {
+  await connection();
   const [t, recommendations] = await Promise.all([
     getTranslations("product"),
     getProductRecommendations(handle, locale),


### PR DESCRIPTION
## Summary
- Add `await connection()` to the recommendations `Render` component so it always suspends and fetches fresh per request

## Test plan
- [ ] PDP recommendations load dynamically per request inside the Suspense boundary
- [ ] Skeleton fallback displays while recommendations are fetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)