### PR TITLE
style: black primary color, rename agent

### DIFF
--- a/apps/template/app/globals.css
+++ b/apps/template/app/globals.css
@@ -64,7 +64,7 @@
   --card-foreground: #010101;
   --popover: #ffffff;
   --popover-foreground: #010101;
-  --primary: #2986ff;
+  --primary: #000000;
   --primary-foreground: #ffffff;
   --secondary: #e9e9e9;
   --secondary-foreground: #020202;

--- a/apps/template/components/agent/agent.tsx
+++ b/apps/template/components/agent/agent.tsx
@@ -589,7 +589,7 @@ export function AgentPanel({ open, onOpenChange, triggerRef }: AgentPanelProps) 
             <div className="flex shrink-0 items-center justify-between border-b border-border/35 px-5 py-3">
               <div className="flex items-center gap-2">
                 <span className="font-semibold text-sm">{t("name")}</span>
-                <span className="text-muted-foreground text-sm">{t("title")}</span>
+                {t("title") && <span className="text-muted-foreground text-sm">{t("title")}</span>}
               </div>
               <div className="flex items-center gap-1">
                 <button

--- a/apps/template/lib/i18n/messages/en.d.json.ts
+++ b/apps/template/lib/i18n/messages/en.d.json.ts
@@ -293,8 +293,8 @@ declare const messages: {
     "cartItemsLabel": "Cart items"
   },
   "agent": {
-    "name": "Ecto",
-    "title": "Personal assistant",
+    "name": "Agent",
+    "title": "",
     "openAssistant": "Open shopping assistant",
     "assistantLabel": "Shopping assistant",
     "minimizeAssistant": "Minimize assistant",

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -290,8 +290,8 @@
     "cartItemsLabel": "Cart items"
   },
   "agent": {
-    "name": "Ecto",
-    "title": "Personal assistant",
+    "name": "Agent",
+    "title": "",
     "openAssistant": "Open shopping assistant",
     "assistantLabel": "Shopping assistant",
     "minimizeAssistant": "Minimize assistant",


### PR DESCRIPTION
## Summary
- Change `--primary` from `#2986ff` (blue) to `#000000` (black)
- Rename agent from "Ecto" to "Agent"
- Remove "Personal assistant" subtitle

## Test plan
- [ ] Primary-colored elements (buttons, links) render in black
- [ ] Agent panel header shows "Agent" with no subtitle
- [ ] No visual regressions on primary-foreground contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)