### PR TITLE
Add prompt copy option to the docs homepage

### DIFF
--- a/apps/docs/app/(home)/components/prompt-copy.tsx
+++ b/apps/docs/app/(home)/components/prompt-copy.tsx
@@ -68,8 +68,8 @@ export const PromptCopy = ({
   const Icon = copied ? CheckIcon : CopyIcon;
 
   return (
-    <div className={cn("mx-auto flex w-full max-w-[36rem] flex-col items-center gap-2", className)}>
-      <div className="flex items-center justify-center gap-6">
+    <div className={cn("mx-auto w-full max-w-[36rem] space-y-2", className)}>
+      <div className="flex w-fit items-center gap-6">
         {(["cli", "prompt"] as const).map((option) => {
           const isActive = option === mode;
 
@@ -91,7 +91,7 @@ export const PromptCopy = ({
           );
         })}
       </div>
-      <InputGroup className="mx-auto h-10 w-full bg-background shadow-none text-sm overflow-hidden">
+      <InputGroup className="h-10 w-full bg-background shadow-none text-sm overflow-hidden">
         {activeOption.prefix ? (
           <InputGroupAddon>
             <InputGroupText className="font-mono font-normal text-muted-foreground">

--- a/apps/docs/app/(home)/components/prompt-copy.tsx
+++ b/apps/docs/app/(home)/components/prompt-copy.tsx
@@ -68,8 +68,8 @@ export const PromptCopy = ({
   const Icon = copied ? CheckIcon : CopyIcon;
 
   return (
-    <div className={cn("w-full max-w-[42rem] space-y-2", className)}>
-      <div className="inline-flex rounded-full border bg-background/80 p-1 shadow-xs">
+    <div className={cn("mx-auto flex w-full max-w-[36rem] flex-col items-center gap-2", className)}>
+      <div className="flex items-center justify-center gap-6">
         {(["cli", "prompt"] as const).map((option) => {
           const isActive = option === mode;
 
@@ -78,10 +78,10 @@ export const PromptCopy = ({
               key={option}
               aria-pressed={isActive}
               className={cn(
-                "rounded-full px-3 py-1 text-sm transition-colors",
+                "border-b px-0 pb-1 text-sm transition-colors",
                 isActive
-                  ? "bg-foreground text-background"
-                  : "text-muted-foreground hover:text-foreground",
+                  ? "border-foreground text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
               )}
               onClick={() => setMode(option)}
               type="button"
@@ -91,7 +91,7 @@ export const PromptCopy = ({
           );
         })}
       </div>
-      <InputGroup className="h-10 bg-background shadow-none text-sm overflow-hidden">
+      <InputGroup className="mx-auto h-10 w-full bg-background shadow-none text-sm overflow-hidden">
         {activeOption.prefix ? (
           <InputGroupAddon>
             <InputGroupText className="font-mono font-normal text-muted-foreground">

--- a/apps/docs/app/(home)/components/prompt-copy.tsx
+++ b/apps/docs/app/(home)/components/prompt-copy.tsx
@@ -3,25 +3,48 @@
 import { track } from "@vercel/analytics";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupText,
+} from "@/components/ui/input-group";
 import { cn } from "@/lib/utils";
 
 const COPY_TIMEOUT = 2000;
 
+type CopyMode = "cli" | "prompt";
+
 interface PromptCopyProps {
   className?: string;
-  description?: string;
+  command: string;
   prompt: string;
-  title?: string;
 }
 
 export const PromptCopy = ({
   className,
-  description = "Paste into Codex, Claude Code, or Cursor.",
+  command,
   prompt,
-  title = "Agent prompt",
 }: PromptCopyProps) => {
+  const [mode, setMode] = useState<CopyMode>("cli");
   const [copied, setCopied] = useState(false);
+
+  const activeOption =
+    mode === "cli"
+      ? {
+          description: "Run the starter directly in your terminal.",
+          label: "CLI",
+          prefix: "$",
+          value: command,
+        }
+      : {
+          description:
+            "Paste into your coding agent. It tells the agent to use the CLI, collect Shopify env vars, and stop when local dev is running.",
+          label: "Prompt",
+          prefix: null,
+          value: prompt,
+        };
 
   useEffect(() => {
     if (!copied) {
@@ -35,31 +58,69 @@ export const PromptCopy = ({
     return () => window.clearTimeout(timeoutId);
   }, [copied]);
 
+  useEffect(() => {
+    setCopied(false);
+  }, [mode]);
+
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(prompt);
+    await navigator.clipboard.writeText(activeOption.value);
     setCopied(true);
-    track("Copied starter prompt");
+    track(mode === "cli" ? "Copied installer command" : "Copied starter prompt");
   };
 
   const Icon = copied ? CheckIcon : CopyIcon;
 
   return (
-    <div className={cn("w-full rounded-xl border bg-background/90 p-3 text-left shadow-xs", className)}>
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="space-y-1">
-          <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
-            {title}
-          </p>
-          <p className="text-sm text-muted-foreground">{description}</p>
-        </div>
-        <Button className="shrink-0" onClick={handleCopy} size="sm" type="button" variant="outline">
-          <Icon className="size-3.5" />
-          <span>{copied ? "Copied" : "Copy prompt"}</span>
-        </Button>
+    <div className={cn("w-full max-w-3xl space-y-3", className)}>
+      <div className="inline-flex rounded-full border bg-background/80 p-1 shadow-xs">
+        {(["cli", "prompt"] as const).map((option) => {
+          const isActive = option === mode;
+
+          return (
+            <button
+              key={option}
+              aria-pressed={isActive}
+              className={cn(
+                "rounded-full px-3 py-1 text-sm transition-colors",
+                isActive
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+              onClick={() => setMode(option)}
+              type="button"
+            >
+              {option === "cli" ? "CLI" : "Prompt"}
+            </button>
+          );
+        })}
       </div>
-      <pre className="mt-3 overflow-x-auto rounded-lg border bg-muted/20 p-3 font-mono text-sm leading-6 whitespace-pre-wrap">
-        {prompt}
-      </pre>
+      <InputGroup className="h-10 bg-background shadow-none text-sm overflow-hidden">
+        {activeOption.prefix ? (
+          <InputGroupAddon>
+            <InputGroupText className="font-mono font-normal text-muted-foreground">
+              {activeOption.prefix}
+            </InputGroupText>
+          </InputGroupAddon>
+        ) : null}
+        <InputGroupInput
+          className="min-w-0 font-mono text-sm"
+          readOnly
+          title={activeOption.value}
+          value={activeOption.value}
+        />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton
+            aria-label={`Copy ${activeOption.label.toLowerCase()}`}
+            className="hover:bg-muted hover:text-foreground"
+            onClick={handleCopy}
+            size="icon-xs"
+            title={`Copy ${activeOption.label.toLowerCase()}`}
+          >
+            <Icon className="size-3.5" size={14} />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+      <p className="text-sm text-muted-foreground">{activeOption.description}</p>
     </div>
   );
 };

--- a/apps/docs/app/(home)/components/prompt-copy.tsx
+++ b/apps/docs/app/(home)/components/prompt-copy.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { track } from "@vercel/analytics";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const COPY_TIMEOUT = 2000;
+
+interface PromptCopyProps {
+  className?: string;
+  description?: string;
+  prompt: string;
+  title?: string;
+}
+
+export const PromptCopy = ({
+  className,
+  description = "Paste into Codex, Claude Code, or Cursor.",
+  prompt,
+  title = "Agent prompt",
+}: PromptCopyProps) => {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setCopied(false);
+    }, COPY_TIMEOUT);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(prompt);
+    setCopied(true);
+    track("Copied starter prompt");
+  };
+
+  const Icon = copied ? CheckIcon : CopyIcon;
+
+  return (
+    <div className={cn("w-full rounded-xl border bg-background/90 p-3 text-left shadow-xs", className)}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+            {title}
+          </p>
+          <p className="text-sm text-muted-foreground">{description}</p>
+        </div>
+        <Button className="shrink-0" onClick={handleCopy} size="sm" type="button" variant="outline">
+          <Icon className="size-3.5" />
+          <span>{copied ? "Copied" : "Copy prompt"}</span>
+        </Button>
+      </div>
+      <pre className="mt-3 overflow-x-auto rounded-lg border bg-muted/20 p-3 font-mono text-sm leading-6 whitespace-pre-wrap">
+        {prompt}
+      </pre>
+    </div>
+  );
+};

--- a/apps/docs/app/(home)/components/prompt-copy.tsx
+++ b/apps/docs/app/(home)/components/prompt-copy.tsx
@@ -19,13 +19,13 @@ type CopyMode = "cli" | "prompt";
 interface PromptCopyProps {
   className?: string;
   command: string;
-  prompt: string;
+  agentCommand: string;
 }
 
 export const PromptCopy = ({
   className,
   command,
-  prompt,
+  agentCommand,
 }: PromptCopyProps) => {
   const [mode, setMode] = useState<CopyMode>("cli");
   const [copied, setCopied] = useState(false);
@@ -39,8 +39,8 @@ export const PromptCopy = ({
         }
       : {
           label: "For agents",
-          prefix: null,
-          value: prompt,
+          prefix: "$",
+          value: agentCommand,
         };
 
   useEffect(() => {
@@ -62,7 +62,7 @@ export const PromptCopy = ({
   const handleCopy = async () => {
     await navigator.clipboard.writeText(activeOption.value);
     setCopied(true);
-    track(mode === "cli" ? "Copied installer command" : "Copied starter prompt");
+    track(mode === "cli" ? "Copied installer command" : "Copied agent install command");
   };
 
   const Icon = copied ? CheckIcon : CopyIcon;

--- a/apps/docs/app/(home)/components/prompt-copy.tsx
+++ b/apps/docs/app/(home)/components/prompt-copy.tsx
@@ -68,8 +68,8 @@ export const PromptCopy = ({
   const Icon = copied ? CheckIcon : CopyIcon;
 
   return (
-    <div className={cn("mx-auto w-full max-w-[36rem] space-y-2", className)}>
-      <div className="flex w-fit items-center gap-6">
+    <div className={cn("mx-auto flex w-full max-w-[34rem] flex-col items-center gap-2", className)}>
+      <div className="flex w-full items-center justify-center gap-6">
         {(["cli", "prompt"] as const).map((option) => {
           const isActive = option === mode;
 

--- a/apps/docs/app/(home)/components/prompt-copy.tsx
+++ b/apps/docs/app/(home)/components/prompt-copy.tsx
@@ -33,15 +33,12 @@ export const PromptCopy = ({
   const activeOption =
     mode === "cli"
       ? {
-          description: "Run the starter directly in your terminal.",
-          label: "CLI",
+          label: "For humans",
           prefix: "$",
           value: command,
         }
       : {
-          description:
-            "Paste into your coding agent. It tells the agent to use the CLI, collect Shopify env vars, and stop when local dev is running.",
-          label: "Prompt",
+          label: "For agents",
           prefix: null,
           value: prompt,
         };
@@ -71,7 +68,7 @@ export const PromptCopy = ({
   const Icon = copied ? CheckIcon : CopyIcon;
 
   return (
-    <div className={cn("w-full max-w-3xl space-y-3", className)}>
+    <div className={cn("w-full max-w-[42rem] space-y-2", className)}>
       <div className="inline-flex rounded-full border bg-background/80 p-1 shadow-xs">
         {(["cli", "prompt"] as const).map((option) => {
           const isActive = option === mode;
@@ -89,7 +86,7 @@ export const PromptCopy = ({
               onClick={() => setMode(option)}
               type="button"
             >
-              {option === "cli" ? "CLI" : "Prompt"}
+              {option === "cli" ? "For humans" : "For agents"}
             </button>
           );
         })}
@@ -120,7 +117,6 @@ export const PromptCopy = ({
           </InputGroupButton>
         </InputGroupAddon>
       </InputGroup>
-      <p className="text-sm text-muted-foreground">{activeOption.description}</p>
     </div>
   );
 };

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -12,9 +12,13 @@ import { FakeBrowser } from "./components/fake-browser";
 import { ContentNegotiationDemo } from "./components/content-negotiation-demo";
 import { Hero } from "./components/hero";
 import { OneTwoSection } from "./components/one-two-section";
+import { PromptCopy } from "./components/prompt-copy";
+
 const title = "Vercel Shop";
 const description =
 	"Ship a production-ready Shopify storefront in days. Customize everything with AI agents. Built on Next.js.";
+const starterPrompt =
+	"Create a new Vercel Shop storefront for me. Use the official create-vercel-shop starter, explain any Shopify or Vercel credentials you need, and stop once the local dev server is running.";
 
 export const metadata: Metadata = {
 	title,
@@ -28,8 +32,14 @@ const HomePage = () => (
 			description={description}
 			title={title}
 		>
-			<div className="flex flex-col items-center gap-4">
-				<Installer className="w-full max-w-[20rem]" command="npx create-vercel-shop@latest my-store" />
+			<div className="flex w-full max-w-3xl flex-col items-center gap-4">
+				<div className="w-full max-w-[20rem] space-y-2 text-left">
+					<p className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+						CLI
+					</p>
+					<Installer className="w-full" command="npx create-vercel-shop@latest my-store" />
+				</div>
+				<PromptCopy className="max-w-3xl" prompt={starterPrompt} />
 				<Button asChild className="px-4" size="lg">
 					<Link href="/docs/getting-started">
 						Get Started

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -32,7 +32,9 @@ const HomePage = () => (
 			title={title}
 		>
 			<div className="flex w-full max-w-3xl flex-col items-center gap-4">
-				<PromptCopy command="npx create-vercel-shop@latest" prompt={starterPrompt} />
+				<div className="mx-auto w-full">
+					<PromptCopy command="npx create-vercel-shop@latest" prompt={starterPrompt} />
+				</div>
 				<Button asChild className="px-4" size="lg">
 					<Link href="/docs/getting-started">
 						Get Started

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Installer } from "@/components/fromsrc/installer";
 import { Button } from "@/components/ui/button";
 import { nav } from "@/lib/constants";
 import { AgentDemo } from "./components/agent-demo";
@@ -18,7 +17,7 @@ const title = "Vercel Shop";
 const description =
 	"Ship a production-ready Shopify storefront in days. Customize everything with AI agents. Built on Next.js.";
 const starterPrompt =
-	"Create a new Vercel Shop storefront for me. Use the official create-vercel-shop starter, explain any Shopify or Vercel credentials you need, and stop once the local dev server is running.";
+	"Set up a new Vercel Shop project for me. Use `npx create-vercel-shop@latest` to scaffold it. Then follow the Vercel Shop setup docs: if I do not already have Shopify credentials, tell me to go to Shopify Settings -> Apps and sales channels -> Develop apps, install or open the Headless channel, create a storefront, and copy the Storefront API access token. Ask me for `SHOPIFY_STORE_DOMAIN`, `SHOPIFY_STOREFRONT_ACCESS_TOKEN`, and `NEXT_PUBLIC_SITE_NAME`, create `.env.local`, start the local dev server with the scaffolded package manager, and stop once it is running.";
 
 export const metadata: Metadata = {
 	title,
@@ -33,13 +32,7 @@ const HomePage = () => (
 			title={title}
 		>
 			<div className="flex w-full max-w-3xl flex-col items-center gap-4">
-				<div className="w-full max-w-[20rem] space-y-2 text-left">
-					<p className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
-						CLI
-					</p>
-					<Installer className="w-full" command="npx create-vercel-shop@latest my-store" />
-				</div>
-				<PromptCopy className="max-w-3xl" prompt={starterPrompt} />
+				<PromptCopy command="npx create-vercel-shop@latest" prompt={starterPrompt} />
 				<Button asChild className="px-4" size="lg">
 					<Link href="/docs/getting-started">
 						Get Started

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -16,8 +16,7 @@ import { PromptCopy } from "./components/prompt-copy";
 const title = "Vercel Shop";
 const description =
 	"Ship a production-ready Shopify storefront in days. Customize everything with AI agents. Built on Next.js.";
-const starterPrompt =
-	"Set up a new Vercel Shop project by running `npx create-vercel-shop@latest`; if I do not already have Shopify Headless credentials, walk me through the setup docs to create them, then collect `SHOPIFY_STORE_DOMAIN`, `SHOPIFY_STOREFRONT_ACCESS_TOKEN`, and `NEXT_PUBLIC_SITE_NAME`, create `.env.local`, start the scaffolded local dev server, and stop once it is running.";
+const agentCommand = "npx plugins add vercel/shop";
 
 export const metadata: Metadata = {
 	title,
@@ -32,7 +31,7 @@ const HomePage = () => (
 			title={title}
 		>
 			<div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-4">
-				<PromptCopy command="npx create-vercel-shop@latest" prompt={starterPrompt} />
+				<PromptCopy agentCommand={agentCommand} command="npx create-vercel-shop@latest" />
 				<Button asChild className="px-4" size="lg">
 					<Link href="/docs/getting-started">
 						Get Started

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -31,10 +31,8 @@ const HomePage = () => (
 			description={description}
 			title={title}
 		>
-			<div className="flex w-full max-w-3xl flex-col items-center gap-4">
-				<div className="mx-auto w-full">
-					<PromptCopy command="npx create-vercel-shop@latest" prompt={starterPrompt} />
-				</div>
+			<div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-4">
+				<PromptCopy command="npx create-vercel-shop@latest" prompt={starterPrompt} />
 				<Button asChild className="px-4" size="lg">
 					<Link href="/docs/getting-started">
 						Get Started

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -17,7 +17,7 @@ const title = "Vercel Shop";
 const description =
 	"Ship a production-ready Shopify storefront in days. Customize everything with AI agents. Built on Next.js.";
 const starterPrompt =
-	"Set up a new Vercel Shop project for me. Use `npx create-vercel-shop@latest` to scaffold it. Then follow the Vercel Shop setup docs: if I do not already have Shopify credentials, tell me to go to Shopify Settings -> Apps and sales channels -> Develop apps, install or open the Headless channel, create a storefront, and copy the Storefront API access token. Ask me for `SHOPIFY_STORE_DOMAIN`, `SHOPIFY_STOREFRONT_ACCESS_TOKEN`, and `NEXT_PUBLIC_SITE_NAME`, create `.env.local`, start the local dev server with the scaffolded package manager, and stop once it is running.";
+	"Set up a new Vercel Shop project by running `npx create-vercel-shop@latest`; if I do not already have Shopify Headless credentials, walk me through the setup docs to create them, then collect `SHOPIFY_STORE_DOMAIN`, `SHOPIFY_STOREFRONT_ACCESS_TOKEN`, and `NEXT_PUBLIC_SITE_NAME`, create `.env.local`, start the scaffolded local dev server, and stop once it is running.";
 
 export const metadata: Metadata = {
 	title,
@@ -31,7 +31,7 @@ const HomePage = () => (
 			description={description}
 			title={title}
 		>
-			<div className="flex w-full max-w-3xl flex-col items-center gap-4">
+			<div className="flex w-full max-w-3xl flex-col items-center gap-3">
 				<PromptCopy command="npx create-vercel-shop@latest" prompt={starterPrompt} />
 				<Button asChild className="px-4" size="lg">
 					<Link href="/docs/getting-started">

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -31,7 +31,7 @@ const HomePage = () => (
 			description={description}
 			title={title}
 		>
-			<div className="flex w-full max-w-3xl flex-col items-center gap-3">
+			<div className="flex w-full max-w-3xl flex-col items-center gap-4">
 				<PromptCopy command="npx create-vercel-shop@latest" prompt={starterPrompt} />
 				<Button asChild className="px-4" size="lg">
 					<Link href="/docs/getting-started">

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260414.1"
+	"version": "0.20260414.2"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260413.5"
+	"version": "0.20260413.6"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260413.3"
+	"version": "0.20260413.4"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260413.4"
+	"version": "0.20260413.5"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260413.2"
+	"version": "0.20260413.3"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260414.0"
+	"version": "0.20260414.1"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260413.6"
+	"version": "0.20260414.0"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260414.1"
+	"version": "0.20260413.1"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260413.1"
+	"version": "0.20260413.2"
 }


### PR DESCRIPTION
## Summary
- add a reusable `PromptCopy` component for copying an agent-ready starter prompt
- show both the CLI install command and a prompt copy block in the docs homepage hero
- bump the docs package version to `0.20260413.1`

## Testing
- Not run (not requested)