### PR TITLE
chore(template): use canonical Tailwind CSS classes

### DIFF
--- a/apps/template/app/cart/page.tsx
+++ b/apps/template/app/cart/page.tsx
@@ -58,7 +58,7 @@ async function CartContent({ locale }: { locale: Locale }) {
               </div>
 
               <aside className="hidden lg:block shrink-0">
-                <div className="w-[380px] xl:w-[420px] 2xl:w-[480px] min-h-full bg-input/50 rounded-tl-3xl shadow-[100vw_0_0_0_rgba(236,236,236,0.5)]">
+                <div className="w-95 xl:w-105 2xl:w-120 min-h-full bg-input/50 rounded-tl-3xl shadow-[100vw_0_0_0_rgba(236,236,236,0.5)]">
                   <div className="sticky top-0 p-8">
                     <Summary locale={locale} />
                   </div>

--- a/apps/template/app/pages/[slug]/page.tsx
+++ b/apps/template/app/pages/[slug]/page.tsx
@@ -93,7 +93,7 @@ function MarketingPageSkeleton() {
 
   return (
     <div className="flex flex-col gap-8 pb-16">
-      <Skeleton className="h-[400px] w-full rounded-xl" />
+      <Skeleton className="h-100 w-full rounded-xl" />
       <section className="py-12 px-4">
         <div className="container mx-auto">
           <Skeleton className="mb-8 h-8 w-48" />

--- a/apps/template/components/ai-elements/chain-of-thought.tsx
+++ b/apps/template/components/ai-elements/chain-of-thought.tsx
@@ -182,7 +182,7 @@ export type ChainOfThoughtImageProps = ComponentProps<"div"> & {
 export const ChainOfThoughtImage = memo(
   ({ className, children, caption, ...props }: ChainOfThoughtImageProps) => (
     <div className={cn("mt-2 space-y-2", className)} {...props}>
-      <div className="relative flex max-h-[22rem] items-center justify-center overflow-hidden rounded-lg bg-muted p-3">
+      <div className="relative flex max-h-88 items-center justify-center overflow-hidden rounded-lg bg-muted p-3">
         {children}
       </div>
       {caption && <p className="text-muted-foreground text-xs">{caption}</p>}

--- a/apps/template/components/cart/item-row.tsx
+++ b/apps/template/components/cart/item-row.tsx
@@ -38,7 +38,7 @@ export function ItemRow({ item, locale }: ItemRowProps) {
     <div className="flex gap-6 p-2">
       <Link
         href={`/products/${item.merchandise.product.handle}`}
-        className="shrink-0 relative size-[120px] lg:size-[152px] bg-muted rounded-xl overflow-hidden hover:opacity-80 transition-opacity"
+        className="shrink-0 relative size-30 lg:size-38 bg-muted rounded-xl overflow-hidden hover:opacity-80 transition-opacity"
       >
         <Image
           src={item.merchandise.product.featuredImage.url}

--- a/apps/template/components/cms/blocks/promo-banner.tsx
+++ b/apps/template/components/cms/blocks/promo-banner.tsx
@@ -18,7 +18,7 @@ export function PromoBannerSection({ section }: PromoBannerSectionProps) {
   return (
     <section className="py-8 px-4">
       <div className="container mx-auto">
-        <div className="relative rounded-xl overflow-hidden h-[200px] sm:h-[280px] bg-linear-to-r from-primary/90 to-primary/70">
+        <div className="relative rounded-xl overflow-hidden h-50 sm:h-70 bg-linear-to-r from-primary/90 to-primary/70">
           {backgroundImage && (
             <Image
               src={backgroundImage.url}

--- a/apps/template/components/cms/hero-section.tsx
+++ b/apps/template/components/cms/hero-section.tsx
@@ -10,7 +10,7 @@ interface HeroSectionProps {
 export function HeroSection({ hero }: HeroSectionProps) {
   return (
     <section className="relative w-full rounded-lg overflow-hidden">
-      <div className="relative h-[300px] sm:h-[400px] md:h-[500px] bg-linear-to-r from-slate-900 via-slate-800 to-slate-900">
+      <div className="relative h-75 sm:h-100 md:h-125 bg-linear-to-r from-slate-900 via-slate-800 to-slate-900">
         {hero.backgroundImage && (
           <>
             <Image

--- a/apps/template/components/cms/page-renderer.tsx
+++ b/apps/template/components/cms/page-renderer.tsx
@@ -91,7 +91,7 @@ function SectionSkeleton({ blockType }: { blockType: string }) {
             {skeletonSlots.map((slot) => (
               <Skeleton
                 key={`carousel-skeleton-${slot}`}
-                className="aspect-square w-[200px] shrink-0 rounded-lg"
+                className="aspect-square w-50 shrink-0 rounded-lg"
               />
             ))}
           </div>

--- a/apps/template/components/layout/nav/megamenu/megamenu-client.tsx
+++ b/apps/template/components/layout/nav/megamenu/megamenu-client.tsx
@@ -28,7 +28,7 @@ type MegamenuTopLevelTriggerProps = {
 };
 
 const TRIGGER_CLASS =
-  "relative block py-0.5 text-3xl font-medium leading-[1.1] tracking-tight transition-colors text-muted-foreground/70 hover:text-foreground data-[active=true]:text-foreground data-[active=true]:after:absolute data-[active=true]:after:-left-3 data-[active=true]:after:top-1/2 data-[active=true]:after:h-2 data-[active=true]:after:w-2 data-[active=true]:after:-translate-y-1/2 data-[active=true]:after:rounded-full data-[active=true]:after:bg-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm";
+  "relative block py-0.5 text-3xl font-medium leading-[1.1] tracking-tight transition-colors text-muted-foreground/70 hover:text-foreground data-[active=true]:text-foreground data-[active=true]:after:absolute data-[active=true]:after:-left-3 data-[active=true]:after:top-1/2 data-[active=true]:after:h-2 data-[active=true]:after:w-2 data-[active=true]:after:-translate-y-1/2 data-[active=true]:after:rounded-full data-[active=true]:after:bg-foreground outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm";
 
 function MegamenuTopLevelTrigger({
   item,
@@ -252,10 +252,10 @@ export function MegamenuClient({ items, children }: Props) {
                   {hasPanels ? (
                     <div ref={panelRef} className="relative flex h-full min-w-0 flex-col">
                       <MouseSafeArea parentRef={panelRef} />
-                      <div className="h-[20px]" aria-hidden />
+                      <div className="h-5" aria-hidden />
 
                       <div className="flex-1 min-h-0 overflow-y-auto pr-4 [scrollbar-gutter:stable]">
-                        <div className="max-w-[720px]">
+                        <div className="max-w-180">
                           <div className="flex flex-col gap-16">
                             {(activeItem?.panels ?? []).map((panel) => (
                               <MegamenuPanel
@@ -274,7 +274,7 @@ export function MegamenuClient({ items, children }: Props) {
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     onClick={handleClose}
-                                    className="text-sm font-medium text-foreground hover:underline outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm"
+                                    className="text-sm font-medium text-foreground hover:underline outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm"
                                   >
                                     {t("showAllCategory", {
                                       category: activeItem.label || categoriesLabel,
@@ -284,7 +284,7 @@ export function MegamenuClient({ items, children }: Props) {
                                   <Link
                                     href={activeItem.href}
                                     onClick={handleClose}
-                                    className="text-sm font-medium text-foreground hover:underline outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm"
+                                    className="text-sm font-medium text-foreground hover:underline outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm"
                                   >
                                     {t("showAllCategory", {
                                       category: activeItem.label || categoriesLabel,

--- a/apps/template/components/layout/nav/megamenu/megamenu-mobile.tsx
+++ b/apps/template/components/layout/nav/megamenu/megamenu-mobile.tsx
@@ -20,7 +20,7 @@ type MegamenuMobileProps = {
 };
 
 const TOP_LEVEL_ITEM_CLASS =
-  "relative block w-full py-0.5 text-left text-2xl font-medium leading-[1.1] tracking-tight transition-colors text-muted-foreground/70 hover:text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm";
+  "relative block w-full py-0.5 text-left text-2xl font-medium leading-[1.1] tracking-tight transition-colors text-muted-foreground/70 hover:text-foreground outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm";
 
 function MobileLink({
   href,
@@ -173,7 +173,7 @@ export function MegamenuMobile({ data, children }: MegamenuMobileProps) {
                                               {panel.href ? (
                                                 <MobileLink
                                                   href={panel.href}
-                                                  className="text-lg font-medium text-muted-foreground hover:text-foreground transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm"
+                                                  className="text-lg font-medium text-muted-foreground hover:text-foreground transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm"
                                                   onClick={handleClose}
                                                 >
                                                   {panel.header}
@@ -190,7 +190,7 @@ export function MegamenuMobile({ data, children }: MegamenuMobileProps) {
                                               <li key={category.href}>
                                                 <MobileLink
                                                   href={category.href}
-                                                  className="block py-1 text-base hover:underline outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm"
+                                                  className="block py-1 text-base hover:underline outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm"
                                                   onClick={handleClose}
                                                 >
                                                   {category.title}
@@ -204,7 +204,7 @@ export function MegamenuMobile({ data, children }: MegamenuMobileProps) {
                                       {item.href ? (
                                         <MobileLink
                                           href={item.href}
-                                          className="mt-4 block text-sm font-medium hover:underline outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm"
+                                          className="mt-4 block text-sm font-medium hover:underline outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm"
                                           onClick={handleClose}
                                         >
                                           {t("showAllCategory", {

--- a/apps/template/components/layout/nav/megamenu/megamenu-panel.tsx
+++ b/apps/template/components/layout/nav/megamenu/megamenu-panel.tsx
@@ -21,7 +21,7 @@ export function MegamenuPanel({ panel, fallbackHeader, onLinkClick }: Props) {
               target="_blank"
               rel="noopener noreferrer"
               onClick={onLinkClick}
-              className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm"
+              className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm"
             >
               {panel.header || fallbackHeader}
             </a>
@@ -29,7 +29,7 @@ export function MegamenuPanel({ panel, fallbackHeader, onLinkClick }: Props) {
             <Link
               href={panel.href}
               onClick={onLinkClick}
-              className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm"
+              className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm"
             >
               {panel.header || fallbackHeader}
             </Link>
@@ -52,7 +52,7 @@ export function MegamenuPanel({ panel, fallbackHeader, onLinkClick }: Props) {
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={onLinkClick}
-                  className="block truncate text-base font-medium text-foreground transition-colors hover:text-foreground/80 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm"
+                  className="block truncate text-base font-medium text-foreground transition-colors hover:text-foreground/80 outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm"
                 >
                   {category.title}
                 </a>
@@ -60,7 +60,7 @@ export function MegamenuPanel({ panel, fallbackHeader, onLinkClick }: Props) {
                 <Link
                   href={category.href}
                   onClick={onLinkClick}
-                  className="block truncate text-base font-medium text-foreground transition-colors hover:text-foreground/80 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm"
+                  className="block truncate text-base font-medium text-foreground transition-colors hover:text-foreground/80 outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm"
                 >
                   {category.title}
                 </Link>

--- a/apps/template/components/layout/nav/quick-links.tsx
+++ b/apps/template/components/layout/nav/quick-links.tsx
@@ -21,7 +21,7 @@ export async function QuickLinks({ locale }: { locale: string }) {
               href={item.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-1 text-sm hover:opacity-70 focus-visible:opacity-70 transition-opacity outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm"
+              className="flex items-center gap-1 text-sm hover:opacity-70 focus-visible:opacity-70 transition-opacity outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm"
             >
               {item.title}
             </a>

--- a/apps/template/components/product/client.tsx
+++ b/apps/template/components/product/client.tsx
@@ -83,7 +83,7 @@ export function AddToCartClient({ product }: AddToCartSectionProps) {
           <NativeSelect
             value={quantity}
             onChange={(e) => setQuantity(Number(e.target.value))}
-            className="rounded-full bg-muted border-0 min-w-[60px] h-8"
+            className="rounded-full bg-muted border-0 min-w-15 h-8"
             size="sm"
           >
             {Array.from({ length: 99 }, (_, i) => i + 1).map((num) => (

--- a/apps/template/components/product/image-gallery.tsx
+++ b/apps/template/components/product/image-gallery.tsx
@@ -152,14 +152,14 @@ export function ImageGallery({
   return (
     <div className="flex flex-col lg:flex-row gap-4">
       {/* Vertical thumbnails - Desktop left side, Mobile top
-      <div className="flex flex-row lg:flex-col gap-3 order-2 lg:order-1 overflow-x-auto lg:overflow-y-auto lg:max-h-[600px] scrollbar-hide">
+      <div className="flex flex-row lg:flex-col gap-3 order-2 lg:order-1 overflow-x-auto lg:overflow-y-auto lg:max-h-150 scrollbar-hide">
         {images.map((image, idx) => (
           <button
             key={image.url}
             type="button"
             onClick={() => scrollToImage(idx)}
             className={`
-              relative flex-shrink-0 size-20 aspect-square overflow-hidden rounded-lg border-2 transition-all
+              relative shrink-0 size-20 aspect-square overflow-hidden rounded-lg border-2 transition-all
               ${
                 idx === selectedImageIndex
                   ? "border-foreground"

--- a/apps/template/components/product/images.tsx
+++ b/apps/template/components/product/images.tsx
@@ -8,7 +8,7 @@ import { ImageGallery } from "./image-gallery";
 function Fallback() {
   return (
     <div className="flex flex-col lg:flex-row gap-4">
-      <div className="flex flex-row lg:flex-col gap-3 order-2 lg:order-1 overflow-x-auto lg:overflow-y-auto lg:max-h-[600px] scrollbar-hide">
+      <div className="flex flex-row lg:flex-col gap-3 order-2 lg:order-1 overflow-x-auto lg:overflow-y-auto lg:max-h-150 scrollbar-hide">
         <Skeleton className="shrink-0 size-20 aspect-square rounded-lg" />
         <Skeleton className="shrink-0 size-20 aspect-square rounded-lg" />
         <Skeleton className="shrink-0 size-20 aspect-square rounded-lg" />

--- a/apps/template/components/product/pdp/mobile-carousel.tsx
+++ b/apps/template/components/product/pdp/mobile-carousel.tsx
@@ -90,7 +90,7 @@ export function MobileCarousel({
         {mediaItems.map((item, idx) => (
           <div
             key={item.type === "video" ? item.video.url : item.image.url}
-            className="relative flex-shrink-0 w-full aspect-square snap-start snap-always overflow-hidden bg-accent"
+            className="relative shrink-0 w-full aspect-square snap-start snap-always overflow-hidden bg-accent"
           >
             {item.type === "video" ? (
               <AutoPlayVideo

--- a/apps/template/components/ui/accordion.tsx
+++ b/apps/template/components/ui/accordion.tsx
@@ -33,7 +33,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-3 disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
           className,
         )}
         {...props}

--- a/apps/template/components/ui/badge.tsx
+++ b/apps/template/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3 aria-invalid:ring-destructive/20 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {

--- a/apps/template/components/ui/button.tsx
+++ b/apps/template/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3 aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/apps/template/components/ui/command.tsx
+++ b/apps/template/components/ui/command.tsx
@@ -80,7 +80,7 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
   return (
     <CommandPrimitive.List
       data-slot="command-list"
-      className={cn("max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto", className)}
+      className={cn("max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto", className)}
       {...props}
     />
   );

--- a/apps/template/components/ui/drawer.tsx
+++ b/apps/template/components/ui/drawer.tsx
@@ -48,7 +48,7 @@ const DrawerContent = React.forwardRef<
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      <div className="mx-auto mt-4 h-2 w-25 rounded-full bg-muted" />
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>

--- a/apps/template/components/ui/input-group.tsx
+++ b/apps/template/components/ui/input-group.tsx
@@ -23,7 +23,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
         "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
 
         // Focus state.
-        "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-[3px]",
+        "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-3",
 
         // Error state.
         "has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive",

--- a/apps/template/components/ui/input.tsx
+++ b/apps/template/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       data-slot="input"
       className={cn(
         "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3",
         "aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
         className,
       )}

--- a/apps/template/components/ui/native-select.tsx
+++ b/apps/template/components/ui/native-select.tsx
@@ -18,7 +18,7 @@ function NativeSelect({
         data-size={size}
         className={cn(
           "border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground h-9 w-full min-w-0 appearance-none rounded-md border bg-transparent px-3 py-2 pr-9 text-sm shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1",
-          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3",
           "aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
           className,
         )}

--- a/apps/template/components/ui/select-panel.tsx
+++ b/apps/template/components/ui/select-panel.tsx
@@ -47,7 +47,7 @@ function SelectPanelTrigger({
     return (
       <PopoverTrigger
         className={cn(
-          "flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+          "flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
           "data-[state=open]:rounded-t-xl data-[state=open]:border data-[state=open]:border-border data-[state=open]:bg-popover/80 data-[state=open]:backdrop-blur-xl",
           className,
         )}
@@ -61,7 +61,7 @@ function SelectPanelTrigger({
   return (
     <DrawerTrigger
       className={cn(
-        "flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "flex items-center text-sm text-muted-foreground hover:text-foreground transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
         className,
       )}
       {...props}
@@ -177,7 +177,7 @@ function SelectPanelItem({
       data-slot="select-panel-item"
       data-selected={selected}
       className={cn(
-        "flex items-center justify-between gap-2 px-1 py-1 rounded text-left transition-colors outline-none focus-visible:bg-accent focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "flex items-center justify-between gap-2 px-1 py-1 rounded text-left transition-colors outline-none focus-visible:bg-accent focus-visible:ring-3 focus-visible:ring-ring/50",
         "hover:bg-accent",
         selected && [
           "bg-background border border-ring/35 rounded",
@@ -213,7 +213,7 @@ function SelectPanelShowMore({
       data-slot="select-panel-show-more"
       onClick={onToggle}
       className={cn(
-        "text-sm text-foreground hover:text-foreground/80 transition-colors mt-4 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:rounded-sm",
+        "text-sm text-foreground hover:text-foreground/80 transition-colors mt-4 outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:rounded-sm",
         className,
       )}
       {...props}
@@ -252,7 +252,7 @@ function SelectPanelRow({
       onClick={onClick}
       className={cn(
         "w-full flex items-center gap-2 px-6 py-3 bg-input/80 border-t border-border/50",
-        "text-left hover:bg-input transition-colors outline-none focus-visible:bg-input focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "text-left hover:bg-input transition-colors outline-none focus-visible:bg-input focus-visible:ring-3 focus-visible:ring-ring/50",
         className,
       )}
       {...props}

--- a/apps/template/components/ui/select.tsx
+++ b/apps/template/components/ui/select.tsx
@@ -31,7 +31,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/apps/template/components/ui/switch.tsx
+++ b/apps/template/components/ui/switch.tsx
@@ -10,7 +10,7 @@ function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimi
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/apps/template/components/ui/textarea.tsx
+++ b/apps/template/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Replace `flex-shrink-0` → `shrink-0` (2 files)
- Replace `ring-[3px]` → `ring-3` (14 files, ~30 occurrences)
- Replace spacing arbitrary values with canonical classes across 11 files (e.g. `h-[20px]` → `h-5`, `max-h-[600px]` → `max-h-150`, `w-[200px]` → `w-50`)

Satisfies Tailwind's `suggestCanonicalClasses` lint rule. No visual changes — all replacements produce identical CSS output.

## Test plan
- [x] TypeScript type-check passes
- [ ] Visual review on preview deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)