### PR TITLE
fix(template): add homepage agent context

### DIFF
--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -17,7 +17,7 @@ AgentPanel (client) → POST /api/chat → ToolLoopAgent (Claude) → Shopify to
 ```
 
 1. The client sends conversation history and a `chatId` to `/api/chat`
-2. The server resolves page context from the `Referer` header (product, collection, search, or cart page)
+2. The server resolves page context from the `Referer` header (home, product, collection, search, or cart page)
 3. A Shopify cart is created or retrieved from a cookie before the agent runs
 4. The agent calls tools to search products, manage the cart, or generate navigation links
 5. Tool results include json-render specs that the client renders as product cards, cart summaries, and variant pickers
@@ -30,6 +30,7 @@ The agent adapts its instructions based on where the user is browsing. Page cont
 - **Collection page** - the collection handle and title are included
 - **Search page** - the active search query is passed through
 - **Cart page** - the agent knows the user is viewing their cart
+- **Home page** - the agent knows the user is landing on the storefront and can help them start browsing
 
 The system prompt also includes the user's locale so the agent responds in the correct language.
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260408.0"
+	"version": "0.20260409.0"
 }

--- a/apps/template/.gitignore
+++ b/apps/template/.gitignore
@@ -1,0 +1,1 @@
+.env*.local

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -44,6 +44,10 @@ async function resolvePageContext(
   locale: Locale,
   refererUrl: string | null,
 ): Promise<PageContext> {
+  if (segments.length === 0) {
+    return { type: "home" };
+  }
+
   // segments[0] = page type, segments[1] = handle/id
   const pageType = segments[0];
 

--- a/apps/template/lib/agent/context.ts
+++ b/apps/template/lib/agent/context.ts
@@ -8,6 +8,7 @@ export type User = {
 
 // Page context resolved from Referer header with trusted data
 export type PageContext =
+  | { type: "home" }
   | { type: "product"; product: ProductDetails }
   | { type: "collection"; handle: string; title: string }
   | { type: "search"; query: string }

--- a/apps/template/lib/agent/prompt.ts
+++ b/apps/template/lib/agent/prompt.ts
@@ -42,7 +42,14 @@ export const createSystemPrompt = (ctx: AgentContext) => {
   `;
 
   // Add page-specific context
