### PR TITLE
Add docs stubs for Content Summarization and Virtual Try-On skills

### DIFF
--- a/apps/docs/content/docs/skills/enable-content-negotiation.mdx
+++ b/apps/docs/content/docs/skills/enable-content-negotiation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Enable Content Negotiation
+title: Content Negotiation
 description: Serve product pages as markdown to LLM agents via Accept header content negotiation.
 type: guide
 ---

--- a/apps/docs/content/docs/skills/enable-content-summarization.mdx
+++ b/apps/docs/content/docs/skills/enable-content-summarization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Enable Content Summarization
+title: Content Summarization
 description: Use AI to generate concise product and collection summaries for search, social, and agentic surfaces.
 type: guide
 ---

--- a/apps/docs/content/docs/skills/enable-content-summarization.mdx
+++ b/apps/docs/content/docs/skills/enable-content-summarization.mdx
@@ -1,0 +1,13 @@
+---
+title: Enable Content Summarization
+description: Use AI to generate concise product and collection summaries for search, social, and agentic surfaces.
+type: guide
+---
+
+## How to use
+
+```bash
+/enable-content-summarization
+```
+
+_This skill is coming soon._

--- a/apps/docs/content/docs/skills/enable-shopify-auth.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-auth.mdx
@@ -1,5 +1,5 @@
 ---
-title: Enable Shopify Auth
+title: Shopify Auth
 description: Add customer authentication with login, account pages, and nav integration.
 type: guide
 ---

--- a/apps/docs/content/docs/skills/enable-shopify-cms.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-cms.mdx
@@ -1,5 +1,5 @@
 ---
-title: Enable Shopify CMS
+title: Shopify CMS
 description: Wire Shopify metaobjects as the CMS for homepage and marketing page content.
 type: guide
 ---

--- a/apps/docs/content/docs/skills/enable-shopify-markets.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-markets.mdx
@@ -1,5 +1,5 @@
 ---
-title: Enable Shopify Markets
+title: Shopify Markets
 description: Add multi-locale and multi-currency support with Shopify Markets.
 type: guide
 ---

--- a/apps/docs/content/docs/skills/enable-virtual-try-on.mdx
+++ b/apps/docs/content/docs/skills/enable-virtual-try-on.mdx
@@ -1,0 +1,13 @@
+---
+title: Enable Virtual Try-On
+description: Let shoppers visualize products on themselves with AI-powered virtual try-on.
+type: guide
+---
+
+## How to use
+
+```bash
+/enable-virtual-try-on
+```
+
+_This skill is coming soon._

--- a/apps/docs/content/docs/skills/enable-virtual-try-on.mdx
+++ b/apps/docs/content/docs/skills/enable-virtual-try-on.mdx
@@ -1,5 +1,5 @@
 ---
-title: Enable Virtual Try-On
+title: Virtual Try-On
 description: Let shoppers visualize products on themselves with AI-powered virtual try-on.
 type: guide
 ---

--- a/apps/docs/content/docs/skills/index.mdx
+++ b/apps/docs/content/docs/skills/index.mdx
@@ -9,10 +9,10 @@ prerequisites:
 Skills are agent-ready guides that transform your storefront. Run them with Claude Code or follow along manually.
 
 <Cards>
-  <Card title="Enable Shopify Markets" href="/docs/skills/enable-shopify-markets">
+  <Card title="Shopify Markets" href="/docs/skills/enable-shopify-markets">
     Add multi-locale and multi-currency support with Shopify Markets.
   </Card>
-  <Card title="Enable Shopify Auth" href="/docs/skills/enable-shopify-auth">
+  <Card title="Shopify Auth" href="/docs/skills/enable-shopify-auth">
     Add customer authentication with login, account pages, and nav integration.
   </Card>
   <Card title="Shopify CMS" href="/docs/skills/enable-shopify-cms">

--- a/apps/docs/content/docs/skills/index.mdx
+++ b/apps/docs/content/docs/skills/index.mdx
@@ -21,4 +21,10 @@ Skills are agent-ready guides that transform your storefront. Run them with Clau
   <Card title="Content Negotiation" href="/docs/skills/enable-content-negotiation">
     Serve product pages as markdown to LLM agents via Accept header.
   </Card>
+  <Card title="Content Summarization" href="/docs/skills/enable-content-summarization">
+    Use AI to generate concise product and collection summaries for search, social, and agentic surfaces.
+  </Card>
+  <Card title="Virtual Try-On" href="/docs/skills/enable-virtual-try-on">
+    Let shoppers visualize products on themselves with AI-powered virtual try-on.
+  </Card>
 </Cards>


### PR DESCRIPTION
## Summary
- Adds stub docs pages for two upcoming agentic commerce skills: Content Summarization and Virtual Try-On
- Links both from the skills index page
- Skills themselves are not yet in the template — pages show "coming soon"

## Test plan
- [ ] Verify both new pages render at `/docs/skills/enable-content-summarization` and `/docs/skills/enable-virtual-try-on`
- [ ] Verify skills index page shows both new cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)