### PR TITLE
Improve docs AI context and add homepage store prompts

### DIFF
--- a/apps/docs/app/(home)/components/example-prompts.tsx
+++ b/apps/docs/app/(home)/components/example-prompts.tsx
@@ -10,25 +10,25 @@ const COPY_TIMEOUT = 2000;
 
 const EXAMPLE_PROMPTS = [
   {
-    id: "shopping-assistant",
-    title: "Build a shopping assistant",
-    description: "Add an AI-powered assistant that recommends products and updates cart state.",
+    id: "single-product-drop",
+    title: "Single-product drop store",
+    description: "Launch a fast hype-drop storefront for one hero product with urgency built in.",
     prompt:
-      "Add an AI shopping assistant to the template storefront using AI SDK and AI Gateway. It should answer product questions from our catalog, recommend products by intent, and support add-to-cart actions with optimistic UI. Include server route changes, UI updates, and a short test plan.",
+      "Turn this project into a single-product drop store for a limited sneaker release. Replace homepage demos with a launch countdown, product story section, social proof strip, and a sticky buy panel. Keep checkout flow intact, add tasteful motion, and include a concise README on how to swap in a new drop later.",
   },
   {
-    id: "agent-readable-pages",
-    title: "Make product pages agent-readable",
-    description: "Serve structured markdown from product pages for LLM agents via Accept headers.",
+    id: "subscription-coffee",
+    title: "Subscription coffee store",
+    description: "Create a cozy DTC coffee shop with one-time and subscription purchase paths.",
     prompt:
-      "Implement content negotiation for product detail routes so browser requests return HTML while agent requests can receive structured markdown. Reuse our existing catalog data, include SEO-safe defaults, and add docs explaining how clients request markdown responses.",
+      "Create an example coffee subscription storefront with three blends, delivery cadence options, and a simple build-a-box experience. Update copy, imagery placeholders, and merchandising blocks so it feels like a complete vertical store, not a generic template. Keep the code modular so this example can be reused as a starter.",
   },
   {
-    id: "skills-and-recipe",
-    title: "Ship a new skill recipe",
-    description: "Extend agent workflows with a reusable skill and docs for one-command setup.",
+    id: "b2b-wholesale-catalog",
+    title: "B2B wholesale catalog",
+    description: "Model a wholesale-first store experience with MOQ and tiered pricing patterns.",
     prompt:
-      "Create a new skill recipe that helps merchants launch a localized market experience (currency, locale copy, and region-specific merchandising). Add implementation steps for apps/template and corresponding docs updates in apps/docs so the feature can be installed with one command.",
+      "Build a B2B wholesale example store for boutique retailers. Add collection pages with case-pack quantities, tiered price messaging, and a request-a-quote flow for large orders. Rework homepage and product page structure to highlight wholesale trust signals and operational details while preserving existing architecture.",
   },
 ] as const;
 