-  if (page?.type === "product") {
+  if (page?.type === "home") {
+    prompt += dedent`\n
+      ## Current Page Context
+
+      The user is on the home page.
+      Help them discover products, browse collections, or get started shopping.
+    `;
+  } else if (page?.type === "product") {
     const { product } = page;
     const variantInfo = product.variants
       .map((v) => {

--- a/apps/template/lib/i18n/messages/en.d.json.ts
+++ b/apps/template/lib/i18n/messages/en.d.json.ts
@@ -2,312 +2,312 @@
 // See: https://next-intl.dev/docs/workflows/typescript#messages-arguments
 
 declare const messages: {
-  nav: {
-    search: "Search";
-    searchPlaceholder: "Search products";
-    searchPlaceholderAi: "AI-Powered Search";
-    aiSearch: "AI Search";
-    toggleAiSearch: "Toggle AI Search";
-    cart: "Cart";
-    account: "Account";
-    switchLanguage: "Switch language";
-    categories: "Browse";
-    exploreCategories: "Explore categories";
-    showAllCategory: "Show all {category}";
-    expandCategory: "Expand";
-    collapseCategory: "Collapse";
-    deliverTo: "Deliver to";
-    shoppingAddress: "Shipping address";
-    addressSubtitle: "Changing your address might affect results and delivery times";
-    setAddress: "Set address";
-    manageAddressBook: "Manage address book";
-    seeAll: "See All";
-    addNew: "Add new";
-    changeAddress: "Change";
-    saveAddress: "Save";
-    city: "City";
-    zipCode: "ZIP code";
-    country: "Country";
-    predictiveSearch: {
-      products: "Products";
-      collections: "Collections";
-      suggestions: "Suggestions";
-      noResults: 'No results for "{query}"';
-      viewAll: 'View all results for "{query}"';
-    };
-  };
-  product: {
-    addToCart: "Add to Cart";
-    addingToCart: "Adding to Cart...";
-    addedToCart: "✓ Added to Cart!";
-    outOfStock: "Out of Stock";
-    selectVariant: "Please select a variant";
-    quantity: "Quantity";
-    decreaseQuantity: "Decrease quantity";
-    increaseQuantity: "Increase quantity";
-    sku: "SKU";
-    inCart: "You have {quantity} {quantity, plural, one {item} other {items}} in your cart";
-    selectVariantLabel: "Select {name}: {value}";
-    viewImage: "View image {current} of {total}";
-    goToImage: "Go to image {number}";
-    recommendations: "You May Also Like";
-    inStock: "In Stock";
-    buyNow: "Buy now";
-    buyWithShop: "Buy with";
-    addingQuantity: "Adding {quantity}...";
-    freeShipping: "FREE";
-    manageAddressBook: "Manage address book";
-    stockLeft: "({stock} left)";
-    aboutThisItem: "Description";
-    seeAllSpecs: "See all specs";
-    noImage: "No image";
-    visitStore: "Visit the store";
-    officialStore: "Official Store";
-    brand: "Brand";
-    color: "Color";
-    featuredBadge: "Assistant's pick";
-    details: {
-      title: "Product Details";
-      brand: "Brand";
-      materialsTitle: "Materials & Features";
-      materials: {
-        fabric: "Premium washed cotton twill fabric";
-        fit: "Slim fit through hip and thigh";
-        pockets: "Classic five-pocket styling";
-        belt: "Belt loops at waist";
-        closure: "Zip fly with button closure";
-      };
-      sizeTitle: "Size & Fit";
-      sizeFit: "Fit";
-      sizeFitDesc: "Slim fit - sits at waist, slim through hip and thigh";
-      modelMeasurements: "Model Measurements";
-      modelDesc: 'Model is 6\'1" and wearing size 32 with a 30" inseam';
-      sizeGuide: "Size Guide";
-      sizeTableSize: "Size";
-      sizeTableWaist: "Waist (in)";
-      sizeTableInseam: "Inseam (in)";
-      shippingTitle: "Shipping & Returns";
-      shipping: "Shipping";
-      shippingFree: "Free standard shipping on orders over $100";
-      shippingStandard: "Standard delivery: 3-5 business days";
-      shippingExpress: "Express shipping: 1-2 business days";
-      shippingIntl: "International shipping available";
-      returns: "Returns";
-      returnsDesc: "We offer free returns within 30 days of purchase. Items must be unworn, unwashed, and in original condition with tags attached.";
-      exchanges: "Exchanges";
-      exchangesDesc: "Need a different size or color? We'll process your exchange for free within 30 days.";
-      careTitle: "Care Instructions";
-      washing: "Washing";
-      washCold: "Machine wash cold with like colors";
-      washGentle: "Use gentle cycle";
-      noBleach: "Do not bleach";
-      tumbleDry: "Tumble dry low";
-      ironingStorage: "Ironing & Storage";
-      ironMedium: "Iron on medium heat if needed";
-      hangFold: "Hang or fold to store";
-      avoidSun: "Avoid prolonged exposure to direct sunlight";
-      professional: "Professional Care";
-      professionalDesc: "Dry cleaning is optional but recommended for best results and longevity.";
-    };
-    breadcrumb: {
-      home: "Home";
-      toggleMenu: "Toggle menu";
-    };
-  };
-  category: {
-    categories: "Categories";
-    browseAll: "Browse all products in this category";
-    filters: "Filter";
-    activeFilters: "Active Filters";
-    clearFilters: "Clear all";
-    noProducts: "No products found in this category";
-    productCount: "{count, plural, one {# product} other {# products}}";
-    brand: "Brand";
-    subcategory: "Subcategory";
-    type: "Type";
-    color: "Color";
-    material: "Material";
-    size: "Size";
-    price: "Price";
-    min: "Min";
-    max: "Max";
-    apply: "Apply";
-    clear: "Clear";
-    totalResults: "{count, plural, one {# product} other {# products}}";
-    pages: "pages";
-    firstPage: "First";
-    nextPage: "Next";
-    sortBy: "Sort By";
-    sortRelevance: "Relevance";
-    sortPriceLow: "Price: Low to High";
-    sortPriceHigh: "Price: High to Low";
-    sortNewest: "Newest";
-  };
-  search: {
-    sortBy: "Sort By";
-    category: "Collection";
-    allCategories: "All Collections";
-    filters: "Filters";
-    filter: "Filter";
-    reset: "Reset";
-    results: "Results";
-    clearFilters: "Clear all filters";
-    selectSort: "Select sort order";
-    selectCategory: "Select collection";
-    noResults: "No products found";
-    noResultsQuery: 'We couldn\'t find any products matching "{query}"';
-    noResultsAvailable: "No products available";
-    resultCount: "{count, plural, one {# Result} other {# Results}}";
-    resultRange: "(showing {start}-{end})";
-    priceUpTo: "up to";
-    title: "All Products";
-    titleQuery: 'Search results for "{query}"';
-    titleSubtext: "Showing results for your search query";
-    breadcrumb: {
-      home: "Home";
-      search: "Search";
-      searchQuery: 'Search: "{query}"';
-    };
-    sort: {
-      bestMatches: "Best Matches";
-      priceLowToHigh: "Price: Low to High";
-      priceHighToLow: "Price: High to Low";
-      nameAscending: "Name: A-Z";
-      nameDescending: "Name: Z-A";
-    };
-    pagination: {
-      resultsPerPage: "Showing {startResult}-{endResult} of {totalResults} products";
-      totalResults: "{totalResults} products";
-      shown: "({count} shown)";
-      firstPage: "First page";
-      previousPage: "Previous page";
-      nextPage: "Next page";
-      lastPage: "Last page";
-      goToPage: "Page {page}";
-      first: "First";
-      next: "Next";
-    };
-  };
-  collections: {
-    title: "Collections";
-    description: "Browse products by collection.";
-    viewCollection: "View this collection";
-    breadcrumb: {
-      home: "Home";
-      collections: "Collections";
-    };
-  };
-  seo: {
-    defaultDescription: "Shop premium products, curated collections, and latest offers from Vercel Shop.";
-    homeTitle: "Home";
-    homeDescription: "Explore featured products, curated collections, and seasonal campaigns.";
-    collectionsTitle: "Collections";
-    collectionsDescription: "Browse all product collections.";
-    collectionFallbackTitle: "Collection";
-    collectionFallbackDescription: "Browse collection products.";
-    searchTitle: "Search";
-    searchDescription: "Search for products in our store";
-    searchTitleQuery: 'Search results for "{query}"';
-    searchDescriptionQuery: 'Find products matching "{query}"';
-  };
-  content: {
-    homepage: {
-      hero: {
-        headline: "Start selling with {storeName}";
-        subheadline: "A clean Shopify storefront you can shape as you go.";
-        ctaText: "Browse the catalog";
-      };
-      intro: {
-        title: "Built to launch first, customize later";
-        paragraphOne: "This homepage is intentionally defined in code so a new store never starts from a blank CMS.";
-        paragraphTwo: "Swap the content system later or keep editing the local structure as your storefront evolves.";
-      };
-      featuredCollection: {
-        title: "From {collectionTitle}";
-      };
-      featuredProducts: {
-        title: "Featured products";
-      };
-    };
-  };
-  common: {
-    notFound: "Not Found";
-    notFoundDesc: "The page you are looking for does not exist.";
-    goHome: "Go back to the home page";
-    error: "Something went wrong";
-    errorDesc: "An unexpected error occurred. Please try again.";
-    tryAgain: "Try again";
-  };
-  home: {
-    title: "Enterprise Commerce Template";
-    viewAllProducts: "See All Products";
-    viewSampleProduct: "View Sample Product";
-  };
-  cart: {
-    title: "Cart";
-    cartTotalIs: "Cart total is";
-    itemCount: "{count, plural, one {# item} other {# items}}";
-    empty: "Your cart is empty";
-    emptyDescription: "Looks like you haven't added anything yet. Let's explore our products and find something great!";
-    continueShopping: "Continue Shopping";
-    addToCart: "Add to Cart";
-    adding: "Adding...";
-    removeItem: "Remove item";
-    decreaseQuantity: "Decrease quantity";
-    increaseQuantity: "Increase quantity";
-    itemQuantity: "Item quantity";
-    subtotal: "Subtotal";
-    shipping: "Shipping";
-    total: "Total";
-    orderTotal: "Order total";
-    items: "Items";
-    shippingAndHandling: "Shipping & Handling";
-    estimatedTax: "Estimated Tax";
-    shippingCalculatedAtCheckout: "Calculated at checkout";
-    shoppingAddress: "Shipping address";
-    addressPlaceholder: "Address will be added at checkout";
-    completeCheckout: "Complete checkout";
-    updatingCart: "Updating cart...";
-    proceedToCheckout: "Proceed to Checkout";
-    shippingMethod: "Shipping Method";
-    standardShipping: "Standard Shipping";
-    expressShipping: "Express Shipping";
-    overnightShipping: "Overnight Shipping";
-    delivery: {
-      standard: "Delivery in 5-7 business days";
-      express: "Delivery in 2-3 business days";
-      overnight: "Delivery next business day";
-    };
-    upsell: {
-      title: "You might also like";
-      description: "Complete your order with these complementary products";
-    };
-    isThisAGift: "Is this a gift?";
-    moreInfo: "More information";
-    viewFullCart: "View full cart";
-    shoppingCart: "Shopping Cart";
-    reviewCartDescription: "Review your cart items and proceed to checkout";
-    redirecting: "Redirecting...";
-    shoppingBagTitle: "Shopping Bag";
-    startAdding: "Start adding items to your cart";
-    cartItemsLabel: "Cart items";
-  };
-  agent: {
-    name: "Ecto";
-    title: "Personal assistant";
-    openAssistant: "Open shopping assistant";
-    assistantLabel: "Shopping assistant";
-    minimizeAssistant: "Minimize assistant";
-    greeting: "Hi, how can I help?";
-    dropFiles: "Drop files here";
-    retry: "Retry";
-    copy: "Copy";
-  };
-  accessibility: {
-    skipToContent: "Skip to content";
-  };
-  footer: {
-    copyright: "© {year} Vercel Shop. All rights reserved.";
-  };
+  "nav": {
+    "search": "Search",
+    "searchPlaceholder": "Search products",
+    "searchPlaceholderAi": "AI-Powered Search",
+    "aiSearch": "AI Search",
+    "toggleAiSearch": "Toggle AI Search",
+    "cart": "Cart",
+    "account": "Account",
+    "switchLanguage": "Switch language",
+    "categories": "Browse",
+    "exploreCategories": "Explore categories",
+    "showAllCategory": "Show all {category}",
+    "expandCategory": "Expand",
+    "collapseCategory": "Collapse",
+    "deliverTo": "Deliver to",
+    "shoppingAddress": "Shipping address",
+    "addressSubtitle": "Changing your address might affect results and delivery times",
+    "setAddress": "Set address",
+    "manageAddressBook": "Manage address book",
+    "seeAll": "See All",
+    "addNew": "Add new",
+    "changeAddress": "Change",
+    "saveAddress": "Save",
+    "city": "City",
+    "zipCode": "ZIP code",
+    "country": "Country",
+    "predictiveSearch": {
+      "products": "Products",
+      "collections": "Collections",
+      "suggestions": "Suggestions",
+      "noResults": "No results for \"{query}\"",
+      "viewAll": "View all results for \"{query}\""
+    }
+  },
+  "product": {
+    "addToCart": "Add to Cart",
+    "addingToCart": "Adding to Cart...",
+    "addedToCart": "✓ Added to Cart!",
+    "outOfStock": "Out of Stock",
+    "selectVariant": "Please select a variant",
+    "quantity": "Quantity",
+    "decreaseQuantity": "Decrease quantity",
+    "increaseQuantity": "Increase quantity",
+    "sku": "SKU",
+    "inCart": "You have {quantity} {quantity, plural, one {item} other {items}} in your cart",
+    "selectVariantLabel": "Select {name}: {value}",
+    "viewImage": "View image {current} of {total}",
+    "goToImage": "Go to image {number}",
+    "recommendations": "You May Also Like",
+    "inStock": "In Stock",
+    "buyNow": "Buy now",
+    "buyWithShop": "Buy with",
+    "addingQuantity": "Adding {quantity}...",
+    "freeShipping": "FREE",
+    "manageAddressBook": "Manage address book",
+    "stockLeft": "({stock} left)",
+    "aboutThisItem": "Description",
+    "seeAllSpecs": "See all specs",
+    "noImage": "No image",
+    "visitStore": "Visit the store",
+    "officialStore": "Official Store",
+    "brand": "Brand",
+    "color": "Color",
+    "featuredBadge": "Assistant's pick",
+    "details": {
+      "title": "Product Details",
+      "brand": "Brand",
+      "materialsTitle": "Materials & Features",
+      "materials": {
+        "fabric": "Premium washed cotton twill fabric",
+        "fit": "Slim fit through hip and thigh",
+        "pockets": "Classic five-pocket styling",
+        "belt": "Belt loops at waist",
+        "closure": "Zip fly with button closure"
+      },
+      "sizeTitle": "Size & Fit",
+      "sizeFit": "Fit",
+      "sizeFitDesc": "Slim fit - sits at waist, slim through hip and thigh",
+      "modelMeasurements": "Model Measurements",
+      "modelDesc": "Model is 6'1\" and wearing size 32 with a 30\" inseam",
+      "sizeGuide": "Size Guide",
+      "sizeTableSize": "Size",
+      "sizeTableWaist": "Waist (in)",
+      "sizeTableInseam": "Inseam (in)",
+      "shippingTitle": "Shipping & Returns",
+      "shipping": "Shipping",
+      "shippingFree": "Free standard shipping on orders over $100",
+      "shippingStandard": "Standard delivery: 3-5 business days",
+      "shippingExpress": "Express shipping: 1-2 business days",
+      "shippingIntl": "International shipping available",
+      "returns": "Returns",
+      "returnsDesc": "We offer free returns within 30 days of purchase. Items must be unworn, unwashed, and in original condition with tags attached.",
+      "exchanges": "Exchanges",
+      "exchangesDesc": "Need a different size or color? We'll process your exchange for free within 30 days.",
+      "careTitle": "Care Instructions",
+      "washing": "Washing",
+      "washCold": "Machine wash cold with like colors",
+      "washGentle": "Use gentle cycle",
+      "noBleach": "Do not bleach",
+      "tumbleDry": "Tumble dry low",
+      "ironingStorage": "Ironing & Storage",
+      "ironMedium": "Iron on medium heat if needed",
+      "hangFold": "Hang or fold to store",
+      "avoidSun": "Avoid prolonged exposure to direct sunlight",
+      "professional": "Professional Care",
+      "professionalDesc": "Dry cleaning is optional but recommended for best results and longevity."
+    },
+    "breadcrumb": {
+      "home": "Home",
+      "toggleMenu": "Toggle menu"
+    }
+  },
+  "category": {
+    "categories": "Categories",
+    "browseAll": "Browse all products in this category",
+    "filters": "Filter",
+    "activeFilters": "Active Filters",
+    "clearFilters": "Clear all",
+    "noProducts": "No products found in this category",
+    "productCount": "{count, plural, one {# product} other {# products}}",
+    "brand": "Brand",
+    "subcategory": "Subcategory",
+    "type": "Type",
+    "color": "Color",
+    "material": "Material",
+    "size": "Size",
+    "price": "Price",
+    "min": "Min",
+    "max": "Max",
+    "apply": "Apply",
+    "clear": "Clear",
+    "totalResults": "{count, plural, one {# product} other {# products}}",
+    "pages": "pages",
+    "firstPage": "First",
+    "nextPage": "Next",
+    "sortBy": "Sort By",
+    "sortRelevance": "Relevance",
+    "sortPriceLow": "Price: Low to High",
+    "sortPriceHigh": "Price: High to Low",
+    "sortNewest": "Newest"
+  },
+  "search": {
+    "sortBy": "Sort By",
+    "category": "Collection",
+    "allCategories": "All Collections",
+    "filters": "Filters",
+    "filter": "Filter",
+    "reset": "Reset",
+    "results": "Results",
+    "clearFilters": "Clear all filters",
+    "selectSort": "Select sort order",
+    "selectCategory": "Select collection",
+    "noResults": "No products found",
+    "noResultsQuery": "We couldn't find any products matching \"{query}\"",
+    "noResultsAvailable": "No products available",
+    "resultCount": "{count, plural, one {# Result} other {# Results}}",
+    "resultRange": "(showing {start}-{end})",
+    "priceUpTo": "up to",
+    "title": "All Products",
+    "titleQuery": "Search results for \"{query}\"",
+    "titleSubtext": "Showing results for your search query",
+    "breadcrumb": {
+      "home": "Home",
+      "search": "Search",
+      "searchQuery": "Search: \"{query}\""
+    },
+    "sort": {
+      "bestMatches": "Best Matches",
+      "priceLowToHigh": "Price: Low to High",
+      "priceHighToLow": "Price: High to Low",
+      "nameAscending": "Name: A-Z",
+      "nameDescending": "Name: Z-A"
+    },
+    "pagination": {
+      "resultsPerPage": "Showing {startResult}-{endResult} of {totalResults} products",
+      "totalResults": "{totalResults} products",
+      "shown": "({count} shown)",
+      "firstPage": "First page",
+      "previousPage": "Previous page",
+      "nextPage": "Next page",
+      "lastPage": "Last page",
+      "goToPage": "Page {page}",
+      "first": "First",
+      "next": "Next"
+    }
+  },
+  "collections": {
+    "title": "Collections",
+    "description": "Browse products by collection.",
+    "viewCollection": "View this collection",
+    "breadcrumb": {
+      "home": "Home",
+      "collections": "Collections"
+    }
+  },
+  "seo": {
+    "defaultDescription": "Shop premium products, curated collections, and latest offers from Vercel Shop.",
+    "homeTitle": "Home",
+    "homeDescription": "Explore featured products, curated collections, and seasonal campaigns.",
+    "collectionsTitle": "Collections",
+    "collectionsDescription": "Browse all product collections.",
+    "collectionFallbackTitle": "Collection",
+    "collectionFallbackDescription": "Browse collection products.",
+    "searchTitle": "Search",
+    "searchDescription": "Search for products in our store",
+    "searchTitleQuery": "Search results for \"{query}\"",
+    "searchDescriptionQuery": "Find products matching \"{query}\""
+  },
+  "content": {
+    "homepage": {
+      "hero": {
+        "headline": "Start selling with {storeName}",
+        "subheadline": "A clean Shopify storefront you can shape as you go.",
+        "ctaText": "Browse the catalog"
+      },
+      "intro": {
+        "title": "Built to launch first, customize later",
+        "paragraphOne": "This homepage is intentionally defined in code so a new store never starts from a blank CMS.",
+        "paragraphTwo": "Swap the content system later or keep editing the local structure as your storefront evolves."
+      },
+      "featuredCollection": {
+        "title": "From {collectionTitle}"
+      },
+      "featuredProducts": {
+        "title": "Featured products"
+      }
+    }
+  },
+  "common": {
+    "notFound": "Not Found",
+    "notFoundDesc": "The page you are looking for does not exist.",
+    "goHome": "Go back to the home page",
+    "error": "Something went wrong",
+    "errorDesc": "An unexpected error occurred. Please try again.",
+    "tryAgain": "Try again"
+  },
+  "home": {
+    "title": "Enterprise Commerce Template",
+    "viewAllProducts": "See All Products",
+    "viewSampleProduct": "View Sample Product"
+  },
+  "cart": {
+    "title": "Cart",
+    "cartTotalIs": "Cart total is",
+    "itemCount": "{count, plural, one {# item} other {# items}}",
+    "empty": "Your cart is empty",
+    "emptyDescription": "Looks like you haven't added anything yet. Let's explore our products and find something great!",
+    "continueShopping": "Continue Shopping",
+    "addToCart": "Add to Cart",
+    "adding": "Adding...",
+    "removeItem": "Remove item",
+    "decreaseQuantity": "Decrease quantity",
+    "increaseQuantity": "Increase quantity",
+    "itemQuantity": "Item quantity",
+    "subtotal": "Subtotal",
+    "shipping": "Shipping",
+    "total": "Total",
+    "orderTotal": "Order total",
+    "items": "Items",
+    "shippingAndHandling": "Shipping & Handling",
+    "estimatedTax": "Estimated Tax",
+    "shippingCalculatedAtCheckout": "Calculated at checkout",
+    "shoppingAddress": "Shipping address",
+    "addressPlaceholder": "Address will be added at checkout",
+    "completeCheckout": "Complete checkout",
+    "updatingCart": "Updating cart...",
+    "proceedToCheckout": "Proceed to Checkout",
+    "shippingMethod": "Shipping Method",
+    "standardShipping": "Standard Shipping",
+    "expressShipping": "Express Shipping",
+    "overnightShipping": "Overnight Shipping",
+    "delivery": {
+      "standard": "Delivery in 5-7 business days",
+      "express": "Delivery in 2-3 business days",
+      "overnight": "Delivery next business day"
+    },
+    "upsell": {
+      "title": "You might also like",
+      "description": "Complete your order with these complementary products"
+    },
+    "isThisAGift": "Is this a gift?",
+    "moreInfo": "More information",
+    "viewFullCart": "View full cart",
+    "shoppingCart": "Shopping Cart",
+    "reviewCartDescription": "Review your cart items and proceed to checkout",
+    "redirecting": "Redirecting...",
+    "shoppingBagTitle": "Shopping Bag",
+    "startAdding": "Start adding items to your cart",
+    "cartItemsLabel": "Cart items"
+  },
+  "agent": {
+    "name": "Ecto",
+    "title": "Personal assistant",
+    "openAssistant": "Open shopping assistant",
+    "assistantLabel": "Shopping assistant",
+    "minimizeAssistant": "Minimize assistant",
+    "greeting": "Hi, how can I help?",
+    "dropFiles": "Drop files here",
+    "retry": "Retry",
+    "copy": "Copy"
+  },
+  "accessibility": {
+    "skipToContent": "Skip to content"
+  },
+  "footer": {
+    "copyright": "© {year} Vercel Shop. All rights reserved."
+  }
 };
 export default messages;

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template",
-  "version": "0.20260408.0",
+  "version": "0.20260409.0",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
## Summary
- add a minimal home page agent context so the shopping assistant no longer falls through to a null page context on `/`
- update the agent prompt and docs to reflect homepage-aware behavior
- bump the template and docs versions, and include the related generated/template housekeeping files in this scoped change

## Test plan
- [x] `pnpm --filter template lint` (currently fails on pre-existing hook warnings and unrelated formatting issues)
- [x] `pnpm --filter docs typecheck` (currently fails on a pre-existing `baseUrl` deprecation error in `tsconfig.json`)
- [ ] Manually verify the agent recognizes the home page context on `/`
- [ ] Manually verify product, collection, search, and cart page contexts still behave as before

Made with [Cursor](https://cursor.com)