### PR TITLE
debug: static PDP rendering without useSearchParams

### DIFF
--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -8,13 +8,13 @@ import { getProduct } from "@/lib/shopify/operations/products";
 
 import { buildProductMetadata } from "./shared";
 
-export async function generateMetadata({
-  params,
-}: PageProps<"/products/[handle]">): Promise<Metadata> {
-  const [{ handle }, locale] = await Promise.all([params, getLocale()]);
+// export async function generateMetadata({
+//   params,
+// }: PageProps<"/products/[handle]">): Promise<Metadata> {
+//   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
 
-  return buildProductMetadata(handle, locale, `/products/${handle}`);
-}
+//   return buildProductMetadata(handle, locale, `/products/${handle}`);
+// }
 
 export default async function ProductPage({ params }: PageProps<"/products/[handle]">) {
   const locale = await getLocale();

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -8,13 +8,13 @@ import { getProduct } from "@/lib/shopify/operations/products";
 
 import { buildProductMetadata } from "./shared";
 
-// export async function generateMetadata({
-//   params,
-// }: PageProps<"/products/[handle]">): Promise<Metadata> {
-//   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
+export async function generateMetadata({
+  params,
+}: PageProps<"/products/[handle]">): Promise<Metadata> {
+  const [{ handle }, locale] = await Promise.all([params, getLocale()]);
 
-//   return buildProductMetadata(handle, locale, `/products/${handle}`);
-// }
+  return buildProductMetadata(handle, locale, `/products/${handle}`);
+}
 
 export default async function ProductPage({
   params,

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -16,7 +16,10 @@ import { buildProductMetadata } from "./shared";
 //   return buildProductMetadata(handle, locale, `/products/${handle}`);
 // }
 
-export default async function ProductPage({ params }: PageProps<"/products/[handle]">) {
+export default async function ProductPage({
+  params,
+  searchParams,
+}: PageProps<"/products/[handle]">) {
   const locale = await getLocale();
   const handlePromise = params.then(({ handle }) => handle);
 
@@ -24,5 +27,15 @@ export default async function ProductPage({ params }: PageProps<"/products/[hand
     getProduct(handle, locale).catch(() => notFound()),
   );
 
-  return <ProductDetailPage productPromise={productPromise} locale={locale} />;
+  const variantIdPromise = searchParams.then(
+    (sp) => (sp?.variantId as string | undefined),
+  );
+
+  return (
+    <ProductDetailPage
+      productPromise={productPromise}
+      locale={locale}
+      variantIdPromise={variantIdPromise}
+    />
+  );
 }

--- a/apps/template/components/product/pdp/product-detail-page.tsx
+++ b/apps/template/components/product/pdp/product-detail-page.tsx
@@ -86,9 +86,9 @@ async function ProductContent({
         <VariantSection product={product} locale={locale} variantId={variantId} />
       </div>
 
-      {/* <div className="mt-16">
+      <div className="mt-16">
         <Recommendations handle={handle} locale={locale} />
-      </div> */}
+      </div>
     </>
   );
 }

--- a/apps/template/components/product/pdp/product-detail-page.tsx
+++ b/apps/template/components/product/pdp/product-detail-page.tsx
@@ -55,11 +55,13 @@ function ProductPageFallback() {
 async function ProductContent({
   productPromise,
   locale,
+  variantIdPromise,
 }: {
   productPromise: Promise<ProductDetails>;
   locale: Locale;
+  variantIdPromise: Promise<string | undefined>;
 }) {
-  const product = await productPromise;
+  const [product, variantId] = await Promise.all([productPromise, variantIdPromise]);
   const { handle, title } = product;
 
   return (
@@ -81,7 +83,7 @@ async function ProductContent({
       <ProductBreadcrumbSchema title={title} handle={handle} />
 
       <div className="space-y-8">
-        <VariantSection product={product} locale={locale} />
+        <VariantSection product={product} locale={locale} variantId={variantId} />
       </div>
 
       <div className="mt-16">
@@ -94,14 +96,16 @@ async function ProductContent({
 export async function ProductDetailPage({
   productPromise,
   locale,
+  variantIdPromise,
 }: {
   productPromise: Promise<ProductDetails>;
   locale: Locale;
+  variantIdPromise: Promise<string | undefined>;
 }) {
   return (
     <Container className="bg-background">
       <Suspense fallback={<ProductPageFallback />}>
-        <ProductContent productPromise={productPromise} locale={locale} />
+        <ProductContent productPromise={productPromise} locale={locale} variantIdPromise={variantIdPromise} />
       </Suspense>
     </Container>
   );

--- a/apps/template/components/product/pdp/product-detail-page.tsx
+++ b/apps/template/components/product/pdp/product-detail-page.tsx
@@ -86,9 +86,9 @@ async function ProductContent({
         <VariantSection product={product} locale={locale} variantId={variantId} />
       </div>
 
-      <div className="mt-16">
+      {/* <div className="mt-16">
         <Recommendations handle={handle} locale={locale} />
-      </div>
+      </div> */}
     </>
   );
 }

--- a/apps/template/components/product/pdp/product-detail-page.tsx
+++ b/apps/template/components/product/pdp/product-detail-page.tsx
@@ -91,7 +91,7 @@ async function ProductContent({
   );
 }
 
-export function ProductDetailPage({
+export async function ProductDetailPage({
   productPromise,
   locale,
 }: {

--- a/apps/template/components/product/pdp/variant-section.tsx
+++ b/apps/template/components/product/pdp/variant-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+// DEBUG: useSearchParams disabled to test static PDP rendering
+// import { useSearchParams } from "next/navigation";
 
 import { BuyButtons } from "@/components/product/pdp/buy-buttons";
 import {
@@ -24,8 +25,10 @@ export function VariantSection({
   product: ProductDetails;
   locale: Locale;
 }) {
-  const searchParams = useSearchParams();
-  const variantId = searchParams.get("variantId") ?? undefined;
+  // DEBUG: hardcode variantId to undefined to skip useSearchParams
+  // const searchParams = useSearchParams();
+  // const variantId = searchParams.get("variantId") ?? undefined;
+  const variantId = undefined;
 
   const { handle, title, featuredImage, images, videos, variants, options } = product;
 

--- a/apps/template/components/product/pdp/variant-section.tsx
+++ b/apps/template/components/product/pdp/variant-section.tsx
@@ -1,8 +1,3 @@
-"use client";
-
-// DEBUG: useSearchParams disabled to test static PDP rendering
-// import { useSearchParams } from "next/navigation";
-
 import { BuyButtons } from "@/components/product/pdp/buy-buttons";
 import {
   ProductInfoDescription,
@@ -21,14 +16,12 @@ import type { ProductDetails } from "@/lib/types";
 export function VariantSection({
   product,
   locale,
+  variantId,
 }: {
   product: ProductDetails;
   locale: Locale;
+  variantId?: string;
 }) {
-  // DEBUG: hardcode variantId to undefined to skip useSearchParams
-  // const searchParams = useSearchParams();
-  // const variantId = searchParams.get("variantId") ?? undefined;
-  const variantId = undefined;
 
   const { handle, title, featuredImage, images, videos, variants, options } = product;
 


### PR DESCRIPTION
## Summary
- Disables `useSearchParams` in the PDP `VariantSection` to isolate whether it causes rendering issues
- Hardcodes `variantId` to `undefined` so the page always loads with the default variant

## Test plan
- [ ] Visit a product page and verify it renders correctly without search params
- [ ] Check that variant selection still works via client-side interaction
- [ ] Compare rendering behavior with the parent branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)