### PR TITLE
fix(docs): fix broken text colors on fromsrc content pages

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -1,1 +1,2 @@
 .vercel
+.env*.local

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -191,16 +191,9 @@
 
 /* fromsrc uses text-muted for dim text and text-accent for highlights,
    but shadcn's muted/accent are background swatches. Override the raw
-   CSS variables inside fromsrc's sidebar so text is readable.
-   The main content area uses fromsrc's <Content> renderer which also
-   relies on text-muted/text-accent as text colors, so override there too
-   but scope shadcn bg-muted/bg-accent fixes to specific selectors. */
+   CSS variables inside fromsrc's sidebar so text is readable. */
 [aria-label="sidebar navigation"],
 [aria-expanded][data-collapsed] {
-  --muted: var(--muted-foreground);
-  --accent: var(--primary);
-}
-.fromsrc > main article {
   --muted: var(--muted-foreground);
   --accent: var(--primary);
 }

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -69,10 +69,8 @@
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-original: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
   --accent: oklch(0.97 0 0);
-  --accent-original: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
@@ -105,10 +103,8 @@
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
-  --muted-original: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
   --accent: oklch(0.269 0 0);
-  --accent-original: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
@@ -195,14 +191,18 @@
 
 /* fromsrc uses text-muted for dim text and text-accent for highlights,
    but shadcn's muted/accent are background swatches. Override the raw
-   CSS variables inside .fromsrc (sidebar) and reset on main content. */
-.fromsrc {
+   CSS variables inside fromsrc's sidebar so text is readable.
+   The main content area uses fromsrc's <Content> renderer which also
+   relies on text-muted/text-accent as text colors, so override there too
+   but scope shadcn bg-muted/bg-accent fixes to specific selectors. */
+[aria-label="sidebar navigation"],
+[aria-expanded][data-collapsed] {
   --muted: var(--muted-foreground);
   --accent: var(--primary);
 }
-.fromsrc > main {
-  --muted: var(--muted-original);
-  --accent: var(--accent-original);
+.fromsrc > main article {
+  --muted: var(--muted-foreground);
+  --accent: var(--primary);
 }
 
 @layer utilities {

--- a/apps/docs/components/geistdocs/skill-content.tsx
+++ b/apps/docs/components/geistdocs/skill-content.tsx
@@ -20,7 +20,7 @@ export async function SkillContent({ skill }: { skill: string }) {
   const content = stripFrontmatter(raw);
 
   return (
-    <div className="prose prose-fd">
+    <div className="prose dark:prose-invert">
       <Streamdown>{content}</Streamdown>
     </div>
   );


### PR DESCRIPTION
## Summary
- The `.fromsrc > main` CSS reset was restoring `--muted` and `--accent` to shadcn background swatch values, making fromsrc prose text nearly invisible on dark backgrounds (e.g. `/docs/skills/enable-shopify-markets`)
- Scoped the color overrides to the sidebar selectors and `.fromsrc > main article` so fromsrc content renders readable text without breaking shadcn `bg-muted`/`bg-accent` usage elsewhere
- Removed unused `--muted-original` / `--accent-original` CSS variables

## Test plan
- [ ] Verify docs content pages (e.g. `/docs/skills/enable-shopify-markets`) have readable text in dark mode
- [ ] Verify sidebar text remains readable
- [ ] Verify shadcn components using `bg-muted`/`bg-accent` (tabs, buttons, etc.) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)