### PR TITLE
fix: footer bottom padding for bottom bar clearance

### DIFF
--- a/apps/template/components/layout/footer.tsx
+++ b/apps/template/components/layout/footer.tsx
@@ -22,7 +22,7 @@ export function Footer({ locale }: { locale: string }) {
 
   return (
     <footer>
-      <div className="mx-auto px-4 py-12 lg:px-8">
+      <div className="mx-auto px-4 pt-12 pb-22 lg:px-8">
         <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
           <Suspense>
             <Copyright />


### PR DESCRIPTION
## Summary
- Adds `pb-22` to the footer so content isn't obscured by the fixed bottom bar
- Changes `py-12` to `pt-12 pb-22` for explicit vertical padding

## Test plan
- [ ] Footer content is fully readable above the bottom bar on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)