### PR TITLE
fix: use main-menu handle for nav quick links

### DIFF
--- a/apps/template/components/layout/nav/quick-links.tsx
+++ b/apps/template/components/layout/nav/quick-links.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { getMenu } from "@/lib/shopify/operations/menu";
 
 export async function QuickLinks({ locale }: { locale: string }) {
-  const menu = await getMenu("quick-links", locale);
+  const menu = await getMenu("main-menu", locale);
 
   if (!menu || menu.items.length === 0) {
     return null;


### PR DESCRIPTION
## Summary

The QuickLinks nav component was fetching the `"quick-links"` menu handle from Shopify, but the store's navigation is configured under `"main-menu"`. This caused the nav to show no menu items. Changed the handle to `"main-menu"` so the nav correctly displays the store's main navigation.

## Test plan

- [ ] Run `pnpm dev` and verify nav shows menu items from the Shopify "main-menu"
- [ ] Run `pnpm build` to confirm no build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)