### PR TITLE
debug: fully static PDP with no searchParams

### DIFF
--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -48,11 +48,11 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
         <SiteSchema locale={locale} />
         <NextIntlClientProvider locale={locale} messages={messages}>
           <CartProvider initialCart={null}>
-            <Nav locale={locale} />
+            <Nav />
             <main id="main-content" className="flex-1 min-w-0">
               {children}
             </main>
-            <Footer locale={locale} />
+            <Footer />
             <Suspense>
               <CartOverlayWithAddress locale={locale} />
             </Suspense>

--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -48,9 +48,17 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
         <SiteSchema locale={locale} />
         <NextIntlClientProvider locale={locale} messages={messages}>
           <CartProvider initialCart={null}>
+            <Nav />
             <main id="main-content" className="flex-1 min-w-0">
               {children}
             </main>
+            <Footer />
+            <Suspense>
+              <CartOverlayWithAddress locale={locale} />
+            </Suspense>
+            <Suspense>
+              <BottomBar>{process.env.AI_AGENT_DISABLED ? null : <AgentButton />}</BottomBar>
+            </Suspense>
           </CartProvider>
         </NextIntlClientProvider>
       </body>

--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -48,17 +48,9 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
         <SiteSchema locale={locale} />
         <NextIntlClientProvider locale={locale} messages={messages}>
           <CartProvider initialCart={null}>
-            <Nav />
             <main id="main-content" className="flex-1 min-w-0">
               {children}
             </main>
-            <Footer />
-            <Suspense>
-              <CartOverlayWithAddress locale={locale} />
-            </Suspense>
-            <Suspense>
-              <BottomBar>{process.env.AI_AGENT_DISABLED ? null : <AgentButton />}</BottomBar>
-            </Suspense>
           </CartProvider>
         </NextIntlClientProvider>
       </body>

