### PR TITLE
style: price weight, bottom bar icon and delimiter

### DIFF
--- a/apps/template/components/layout/bottom-bar.tsx
+++ b/apps/template/components/layout/bottom-bar.tsx
@@ -70,10 +70,10 @@ export function BottomBar({ children }: BottomBarProps) {
               className="flex items-center gap-1.5 px-2 py-1"
               onClick={openSearch}
             >
-              <Search className="size-4 text-foreground opacity-50" />
+              <Search className="size-4 text-foreground" />
               <span className="sr-only">Search</span>
             </button>
-            {children ? <div className="w-px h-5 bg-border/50" /> : null}
+            {children ? <div className="w-px h-5 bg-border" /> : null}
           </motion.div>
         )}
       </AnimatePresence>

--- a/apps/template/components/product/pdp/product-price.tsx
+++ b/apps/template/components/product/pdp/product-price.tsx
@@ -30,14 +30,14 @@ export function ProductPrice({
         amount={amount}
         currencyCode={currencyCode}
         locale={locale}
-        className="text-xl font-medium"
+        className="text-xl"
       />
       {compareAtAmount && Number(compareAtAmount) > Number(amount) && (
         <Price
           amount={compareAtAmount}
           currencyCode={currencyCode}
           locale={locale}
-          className="text-xl font-medium line-through text-foreground/35"
+          className="text-xl line-through text-foreground/35"
         />
       )}
       {discountPercent && <DiscountBadge percent={discountPercent} />}

--- a/apps/template/components/product/price.tsx
+++ b/apps/template/components/product/price.tsx
@@ -17,7 +17,7 @@ export function Price({ amount, currencyCode, locale, className, ...props }: Pri
   }).format(Number(amount));
 
   return (
-    <span className={cn("text-xl font-medium text-foreground", className)} {...props}>
+    <span className={cn("text-xl text-foreground", className)} {...props}>
       {price}
     </span>
   );

--- a/apps/template/components/ui/product-card.tsx
+++ b/apps/template/components/ui/product-card.tsx
@@ -169,7 +169,7 @@ function ProductCardPrice({
           amount={amount}
           currencyCode={currencyCode}
           locale={locale}
-          className="text-base font-medium text-main-foreground"
+          className="text-base text-main-foreground"
         />
         {discountPercent && compareAtAmount && compareAtCurrencyCode && (
           <>
@@ -177,7 +177,7 @@ function ProductCardPrice({
               amount={compareAtAmount}
               currencyCode={compareAtCurrencyCode}
               locale={locale}
-              className="text-sm font-medium text-muted-foreground line-through"
+              className="text-sm text-muted-foreground line-through"
             />
             <DiscountBadge percent={discountPercent} variant={discountVariant} />
           </>


### PR DESCRIPTION
## Summary
- Remove `font-medium` from PDP prices
- Make search icon in bottom bar full opacity to match the agent icon
- Make bottom bar delimiter more visible (`bg-border` instead of `bg-border/50`)

## Test plan
- [ ] PDP prices render without bold weight
- [ ] Bottom bar search icon matches agent icon contrast
- [ ] Delimiter between search and agent is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)