### PR TITLE
fix(docs): use font-sans for feature headings on homepage

### DIFF
--- a/apps/docs/app/(home)/components/centered-section.tsx
+++ b/apps/docs/app/(home)/components/centered-section.tsx
@@ -13,7 +13,7 @@ export const CenteredSection = ({
 }: CenteredSectionProps) => (
   <div className="grid items-center gap-10 overflow-hidden px-4 py-8 sm:px-12 sm:py-12">
     <div className="mx-auto grid max-w-lg gap-4 text-center">
-      <h2 className="font-sans font-normal text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl lg:text-[40px]">
+      <h2 className="font-sans font-semibold text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl lg:text-[40px]">
         {title}
       </h2>
       <p className="text-balance text-lg text-muted-foreground">

--- a/apps/docs/app/(home)/components/centered-section.tsx
+++ b/apps/docs/app/(home)/components/centered-section.tsx
@@ -13,7 +13,7 @@ export const CenteredSection = ({
 }: CenteredSectionProps) => (
   <div className="grid items-center gap-10 overflow-hidden px-4 py-8 sm:px-12 sm:py-12">
     <div className="mx-auto grid max-w-lg gap-4 text-center">
-      <h2 className="font-pixel-square font-normal text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl lg:text-[40px]">
+      <h2 className="font-sans font-normal text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl lg:text-[40px]">
         {title}
       </h2>
       <p className="text-balance text-lg text-muted-foreground">

--- a/apps/docs/app/(home)/components/cta.tsx
+++ b/apps/docs/app/(home)/components/cta.tsx
@@ -9,7 +9,7 @@ interface CTAProps {
 
 export const CTA = ({ title, href, cta }: CTAProps) => (
   <section className="flex flex-col gap-4 px-8 py-10 sm:px-12 md:flex-row md:items-center md:justify-between">
-    <h2 className="font-pixel-square font-normal text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl lg:text-[40px]">
+    <h2 className="font-sans font-semibold text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl lg:text-[40px]">
       {title}
     </h2>
     <Button asChild size="lg">

--- a/apps/docs/app/(home)/components/one-two-section.tsx
+++ b/apps/docs/app/(home)/components/one-two-section.tsx
@@ -15,7 +15,7 @@ export const OneTwoSection = ({
 }: OneTwoSectionProps) => (
   <div className={`grid gap-12 p-8 sm:grid-cols-3 sm:gap-0 sm:p-0 ${reverse ? "" : "sm:divide-x"}`}>
     <div className={`flex flex-col gap-2 text-balance sm:p-12 ${reverse ? "sm:order-last sm:border-l sm:border-fd-border" : ""}`}>
-      <h2 className="font-sans font-normal text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl">
+      <h2 className="font-sans font-semibold text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl">
         {title}
       </h2>
       <p className="mt-2 text-balance text-lg text-muted-foreground">

--- a/apps/docs/app/(home)/components/one-two-section.tsx
+++ b/apps/docs/app/(home)/components/one-two-section.tsx
@@ -15,7 +15,7 @@ export const OneTwoSection = ({
 }: OneTwoSectionProps) => (
   <div className={`grid gap-12 p-8 sm:grid-cols-3 sm:gap-0 sm:p-0 ${reverse ? "" : "sm:divide-x"}`}>
     <div className={`flex flex-col gap-2 text-balance sm:p-12 ${reverse ? "sm:order-last sm:border-l sm:border-fd-border" : ""}`}>
-      <h2 className="font-pixel-square font-normal text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl">
+      <h2 className="font-sans font-normal text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl">
         {title}
       </h2>
       <p className="mt-2 text-balance text-lg text-muted-foreground">

--- a/apps/docs/app/(home)/components/text-grid-section.tsx
+++ b/apps/docs/app/(home)/components/text-grid-section.tsx
@@ -10,7 +10,7 @@ export const TextGridSection = ({ data }: TextGridSectionProps) => (
   <div className="grid gap-8 px-4 py-8 sm:px-12 sm:py-12 md:grid-cols-3">
     {data.map((item) => (
       <div key={item.id}>
-        <h3 className="mb-2 font-sans font-normal text-lg tracking-tight dark:text-white">
+        <h3 className="mb-2 font-sans font-semibold text-lg tracking-tight dark:text-white">
           {item.title}
         </h3>
         <p className="text-muted-foreground">{item.description}</p>

--- a/apps/docs/app/(home)/components/text-grid-section.tsx
+++ b/apps/docs/app/(home)/components/text-grid-section.tsx
@@ -10,7 +10,7 @@ export const TextGridSection = ({ data }: TextGridSectionProps) => (
   <div className="grid gap-8 px-4 py-8 sm:px-12 sm:py-12 md:grid-cols-3">
     {data.map((item) => (
       <div key={item.id}>
-        <h3 className="mb-2 font-pixel-square font-normal text-lg tracking-tight dark:text-white">
+        <h3 className="mb-2 font-sans font-normal text-lg tracking-tight dark:text-white">
           {item.title}
         </h3>
         <p className="text-muted-foreground">{item.description}</p>


### PR DESCRIPTION
Replaces `font-pixel-square` with `font-sans` on all feature section headings on the docs homepage. This affects the `CenteredSection`, `OneTwoSection`, and `TextGridSection` components.