### PR TITLE
Add lightbox to desktop PDP image grid

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -44,7 +44,7 @@ Unavailable options render as inert `<span>` elements instead of links.
 
 The gallery adapts to screen size with two distinct components.
 
-**Desktop** — `ImageGrid` displays a thumbnail sidebar (80px wide, vertically scrollable) alongside a main image. Hovering or clicking a thumbnail selects it. Videos are supported inline with autoplay.
+**Desktop** — `ImageGrid` renders a side-by-side two-column grid of product images and videos. Clicking any image opens it in a lightbox — a full-viewport overlay powered by Radix Dialog. The lightbox supports closing via an explicit close button, clicking outside the image, or pressing Escape. The grid itself remains a server component; the interactive lightbox logic lives in a separate `Lightbox` client component.
 
 **Mobile** — `MobileCarousel` is a horizontal snap-scroll carousel with dot indicators below. Swiping or tapping a dot navigates between images.
 
@@ -109,7 +109,8 @@ The page emits two JSON-LD schemas:
 | `components/product/pdp/color-picker.tsx` | Color swatch Links with variant images |
 | `components/product/pdp/option-picker.tsx` | Text option Links (size, material, etc.) |
 | `components/product/pdp/product-info.tsx` | Header, options, and description composition |
-| `components/product/pdp/image-grid.tsx` | Desktop thumbnail + main image gallery |
+| `components/product/pdp/image-grid.tsx` | Desktop side-by-side image grid |
+| `components/product/pdp/lightbox.tsx` | Client component for full-viewport image lightbox |
 | `components/product/pdp/mobile-carousel.tsx` | Mobile horizontal snap-scroll carousel |
 | `components/product/pdp/buy-section-client.tsx` | Quantity selector, buy now, add to cart |
 | `components/product/pdp/mobile-buy-buttons.tsx` | Simplified mobile buy buttons |

--- a/apps/template/components/product/pdp/image-grid.tsx
+++ b/apps/template/components/product/pdp/image-grid.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import type { Image as ImageType, Video } from "@/lib/types";
 
 import { AutoPlayVideo } from "./auto-play-video";
+import { Lightbox, LightboxTrigger } from "./lightbox";
 
 type MediaItem = { type: "video"; video: Video } | { type: "image"; image: ImageType };
 
@@ -23,34 +24,38 @@ export function ImageGrid({
   if (mediaItems.length === 0) return null;
 
   return (
-    <div className="grid grid-cols-2 gap-2">
-      {mediaItems.map((item, idx) => {
-        const key = item.type === "video" ? item.video.url : item.image.url;
-        return (
-          <div
-            key={key}
-            className="relative aspect-square w-full overflow-hidden rounded-xl bg-accent"
-          >
-            {item.type === "video" ? (
-              <AutoPlayVideo
-                src={item.video.url}
-                poster={item.video.previewImage?.url}
-                className="h-full w-full object-cover rounded-xl"
-              />
-            ) : (
-              <Image
-                src={item.image.url}
-                alt={item.image.altText || `${title} image ${idx + 1}`}
-                fill
-                className="object-cover rounded-xl"
-                sizes="(min-width: 1024px) 25vw, 50vw"
-                priority={idx < 2}
-                loading={idx < 2 ? "eager" : "lazy"}
-              />
-            )}
-          </div>
-        );
-      })}
-    </div>
+    <Lightbox label={title}>
+      <div className="grid grid-cols-2 gap-2">
+        {mediaItems.map((item, idx) => {
+          const key = item.type === "video" ? item.video.url : item.image.url;
+          return (
+            <div
+              key={key}
+              className="relative aspect-square w-full overflow-hidden rounded-xl bg-accent"
+            >
+              {item.type === "video" ? (
+                <AutoPlayVideo
+                  src={item.video.url}
+                  poster={item.video.previewImage?.url}
+                  className="h-full w-full object-cover rounded-xl"
+                />
+              ) : (
+                <LightboxTrigger item={item}>
+                  <Image
+                    src={item.image.url}
+                    alt={item.image.altText || `${title} image ${idx + 1}`}
+                    fill
+                    className="object-cover rounded-xl"
+                    sizes="(min-width: 1024px) 25vw, 50vw"
+                    priority={idx < 2}
+                    loading={idx < 2 ? "eager" : "lazy"}
+                  />
+                </LightboxTrigger>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </Lightbox>
   );
 }

--- a/apps/template/components/product/pdp/lightbox.tsx
+++ b/apps/template/components/product/pdp/lightbox.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { XIcon } from "lucide-react";
+import Image from "next/image";
+import { createContext, useCallback, useContext, useState } from "react";
+import type { ReactNode } from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+
+import type { Image as ImageType, Video } from "@/lib/types";
+
+import { AutoPlayVideo } from "./auto-play-video";
+
+type MediaItem = { type: "video"; video: Video } | { type: "image"; image: ImageType };
+
+const LightboxContext = createContext<((item: MediaItem) => void) | null>(null);
+
+export function Lightbox({ label, children }: { label: string; children: ReactNode }) {
+  const [activeItem, setActiveItem] = useState<MediaItem | null>(null);
+  const close = useCallback(() => setActiveItem(null), []);
+
+  return (
+    <LightboxContext.Provider value={setActiveItem}>
+      {children}
+
+      <DialogPrimitive.Root open={activeItem !== null} onOpenChange={(open) => !open && close()}>
+        <DialogPrimitive.Portal>
+          <DialogPrimitive.Overlay className="fixed inset-0 z-60 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+          <DialogPrimitive.Content
+            className="fixed inset-0 z-60 flex items-center justify-center p-8 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+            aria-label={`${label} enlarged`}
+          >
+            <DialogPrimitive.Close className="absolute top-4 right-4 z-10 rounded-full bg-black/50 p-2 text-white transition-opacity hover:opacity-80 focus:ring-2 focus:ring-white focus:outline-hidden">
+              <XIcon className="size-5" />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+
+            {activeItem?.type === "image" && (
+              <div className="relative h-full w-full">
+                <Image
+                  src={activeItem.image.url}
+                  alt={activeItem.image.altText || `${label} enlarged`}
+                  fill
+                  className="object-contain"
+                  sizes="90vw"
+                  priority
+                />
+              </div>
+            )}
+
+            {activeItem?.type === "video" && (
+              <AutoPlayVideo
+                src={activeItem.video.url}
+                poster={activeItem.video.previewImage?.url}
+                className="max-h-full max-w-full object-contain"
+              />
+            )}
+          </DialogPrimitive.Content>
+        </DialogPrimitive.Portal>
+      </DialogPrimitive.Root>
+    </LightboxContext.Provider>
+  );
+}
+
+export function LightboxTrigger({
+  item,
+  children,
+}: {
+  item: MediaItem;
+  children: ReactNode;
+}) {
+  const open = useContext(LightboxContext);
+  return (
+    <button type="button" onClick={() => open?.(item)} className="h-full w-full cursor-zoom-in">
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Clicking a product image in the desktop PDP grid opens a full-viewport lightbox overlay
- Supports click-outside-to-close and an explicit close button (X icon)
- Client boundary pushed down into a new `Lightbox` component so `ImageGrid` stays a server component
- Uses Radix Dialog primitives for accessible overlay behavior

## Test plan
- [ ] Navigate to a product detail page on desktop
- [ ] Click any product image — verify it opens in a centered overlay with dark backdrop
- [ ] Click the X button — verify the lightbox closes
- [ ] Click outside the image — verify the lightbox closes
- [ ] Press Escape — verify the lightbox closes
- [ ] Verify videos in the grid are unaffected (no lightbox trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)