@@ -50,10 +50,10 @@ export const ExamplePrompts = () => {
     <section className="grid gap-10 px-4 py-8 sm:px-12 sm:py-12">
       <div className="mx-auto grid max-w-2xl gap-4 text-center">
         <h2 className="font-pixel-square font-normal text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl lg:text-[40px]">
-          Build with AI prompt examples
+          Build example stores with prompts
         </h2>
         <p className="text-balance text-lg text-muted-foreground">
-          Start common Vercel Shop workflows with ready-to-copy prompts tailored for your coding agent.
+          Use ready-to-copy prompts to generate complete example storefronts you can use like demos or template starting points.
         </p>
       </div>
 
@@ -81,7 +81,7 @@ export const ExamplePrompts = () => {
                 variant="outline"
               >
                 <Icon className="size-3.5" size={14} />
-                {isCopied ? "Copied" : "Copy install prompt"}
+                {isCopied ? "Copied" : "Copy store prompt"}
               </Button>
             </article>
           );

--- a/apps/docs/app/(home)/components/example-prompts.tsx
+++ b/apps/docs/app/(home)/components/example-prompts.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { track } from "@vercel/analytics";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+const COPY_TIMEOUT = 2000;
+
+const EXAMPLE_PROMPTS = [
+  {
+    id: "shopping-assistant",
+    title: "Build a shopping assistant",
+    description: "Add an AI-powered assistant that recommends products and updates cart state.",
+    prompt:
+      "Add an AI shopping assistant to the template storefront using AI SDK and AI Gateway. It should answer product questions from our catalog, recommend products by intent, and support add-to-cart actions with optimistic UI. Include server route changes, UI updates, and a short test plan.",
+  },
+  {
+    id: "agent-readable-pages",
+    title: "Make product pages agent-readable",
+    description: "Serve structured markdown from product pages for LLM agents via Accept headers.",
+    prompt:
+      "Implement content negotiation for product detail routes so browser requests return HTML while agent requests can receive structured markdown. Reuse our existing catalog data, include SEO-safe defaults, and add docs explaining how clients request markdown responses.",
+  },
+  {
+    id: "skills-and-recipe",
+    title: "Ship a new skill recipe",
+    description: "Extend agent workflows with a reusable skill and docs for one-command setup.",
+    prompt:
+      "Create a new skill recipe that helps merchants launch a localized market experience (currency, locale copy, and region-specific merchandising). Add implementation steps for apps/template and corresponding docs updates in apps/docs so the feature can be installed with one command.",
+  },
+] as const;
+
+export const ExamplePrompts = () => {
+  const [copiedPromptId, setCopiedPromptId] = useState<string | null>(null);
+
+  const handleCopy = (id: string, prompt: string) => {
+    navigator.clipboard.writeText(prompt);
+    toast.success("Copied prompt to clipboard");
+    setCopiedPromptId(id);
+    track("Copied example prompt", { promptId: id });
+
+    setTimeout(() => {
+      setCopiedPromptId((currentPromptId) => (currentPromptId === id ? null : currentPromptId));
+    }, COPY_TIMEOUT);
+  };
+
+  return (
+    <section className="grid gap-10 px-4 py-8 sm:px-12 sm:py-12">
+      <div className="mx-auto grid max-w-2xl gap-4 text-center">
+        <h2 className="font-pixel-square font-normal text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl lg:text-[40px]">
+          Build with AI prompt examples
+        </h2>
+        <p className="text-balance text-lg text-muted-foreground">
+          Start common Vercel Shop workflows with ready-to-copy prompts tailored for your coding agent.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {EXAMPLE_PROMPTS.map((item) => {
+          const Icon = copiedPromptId === item.id ? CheckIcon : CopyIcon;
+          const isCopied = copiedPromptId === item.id;
+
+          return (
+            <article key={item.id} className="flex h-full flex-col rounded-lg border bg-background p-4">
+              <div className="grid gap-2">
+                <h3 className="font-pixel-square font-normal text-base tracking-tight dark:text-white sm:text-lg">
+                  {item.title}
+                </h3>
+                <p className="text-pretty text-muted-foreground text-sm">{item.description}</p>
+              </div>
+              <pre className="mt-4 flex-1 overflow-auto rounded-md border bg-muted/40 p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap">
+                {item.prompt}
+              </pre>
+              <Button
+                className="mt-4 w-full"
+                onClick={() => handleCopy(item.id, item.prompt)}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                <Icon className="size-3.5" size={14} />
+                {isCopied ? "Copied" : "Copy install prompt"}
+              </Button>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+};

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -8,6 +8,7 @@ import { AssistantDemo } from "./components/assistant-demo";
 import { CartDemo } from "./components/cart-demo";
 import { CenteredSection } from "./components/centered-section";
 import { CTA } from "./components/cta";
+import { ExamplePrompts } from "./components/example-prompts";
 import { FakeBrowser } from "./components/fake-browser";
 import { ContentNegotiationDemo } from "./components/content-negotiation-demo";
 import { Hero } from "./components/hero";
@@ -77,6 +78,7 @@ const HomePage = () => (
 			>
 				<ContentNegotiationDemo />
 			</OneTwoSection>
+			<ExamplePrompts />
 			<CTA cta="Get started" href="/docs" title="Start your shop today" />
 		</div>
 	</div>

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -5,6 +5,7 @@ import {
   stepCountIs,
   streamText,
 } from "ai";
+import { localSearch } from "fromsrc";
 import { createTools } from "./tools";
 import type { MyUIMessage } from "./types";
 import { createSystemPrompt } from "./utils";
@@ -23,6 +24,7 @@ interface RequestBody {
 }
 
 const MAX_PAGE_CONTEXT_CHARS = 8000;
+const MAX_SEARCH_CONTEXT_RESULTS = 3;
 
 const trimPageContext = (value: string) => {
   const normalized = value
@@ -62,19 +64,79 @@ const getPageContextFromRoute = async (
   };
 };
 
+const getLastUserQuestion = (messages: MyUIMessage[]) => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.role !== "user") {
+      continue;
+    }
+    const text = message.parts
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("\n")
+      .trim();
+    if (text.length > 0) {
+      return text;
+    }
+  }
+  return "";
+};
+
+const getPageContextFromQuery = async (
+  query: string
+): Promise<RequestBody["pageContext"] | undefined> => {
+  if (!query) {
+    return undefined;
+  }
+
+  const searchDocs = await docs.getSearchDocs();
+  const results = await localSearch.search(
+    query,
+    searchDocs,
+    MAX_SEARCH_CONTEXT_RESULTS
+  );
+
+  if (results.length === 0) {
+    return undefined;
+  }
+
+  const content = results
+    .map(({ doc, heading, snippet, anchor }) => {
+      const url = doc.slug ? `/docs/${doc.slug}` : "/docs";
+      const sourceUrl = anchor ? `${url}#${anchor}` : url;
+      return [
+        `Title: ${doc.title}`,
+        `URL: ${sourceUrl}`,
+        heading ? `Heading: ${heading}` : undefined,
+        doc.description ? `Description: ${doc.description}` : undefined,
+        `Snippet: ${snippet}`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+    })
+    .join("\n\n---\n\n");
+
+  return {
+    title: "Relevant docs context",
+    url: "/docs",
+    content: trimPageContext(content),
+  };
+};
+
 export async function POST(req: Request) {
   try {
-    const { messages, currentRoute, pageContext }: RequestBody =
-      await req.json();
-    const resolvedPageContext =
-      pageContext ?? (await getPageContextFromRoute(currentRoute));
-
+    const { messages, currentRoute, pageContext }: RequestBody = await req.json();
     // Filter out UI-only page context messages (they're just visual feedback)
     const actualMessages = messages.filter(
       (msg) => !msg.metadata?.isPageContext
     );
+    const latestUserQuestion = getLastUserQuestion(actualMessages);
+    const resolvedPageContext =
+      pageContext ??
+      (await getPageContextFromRoute(currentRoute)) ??
+      (await getPageContextFromQuery(latestUserQuestion));
 
-    // Prepend page context (client-provided or route-derived) to the latest user message.
+    // Prepend docs context (client-provided, route-derived, or query-derived) to the latest user message.
     let processedMessages = actualMessages;
 
     if (resolvedPageContext && actualMessages.length > 0) {
@@ -103,9 +165,9 @@ export async function POST(req: Request) {
             parts: [
               {
                 type: "text",
-                text: `Here's the content from the current page:
+                text: `Here's documentation context to help answer the question:
 
-**Page:** ${resolvedPageContext.title}
+**Context:** ${resolvedPageContext.title}
 **URL:** ${resolvedPageContext.url}
 
 ---

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -8,6 +8,7 @@ import {
 import { createTools } from "./tools";
 import type { MyUIMessage } from "./types";
 import { createSystemPrompt } from "./utils";
+import { docs } from "@/lib/fromsrc/content";
 
 export const maxDuration = 800;
 
@@ -21,20 +22,62 @@ interface RequestBody {
   };
 }
 
+const MAX_PAGE_CONTEXT_CHARS = 8000;
+
+const trimPageContext = (value: string) => {
+  const normalized = value
+    .replace(/\r\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  if (normalized.length <= MAX_PAGE_CONTEXT_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, MAX_PAGE_CONTEXT_CHARS)}...`;
+};
+
+const getPageContextFromRoute = async (
+  currentRoute: string
+): Promise<RequestBody["pageContext"] | undefined> => {
+  if (!currentRoute?.startsWith("/docs")) {
+    return undefined;
+  }
+
+  const pathname = currentRoute.split(/[?#]/)[0] ?? currentRoute;
+  const normalized = pathname.replace(/^\/docs\/?/, "");
+  const slugParts = normalized.split("/").filter(Boolean);
+  const doc = await docs.getDoc(slugParts);
+
+  if (!doc) {
+    return undefined;
+  }
+
+  const pageContent = [doc.description, doc.content]
+    .filter(Boolean)
+    .join("\n\n");
+
+  return {
+    title: doc.title,
+    url: pathname || "/docs",
+    content: trimPageContext(pageContent),
+  };
+};
+
 export async function POST(req: Request) {
   try {
     const { messages, currentRoute, pageContext }: RequestBody =
       await req.json();
+    const resolvedPageContext =
+      pageContext ?? (await getPageContextFromRoute(currentRoute));
 
     // Filter out UI-only page context messages (they're just visual feedback)
     const actualMessages = messages.filter(
       (msg) => !msg.metadata?.isPageContext
     );
 
-    // If pageContext is provided, prepend it to the last user message
+    // Prepend page context (client-provided or route-derived) to the latest user message.
     let processedMessages = actualMessages;
 
-    if (pageContext && actualMessages.length > 0) {
+    if (resolvedPageContext && actualMessages.length > 0) {
       const lastMessage = actualMessages.at(-1);
 
       if (!lastMessage) {
@@ -62,12 +105,12 @@ export async function POST(req: Request) {
                 type: "text",
                 text: `Here's the content from the current page:
 
-**Page:** ${pageContext.title}
-**URL:** ${pageContext.url}
+**Page:** ${resolvedPageContext.title}
+**URL:** ${resolvedPageContext.url}
 
 ---
 
-${pageContext.content}
+${resolvedPageContext.content}
 
 ---
 

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -37,6 +37,13 @@ const trimPageContext = (value: string) => {
   return `${normalized.slice(0, MAX_PAGE_CONTEXT_CHARS)}...`;
 };
 
+const normalizeSearchText = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
 const getPageContextFromRoute = async (
   currentRoute: string
 ): Promise<RequestBody["pageContext"] | undefined> => {
@@ -90,11 +97,45 @@ const getPageContextFromQuery = async (
   }
 
   const searchDocs = await docs.getSearchDocs();
-  const results = await localSearch.search(
+  let results = await localSearch.search(
     query,
     searchDocs,
     MAX_SEARCH_CONTEXT_RESULTS
   );
+  if (results.length === 0) {
+    const queryNormalized = normalizeSearchText(query);
+    const terms = queryNormalized.split(" ").filter((term) => term.length >= 3);
+
+    const ranked = searchDocs
+      .map((doc) => {
+        const title = normalizeSearchText(doc.title);
+        const description = normalizeSearchText(doc.description ?? "");
+        const content = normalizeSearchText(doc.content);
+        let score = 0;
+
+        if (title.includes(queryNormalized)) score += 20;
+        if (description.includes(queryNormalized)) score += 12;
+        if (content.includes(queryNormalized)) score += 6;
+
+        for (const term of terms) {
+          if (title.includes(term)) score += 6;
+          if (description.includes(term)) score += 4;
+          if (content.includes(term)) score += 1;
+        }
+
+        return { doc, score };
+      })
+      .filter((item) => item.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, MAX_SEARCH_CONTEXT_RESULTS);
+
+    results = ranked.map(({ doc }) => ({
+      doc,
+      anchor: undefined,
+      heading: undefined,
+      snippet: doc.content.slice(0, 320),
+    }));
+  }
 
   if (results.length === 0) {
     return undefined;

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -129,11 +129,12 @@ const getPageContextFromQuery = async (
       .sort((a, b) => b.score - a.score)
       .slice(0, MAX_SEARCH_CONTEXT_RESULTS);
 
-    results = ranked.map(({ doc }) => ({
+    results = ranked.map(({ doc, score }) => ({
       doc,
       anchor: undefined,
       heading: undefined,
       snippet: doc.content.slice(0, 320),
+      score,
     }));
   }
 

--- a/apps/docs/app/api/chat/tools.ts
+++ b/apps/docs/app/api/chat/tools.ts
@@ -1,4 +1,5 @@
 import { type ToolSet, tool, type UIMessageStreamWriter } from "ai";
+import { localSearch } from "fromsrc";
 import z from "zod";
 import { docs } from "@/lib/fromsrc/content";
 
@@ -17,57 +18,34 @@ const search_docs = (writer: UIMessageStreamWriter) =>
         log(`Searching docs for: ${query}`);
 
         const searchDocs = await docs.getSearchDocs();
-        const queryLower = query.toLowerCase();
+        const results = await localSearch.search(query, searchDocs, 8);
+        log(`Found ${results.length} results`);
 
-        // Simple relevance scoring: title match > description match > content match
-        const scored = searchDocs
-          .map((doc) => {
-            let score = 0;
-            const titleLower = doc.title.toLowerCase();
-            const descLower = (doc.description ?? "").toLowerCase();
-            const contentLower = doc.content.toLowerCase();
-
-            if (titleLower.includes(queryLower)) score += 10;
-            if (descLower.includes(queryLower)) score += 5;
-            if (contentLower.includes(queryLower)) score += 1;
-
-            // Boost for individual query words
-            for (const word of queryLower.split(/\s+/)) {
-              if (titleLower.includes(word)) score += 3;
-              if (descLower.includes(word)) score += 2;
-              if (contentLower.includes(word)) score += 1;
-            }
-
-            return { doc, score };
-          })
-          .filter((item) => item.score > 0)
-          .sort((a, b) => b.score - a.score)
-          .slice(0, 8);
-
-        log(`Found ${scored.length} results`);
-
-        if (scored.length === 0) {
+        if (results.length === 0) {
           return `No documentation found for query: "${query}"`;
         }
 
-        for (const [index, { doc }] of scored.entries()) {
+        for (const [index, result] of results.entries()) {
+          const { doc, anchor } = result;
           const url = doc.slug ? `/docs/${doc.slug}` : "/docs";
+          const sourceUrl = anchor ? `${url}#${anchor}` : url;
           writer.write({
             type: "source-url",
-            sourceId: `doc-${index}-${url}`,
-            url,
+            sourceId: `doc-${index}-${sourceUrl}`,
+            url: sourceUrl,
             title: doc.title,
           });
         }
 
-        const formatted = scored
-          .map(({ doc }) => {
+        const formatted = results
+          .map(({ doc, snippet, heading, anchor }) => {
             const url = doc.slug ? `/docs/${doc.slug}` : "/docs";
-            return `**${doc.title}**\nURL: ${url}\n${doc.description ?? ""}\n\n${doc.content.slice(0, 1500)}${doc.content.length > 1500 ? "..." : ""}\n\n---\n`;
+            const sourceUrl = anchor ? `${url}#${anchor}` : url;
+            return `**${doc.title}**\nURL: ${sourceUrl}\n${heading ? `Heading: ${heading}\n` : ""}${doc.description ?? ""}\n\n${snippet}\n\n---\n`;
           })
           .join("\n");
 
-        return `Found ${scored.length} documentation pages for "${query}":\n\n${formatted}`;
+        return `Found ${results.length} documentation pages for "${query}":\n\n${formatted}`;
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "Unknown error";

--- a/apps/docs/app/api/chat/tools.ts
+++ b/apps/docs/app/api/chat/tools.ts
@@ -7,6 +7,53 @@ const log = (message: string) => {
   console.log(`🤖 [fromsrc] ${message}`);
 };
 
+const normalizeSearchText = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const lexicalFallbackSearch = async (query: string, limit = 8) => {
+  const queryNormalized = normalizeSearchText(query);
+  const terms = queryNormalized.split(" ").filter((term) => term.length >= 3);
+
+  if (!queryNormalized) {
+    return [];
+  }
+
+  const searchDocs = await docs.getSearchDocs();
+  const ranked = searchDocs
+    .map((doc) => {
+      const title = normalizeSearchText(doc.title);
+      const description = normalizeSearchText(doc.description ?? "");
+      const content = normalizeSearchText(doc.content);
+      let score = 0;
+
+      if (title.includes(queryNormalized)) score += 20;
+      if (description.includes(queryNormalized)) score += 12;
+      if (content.includes(queryNormalized)) score += 6;
+
+      for (const term of terms) {
+        if (title.includes(term)) score += 6;
+        if (description.includes(term)) score += 4;
+        if (content.includes(term)) score += 1;
+      }
+
+      return { doc, score };
+    })
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+
+  return ranked.map(({ doc }) => ({
+    doc,
+    anchor: undefined,
+    heading: undefined,
+    snippet: doc.content.slice(0, 320),
+  }));
+};
+
 const search_docs = (writer: UIMessageStreamWriter) =>
   tool({
     description: "Search through documentation content by query",
@@ -18,7 +65,11 @@ const search_docs = (writer: UIMessageStreamWriter) =>
         log(`Searching docs for: ${query}`);
 
         const searchDocs = await docs.getSearchDocs();
-        const results = await localSearch.search(query, searchDocs, 8);
+        let results = await localSearch.search(query, searchDocs, 8);
+        if (results.length === 0) {
+          log(`No localSearch results for "${query}", running lexical fallback`);
+          results = await lexicalFallbackSearch(query, 8);
+        }
         log(`Found ${results.length} results`);
 
         if (results.length === 0) {

--- a/apps/docs/app/api/chat/tools.ts
+++ b/apps/docs/app/api/chat/tools.ts
@@ -46,11 +46,12 @@ const lexicalFallbackSearch = async (query: string, limit = 8) => {
     .sort((a, b) => b.score - a.score)
     .slice(0, limit);
 
-  return ranked.map(({ doc }) => ({
+  return ranked.map(({ doc, score }) => ({
     doc,
     anchor: undefined,
     heading: undefined,
     snippet: doc.content.slice(0, 320),
+    score,
   }));
 };
 

--- a/apps/docs/app/api/chat/utils.ts
+++ b/apps/docs/app/api/chat/utils.ts
@@ -10,8 +10,8 @@ You are a helpful assistant specializing in answering questions strictly. If inf
 - If there is doubt as to what the user wants, always search proactively.
 - Always link to relevant documentation using Markdown.
 - Direct users to the documentation that addresses their needs.
-- The user is viewing \`${currentRoute}\`. If the question matches this page, use the \`get_doc_page\` tool with its slug. If ambiguous, default to fetching the current page first.
-- If the answer isn't in the current page, use \`search_docs\` once per message to search the docs.
+- The user is viewing \`${currentRoute}\`. If this is a \`/docs\` route and the question is about that page, use \`get_doc_page\` with that slug.
+- If the route is not a docs page or the question is about a different topic/page, use \`search_docs\` first.
 - Never use more than one tool call consecutively.
 - After each tool call, validate the result in 1-2 lines and either proceed or self-correct if validation fails.
 - Format all responses strictly in Markdown.

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -4,6 +4,14 @@ const config: NextConfig = {
   experimental: {
     turbopackFileSystemCacheForDev: true,
   },
+  outputFileTracingIncludes: {
+    // fromsrc reads markdown files directly from content/docs at runtime.
+    // Ensure serverless API routes bundle those files in preview/prod.
+    "/api/chat": ["./content/docs/**/*"],
+    "/api/chat/route": ["./content/docs/**/*"],
+    "/api/search": ["./content/docs/**/*"],
+    "/api/search/route": ["./content/docs/**/*"],
+  },
 
   images: {
     formats: ["image/avif", "image/webp"],


### PR DESCRIPTION
> This needs more complete examples but I like the idea

## Summary
- improve docs Ask AI grounding and fallback behavior by strengthening API context retrieval, scoring metadata, and route tracing
- add an AI prompt examples section to the docs homepage with copy-to-clipboard interactions
- refocus homepage prompt cards from feature prompts to example-store concepts (drop, subscription, and wholesale)

## Test plan
- [x] `pnpm --filter docs exec tsc --noEmit --ignoreDeprecations 6.0`
- [x] `pnpm --filter docs build`
- [ ] Verify homepage prompt card copy/actions visually in light mode
- [ ] Verify homepage prompt card copy/actions visually in dark mode

Made with [Cursor](https://cursor.com)