--- a/apps/template/app/products/[handle]/loading.tsx
+++ b/apps/template/app/products/[handle]/loading.tsx
@@ -1,0 +1,34 @@
+import { Container } from "@/components/layout/container";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ProductPageLoading() {
+  return (
+    <Container className="bg-background">
+      <div className="space-y-8">
+        <div className="lg:grid lg:grid-cols-2 lg:items-start lg:gap-4 space-y-8 lg:space-y-0">
+          <div className="space-y-2">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+          </div>
+          <div className="space-y-8 lg:sticky lg:top-20">
+            <div>
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-6 w-24 mt-3" />
+            </div>
+            <div className="space-y-3">
+              <Skeleton className="h-4 w-20" />
+              <div className="grid grid-cols-5 gap-3">
+                {["a", "b", "c", "d"].map((k) => (
+                  <Skeleton key={k} className="aspect-square rounded-lg" />
+                ))}
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Skeleton className="h-11 flex-1 rounded-lg" />
+              <Skeleton className="h-11 flex-1 rounded-lg" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -8,6 +8,10 @@ import { getProduct } from "@/lib/shopify/operations/products";
 
 import { buildProductMetadata } from "./shared";
 
+export function generateStaticParams() {
+  return [{ handle: "__placeholder__" }];
+}
+
 export async function generateMetadata({
   params,
 }: PageProps<"/products/[handle]">): Promise<Metadata> {

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -17,11 +17,20 @@ export async function generateMetadata({
 }: PageProps<"/products/[handle]">): Promise<Metadata> {
   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
 
+  if (handle === "__placeholder__") {
+    notFound();
+  }
+
   return buildProductMetadata(handle, locale, `/products/${handle}`);
 }
 
 export default async function ProductPage({ params }: PageProps<"/products/[handle]">) {
   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
+
+  if (handle === "__placeholder__") {
+    notFound();
+  }
+
   const product = await getProduct(handle, locale).catch(() => notFound());
 
   // return <ProductDetailPage product={product} locale={locale} />;

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -20,5 +20,6 @@ export default async function ProductPage({ params }: PageProps<"/products/[hand
   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
   const product = await getProduct(handle, locale).catch(() => notFound());
 
-  return <ProductDetailPage product={product} locale={locale} />;
+  // return <ProductDetailPage product={product} locale={locale} />;
+  return <pre>{JSON.stringify(product, null, 2)}</pre>;
 }

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -16,10 +16,7 @@ export async function generateMetadata({
   return buildProductMetadata(handle, locale, `/products/${handle}`);
 }
 
-export default async function ProductPage({
-  params,
-  searchParams,
-}: PageProps<"/products/[handle]">) {
+export default async function ProductPage({ params }: PageProps<"/products/[handle]">) {
   const locale = await getLocale();
   const handlePromise = params.then(({ handle }) => handle);
 
@@ -27,15 +24,5 @@ export default async function ProductPage({
     getProduct(handle, locale).catch(() => notFound()),
   );
 
-  const variantIdPromise = searchParams.then(
-    (sp) => (sp?.variantId as string | undefined),
-  );
-
-  return (
-    <ProductDetailPage
-      productPromise={productPromise}
-      locale={locale}
-      variantIdPromise={variantIdPromise}
-    />
-  );
+  return <ProductDetailPage productPromise={productPromise} locale={locale} />;
 }

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -17,12 +17,8 @@ export async function generateMetadata({
 }
 
 export default async function ProductPage({ params }: PageProps<"/products/[handle]">) {
-  const locale = await getLocale();
-  const handlePromise = params.then(({ handle }) => handle);
+  const [{ handle }, locale] = await Promise.all([params, getLocale()]);
+  const product = await getProduct(handle, locale).catch(() => notFound());
 
-  const productPromise = handlePromise.then((handle) =>
-    getProduct(handle, locale).catch(() => notFound()),
-  );
-
-  return <ProductDetailPage productPromise={productPromise} locale={locale} />;
+  return <ProductDetailPage product={product} locale={locale} />;
 }

--- a/apps/template/components/layout/footer.tsx
+++ b/apps/template/components/layout/footer.tsx
@@ -17,7 +17,7 @@ async function Copyright() {
   );
 }
 
-export function Footer({ locale }: { locale: string }) {
+export async function Footer() {
   const { socialLinks } = siteConfig;
 
   return (

--- a/apps/template/components/layout/nav/index.tsx
+++ b/apps/template/components/layout/nav/index.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { CartIcon, CartIconFallback } from "./cart";
 import { QuickLinks } from "./quick-links";
 
-export function Nav({ locale }: { locale: string }) {
+export async function Nav() {
   return (
     <nav
       className="sticky top-0 z-30 w-full bg-white pt-[env(safe-area-inset-top,0px)] transition-shadow duration-250"

--- a/apps/template/components/product/pdp/product-detail-page.tsx
+++ b/apps/template/components/product/pdp/product-detail-page.tsx
@@ -19,7 +19,7 @@ function ProductBreadcrumbSchema({ title, handle }: { title: string; handle: str
   );
 }
 
-export function ProductDetailPage({
+export async function ProductDetailPage({
   product,
   locale,
 }: {

--- a/apps/template/components/product/pdp/product-detail-page.tsx
+++ b/apps/template/components/product/pdp/product-detail-page.tsx
@@ -55,13 +55,11 @@ function ProductPageFallback() {
 async function ProductContent({
   productPromise,
   locale,
-  variantIdPromise,
 }: {
   productPromise: Promise<ProductDetails>;
   locale: Locale;
-  variantIdPromise: Promise<string | undefined>;
 }) {
-  const [product, variantId] = await Promise.all([productPromise, variantIdPromise]);
+  const product = await productPromise;
   const { handle, title } = product;
 
   return (
@@ -83,7 +81,7 @@ async function ProductContent({
       <ProductBreadcrumbSchema title={title} handle={handle} />
 
       <div className="space-y-8">
-        <VariantSection product={product} locale={locale} variantId={variantId} />
+        <VariantSection product={product} locale={locale} />
       </div>
 
       <div className="mt-16">
@@ -96,16 +94,14 @@ async function ProductContent({
 export async function ProductDetailPage({
   productPromise,
   locale,
-  variantIdPromise,
 }: {
   productPromise: Promise<ProductDetails>;
   locale: Locale;
-  variantIdPromise: Promise<string | undefined>;
 }) {
   return (
     <Container className="bg-background">
       <Suspense fallback={<ProductPageFallback />}>
-        <ProductContent productPromise={productPromise} locale={locale} variantIdPromise={variantIdPromise} />
+        <ProductContent productPromise={productPromise} locale={locale} />
       </Suspense>
     </Container>
   );

--- a/apps/template/components/product/pdp/product-detail-page.tsx
+++ b/apps/template/components/product/pdp/product-detail-page.tsx
@@ -1,10 +1,7 @@
-import { Suspense } from "react";
-
 import { Container } from "@/components/layout/container";
 import { Recommendations } from "@/components/product/recommendations";
 import { ProductSchema } from "@/components/product/schema";
 import { BreadcrumbSchema } from "@/components/schema/breadcrumb-schema";
-import { Skeleton } from "@/components/ui/skeleton";
 import { siteConfig } from "@/lib/config";
 import type { Locale } from "@/lib/i18n";
 import type { ProductDetails } from "@/lib/types";
@@ -22,48 +19,17 @@ function ProductBreadcrumbSchema({ title, handle }: { title: string; handle: str
   );
 }
 
-function ProductPageFallback() {
-  return (
-    <div className="space-y-8">
-      <div className="lg:grid lg:grid-cols-2 lg:items-start lg:gap-4 space-y-8 lg:space-y-0">
-        <div className="space-y-2">
-          <Skeleton className="aspect-square w-full rounded-xl" />
-        </div>
-        <div className="space-y-8 lg:sticky lg:top-20">
-          <div>
-            <Skeleton className="h-8 w-3/4" />
-            <Skeleton className="h-6 w-24 mt-3" />
-          </div>
-          <div className="space-y-3">
-            <Skeleton className="h-4 w-20" />
-            <div className="grid grid-cols-5 gap-3">
-              {["a", "b", "c", "d"].map((k) => (
-                <Skeleton key={k} className="aspect-square rounded-lg" />
-              ))}
-            </div>
-          </div>
-          <div className="flex gap-2">
-            <Skeleton className="h-11 flex-1 rounded-lg" />
-            <Skeleton className="h-11 flex-1 rounded-lg" />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-async function ProductContent({
-  productPromise,
+export function ProductDetailPage({
+  product,
   locale,
 }: {
-  productPromise: Promise<ProductDetails>;
+  product: ProductDetails;
   locale: Locale;
 }) {
-  const product = await productPromise;
   const { handle, title } = product;
 
   return (
-    <>
+    <Container className="bg-background">
       <ProductSchema
         product={{
           id: product.id,
@@ -87,22 +53,6 @@ async function ProductContent({
       <div className="mt-16">
         <Recommendations handle={handle} locale={locale} />
       </div>
-    </>
-  );
-}
-
-export async function ProductDetailPage({
-  productPromise,
-  locale,
-}: {
-  productPromise: Promise<ProductDetails>;
-  locale: Locale;
-}) {
-  return (
-    <Container className="bg-background">
-      <Suspense fallback={<ProductPageFallback />}>
-        <ProductContent productPromise={productPromise} locale={locale} />
-      </Suspense>
     </Container>
   );
 }

--- a/apps/template/components/product/pdp/variant-section.tsx
+++ b/apps/template/components/product/pdp/variant-section.tsx
@@ -16,16 +16,13 @@ import type { ProductDetails } from "@/lib/types";
 export function VariantSection({
   product,
   locale,
-  variantId,
 }: {
   product: ProductDetails;
   locale: Locale;
-  variantId?: string;
 }) {
-
   const { handle, title, featuredImage, images, videos, variants, options } = product;
 
-  const selectedOptions = computeInitialSelectedOptions(variants, variantId);
+  const selectedOptions = computeInitialSelectedOptions(variants);
   const selectedVariant = resolveSelectedVariant(variants, selectedOptions);
   const filteredImages = getImagesForSelectedColor(images, options, variants, selectedOptions);
 

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -48,24 +48,26 @@ export async function getProduct(handle: string, locale: string = defaultLocale)
   "use cache: remote";
   cacheLife("max");
   cacheTag("products", `product-${handle}`);
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
+  // const country = getCountryCode(locale);
+  // const language = getLanguageCode(locale);
 
-  const data = await shopifyFetch<{
-    productByHandle: ShopifyProduct;
-  }>({
-    operation: "getProductByHandle",
-    query: GET_PRODUCT_BY_HANDLE_QUERY,
-    variables: { handle, country, language },
-  });
+  return { testing: true }
 
-  if (!data.productByHandle) {
-    throw new Error(`Product not found: ${handle}`);
-  }
+  // const data = await shopifyFetch<{
+  //   productByHandle: ShopifyProduct;
+  // }>({
+  //   operation: "getProductByHandle",
+  //   query: GET_PRODUCT_BY_HANDLE_QUERY,
+  //   variables: { handle, country, language },
+  // });
 
-  tagProducts([data.productByHandle]);
+  // if (!data.productByHandle) {
+  //   throw new Error(`Product not found: ${handle}`);
+  // }
 
-  return transformShopifyProductDetails(data.productByHandle);
+  // tagProducts([data.productByHandle]);
+
+  // return transformShopifyProductDetails(data.productByHandle);
 }
 
 const PRODUCTS_SEARCH_QUERY = `

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -48,26 +48,24 @@ export async function getProduct(handle: string, locale: string = defaultLocale)
   "use cache: remote";
   cacheLife("max");
   cacheTag("products", `product-${handle}`);
-  // const country = getCountryCode(locale);
-  // const language = getLanguageCode(locale);
+  const country = getCountryCode(locale);
+  const language = getLanguageCode(locale);
 
-  return { testing: true }
+  const data = await shopifyFetch<{
+    productByHandle: ShopifyProduct;
+  }>({
+    operation: "getProductByHandle",
+    query: GET_PRODUCT_BY_HANDLE_QUERY,
+    variables: { handle, country, language },
+  });
 
-  // const data = await shopifyFetch<{
-  //   productByHandle: ShopifyProduct;
-  // }>({
-  //   operation: "getProductByHandle",
-  //   query: GET_PRODUCT_BY_HANDLE_QUERY,
-  //   variables: { handle, country, language },
-  // });
+  if (!data.productByHandle) {
+    throw new Error(`Product not found: ${handle}`);
+  }
 
-  // if (!data.productByHandle) {
-  //   throw new Error(`Product not found: ${handle}`);
-  // }
+  tagProducts([data.productByHandle]);
 
-  // tagProducts([data.productByHandle]);
-
-  // return transformShopifyProductDetails(data.productByHandle);
+  return transformShopifyProductDetails(data.productByHandle);
 }
 
 const PRODUCTS_SEARCH_QUERY = `


### PR DESCRIPTION
## Summary
- Strips all `searchParams` / `variantId` handling from the PDP
- Page always renders with the default variant (first in list)
- No `useSearchParams`, no `searchParams` prop, no query param reading at any level
- `VariantSection` remains a server component

Purpose: isolate whether searchParams access is causing PDP rendering issues.

## Test plan
- [ ] Visit a PDP — should render with default variant
- [ ] Build should pass without prerender errors
- [ ] No client-side hydration issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)