### PR TITLE
fix(docs): scope fromsrc color overrides, restore home page

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -46,12 +46,6 @@ const HomePage = () => (
 			</div>
 		</Hero>
 		<div className="grid divide-y border-y sm:border-x">
-			<OneTwoSection
-				description="Skills and recipes let agents extend your store with a single command. Add markets, CMS, auth, and more."
-				title="Agentic development"
-			>
-				<AgentDemo />
-			</OneTwoSection>
 			<CenteredSection
 				description="Using Cache Components you can instantly show static content while streaming in dynamic data."
 				title="Dynamic storefronts with instant static responses"
@@ -59,17 +53,24 @@ const HomePage = () => (
 				<FakeBrowser />
 			</CenteredSection>
 			<OneTwoSection
-				description="Optimistic UI means the cart updates before the server responds. No spinners, no delays."
-				title="Instant cart updates"
+				description="Skills and recipes let agents extend your store with a single command. Add markets, CMS, auth, and more."
+				title="Agentic development"
 				reverse
 			>
-				<CartDemo />
+				<AgentDemo />
 			</OneTwoSection>
 			<OneTwoSection
 				description="Built-in shopping assistant for your store powered by the AI SDK and AI Gateway."
 				title="Shopping assistant"
 			>
 				<AssistantDemo />
+			</OneTwoSection>
+			<OneTwoSection
+				description="Optimistic UI means the cart updates before the server responds. No spinners, no delays."
+				title="Instant cart updates"
+				reverse
+			>
+				<CartDemo />
 			</OneTwoSection>
 			<CTA cta="Get started" href="/docs" title="Start your shop today" />
 		</div>

--- a/apps/docs/app/docs/layout.tsx
+++ b/apps/docs/app/docs/layout.tsx
@@ -37,7 +37,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
   ];
 
   return (
-    <div className="flex min-h-screen">
+    <div className="fromsrc flex min-h-screen">
       <Sidebar
         basePath="/docs"
         collapsible

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -69,8 +69,10 @@
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
+  --muted-original: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
   --accent: oklch(0.97 0 0);
+  --accent-original: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
@@ -103,8 +105,10 @@
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
+  --muted-original: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
   --accent: oklch(0.269 0 0);
+  --accent-original: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
@@ -190,15 +194,15 @@
 }
 
 /* fromsrc uses text-muted for dim text and text-accent for highlights,
-   but shadcn's muted/accent are background swatches. Override inside
-   the .fromsrc wrapper (sidebar) and reset on main content. */
+   but shadcn's muted/accent are background swatches. Override the raw
+   CSS variables inside .fromsrc (sidebar) and reset on main content. */
 .fromsrc {
-  --color-muted: var(--muted-foreground);
-  --color-accent: var(--primary);
+  --muted: var(--muted-foreground);
+  --accent: var(--primary);
 }
 .fromsrc > main {
-  --color-muted: var(--muted);
-  --color-accent: var(--accent);
+  --muted: var(--muted-original);
+  --accent: var(--accent-original);
 }
 
 @layer utilities {

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -189,13 +189,16 @@
   line-height: 1.25rem;
 }
 
-/* Scope fromsrc color token overrides to the sidebar only.
-   fromsrc uses text-muted for dim text and text-accent for highlights,
-   but shadcn's muted/accent are background swatches. */
-[aria-label="sidebar navigation"],
-[aria-expanded][data-collapsed] {
+/* fromsrc uses text-muted for dim text and text-accent for highlights,
+   but shadcn's muted/accent are background swatches. Override inside
+   the .fromsrc wrapper (sidebar) and reset on main content. */
+.fromsrc {
   --color-muted: var(--muted-foreground);
   --color-accent: var(--primary);
+}
+.fromsrc > main {
+  --color-muted: var(--muted);
+  --color-accent: var(--accent);
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- Wraps the docs layout in a `.fromsrc` class so fromsrc's color token overrides (`muted` → readable text, `accent` → primary) only apply to the sidebar
- Resets `--color-muted` and `--color-accent` back to shadcn defaults on `main` content so tabs and other shadcn components render correctly in dark mode
- Home page navbar/footer were already restored in the previous commit on main

## Test plan
- [ ] Verify sidebar text is readable on `/docs` (not too dark)
- [ ] Verify home page tabs in "Agentic development" section have visible text in dark mode
- [ ] Verify home page has navbar and footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)