### PR TITLE
fix: align carousel arrow scroll to card boundaries

### DIFF
--- a/apps/template/components/ui/scroll-carousel.tsx
+++ b/apps/template/components/ui/scroll-carousel.tsx
@@ -53,7 +53,11 @@ function ScrollCarousel({ className, children, ...props }: React.ComponentProps<
   const scroll = useCallback((direction: "left" | "right") => {
     const container = scrollContainerRef.current;
     if (!container) return;
-    const scrollAmount = container.clientWidth * 0.8;
+    const firstItem = container.querySelector<HTMLElement>("[data-slot='scroll-carousel-item']");
+    const gap = Number.parseFloat(getComputedStyle(container).columnGap) || 0;
+    const itemWidth = firstItem ? firstItem.offsetWidth + gap : container.clientWidth * 0.8;
+    const visibleItems = Math.floor(container.clientWidth / itemWidth);
+    const scrollAmount = itemWidth * Math.max(visibleItems, 1);
     container.scrollBy({
       left: direction === "left" ? -scrollAmount : scrollAmount,
       behavior: "smooth",


### PR DESCRIPTION
## Summary
- Fixes desktop carousel arrow navigation scrolling to misaligned positions, causing cards to be visually cut off
- Calculates scroll distance from actual item width + gap × visible item count instead of `clientWidth * 0.8`

## Test plan
- [ ] Click carousel arrows on desktop — cards should snap cleanly without cutoff
- [ ] Verify mobile swipe/scroll still works with snap behavior
- [ ] Test at various breakpoints (sm, lg, xl, 2xl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)