### PR TITLE
fix: reset checkout pending state on bfcache restore

### DIFF
--- a/apps/template/components/cart/overlay-content.tsx
+++ b/apps/template/components/cart/overlay-content.tsx
@@ -4,7 +4,7 @@ import { ArrowRightIcon, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
@@ -64,6 +64,15 @@ export function OverlayContent({ locale }: OverlayContentProps) {
   const { cart, cartWithPending, setOverlayOpen, isUpdatingCart } = useCart();
   const [isCheckingOut, setIsCheckingOut] = useState(false);
   const t = useTranslations("cart");
+
+  // Reset pending state when returning from checkout (bfcache / back navigation)
+  useEffect(() => {
+    const handlePageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) setIsCheckingOut(false);
+    };
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
 
   const handleCheckout = async () => {
     if (!cart?.checkoutUrl && !displayCart?.checkoutUrl) return;

--- a/apps/template/components/cart/summary.tsx
+++ b/apps/template/components/cart/summary.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowRightIcon, InfoIcon, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useOptimistic, useState, useTransition } from "react";
+import { useEffect, useOptimistic, useState, useTransition } from "react";
 
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
@@ -26,6 +26,16 @@ function CheckoutLink({
   checkoutText: string;
 }) {
   const [isCheckingOut, setIsCheckingOut] = useState(false);
+
+  // Reset pending state when returning from checkout (bfcache / back navigation)
+  useEffect(() => {
+    const handlePageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) setIsCheckingOut(false);
+    };
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
+
   const baseClassName =
     "flex items-center justify-between w-full bg-primary text-primary-foreground font-medium py-4 px-6 rounded-lg transition-colors";
 

--- a/apps/template/components/product/pdp/buy-buttons.tsx
+++ b/apps/template/components/product/pdp/buy-buttons.tsx
@@ -2,7 +2,7 @@
 
 import { Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 
 import { buyNowAction } from "@/components/cart/actions";
 import { useCart } from "@/components/cart/context";
@@ -29,8 +29,18 @@ export function BuyButtons({
   const selectedVariantId = selectedVariant?.id;
 
   const t = useTranslations("product");
-  const [isBuyingNow, startBuyNowTransition] = useTransition();
+  const [, startBuyNowTransition] = useTransition();
+  const [isBuyingNow, setIsBuyingNow] = useState(false);
   const { addToCartOptimistic, pendingQuantity, isAddingToCart } = useCart();
+
+  // Reset pending state when returning from checkout (bfcache / back navigation)
+  useEffect(() => {
+    const handlePageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) setIsBuyingNow(false);
+    };
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
 
   const handleAddToCart = () => {
     if (selectedVariantId && selectedVariant) {
@@ -48,10 +58,13 @@ export function BuyButtons({
 
   const handleBuyNow = () => {
     if (!selectedVariantId) return;
+    setIsBuyingNow(true);
     startBuyNowTransition(async () => {
       const { checkoutUrl } = await buyNowAction(selectedVariantId, 1);
       if (checkoutUrl) {
         window.location.href = checkoutUrl;
+      } else {
+        setIsBuyingNow(false);
       }
     });
   };

--- a/apps/template/components/product/pdp/buy-buttons.tsx
+++ b/apps/template/components/product/pdp/buy-buttons.tsx
@@ -60,10 +60,14 @@ export function BuyButtons({
     if (!selectedVariantId) return;
     setIsBuyingNow(true);
     startBuyNowTransition(async () => {
-      const { checkoutUrl } = await buyNowAction(selectedVariantId, 1);
-      if (checkoutUrl) {
-        window.location.href = checkoutUrl;
-      } else {
+      try {
+        const { checkoutUrl } = await buyNowAction(selectedVariantId, 1);
+        if (checkoutUrl) {
+          window.location.href = checkoutUrl;
+        } else {
+          setIsBuyingNow(false);
+        }
+      } catch {
         setIsBuyingNow(false);
       }
     });


### PR DESCRIPTION
## Summary
- Checkout buttons got stuck in pending/loading state when navigating to Shopify checkout and pressing back (bfcache restore)
- Added `pageshow` event listener with `e.persisted` check to reset `isCheckingOut` / `isBuyingNow` state in all three checkout buttons:
  - Cart page checkout (`cart/summary.tsx`)
  - Cart overlay checkout (`cart/overlay-content.tsx`)
  - PDP "Buy with Shop" button (`product/pdp/buy-buttons.tsx`)

## Test plan
- [ ] Add items to cart, click checkout, then press browser back — button should no longer be stuck in loading state
- [ ] Same test from cart overlay
- [ ] Same test from PDP "Buy with Shop" button
- [ ] Verify checkout still navigates correctly on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)