### PR TITLE
Fix PDP hard navigation caused by notFound() in cache boundary

### DIFF
--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -48,12 +48,10 @@ async function resolvePageContext(
   const pageType = segments[0];
 
   if (pageType === "products" && segments.length >= 2) {
-    try {
-      const handle = segments[1];
-      const product = await getProduct(handle, locale);
+    const handle = segments[1];
+    const product = await getProduct(handle, locale);
+    if (product) {
       return { type: "product", product };
-    } catch {
-      // Product not found
     }
   }
 

--- a/apps/template/app/products/[handle]/[variantId]/page.tsx
+++ b/apps/template/app/products/[handle]/[variantId]/page.tsx
@@ -6,6 +6,10 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "../shared";
 
+export async function generateStaticParams() {
+  return [];
+}
+
 export async function generateMetadata({
   params,
 }: PageProps<"/products/[handle]/[variantId]">): Promise<Metadata> {

--- a/apps/template/app/products/[handle]/[variantId]/page.tsx
+++ b/apps/template/app/products/[handle]/[variantId]/page.tsx
@@ -33,5 +33,9 @@ export default async function ProductVariantPage({
 
   const product = await getProductDetails(handle, locale);
 
+  if (!product) {
+    notFound();
+  }
+
   return <ProductDetailPage product={product} locale={locale} variantId={variantId} />;
 }

--- a/apps/template/app/products/[handle]/[variantId]/page.tsx
+++ b/apps/template/app/products/[handle]/[variantId]/page.tsx
@@ -6,10 +6,6 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "../shared";
 
-export async function generateStaticParams() {
-  return [{ handle: "__placeholder__", variantId: "__placeholder__" }];
-}
-
 export async function generateMetadata({
   params,
 }: PageProps<"/products/[handle]/[variantId]">): Promise<Metadata> {

--- a/apps/template/app/products/[handle]/[variantId]/page.tsx
+++ b/apps/template/app/products/[handle]/[variantId]/page.tsx
@@ -7,7 +7,7 @@ import { getLocale } from "@/lib/params";
 import { buildProductMetadata, getProductDetails } from "../shared";
 
 export async function generateStaticParams() {
-  return [];
+  return [{ handle: "__placeholder__", variantId: "__placeholder__" }];
 }
 
 export async function generateMetadata({

--- a/apps/template/app/products/[handle]/[variantId]/page.tsx
+++ b/apps/template/app/products/[handle]/[variantId]/page.tsx
@@ -6,18 +6,10 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "../shared";
 
-export async function generateStaticParams() {
-  return [{ handle: "__placeholder__", variantId: "__placeholder__" }];
-}
-
 export async function generateMetadata({
   params,
 }: PageProps<"/products/[handle]/[variantId]">): Promise<Metadata> {
   const [{ handle, variantId }, locale] = await Promise.all([params, getLocale()]);
-
-  if (handle === "__placeholder__") {
-    notFound();
-  }
 
   return buildProductMetadata(handle, locale, `/products/${handle}?variantId=${variantId}`);
 }
@@ -26,10 +18,6 @@ export default async function ProductVariantPage({
   params,
 }: PageProps<"/products/[handle]/[variantId]">) {
   const [{ handle, variantId }, locale] = await Promise.all([params, getLocale()]);
-
-  if (handle === "__placeholder__") {
-    notFound();
-  }
 
   const product = await getProductDetails(handle, locale);
 

--- a/apps/template/app/products/[handle]/[variantId]/page.tsx
+++ b/apps/template/app/products/[handle]/[variantId]/page.tsx
@@ -6,7 +6,9 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "../shared";
 
-export const dynamic = "force-dynamic";
+export async function generateStaticParams() {
+  return [{ handle: "__placeholder__", variantId: "__placeholder__" }];
+}
 
 export async function generateMetadata({
   params,

--- a/apps/template/app/products/[handle]/[variantId]/page.tsx
+++ b/apps/template/app/products/[handle]/[variantId]/page.tsx
@@ -6,6 +6,10 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "../shared";
 
+export async function generateStaticParams() {
+  return [{ handle: "__placeholder__", variantId: "__placeholder__" }];
+}
+
 export async function generateMetadata({
   params,
 }: PageProps<"/products/[handle]/[variantId]">): Promise<Metadata> {

--- a/apps/template/app/products/[handle]/[variantId]/page.tsx
+++ b/apps/template/app/products/[handle]/[variantId]/page.tsx
@@ -6,9 +6,7 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "../shared";
 
-export async function generateStaticParams() {
-  return [{ handle: "__placeholder__", variantId: "__placeholder__" }];
-}
+export const dynamic = "force-dynamic";
 
 export async function generateMetadata({
   params,

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -6,10 +6,6 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "./shared";
 
-export async function generateStaticParams() {
-  return [{ handle: "__placeholder__" }];
-}
-
 export async function generateMetadata({
   params,
 }: PageProps<"/products/[handle]">): Promise<Metadata> {

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -6,6 +6,10 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "./shared";
 
+export async function generateStaticParams() {
+  return [{ handle: "__placeholder__" }];
+}
+
 export async function generateMetadata({
   params,
 }: PageProps<"/products/[handle]">): Promise<Metadata> {

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -6,7 +6,9 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "./shared";
 
-export const dynamic = "force-dynamic";
+export async function generateStaticParams() {
+  return [{ handle: "__placeholder__" }];
+}
 
 export async function generateMetadata({
   params,

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -6,28 +6,16 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "./shared";
 
-export async function generateStaticParams() {
-  return [{ handle: "__placeholder__" }];
-}
-
 export async function generateMetadata({
   params,
 }: PageProps<"/products/[handle]">): Promise<Metadata> {
   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
-
-  if (handle === "__placeholder__") {
-    notFound();
-  }
 
   return buildProductMetadata(handle, locale, `/products/${handle}`);
 }
 
 export default async function ProductPage({ params }: PageProps<"/products/[handle]">) {
   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
-
-  if (handle === "__placeholder__") {
-    notFound();
-  }
 
   const product = await getProductDetails(handle, locale);
 

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -6,6 +6,10 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "./shared";
 
+export async function generateStaticParams() {
+  return [];
+}
+
 export async function generateMetadata({
   params,
 }: PageProps<"/products/[handle]">): Promise<Metadata> {

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -7,7 +7,7 @@ import { getLocale } from "@/lib/params";
 import { buildProductMetadata, getProductDetails } from "./shared";
 
 export async function generateStaticParams() {
-  return [];
+  return [{ handle: "__placeholder__" }];
 }
 
 export async function generateMetadata({

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -31,5 +31,9 @@ export default async function ProductPage({ params }: PageProps<"/products/[hand
 
   const product = await getProductDetails(handle, locale);
 
+  if (!product) {
+    notFound();
+  }
+
   return <ProductDetailPage product={product} locale={locale} />;
 }

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -6,9 +6,7 @@ import { getLocale } from "@/lib/params";
 
 import { buildProductMetadata, getProductDetails } from "./shared";
 
-export async function generateStaticParams() {
-  return [{ handle: "__placeholder__" }];
-}
+export const dynamic = "force-dynamic";
 
 export async function generateMetadata({
   params,

--- a/apps/template/app/products/[handle]/shared.ts
+++ b/apps/template/app/products/[handle]/shared.ts
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
-import { notFound } from "next/navigation";
 
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
 import { getProduct } from "@/lib/shopify/operations/products";
@@ -11,11 +10,7 @@ export async function getProductDetails(handle: string, locale: string) {
   cacheTag("products", `product:${handle}`);
   const product = await getProduct(handle, locale);
 
-  if (!product) {
-    notFound();
-  }
-
-  return product;
+  return product ?? null;
 }
 
 export async function buildProductMetadata(
@@ -24,6 +19,7 @@ export async function buildProductMetadata(
   canonicalPath: string,
 ): Promise<Metadata> {
   const product = await getProductDetails(handle, locale);
+  if (!product) return {};
   const images = product.featuredImage
     ? [
         {

--- a/apps/template/app/products/[handle]/shared.ts
+++ b/apps/template/app/products/[handle]/shared.ts
@@ -1,16 +1,10 @@
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
 
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
 import { getProduct } from "@/lib/shopify/operations/products";
 
 export async function getProductDetails(handle: string, locale: string) {
-  "use cache";
-  cacheLife("max");
-  cacheTag("products", `product:${handle}`);
-  const product = await getProduct(handle, locale);
-
-  return product ?? null;
+  return getProduct(handle, locale);
 }
 
 export async function buildProductMetadata(

--- a/apps/template/lib/agent/tools/get-product-details.ts
+++ b/apps/template/lib/agent/tools/get-product-details.ts
@@ -22,6 +22,10 @@ You can get handles from search results or the current page context.`,
       try {
         const product = await getProduct(handle, user.locale);
 
+        if (!product) {
+          return { success: false, error: `Product not found: ${handle}` };
+        }
+
         return {
           success: true,
           product: {

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -55,7 +55,7 @@ export async function getProduct(handle: string, locale: string = defaultLocale)
   });
 
   if (!data.productByHandle) {
-    throw new Error(`Product not found: ${handle}`);
+    return null;
   }
 
   tagProducts([data.productByHandle]);

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -40,7 +40,7 @@ const GET_PRODUCT_BY_HANDLE_QUERY = `
 `;
 
 export async function getProduct(handle: string, locale: string = defaultLocale) {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("products", `product-${handle}`);
   const country = getCountryCode(locale);

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -40,6 +40,9 @@ const GET_PRODUCT_BY_HANDLE_QUERY = `
 `;
 
 export async function getProduct(handle: string, locale: string = defaultLocale) {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("products", `product-${handle}`);
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -40,9 +40,6 @@ const GET_PRODUCT_BY_HANDLE_QUERY = `
 `;
 
 export async function getProduct(handle: string, locale: string = defaultLocale) {
-  "use cache";
-  cacheLife("max");
-  cacheTag("products", `product-${handle}`);
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
 const nextConfig: NextConfig = {
-  cacheComponents: true,
+  // cacheComponents: true, // Disabled: causes ISR fallback pages to serve text/html for RSC requests, breaking client-side navigation
   experimental: {
     turbopackFileSystemCacheForDev: true,
   },

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
 const nextConfig: NextConfig = {
-  // cacheComponents: true, // Disabled: causes ISR fallback pages to serve text/html for RSC requests, breaking client-side navigation
+  cacheComponents: true,
   experimental: {
     turbopackFileSystemCacheForDev: true,
   },


### PR DESCRIPTION
## Summary
- Product page navigations from the home page cause a full page reload instead of smooth client-side transitions
- **Root cause: ISR fallback pages do not generate RSC flight payloads** when `cacheComponents: true` + `generateStaticParams` with a placeholder are used together. The server returns `text/html` (instead of `text/x-component`) for RSC requests to dynamically-rendered product pages. This causes the Next.js router to fall back to hard navigation.
- This affects **all ISR fallback pages** in the template — only pre-rendered paths (like `__placeholder__`) have correct RSC variants. This is a Next.js framework behavior that likely needs to be addressed upstream.

## Changes (still valuable independent of the RSC issue)
- **`getProduct` returns `null` instead of throwing** for missing products — throwing inside `"use cache: remote"` boundaries causes build failures and server errors
- **Removed `notFound()` from `"use cache"` functions** — moved to page components where the framework handles it correctly
- **Simplified `getProductDetails`** — removed redundant `"use cache"` wrapper since `getProduct` already has `"use cache: remote"`
- **Fixed null handling** in agent tools and chat route for the new nullable return type

## Investigation
- Confirmed via `agent-browser`: `window.__NAV_TEST_MARKER` is destroyed on PDP navigation (hard nav)
- RSC requests (`RSC: 1` header) to `/products/[handle]` return `text/html` instead of `text/x-component`
- All non-ISR routes (`/`, `/search`, `/about`, `/cart`, `/collections/all`) correctly return `text/x-component`
- The prerendered `__placeholder__` path returns correct `text/x-component` — only ISR fallbacks are broken
- Tested multiple approaches: removing `generateStaticParams`, changing cache scopes, removing cache wrappers — none resolve the RSC content-type issue
- **This same issue exists on the current production deployment** (main branch) — it is not a regression

## Next steps
- File an issue with Next.js about ISR fallback + `cacheComponents: true` not generating RSC flight payloads
- Consider disabling `cacheComponents` if client-side navigation is a higher priority than cache components

## Test plan
- [ ] Build passes (type-check + Vercel deployment)
- [ ] Product pages still render correctly on direct navigation
- [ ] Missing products show 404 instead of 500
- [ ] Agent tool and chat route handle null products gracefully
- [ ] ~~Client-side navigation works~~ (blocked by Next.js framework issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)