### PR TITLE
fix(docs): split setup from Shopify reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ See [docs.vercel.shop](https://docs.vercel.shop) for full documentation.
 
 ## Getting Started
 
-Scaffold a new project using the CLI:
+1. Scaffold a new project using the CLI:
 
 ```sh
-npx create-vercel-shop
+npx create-vercel-shop@latest
 ```
 
-Then add your Shopify credentials:
+2. In Shopify admin, create a storefront token in **Settings → Apps and sales channels → Headless**, enable the required Storefront API permissions, then add your Shopify credentials:
 
 ```sh
 cp .env.example .env.local
@@ -23,13 +23,19 @@ cp .env.example .env.local
 ```
 SHOPIFY_STORE_DOMAIN=your-store.myshopify.com
 SHOPIFY_STOREFRONT_ACCESS_TOKEN=your-token
+NEXT_PUBLIC_SITE_NAME="Your Store Name"
 ```
 
-Start the development server:
+3. Start the development server with the same package manager you used to scaffold the project:
 
 ```sh
+pnpm dev
 npm run dev
+yarn dev
+bun dev
 ```
+
+See [docs.vercel.shop/docs/getting-started](https://docs.vercel.shop/docs/getting-started) for the full setup guide and [Storefront API Permissions](https://docs.vercel.shop/docs/reference/storefront-api-permissions) for the complete scope reference.
 
 ## Features
 

--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -1,10 +1,10 @@
 ---
-description: How to get up and running with Vercel Shop.
+description: Set up Shopify, create a project, and run Vercel Shop locally.
 title: Setup
 type: guide
 ---
 
-## Set up Shopify for headless
+## Step 1: Set up Shopify for headless
 
 If you don't already have a Shopify store, create one at [shopify.com](https://www.shopify.com). Then set up the Headless channel:
 
@@ -12,26 +12,11 @@ If you don't already have a Shopify store, create one at [shopify.com](https://w
 2. Install the **Headless** channel from the Shopify App Store
 3. Open the Headless channel and create a new storefront
 4. Copy the **Storefront API access token** - you'll need this for your environment variables
-5. Under **Storefront API permissions**, enable the scopes listed below
+5. Under **Storefront API permissions**, enable the scopes required by the template
 
-### Required API permissions
+The default storefront needs product listings, inventory, collection listings, checkout, and content access. For the exact scope names, plus optional scopes for Shopify Auth and Shopify CMS, see [Storefront API permissions](/docs/reference/storefront-api-permissions).
 
-| Scope | Purpose |
-|---|---|
-| `unauthenticated_read_product_listings` | Product pages, search, recommendations |
-| `unauthenticated_read_product_inventory` | Stock availability on PDPs and PLPs |
-| `unauthenticated_read_collection_listings` | Collection pages and navigation |
-| `unauthenticated_write_checkouts` | Cart operations and checkout |
-| `unauthenticated_read_content` | Shopify pages and metaobjects |
-
-Additional scopes are needed if you enable optional features:
-
-| Scope | Required by |
-|---|---|
-| `unauthenticated_read_customer_tags` | [Enable Shopify Auth](/docs/skills/enable-shopify-auth) skill |
-| `unauthenticated_read_metaobjects` | [Enable Shopify CMS](/docs/skills/enable-shopify-cms) skill |
-
-## Create your project
+## Step 2: Create your project
 
 There are three ways to get started:
 
@@ -39,7 +24,7 @@ There are three ways to get started:
 
 The fastest way - deploy directly to Vercel and it will create the repository for you.
 
-<a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fshop%2Ftree%2Fmain%2Fapps%2Ftemplate&env=SHOPIFY_STOREFRONT_ACCESS_TOKEN,SHOPIFY_STORE_DOMAIN,NEXT_PUBLIC_SITE_NAME&envDescription=Required%20values%20to%20work%20with%20Shopify&envLink=https%3A%2F%2Fvercel.shop%2Fdocs%2Fenv-vars">
+<a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fshop%2Ftree%2Fmain%2Fapps%2Ftemplate&env=SHOPIFY_STOREFRONT_ACCESS_TOKEN,SHOPIFY_STORE_DOMAIN,NEXT_PUBLIC_SITE_NAME&envDescription=Required%20values%20to%20work%20with%20Shopify&envLink=https%3A%2F%2Fvercel.shop%2Fdocs%2Freference%2Fenv-vars">
   <img src="https://vercel.com/button" alt="Deploy with Vercel" />
 </a>
 
@@ -53,9 +38,9 @@ npx create-vercel-shop@latest
 
 You can also use [v0](https://v0.dev) to generate a storefront and iterate on the design before connecting it to Shopify.
 
-## Environment variables
+## Step 3: Add your environment variables
 
-In your Shopify admin, go to **Settings → Apps and sales channels → Headless** and copy the Storefront API credentials. Create a `.env.local` file in your project root:
+Create a `.env.local` file in your project root:
 
 ```bash
 SHOPIFY_STORE_DOMAIN="your-store.myshopify.com"
@@ -63,33 +48,37 @@ SHOPIFY_STOREFRONT_ACCESS_TOKEN="your-storefront-access-token"
 NEXT_PUBLIC_SITE_NAME="Your Store Name"
 ```
 
-## Run locally
+You can find the storefront token in **Settings → Apps and sales channels → Headless**. For the full variable list, see [Environment Variables](/docs/reference/env-vars).
+
+## Step 4: Run locally
+
+`create-vercel-shop` uses the package manager you used to scaffold the project. Start the dev server with the matching command:
 
 ```bash
-pnpm install
 pnpm dev
+npm run dev
+yarn dev
+bun dev
 ```
 
 Your store is now running at [localhost:3000](http://localhost:3000).
 
-## AI coding agents
+## Next steps
 
-If you use [Claude Code](https://claude.ai/code) or [Cursor](https://cursor.sh), install the [Vercel plugin](https://vercel.com/changelog/introducing-vercel-plugin-for-coding-agents) to get platform-aware guidance for Next.js, AI SDK, shadcn/ui, caching, and more - 47+ skills that activate automatically as you work.
-
-### Claude Code
-
-```bash
-npx plugins add vercel/vercel-plugin
-```
-
-### Cursor
-
-```bash
-/add-plugin vercel
-```
-
-The plugin provides real-time context about Vercel APIs, catches deprecated patterns, and includes slash commands like `/bootstrap`, `/deploy`, `/env`, `/status`, and `/marketplace`.
-
-## Deploy
-
-Push your repository to GitHub and import it on [vercel.com/new](https://vercel.com/new). Add the same environment variables from your `.env.local` to your Vercel project settings.
+<Cards>
+  <Card title="Environment Variables" href="/docs/reference/env-vars">
+    Full reference for required and optional environment variables.
+  </Card>
+  <Card title="Storefront API Permissions" href="/docs/reference/storefront-api-permissions">
+    Required Shopify scopes for the default storefront and optional skills.
+  </Card>
+  <Card title="Storefront API" href="/docs/reference/storefront-api">
+    How the template structures Shopify queries, caching, and transforms.
+  </Card>
+  <Card title="Shopify Integration" href="/docs/shopify">
+    How the template maps Shopify products, collections, menus, and webhooks.
+  </Card>
+  <Card title="Using a Coding Agent" href="/docs/getting-started/using-a-coding-agent">
+    Extend and customize the storefront with Claude Code or Cursor.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/reference/_meta.json
+++ b/apps/docs/content/docs/reference/_meta.json
@@ -1,4 +1,10 @@
 {
   "title": "Reference",
-  "pages": ["routes", "env-vars", "storefront-api", "troubleshooting"]
+  "pages": [
+    "routes",
+    "env-vars",
+    "storefront-api-permissions",
+    "storefront-api",
+    "troubleshooting"
+  ]
 }

--- a/apps/docs/content/docs/reference/storefront-api-permissions.mdx
+++ b/apps/docs/content/docs/reference/storefront-api-permissions.mdx
@@ -1,0 +1,42 @@
+---
+title: Storefront API Permissions
+description: Shopify Storefront API scopes required by Vercel Shop and its optional skills.
+type: reference
+prerequisites:
+  - /docs/getting-started
+---
+
+After you create a storefront in Shopify Headless, open **Settings → Apps and sales channels → Headless → your storefront** and review the **Storefront API permissions** for that token.
+
+## Required for the default storefront
+
+| Scope | Purpose |
+|---|---|
+| `unauthenticated_read_product_listings` | Product pages, search, and recommendations |
+| `unauthenticated_read_product_inventory` | Stock availability on product and collection pages |
+| `unauthenticated_read_collection_listings` | Collection pages and navigation |
+| `unauthenticated_write_checkouts` | Cart operations and checkout |
+| `unauthenticated_read_content` | Shopify pages and metaobjects |
+
+## Optional skills
+
+Enable these only when you add the corresponding feature:
+
+| Scope | Required by |
+|---|---|
+| `unauthenticated_read_customer_tags` | [Enable Shopify Auth](/docs/skills/enable-shopify-auth) |
+| `unauthenticated_read_metaobjects` | [Enable Shopify CMS](/docs/skills/enable-shopify-cms) |
+
+## Related docs
+
+<Cards>
+  <Card title="Getting Started" href="/docs/getting-started">
+    The shortest path from Shopify token to a local storefront.
+  </Card>
+  <Card title="Environment Variables" href="/docs/reference/env-vars">
+    Required and optional environment variables for local development and deploys.
+  </Card>
+  <Card title="Storefront API" href="/docs/reference/storefront-api">
+    Query patterns, caching, and the shared Shopify client used by the template.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/reference/storefront-api.mdx
+++ b/apps/docs/content/docs/reference/storefront-api.mdx
@@ -8,6 +8,8 @@ prerequisites:
 
 All Shopify data flows through a single `shopifyFetch` function in `lib/shopify/client.ts`. It wraps the native `fetch` API with Shopify authentication, variable hashing for cache keys, and error handling.
 
+For Shopify admin setup and required token scopes, see [Storefront API Permissions](/docs/reference/storefront-api-permissions).
+
 ## shopifyFetch
 
 ```ts

--- a/apps/docs/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/content/docs/reference/troubleshooting.mdx
@@ -6,15 +6,7 @@ type: troubleshooting
 
 ## Products not showing up
 
-The most common cause is missing Storefront API permissions. In your Shopify admin, go to **Settings → Apps and sales channels → Headless → your storefront** and verify these scopes are enabled:
-
-| Scope | Required for |
-|---|---|
-| `unauthenticated_read_product_listings` | Product pages and search |
-| `unauthenticated_read_product_inventory` | Stock availability |
-| `unauthenticated_read_collection_listings` | Collection pages |
-| `unauthenticated_write_checkouts` | Cart and checkout |
-| `unauthenticated_read_content` | Shopify pages |
+The most common cause is missing Storefront API permissions. In your Shopify admin, go to **Settings → Apps and sales channels → Headless → your storefront** and compare your token scopes against [Storefront API Permissions](/docs/reference/storefront-api-permissions).
 
 Also check that your products are set to the **Online Store** and **Headless** sales channels in Shopify admin.
 

--- a/apps/docs/content/docs/shopify/index.mdx
+++ b/apps/docs/content/docs/shopify/index.mdx
@@ -6,7 +6,9 @@ prerequisites:
   - /docs/getting-started
 ---
 
-The template connects to Shopify through the Storefront API. This page covers the Shopify-side configuration that the template expects - concept mapping, required menus, and cache invalidation.
+The template connects to Shopify through the Storefront API. This page covers the Shopify-side configuration that the template expects after your storefront token and permissions are in place - concept mapping, required menus, and cache invalidation.
+
+For token setup and required scopes, see [Getting Started](/docs/getting-started) and [Storefront API Permissions](/docs/reference/storefront-api-permissions).
 
 For the API client and query patterns, see [Storefront API](/docs/reference/storefront-api).
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260409.0"
+	"version": "0.20260409.1"
 }


### PR DESCRIPTION
## Summary
- turn getting started into a short first-run guide focused on Shopify setup, project creation, env vars, and local run
- move Storefront API permission tables into a dedicated reference page and point related docs back to that canonical source
- align the README quickstart and docs cross-links with the new guide/reference split

## Test plan
- [x] `pnpm --filter docs build`


Made with [Cursor](https://cursor.com)