### PR TITLE
fix: PDP variant scroll and equal-width buy buttons

### DIFF
--- a/apps/template/components/product/pdp/buy-buttons.tsx
+++ b/apps/template/components/product/pdp/buy-buttons.tsx
@@ -88,7 +88,7 @@ export function BuyButtons({
   };
 
   return (
-    <div className="flex gap-2">
+    <div className="grid grid-cols-2 gap-2">
       <button
         type="button"
         className={cn(

--- a/apps/template/components/product/pdp/color-picker.tsx
+++ b/apps/template/components/product/pdp/color-picker.tsx
@@ -100,6 +100,7 @@ export function ColorPicker({
             <Link
               key={value.id}
               href={href}
+              scroll={false}
               className="flex flex-col items-center gap-2"
               aria-label={`Select ${option.name}: ${value.name}`}
             >

--- a/apps/template/components/product/pdp/option-picker.tsx
+++ b/apps/template/components/product/pdp/option-picker.tsx
@@ -58,7 +58,7 @@ export function OptionPicker({
           }
 
           return (
-            <Link key={value.id} href={href} className={classes}>
+            <Link key={value.id} href={href} scroll={false} className={classes}>
               {value.name}
             </Link>
           );


### PR DESCRIPTION
## Summary
- Add `scroll={false}` to color picker and option picker links so selecting a variant doesn't scroll the page
- Change buy buttons container from flex to a 2-column grid for consistent equal widths

## Test plan
- [ ] Select variant options on PDP — page should not scroll
- [ ] Buy with Shop Pay and Add to Cart buttons should be equal width on all viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)