### PR TITLE
feat: unstable_instant on PDP for instant navigations

### DIFF
--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -8,6 +8,16 @@ import { getProduct } from "@/lib/shopify/operations/products";
 
 import { buildProductMetadata } from "./shared";
 
+export const unstable_instant = {
+  prefetch: "static" as const,
+  samples: [
+    {
+      cookies: [{ name: "shopify_cartId", value: null }],
+      searchParams: { variantId: null },
+    },
+  ],
+};
+
 export async function generateMetadata({
   params,
 }: PageProps<"/products/[handle]">): Promise<Metadata> {


### PR DESCRIPTION
## Summary
- Adds `unstable_instant` config to the PDP page with `prefetch: "static"`
- Declares `shopify_cartId` cookie and `variantId` searchParam as samples so Next.js generates a static shell at build time
- On client navigation, the shell is served instantly while dynamic data resolves inside the existing Suspense boundary

Builds on #89 which moved `VariantSection` to a server component and threads `searchParams` as a promise through Suspense.

## Test plan
- [ ] Client-side navigation to a PDP should feel instant (static shell shown immediately)
- [ ] Variant selection via `?variantId=` should still resolve correctly
- [ ] Cart icon in nav should still reflect current cart state
- [ ] Build should pass without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)