### PR TITLE
fix: ground Ask AI responses in docs context

### DIFF
--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -5,6 +5,7 @@ import {
   stepCountIs,
   streamText,
 } from "ai";
+import { localSearch } from "fromsrc";
 import { createTools } from "./tools";
 import type { MyUIMessage } from "./types";
 import { createSystemPrompt } from "./utils";
@@ -23,6 +24,7 @@ interface RequestBody {
 }
 
 const MAX_PAGE_CONTEXT_CHARS = 8000;
+const MAX_SEARCH_CONTEXT_RESULTS = 3;
 
 const trimPageContext = (value: string) => {
   const normalized = value
@@ -62,19 +64,79 @@ const getPageContextFromRoute = async (
   };
 };
 
+const getLastUserQuestion = (messages: MyUIMessage[]) => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.role !== "user") {
+      continue;
+    }
+    const text = message.parts
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("\n")
+      .trim();
+    if (text.length > 0) {
+      return text;
+    }
+  }
+  return "";
+};
+
+const getPageContextFromQuery = async (
+  query: string
+): Promise<RequestBody["pageContext"] | undefined> => {
+  if (!query) {
+    return undefined;
+  }
+
+  const searchDocs = await docs.getSearchDocs();
+  const results = await localSearch.search(
+    query,
+    searchDocs,
+    MAX_SEARCH_CONTEXT_RESULTS
+  );
+
+  if (results.length === 0) {
+    return undefined;
+  }
+
+  const content = results
+    .map(({ doc, heading, snippet, anchor }) => {
+      const url = doc.slug ? `/docs/${doc.slug}` : "/docs";
+      const sourceUrl = anchor ? `${url}#${anchor}` : url;
+      return [
+        `Title: ${doc.title}`,
+        `URL: ${sourceUrl}`,
+        heading ? `Heading: ${heading}` : undefined,
+        doc.description ? `Description: ${doc.description}` : undefined,
+        `Snippet: ${snippet}`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+    })
+    .join("\n\n---\n\n");
+
+  return {
+    title: "Relevant docs context",
+    url: "/docs",
+    content: trimPageContext(content),
+  };
+};
+
 export async function POST(req: Request) {
   try {
-    const { messages, currentRoute, pageContext }: RequestBody =
-      await req.json();
-    const resolvedPageContext =
-      pageContext ?? (await getPageContextFromRoute(currentRoute));
-
+    const { messages, currentRoute, pageContext }: RequestBody = await req.json();
     // Filter out UI-only page context messages (they're just visual feedback)
     const actualMessages = messages.filter(
       (msg) => !msg.metadata?.isPageContext
     );
+    const latestUserQuestion = getLastUserQuestion(actualMessages);
+    const resolvedPageContext =
+      pageContext ??
+      (await getPageContextFromRoute(currentRoute)) ??
+      (await getPageContextFromQuery(latestUserQuestion));
 
-    // Prepend page context (client-provided or route-derived) to the latest user message.
+    // Prepend docs context (client-provided, route-derived, or query-derived) to the latest user message.
     let processedMessages = actualMessages;
 
     if (resolvedPageContext && actualMessages.length > 0) {
@@ -103,9 +165,9 @@ export async function POST(req: Request) {
             parts: [
               {
                 type: "text",
-                text: `Here's the content from the current page:
+                text: `Here's documentation context to help answer the question:
 
-**Page:** ${resolvedPageContext.title}
+**Context:** ${resolvedPageContext.title}
 **URL:** ${resolvedPageContext.url}
 
 ---

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -8,6 +8,7 @@ import {
 import { createTools } from "./tools";
 import type { MyUIMessage } from "./types";
 import { createSystemPrompt } from "./utils";
+import { docs } from "@/lib/fromsrc/content";
 
 export const maxDuration = 800;
 
@@ -21,20 +22,62 @@ interface RequestBody {
   };
 }
 
+const MAX_PAGE_CONTEXT_CHARS = 8000;
+
+const trimPageContext = (value: string) => {
+  const normalized = value
+    .replace(/\r\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  if (normalized.length <= MAX_PAGE_CONTEXT_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, MAX_PAGE_CONTEXT_CHARS)}...`;
+};
+
+const getPageContextFromRoute = async (
+  currentRoute: string
+): Promise<RequestBody["pageContext"] | undefined> => {
+  if (!currentRoute?.startsWith("/docs")) {
+    return undefined;
+  }
+
+  const pathname = currentRoute.split(/[?#]/)[0] ?? currentRoute;
+  const normalized = pathname.replace(/^\/docs\/?/, "");
+  const slugParts = normalized.split("/").filter(Boolean);
+  const doc = await docs.getDoc(slugParts);
+
+  if (!doc) {
+    return undefined;
+  }
+
+  const pageContent = [doc.description, doc.content]
+    .filter(Boolean)
+    .join("\n\n");
+
+  return {
+    title: doc.title,
+    url: pathname || "/docs",
+    content: trimPageContext(pageContent),
+  };
+};
+
 export async function POST(req: Request) {
   try {
     const { messages, currentRoute, pageContext }: RequestBody =
       await req.json();
+    const resolvedPageContext =
+      pageContext ?? (await getPageContextFromRoute(currentRoute));
 
     // Filter out UI-only page context messages (they're just visual feedback)
     const actualMessages = messages.filter(
       (msg) => !msg.metadata?.isPageContext
     );
 
-    // If pageContext is provided, prepend it to the last user message
+    // Prepend page context (client-provided or route-derived) to the latest user message.
     let processedMessages = actualMessages;
 
-    if (pageContext && actualMessages.length > 0) {
+    if (resolvedPageContext && actualMessages.length > 0) {
       const lastMessage = actualMessages.at(-1);
 
       if (!lastMessage) {
@@ -62,12 +105,12 @@ export async function POST(req: Request) {
                 type: "text",
                 text: `Here's the content from the current page:
 
-**Page:** ${pageContext.title}
-**URL:** ${pageContext.url}
+**Page:** ${resolvedPageContext.title}
+**URL:** ${resolvedPageContext.url}
 
 ---
 
-${pageContext.content}
+${resolvedPageContext.content}
 
 ---
 

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -37,6 +37,13 @@ const trimPageContext = (value: string) => {
   return `${normalized.slice(0, MAX_PAGE_CONTEXT_CHARS)}...`;
 };
 
+const normalizeSearchText = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
 const getPageContextFromRoute = async (
   currentRoute: string
 ): Promise<RequestBody["pageContext"] | undefined> => {
@@ -90,11 +97,45 @@ const getPageContextFromQuery = async (
   }
 
   const searchDocs = await docs.getSearchDocs();
-  const results = await localSearch.search(
+  let results = await localSearch.search(
     query,
     searchDocs,
     MAX_SEARCH_CONTEXT_RESULTS
   );
+  if (results.length === 0) {
+    const queryNormalized = normalizeSearchText(query);
+    const terms = queryNormalized.split(" ").filter((term) => term.length >= 3);
+
+    const ranked = searchDocs
+      .map((doc) => {
+        const title = normalizeSearchText(doc.title);
+        const description = normalizeSearchText(doc.description ?? "");
+        const content = normalizeSearchText(doc.content);
+        let score = 0;
+
+        if (title.includes(queryNormalized)) score += 20;
+        if (description.includes(queryNormalized)) score += 12;
+        if (content.includes(queryNormalized)) score += 6;
+
+        for (const term of terms) {
+          if (title.includes(term)) score += 6;
+          if (description.includes(term)) score += 4;
+          if (content.includes(term)) score += 1;
+        }
+
+        return { doc, score };
+      })
+      .filter((item) => item.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, MAX_SEARCH_CONTEXT_RESULTS);
+
+    results = ranked.map(({ doc }) => ({
+      doc,
+      anchor: undefined,
+      heading: undefined,
+      snippet: doc.content.slice(0, 320),
+    }));
+  }
 
   if (results.length === 0) {
     return undefined;

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -129,11 +129,12 @@ const getPageContextFromQuery = async (
       .sort((a, b) => b.score - a.score)
       .slice(0, MAX_SEARCH_CONTEXT_RESULTS);
 
-    results = ranked.map(({ doc }) => ({
+    results = ranked.map(({ doc, score }) => ({
       doc,
       anchor: undefined,
       heading: undefined,
       snippet: doc.content.slice(0, 320),
+      score,
     }));
   }
 

--- a/apps/docs/app/api/chat/tools.ts
+++ b/apps/docs/app/api/chat/tools.ts
@@ -1,4 +1,5 @@
 import { type ToolSet, tool, type UIMessageStreamWriter } from "ai";
+import { localSearch } from "fromsrc";
 import z from "zod";
 import { docs } from "@/lib/fromsrc/content";
 
@@ -17,57 +18,34 @@ const search_docs = (writer: UIMessageStreamWriter) =>
         log(`Searching docs for: ${query}`);
 
         const searchDocs = await docs.getSearchDocs();
-        const queryLower = query.toLowerCase();
+        const results = await localSearch.search(query, searchDocs, 8);
+        log(`Found ${results.length} results`);
 
-        // Simple relevance scoring: title match > description match > content match
-        const scored = searchDocs
-          .map((doc) => {
-            let score = 0;
-            const titleLower = doc.title.toLowerCase();
-            const descLower = (doc.description ?? "").toLowerCase();
-            const contentLower = doc.content.toLowerCase();
-
-            if (titleLower.includes(queryLower)) score += 10;
-            if (descLower.includes(queryLower)) score += 5;
-            if (contentLower.includes(queryLower)) score += 1;
-
-            // Boost for individual query words
-            for (const word of queryLower.split(/\s+/)) {
-              if (titleLower.includes(word)) score += 3;
-              if (descLower.includes(word)) score += 2;
-              if (contentLower.includes(word)) score += 1;
-            }
-
-            return { doc, score };
-          })
-          .filter((item) => item.score > 0)
-          .sort((a, b) => b.score - a.score)
-          .slice(0, 8);
-
-        log(`Found ${scored.length} results`);
-
-        if (scored.length === 0) {
+        if (results.length === 0) {
           return `No documentation found for query: "${query}"`;
         }
 
-        for (const [index, { doc }] of scored.entries()) {
+        for (const [index, result] of results.entries()) {
+          const { doc, anchor } = result;
           const url = doc.slug ? `/docs/${doc.slug}` : "/docs";
+          const sourceUrl = anchor ? `${url}#${anchor}` : url;
           writer.write({
             type: "source-url",
-            sourceId: `doc-${index}-${url}`,
-            url,
+            sourceId: `doc-${index}-${sourceUrl}`,
+            url: sourceUrl,
             title: doc.title,
           });
         }
 
-        const formatted = scored
-          .map(({ doc }) => {
+        const formatted = results
+          .map(({ doc, snippet, heading, anchor }) => {
             const url = doc.slug ? `/docs/${doc.slug}` : "/docs";
-            return `**${doc.title}**\nURL: ${url}\n${doc.description ?? ""}\n\n${doc.content.slice(0, 1500)}${doc.content.length > 1500 ? "..." : ""}\n\n---\n`;
+            const sourceUrl = anchor ? `${url}#${anchor}` : url;
+            return `**${doc.title}**\nURL: ${sourceUrl}\n${heading ? `Heading: ${heading}\n` : ""}${doc.description ?? ""}\n\n${snippet}\n\n---\n`;
           })
           .join("\n");
 
-        return `Found ${scored.length} documentation pages for "${query}":\n\n${formatted}`;
+        return `Found ${results.length} documentation pages for "${query}":\n\n${formatted}`;
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "Unknown error";

--- a/apps/docs/app/api/chat/tools.ts
+++ b/apps/docs/app/api/chat/tools.ts
@@ -7,6 +7,53 @@ const log = (message: string) => {
   console.log(`🤖 [fromsrc] ${message}`);
 };
 
+const normalizeSearchText = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const lexicalFallbackSearch = async (query: string, limit = 8) => {
+  const queryNormalized = normalizeSearchText(query);
+  const terms = queryNormalized.split(" ").filter((term) => term.length >= 3);
+
+  if (!queryNormalized) {
+    return [];
+  }
+
+  const searchDocs = await docs.getSearchDocs();
+  const ranked = searchDocs
+    .map((doc) => {
+      const title = normalizeSearchText(doc.title);
+      const description = normalizeSearchText(doc.description ?? "");
+      const content = normalizeSearchText(doc.content);
+      let score = 0;
+
+      if (title.includes(queryNormalized)) score += 20;
+      if (description.includes(queryNormalized)) score += 12;
+      if (content.includes(queryNormalized)) score += 6;
+
+      for (const term of terms) {
+        if (title.includes(term)) score += 6;
+        if (description.includes(term)) score += 4;
+        if (content.includes(term)) score += 1;
+      }
+
+      return { doc, score };
+    })
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+
+  return ranked.map(({ doc }) => ({
+    doc,
+    anchor: undefined,
+    heading: undefined,
+    snippet: doc.content.slice(0, 320),
+  }));
+};
+
 const search_docs = (writer: UIMessageStreamWriter) =>
   tool({
     description: "Search through documentation content by query",
@@ -18,7 +65,11 @@ const search_docs = (writer: UIMessageStreamWriter) =>
         log(`Searching docs for: ${query}`);
 
         const searchDocs = await docs.getSearchDocs();
-        const results = await localSearch.search(query, searchDocs, 8);
+        let results = await localSearch.search(query, searchDocs, 8);
+        if (results.length === 0) {
+          log(`No localSearch results for "${query}", running lexical fallback`);
+          results = await lexicalFallbackSearch(query, 8);
+        }
         log(`Found ${results.length} results`);
 
         if (results.length === 0) {

--- a/apps/docs/app/api/chat/tools.ts
+++ b/apps/docs/app/api/chat/tools.ts
@@ -46,11 +46,12 @@ const lexicalFallbackSearch = async (query: string, limit = 8) => {
     .sort((a, b) => b.score - a.score)
     .slice(0, limit);
 
-  return ranked.map(({ doc }) => ({
+  return ranked.map(({ doc, score }) => ({
     doc,
     anchor: undefined,
     heading: undefined,
     snippet: doc.content.slice(0, 320),
+    score,
   }));
 };
 

--- a/apps/docs/app/api/chat/utils.ts
+++ b/apps/docs/app/api/chat/utils.ts
@@ -10,8 +10,8 @@ You are a helpful assistant specializing in answering questions strictly. If inf
 - If there is doubt as to what the user wants, always search proactively.
 - Always link to relevant documentation using Markdown.
 - Direct users to the documentation that addresses their needs.
-- The user is viewing \`${currentRoute}\`. If the question matches this page, use the \`get_doc_page\` tool with its slug. If ambiguous, default to fetching the current page first.
-- If the answer isn't in the current page, use \`search_docs\` once per message to search the docs.
+- The user is viewing \`${currentRoute}\`. If this is a \`/docs\` route and the question is about that page, use \`get_doc_page\` with that slug.
+- If the route is not a docs page or the question is about a different topic/page, use \`search_docs\` first.
 - Never use more than one tool call consecutively.
 - After each tool call, validate the result in 1-2 lines and either proceed or self-correct if validation fails.
 - Format all responses strictly in Markdown.

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -4,6 +4,14 @@ const config: NextConfig = {
   experimental: {
     turbopackFileSystemCacheForDev: true,
   },
+  outputFileTracingIncludes: {
+    // fromsrc reads markdown files directly from content/docs at runtime.
+    // Ensure serverless API routes bundle those files in preview/prod.
+    "/api/chat": ["./content/docs/**/*"],
+    "/api/chat/route": ["./content/docs/**/*"],
+    "/api/search": ["./content/docs/**/*"],
+    "/api/search/route": ["./content/docs/**/*"],
+  },
 
   images: {
     formats: ["image/avif", "image/webp"],


### PR DESCRIPTION
## Summary
- Derive docs page context on the server from the current `/docs/*` route when the client does not send `pageContext`.
- Normalize and cap injected page content so prompts stay bounded while retaining relevant context.
- Replace heuristic `search_docs` scoring with `fromsrc` `localSearch.search`, including anchor-aware source URLs and snippets.

## Test plan
- [ ] Open a docs page (for example `/docs/getting-started/customizing`) and ask: "How do I customize the store?"
- [ ] Verify the response is grounded in current-page docs content and includes relevant sources.
- [ ] Ask a cross-page docs question and verify search results include anchored source links.
- [ ] Confirm Ask AI still behaves correctly on non-docs routes.

Made with [Cursor](https://cursor.com)