### PR TITLE
refactor: Shopify-standard filter query parameters

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/plp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/plp.mdx
@@ -21,7 +21,7 @@ A sidebar provides multi-select faceted filters for:
 - **Size, Color, Vendor, Product Type, Tags** - checkbox-based multi-select
 - **Price range** - slider with 4 presets (Under \$50, \$50–\$100, \$100–\$200, Over \$200)
 
-Active filters appear as badges with remove buttons. Filter state is encoded in URL search params (`?color=red&price_min=10&price_max=100`) so filtered views are shareable.
+Active filters appear as badges with remove buttons. Filter state is encoded in URL search params using Shopify's standard format (`?filter.v.option.color=red&filter.v.price.gte=10&filter.v.price.lte=100`) so filtered views are shareable and compatible with Shopify themes.
 
 Filters use `useOptimistic` for instant UI feedback while the server request is in flight, coordinated through a `FilterTransitionProvider` context.
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260412.1"
+	"version": "0.20260413.0"
 }

--- a/apps/template/components/filters/collection-filter-sidebar.tsx
+++ b/apps/template/components/filters/collection-filter-sidebar.tsx
@@ -102,15 +102,15 @@ function parsePriceValue(value: string | null): number | null {
 
 function applyPriceParams(params: URLSearchParams, min: number | null, max: number | null): void {
   if (min === null) {
-    params.delete("price_min");
+    params.delete("filter.v.price.gte");
   } else {
-    params.set("price_min", min.toString());
+    params.set("filter.v.price.gte", min.toString());
   }
 
   if (max === null) {
-    params.delete("price_max");
+    params.delete("filter.v.price.lte");
   } else {
-    params.set("price_max", max.toString());
+    params.set("filter.v.price.lte", max.toString());
   }
 }
 
@@ -134,8 +134,8 @@ export function CollectionFilterSidebarClient({
   );
 
   const pendingFilterRef = useRef<string | null>(null);
-  const urlPriceMin = parsePriceValue(searchParams.get("price_min"));
-  const urlPriceMax = parsePriceValue(searchParams.get("price_max"));
+  const urlPriceMin = parsePriceValue(searchParams.get("filter.v.price.gte"));
+  const urlPriceMax = parsePriceValue(searchParams.get("filter.v.price.lte"));
   const hasPriceFilter = urlPriceMin !== null || urlPriceMax !== null;
 
   const computeFilterHref = (key: string, value: string) => {
@@ -187,8 +187,8 @@ export function CollectionFilterSidebarClient({
 
   const removePriceRange = () => {
     const params = new URLSearchParams(searchParams.toString());
-    params.delete("price_min");
-    params.delete("price_max");
+    params.delete("filter.v.price.gte");
+    params.delete("filter.v.price.lte");
     params.delete("cursor");
 
     startFilterTransition(() => {
@@ -199,12 +199,10 @@ export function CollectionFilterSidebarClient({
   const clearAllFilters = () => {
     const params = new URLSearchParams(searchParams.toString());
 
-    for (const key of Object.keys(activeFilters)) {
-      params.delete(key);
+    for (const key of [...params.keys()]) {
+      if (key.startsWith("filter.")) params.delete(key);
     }
 
-    params.delete("price_min");
-    params.delete("price_max");
     params.delete("cursor");
 
     startFilterTransition(() => {

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -143,69 +143,81 @@ function toArray(value: string | string[] | undefined): string[] {
   return Array.isArray(value) ? value : [value];
 }
 
+function parsePrice(value: string | string[] | undefined): number | undefined {
+  if (!value || Array.isArray(value)) return undefined;
+  const parsed = Number.parseFloat(value);
+  return !Number.isNaN(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
 export function buildProductFiltersFromParams(
   searchParams: Record<string, string | string[] | undefined>,
 ): ProductFilter[] {
   const filters: ProductFilter[] = [];
 
-  for (const size of toArray(searchParams.size)) {
-    filters.push({ variantOption: { name: "Size", value: size } });
-  }
-
-  for (const color of toArray(searchParams.color)) {
-    filters.push({ variantOption: { name: "Color", value: color } });
-  }
-
-  for (const vendor of toArray(searchParams.vendor)) {
-    filters.push({ productVendor: vendor });
-  }
-
-  for (const type of toArray(searchParams.type)) {
-    filters.push({ productType: type });
-  }
-
-  const priceMin = searchParams.price_min;
-  const priceMax = searchParams.price_max;
-
-  if (priceMin || priceMax) {
-    const parsePrice = (value: string | string[] | undefined): number | undefined => {
-      if (!value || Array.isArray(value)) return undefined;
-      const parsed = Number.parseFloat(value);
-      return !Number.isNaN(parsed) && parsed >= 0 ? parsed : undefined;
-    };
-
-    const min = parsePrice(priceMin);
-    const max = parsePrice(priceMax);
-
-    if (min !== undefined || max !== undefined) {
-      filters.push({ price: { min, max } });
-    }
-  }
-
-  const available = searchParams.available;
-  if (available === "true" || available === "false") {
-    filters.push({ available: available === "true" });
-  }
-
-  for (const tag of toArray(searchParams.tag)) {
-    filters.push({ tag });
-  }
-
   for (const [key, value] of Object.entries(searchParams)) {
-    if (!key.startsWith("meta_") || !value) continue;
+    if (!key.startsWith("filter.") || !value) continue;
 
-    const metaPart = key.slice(5);
-    const underscoreIdx = metaPart.indexOf("_");
-    if (underscoreIdx <= 0) continue;
-
-    const namespace = metaPart.substring(0, underscoreIdx);
-    const metaKey = metaPart.substring(underscoreIdx + 1);
-
-    for (const metafieldValue of toArray(value)) {
-      filters.push({
-        productMetafield: { namespace, key: metaKey, value: metafieldValue },
-      });
+    // filter.v.option.{name} → variantOption
+    const optionMatch = key.match(/^filter\.v\.option\.(.+)$/i);
+    if (optionMatch) {
+      const name = optionMatch[1];
+      for (const v of toArray(value)) {
+        filters.push({ variantOption: { name, value: v } });
+      }
+      continue;
     }
+
+    // filter.v.availability → available
+    if (key === "filter.v.availability") {
+      const v = Array.isArray(value) ? value[0] : value;
+      filters.push({ available: v === "1" });
+      continue;
+    }
+
+    // filter.v.price.gte / filter.v.price.lte → handled after loop
+    if (key.startsWith("filter.v.price.")) continue;
+
+    // filter.p.vendor → productVendor
+    if (key === "filter.p.vendor") {
+      for (const v of toArray(value)) {
+        filters.push({ productVendor: v });
+      }
+      continue;
+    }
+
+    // filter.p.product_type → productType
+    if (key === "filter.p.product_type") {
+      for (const v of toArray(value)) {
+        filters.push({ productType: v });
+      }
+      continue;
+    }
+
+    // filter.p.tag → tag
+    if (key === "filter.p.tag") {
+      for (const v of toArray(value)) {
+        filters.push({ tag: v });
+      }
+      continue;
+    }
+
+    // filter.p.m.{namespace}.{key} → productMetafield
+    const metaMatch = key.match(/^filter\.p\.m\.([^.]+)\.(.+)$/i);
+    if (metaMatch) {
+      for (const v of toArray(value)) {
+        filters.push({
+          productMetafield: { namespace: metaMatch[1], key: metaMatch[2], value: v },
+        });
+      }
+      continue;
+    }
+  }
+
+  // Combine price.gte and price.lte into a single price filter
+  const min = parsePrice(searchParams["filter.v.price.gte"]);
+  const max = parsePrice(searchParams["filter.v.price.lte"]);
+  if (min !== undefined || max !== undefined) {
+    filters.push({ price: { min, max } });
   }
 
   return filters;

--- a/apps/template/lib/shopify/transforms/filters.ts
+++ b/apps/template/lib/shopify/transforms/filters.ts
@@ -113,7 +113,7 @@ export function transformShopifyFilters(
 
   let filters = listFilters
     .map(transformFilter)
-    .filter((filter) => !filter.paramKey.includes("category") && !filter.paramKey.includes("price"));
+    .filter((filter) => !filter.paramKey.includes("category") && !filter.paramKey.includes("price") && !filter.paramKey.includes("vendor"));
 
   if (hideZeroCount) {
     filters = filters

--- a/apps/template/lib/shopify/transforms/filters.ts
+++ b/apps/template/lib/shopify/transforms/filters.ts
@@ -113,7 +113,7 @@ export function transformShopifyFilters(
 
   let filters = listFilters
     .map(transformFilter)
-    .filter((filter) => !filter.paramKey.includes("category") && !filter.paramKey.includes("price") && !filter.paramKey.includes("vendor"));
+    .filter((filter) => !filter.paramKey.includes("category") && !filter.paramKey.includes("price"));
 
   if (hideZeroCount) {
     filters = filters

--- a/apps/template/lib/shopify/transforms/filters.ts
+++ b/apps/template/lib/shopify/transforms/filters.ts
@@ -20,24 +20,9 @@ export interface ActiveFilterBadge {
 }
 
 export function getParamKeyFromShopifyId(filterId: string): string {
-  const id = filterId.toLowerCase();
-
-  if (id.includes("option.size")) return "size";
-  if (id.includes("option.color")) return "color";
-  if (id.includes("vendor")) return "vendor";
-  if (id.includes("availability")) return "available";
-  if (id.includes("price")) return "price";
-  if (id.includes("category")) return "category";
-  if (id.includes("product_type")) return "type";
-  if (id.includes("tag")) return "tag";
-
-  const metafieldMatch = filterId.match(/filter\.p\.m\.([^.]+)\.([^.]+)/i);
-  if (metafieldMatch) {
-    return `meta_${metafieldMatch[1]}_${metafieldMatch[2]}`;
-  }
-
-  const parts = filterId.split(".");
-  return parts[parts.length - 1];
+  // Shopify filter IDs already use the standard format (e.g. "filter.v.option.color",
+  // "filter.p.vendor", "filter.v.availability"). Return them as-is for URL params.
+  return filterId.toLowerCase();
 }
 
 function parseShopifyFilterValue(inputJson: string): string | null {
@@ -47,7 +32,7 @@ function parseShopifyFilterValue(inputJson: string): string | null {
     if (input.productVendor) return input.productVendor;
     if (input.productType) return input.productType;
     if (input.available !== undefined) {
-      return input.available ? "true" : "false";
+      return input.available ? "1" : "0";
     }
     if (input.tag) return input.tag;
     if (input.productMetafield) return input.productMetafield.value;
@@ -128,7 +113,7 @@ export function transformShopifyFilters(
 
   let filters = listFilters
     .map(transformFilter)
-    .filter((filter) => filter.paramKey !== "category" && filter.paramKey !== "price");
+    .filter((filter) => !filter.paramKey.includes("category") && !filter.paramKey.includes("price"));
 
   if (hideZeroCount) {
     filters = filters

--- a/apps/template/lib/utils/filter-params.ts
+++ b/apps/template/lib/utils/filter-params.ts
@@ -1,12 +1,10 @@
-const RESERVED_PARAMS = new Set(["cursor", "sort", "page", "q", "collection"]);
-
 export function parseFiltersFromSearchParams(
   searchParams: Record<string, string | string[] | undefined>,
 ): Record<string, string | string[] | undefined> {
   const filters: Record<string, string | string[] | undefined> = {};
 
   for (const [key, value] of Object.entries(searchParams)) {
-    if (RESERVED_PARAMS.has(key) || value === undefined) {
+    if (!key.startsWith("filter.") || value === undefined) {
       continue;
     }
     filters[key] = value;

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -46,5 +46,5 @@
 		"lint": "oxlint . && oxfmt --check",
 		"start": "next start"
 	},
-	"version": "0.20260412.0"
+	"version": "0.20260413.0"
 }


### PR DESCRIPTION
## Summary
- Adopt Shopify's standard filter URL format instead of custom param keys
- `color=Black` → `filter.v.option.color=Black`
- `price_min=10&price_max=100` → `filter.v.price.gte=10&filter.v.price.lte=100`
- `available=true` → `filter.v.availability=1`
- `vendor=Nike` → `filter.p.vendor=Nike`
- `type=Shoes` → `filter.p.product_type=Shoes`
- `tag=sale` → `filter.p.tag=sale`
- `meta_ns_key=val` → `filter.p.m.ns.key=val`
- Simplifies `getParamKeyFromShopifyId()` — Shopify IDs are used directly as param keys
- Updates PLP docs to reflect new format

## Files changed
- `lib/shopify/transforms/filters.ts` — simplified ID→param mapping, availability `"1"`/`"0"`
- `lib/shopify/operations/products.ts` — rewritten `buildProductFiltersFromParams()` for new format
- `lib/utils/filter-params.ts` — collect `filter.*` params instead of excluding reserved keys
- `components/filters/collection-filter-sidebar.tsx` — price param keys, clear all logic
- `apps/docs/content/docs/anatomy/pages/plp.mdx` — updated filter URL example

## Test plan
- [ ] Apply color/size filters — URL shows `filter.v.option.color=...`
- [ ] Apply price range — URL shows `filter.v.price.gte=...&filter.v.price.lte=...`
- [ ] Multi-select works (repeated params)
- [ ] Clear all removes all `filter.*` params
- [ ] Filter badges display and remove correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)