### PR TITLE
Move variant URL rewrite to proxy.ts

### DIFF
--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -16,13 +16,6 @@ const nextConfig: NextConfig = {
     ],
     unoptimized: !!process.env.V0_CALLBACK_URL,
   },
-  rewrites: async () => [
-    {
-      source: "/products/:handle",
-      has: [{ type: "query", key: "variantId", value: "(?<variantId>.+)" }],
-      destination: "/products/:handle/:variantId",
-    },
-  ],
 };
 
 const withNextIntl = createNextIntlPlugin({

--- a/apps/template/proxy.ts
+++ b/apps/template/proxy.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function proxy(request: NextRequest) {
+  const { pathname, searchParams } = request.nextUrl;
+  const variantId = searchParams.get("variantId");
+
+  if (variantId && pathname.match(/^\/products\/[^/]+$/)) {
+    const url = request.nextUrl.clone();
+    url.pathname = `${pathname}/${variantId}`;
+    url.searchParams.delete("variantId");
+    return NextResponse.rewrite(url);
+  }
+}
+
+export const config = {
+  matcher: "/products/:path*",
+};


### PR DESCRIPTION
## Summary
- Moves the `/products/:handle?variantId=X` → `/products/:handle/X` rewrite from `next.config.ts` to a new `proxy.ts`
- Investigating whether proxy-level `NextResponse.rewrite()` avoids PDP hard navigations on variant changes
- `next.config.ts` rewrites operate at the routing layer (step 4–8 in execution order), while `proxy.ts` runs earlier (step 3), preserving client-side navigation context

## Test plan
- [ ] Navigate to a PDP and switch variants — verify soft navigation (no full page reload)
- [ ] Verify `/products/handle?variantId=X` still resolves to the correct variant page
- [ ] Verify direct navigation to `/products/handle/variantId` still works
- [ ] Check that back/forward browser navigation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)