### PR TITLE
explore: remove searchParams-based variant selection from PDP

### DIFF
--- a/apps/template/components/product/pdp/color-picker.tsx
+++ b/apps/template/components/product/pdp/color-picker.tsx
@@ -1,27 +1,19 @@
 import Image from "next/image";
-import Link from "next/link";
 import type { ComponentPropsWithoutRef } from "react";
 
 import type { ProductOption, ProductVariant } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-import type { SelectedOptions } from "./variants";
-import { getVariantUrl } from "./variants";
-
 interface ColorPickerProps extends ComponentPropsWithoutRef<"div"> {
   option: ProductOption;
   selectedValue: string;
   variants: ProductVariant[];
-  handle: string;
-  selectedOptions: SelectedOptions;
 }
 
 export function ColorPicker({
   option,
   selectedValue,
   variants,
-  handle,
-  selectedOptions,
   className,
   ...props
 }: ColorPickerProps) {
@@ -45,8 +37,6 @@ export function ColorPicker({
           )?.image?.url;
 
           const imageUrl = value.swatch?.image || variantImage;
-
-          const href = getVariantUrl(handle, variants, selectedOptions, option.name, value.name);
 
           const swatch = (
             <div
@@ -97,15 +87,14 @@ export function ColorPicker({
           }
 
           return (
-            <Link
+            <span
               key={value.id}
-              href={href}
               className="flex flex-col items-center gap-2"
-              aria-label={`Select ${option.name}: ${value.name}`}
+              aria-label={`${option.name}: ${value.name}`}
             >
               {swatch}
               {label}
-            </Link>
+            </span>
           );
         })}
       </div>

--- a/apps/template/components/product/pdp/option-picker.tsx
+++ b/apps/template/components/product/pdp/option-picker.tsx
@@ -1,26 +1,18 @@
-import Link from "next/link";
 import type { ComponentPropsWithoutRef } from "react";
 
 import type { ProductOption, ProductVariant } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-import type { SelectedOptions } from "./variants";
-import { getVariantUrl } from "./variants";
-
 interface OptionPickerProps extends ComponentPropsWithoutRef<"div"> {
   option: ProductOption;
   selectedValue: string;
   variants: ProductVariant[];
-  handle: string;
-  selectedOptions: SelectedOptions;
 }
 
 export function OptionPicker({
   option,
   selectedValue,
   variants,
-  handle,
-  selectedOptions,
   className,
   ...props
 }: OptionPickerProps) {
@@ -39,8 +31,6 @@ export function OptionPicker({
               v.selectedOptions.some((opt) => opt.name === option.name && opt.value === value.name),
           );
 
-          const href = getVariantUrl(handle, variants, selectedOptions, option.name, value.name);
-
           const classes = cn(
             "px-4 py-2 text-sm font-medium rounded-lg border transition-all",
             isSelected
@@ -58,9 +48,9 @@ export function OptionPicker({
           }
 
           return (
-            <Link key={value.id} href={href} className={classes}>
+            <span key={value.id} className={classes}>
               {value.name}
-            </Link>
+            </span>
           );
         })}
       </div>

--- a/apps/template/components/product/pdp/product-info.tsx
+++ b/apps/template/components/product/pdp/product-info.tsx
@@ -51,14 +51,12 @@ interface ProductInfoOptionsProps extends ComponentPropsWithoutRef<"div"> {
   variants: ProductVariant[];
   options: ProductOption[];
   selectedOptions: SelectedOptions;
-  handle: string;
 }
 
 function ProductInfoOptions({
   variants,
   options,
   selectedOptions,
-  handle,
   className,
   ...props
 }: ProductInfoOptionsProps) {
@@ -83,8 +81,6 @@ function ProductInfoOptions({
               option={colorOption}
               selectedValue={selectedOptions[colorOption.name]}
               variants={variants}
-              handle={handle}
-              selectedOptions={selectedOptions}
             />
           ) : null,
         )}
@@ -96,8 +92,6 @@ function ProductInfoOptions({
             option={option}
             selectedValue={selectedOptions[option.name] ?? ""}
             variants={variants}
-            handle={handle}
-            selectedOptions={selectedOptions}
           />
         ))}
       </div>

--- a/apps/template/components/product/pdp/variant-section.tsx
+++ b/apps/template/components/product/pdp/variant-section.tsx
@@ -1,7 +1,3 @@
-"use client";
-
-import { useSearchParams } from "next/navigation";
-
 import { BuyButtons } from "@/components/product/pdp/buy-buttons";
 import {
   ProductInfoDescription,
@@ -9,11 +5,7 @@ import {
   ProductInfoOptions,
 } from "@/components/product/pdp/product-info";
 import { ProductMedia } from "@/components/product/pdp/product-media";
-import {
-  computeInitialSelectedOptions,
-  getImagesForSelectedColor,
-  resolveSelectedVariant,
-} from "@/components/product/pdp/variants";
+import { getInitialSelectedOptions } from "@/components/product/pdp/variants";
 import type { Locale } from "@/lib/i18n";
 import type { ProductDetails } from "@/lib/types";
 
@@ -24,18 +16,14 @@ export function VariantSection({
   product: ProductDetails;
   locale: Locale;
 }) {
-  const searchParams = useSearchParams();
-  const variantId = searchParams.get("variantId") ?? undefined;
-
   const { handle, title, featuredImage, images, videos, variants, options } = product;
 
-  const selectedOptions = computeInitialSelectedOptions(variants, variantId);
-  const selectedVariant = resolveSelectedVariant(variants, selectedOptions);
-  const filteredImages = getImagesForSelectedColor(images, options, variants, selectedOptions);
+  const selectedOptions = getInitialSelectedOptions(variants);
+  const selectedVariant = variants[0];
 
   return (
     <div className="lg:grid lg:grid-cols-2 lg:items-start lg:gap-4 space-y-8 lg:space-y-0">
-      <ProductMedia images={filteredImages} videos={videos} title={title} />
+      <ProductMedia images={images} videos={videos} title={title} />
 
       <div className="space-y-8 lg:sticky lg:top-20">
         <ProductInfoHeader selectedVariant={selectedVariant} title={title} locale={locale} />
@@ -43,7 +31,6 @@ export function VariantSection({
           variants={variants}
           options={options}
           selectedOptions={selectedOptions}
-          handle={handle}
         />
         <BuyButtons
           selectedVariant={selectedVariant}


### PR DESCRIPTION
## Summary
- Removes all `variantId` query param logic from the PDP — no more `useSearchParams` or URL-driven variant resolution
- Variant pickers (color + option) remain visible but are inert (render as `<span>` instead of `<Link>`)
- Gallery always shows all product images (no color-based filtering)
- `VariantSection` becomes a server component (no longer needs `"use client"`)
- Always selects `variants[0]` for price display and buy buttons

## Context
Exploration branch to evaluate a simpler PDP without URL-based variant state. The dead code in `variants.ts` (`getVariantUrl`, `computeInitialSelectedOptions`, `getImagesForSelectedColor`) is left in place for now.

## Test plan
- [ ] Visit a multi-variant product page — verify all images show, first variant price/availability displays
- [ ] Verify color and size pickers render but clicking does nothing
- [ ] Verify add-to-cart works with the default (first) variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)