### PR TITLE
Add fromsrc Toc to docs pages

### DIFF
--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -34,7 +34,7 @@ export default async function DocsPage({ params }: Props) {
       </article>
       <aside className="hidden xl:block w-56 shrink-0 py-12">
         <div className="sticky top-12">
-          <Toc title="On this page" />
+          <Toc title="" />
         </div>
       </aside>
     </div>

--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -3,6 +3,7 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 import { notFound } from "next/navigation";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
+import { Toc } from "fromsrc/client";
 import { docs } from "@/lib/fromsrc/content";
 import { mdxComponents } from "@/lib/fromsrc/mdx-components";
 
@@ -19,17 +20,24 @@ export default async function DocsPage({ params }: Props) {
   }
 
   return (
-    <article className="prose dark:prose-invert max-w-3xl px-8 py-12 font-sans">
-      <h1 className="mb-2 text-2xl font-bold">{doc.title}</h1>
-      {doc.description ? (
-        <p className="text-muted-foreground mb-8">{doc.description}</p>
-      ) : null}
-      <MDXRemote
-        source={doc.content}
-        components={mdxComponents}
-        options={{ mdxOptions: { remarkPlugins: [remarkGfm], rehypePlugins: [rehypeSlug] } }}
-      />
-    </article>
+    <div className="flex gap-8">
+      <article className="prose dark:prose-invert max-w-3xl px-8 py-12 font-sans">
+        <h1 className="mb-2 text-2xl font-bold">{doc.title}</h1>
+        {doc.description ? (
+          <p className="text-muted-foreground mb-8">{doc.description}</p>
+        ) : null}
+        <MDXRemote
+          source={doc.content}
+          components={mdxComponents}
+          options={{ mdxOptions: { remarkPlugins: [remarkGfm], rehypePlugins: [rehypeSlug] } }}
+        />
+      </article>
+      <aside className="hidden xl:block w-56 shrink-0 py-12">
+        <div className="sticky top-12">
+          <Toc title="On this page" />
+        </div>
+      </aside>
+    </div>
   );
 }
 

--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -32,7 +32,7 @@ export default async function DocsPage({ params }: Props) {
           options={{ mdxOptions: { remarkPlugins: [remarkGfm], rehypePlugins: [rehypeSlug] } }}
         />
       </article>
-      <aside className="hidden xl:block w-56 shrink-0 py-12">
+      <aside className="hidden xl:block w-56 shrink-0">
         <div className="sticky top-12">
           <Toc title="" />
         </div>


### PR DESCRIPTION
## Summary
- Adds the fromsrc `Toc` component as a sticky right-side aside on doc pages
- Visible on `xl` breakpoint and up, hidden on smaller screens
- Uses `rehype-slug` (already present) for heading anchor links

## Test plan
- [ ] Verify TOC renders on docs pages with multiple headings
- [ ] Verify active heading highlights on scroll
- [ ] Verify TOC is hidden on smaller viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)