### PR TITLE
fix: always render footer with copyright even without menu

### DIFF
--- a/apps/docs/content/docs/anatomy/footer.mdx
+++ b/apps/docs/content/docs/anatomy/footer.mdx
@@ -1,0 +1,28 @@
+---
+title: Footer
+description: The storefront footer — copyright, link columns from Shopify menus, and responsive layout.
+type: guide
+---
+
+The footer renders at the bottom of every page. It always displays a copyright notice and optionally renders link columns sourced from a Shopify menu.
+
+## Default behavior
+
+The footer always renders, even when no footer menu exists in Shopify. At minimum it shows the copyright line with the current year. When a `"footer"` menu is configured in Shopify, the footer also displays a grid of link columns above the copyright.
+
+## Link columns
+
+Link columns are sourced from `getMenu("footer", locale)`. The menu supports a two-level hierarchy: top-level items become column headings and their children become the links. Column headings can optionally link to a URL.
+
+The grid is responsive: 2 columns on mobile, 3 on tablet (`md`), and 4 on desktop (`lg`).
+
+## Copyright
+
+The copyright line is a server component that reads the current year and the `footer.copyright` translation key. It is wrapped in a `Suspense` boundary so the rest of the footer can render without waiting for the translation lookup.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `components/layout/footer.tsx` | Footer composition, link columns, copyright |
+| `lib/shopify/operations/menu.ts` | Shopify menu data fetching |

--- a/apps/docs/content/docs/anatomy/index.mdx
+++ b/apps/docs/content/docs/anatomy/index.mdx
@@ -15,6 +15,9 @@ The anatomy section covers the systems and pages that make up your storefront. S
   <Card title="Cart" href="/docs/anatomy/cart">
     State management, optimistic updates, server actions, and Shopify integration.
   </Card>
+  <Card title="Footer" href="/docs/anatomy/footer">
+    Copyright, link columns from Shopify menus, and responsive layout.
+  </Card>
   <Card title="Pages" href="/docs/anatomy/pages">
     The core page types — home, PDP, PLP, and content.
   </Card>

--- a/apps/docs/content/docs/anatomy/meta.json
+++ b/apps/docs/content/docs/anatomy/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Anatomy",
-  "pages": ["navigation", "cart", "pages"]
+  "pages": ["navigation", "cart", "footer", "pages"]
 }

--- a/apps/template/components/layout/footer.tsx
+++ b/apps/template/components/layout/footer.tsx
@@ -65,32 +65,31 @@ async function Copyright() {
 
 async function FooterContent({ locale }: { locale: string }) {
   const menu = await getMenu("footer", locale);
-
-  if (!menu || menu.items.length === 0) {
-    return null;
-  }
+  const hasMenu = menu && menu.items.length > 0;
 
   return (
     <footer className="bg-muted/30">
       <div className="mx-auto px-4 py-12 lg:px-8">
-        <div className="grid grid-cols-2 gap-8 md:grid-cols-3 lg:grid-cols-4">
-          {menu.items.map((column) => (
-            <div key={column.id}>
-              <FooterHeading title={column.title} url={column.url} />
-              {column.items.length > 0 ? (
-                <ul className="mt-4 space-y-3">
-                  {column.items.map((item) => (
-                    <li key={item.id}>
-                      <FooterLink title={item.title} url={item.url} />
-                    </li>
-                  ))}
-                </ul>
-              ) : null}
-            </div>
-          ))}
-        </div>
+        {hasMenu ? (
+          <div className="grid grid-cols-2 gap-8 md:grid-cols-3 lg:grid-cols-4">
+            {menu.items.map((column) => (
+              <div key={column.id}>
+                <FooterHeading title={column.title} url={column.url} />
+                {column.items.length > 0 ? (
+                  <ul className="mt-4 space-y-3">
+                    {column.items.map((item) => (
+                      <li key={item.id}>
+                        <FooterLink title={item.title} url={item.url} />
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : null}
 
-        <div className="mt-12 border-t border-border/40 pt-8">
+        <div className={hasMenu ? "mt-12 border-t border-border/40 pt-8" : ""}>
           <Suspense>
             <Copyright />
           </Suspense>


### PR DESCRIPTION
## Summary
- Footer now always renders with the copyright line, even when no Shopify footer menu is configured
- Link columns are conditionally shown above the copyright when a menu exists
- Adds a footer anatomy doc page to the storefront docs

## Test plan
- [ ] Verify footer renders with copyright when no `footer` menu exists in Shopify
- [ ] Verify footer renders link columns + copyright when a `footer` menu is configured
- [ ] Verify the new footer doc page loads at `/docs/anatomy/footer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)