### PR TITLE
fix: sync mobile gallery indicator on Activity re-activation

### DIFF
--- a/apps/template/components/product/pdp/product-media.tsx
+++ b/apps/template/components/product/pdp/product-media.tsx
@@ -90,7 +90,7 @@ function Carousel({ mediaItems, title }: { mediaItems: MediaItem[]; title: strin
     const container = scrollContainerRef.current;
     if (!container) return;
 
-    const handleScroll = () => {
+    const syncIndex = () => {
       const newIndex = Math.min(
         Math.max(0, Math.round(container.scrollLeft / container.offsetWidth)),
         mediaItems.length - 1,
@@ -98,8 +98,11 @@ function Carousel({ mediaItems, title }: { mediaItems: MediaItem[]; title: strin
       setSelectedIndex(newIndex);
     };
 
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    return () => container.removeEventListener("scroll", handleScroll);
+    // Sync indicator from actual scroll position on mount / Activity re-activation
+    syncIndex();
+
+    container.addEventListener("scroll", syncIndex, { passive: true });
+    return () => container.removeEventListener("scroll", syncIndex);
   }, [mediaItems.length]);
 
   return (


### PR DESCRIPTION
## Summary
- When navigating away from a PDP and returning, React's Activity preserves the carousel's `selectedIndex` state but the scroll container resets to position 0, causing the dot indicator to show the wrong image
- Fix: call `syncIndex()` at effect setup so the indicator syncs from actual scroll position on mount and Activity re-activation

## Test plan
- [ ] On mobile, scroll to a non-first image on a PDP
- [ ] Navigate away and back — indicator should show the first dot (matching the visible image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)