### PR TITLE
Replace PDP thumbnail gallery with side-by-side image grid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Vercel Shop Monorepo
+
+This is a monorepo for developing a template, docs site, and skills for using Next.js with Shopify and deploying to Vercel.
+
+## Template
+
+The main app in this monorepo is apps/template, which is a template/reference architecture for using Shopify and Next.js. Learn more by reading the AGENTS.md in the directory. It is linked to the vercel-labs/shop-template project on Vercel.
+
+## Docs
+
+The docs app is in apps/docs using [fromsrc](https://www.fromsrc.com). It is linked to the vercel-labs/shop-docs project on Vercel.
+
+## Skills
+
+Skills to be used by the template and docs are written to apps/template/.agent/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/template/components/product/pdp/image-grid.tsx
+++ b/apps/template/components/product/pdp/image-grid.tsx
@@ -1,109 +1,10 @@
-"use client";
-
 import Image from "next/image";
-import { useRef, useState } from "react";
 
 import type { Image as ImageType, Video } from "@/lib/types";
-import { cn } from "@/lib/utils";
 
 import { AutoPlayVideo } from "./auto-play-video";
 
 type MediaItem = { type: "video"; video: Video } | { type: "image"; image: ImageType };
-
-function ImageViewer({
-  images,
-  videos,
-  title,
-}: {
-  images: ImageType[];
-  videos: Video[];
-  title: string;
-}) {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const prevMediaRef = useRef<string>("");
-
-  const mediaItems: MediaItem[] = [
-    ...images.map((image): MediaItem => ({ type: "image", image })),
-    ...videos.map((video): MediaItem => ({ type: "video", video })),
-  ];
-
-  // Reset to first item when filtered media changes (e.g. color switch)
-  const mediaKey = mediaItems
-    .map((m) => (m.type === "video" ? m.video.url : m.image.url))
-    .join(",");
-  if (prevMediaRef.current && prevMediaRef.current !== mediaKey) {
-    setSelectedIndex(0);
-  }
-  prevMediaRef.current = mediaKey;
-
-  if (mediaItems.length === 0) return null;
-
-  const selected = mediaItems[selectedIndex] ?? mediaItems[0];
-
-  return (
-    <div className="flex gap-3">
-      {/* Thumbnail column */}
-      <div className="flex flex-col gap-2 overflow-y-auto max-h-[calc(100vh-200px)] w-20 shrink-0">
-        {mediaItems.map((item, idx) => {
-          const key = item.type === "video" ? item.video.url : item.image.url;
-          return (
-            <button
-              type="button"
-              key={key}
-              onMouseEnter={() => setSelectedIndex(idx)}
-              onClick={() => setSelectedIndex(idx)}
-              className={cn(
-                "relative aspect-square w-full overflow-hidden rounded-lg bg-accent transition-all ring-1 ring-inset",
-                idx === selectedIndex
-                  ? "ring-foreground/50"
-                  : "ring-transparent hover:ring-foreground/50",
-              )}
-            >
-              {item.type === "video" ? (
-                <Image
-                  src={item.video.previewImage?.url ?? ""}
-                  alt={`${title} video ${idx + 1}`}
-                  fill
-                  className="object-cover"
-                  sizes="80px"
-                />
-              ) : (
-                <Image
-                  src={item.image.url}
-                  alt={item.image.altText || `${title} image ${idx + 1}`}
-                  fill
-                  className="object-cover"
-                  sizes="80px"
-                />
-              )}
-            </button>
-          );
-        })}
-      </div>
-
-      {/* Main image */}
-      <div className="relative aspect-square w-full overflow-hidden rounded-xl bg-accent">
-        {selected?.type === "video" ? (
-          <AutoPlayVideo
-            src={selected.video.url}
-            poster={selected.video.previewImage?.url}
-            className="h-full w-full scale-105 object-cover rounded-xl"
-          />
-        ) : selected ? (
-          <Image
-            src={selected.image.url}
-            alt={selected.image.altText || `${title} image ${selectedIndex + 1}`}
-            fill
-            className="object-cover rounded-xl"
-            sizes="(min-width: 1024px) 45vw, 100vw"
-            priority={selectedIndex === 0}
-            loading={selectedIndex === 0 ? "eager" : "lazy"}
-          />
-        ) : null}
-      </div>
-    </div>
-  );
-}
 
 export function ImageGrid({
   images,
@@ -114,5 +15,42 @@ export function ImageGrid({
   videos: Video[];
   title: string;
 }) {
-  return <ImageViewer images={images} videos={videos} title={title} />;
+  const mediaItems: MediaItem[] = [
+    ...images.map((image): MediaItem => ({ type: "image", image })),
+    ...videos.map((video): MediaItem => ({ type: "video", video })),
+  ];
+
+  if (mediaItems.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {mediaItems.map((item, idx) => {
+        const key = item.type === "video" ? item.video.url : item.image.url;
+        return (
+          <div
+            key={key}
+            className="relative aspect-square w-full overflow-hidden rounded-xl bg-accent"
+          >
+            {item.type === "video" ? (
+              <AutoPlayVideo
+                src={item.video.url}
+                poster={item.video.previewImage?.url}
+                className="h-full w-full object-cover rounded-xl"
+              />
+            ) : (
+              <Image
+                src={item.image.url}
+                alt={item.image.altText || `${title} image ${idx + 1}`}
+                fill
+                className="object-cover rounded-xl"
+                sizes="(min-width: 1024px) 25vw, 50vw"
+                priority={idx < 2}
+                loading={idx < 2 ? "eager" : "lazy"}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- Replaced the desktop PDP single-image-with-thumbnails layout with a 2-column side-by-side grid showing all product images and videos
- Removed client-side state (`useState`, `useRef`) and `"use client"` directive — component is now a server component
- Supports both images and videos in the grid layout

## Test plan
- [ ] Verify desktop PDP shows images in a 2×N grid layout
- [ ] Verify videos render and autoplay correctly in grid cells
- [ ] Verify color variant switching still filters images correctly
- [ ] Verify mobile layout (carousel) is unaffected
- [ ] Check that first two images load eagerly (priority) and the rest lazy-load

🤖 Generated with [Claude Code](https://claude.com/claude-code)