### PR TITLE
Add required plugin installation to create-vercel-shop

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ See [docs.vercel.shop](https://docs.vercel.shop) for full documentation.
 npx create-vercel-shop@latest
 ```
 
+`create-vercel-shop` also attempts to add the recommended agent plugins after scaffolding:
+
+```sh
+npx plugins add vercel/vercel-plugin
+npx plugins add shopify/shopify-ai-toolkit
+```
+
 2. In Shopify admin, create a storefront token in **Settings → Apps and sales channels → Headless**, enable the required Storefront API permissions, then add your Shopify credentials:
 
 ```sh

--- a/apps/cli/index.mjs
+++ b/apps/cli/index.mjs
@@ -1,9 +1,25 @@
 #!/usr/bin/env node
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import { spawn } from 'node:child_process';
+import { join, resolve } from 'node:path';
 
 const userAgent = process.env.npm_config_user_agent ?? '';
 const execPath = process.env.npm_execpath ?? '';
 const cliArgs = process.argv.slice(2);
+const startedAtMs = Date.now();
+const startedInDirectory = process.cwd();
+const startingDirectorySnapshot = snapshotDirectories(startedInDirectory);
+const startedInExistingProject = isScaffoldedProject(startedInDirectory);
+const requestedProjectPath = getRequestedProjectPath(cliArgs);
+
+const REQUIRED_PLUGINS = ['vercel/vercel-plugin', 'shopify/shopify-ai-toolkit'];
+const FLAGS_WITH_VALUES = new Set([
+  '--api',
+  '--example',
+  '--example-path',
+  '--import-alias',
+  '-e',
+]);
 
 const hasExplicitPackageManagerFlag = cliArgs.some((arg) =>
   ['--use-pnpm', '--use-npm', '--use-yarn', '--use-bun'].includes(arg),
@@ -54,11 +70,147 @@ function getRunner(packageManager) {
   return { command: 'npx', args: [] };
 }
 
+function getRequestedProjectPath(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--') {
+      return args[index + 1] ?? null;
+    }
+
+    if (FLAGS_WITH_VALUES.has(arg)) {
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      continue;
+    }
+
+    return arg;
+  }
+
+  return null;
+}
+
+function snapshotDirectories(directory) {
+  const snapshot = new Map();
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const fullPath = join(directory, entry.name);
+    snapshot.set(fullPath, safeMtimeMs(fullPath));
+  }
+
+  return snapshot;
+}
+
+function safeMtimeMs(path) {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function isScaffoldedProject(directory) {
+  return (
+    existsSync(join(directory, 'package.json')) &&
+    (existsSync(join(directory, 'app')) || existsSync(join(directory, 'src', 'app')))
+  );
+}
+
+function resolveCreatedProjectDirectory() {
+  if (requestedProjectPath) {
+    const resolvedProjectPath = resolve(startedInDirectory, requestedProjectPath);
+
+    if (isScaffoldedProject(resolvedProjectPath)) {
+      return resolvedProjectPath;
+    }
+  }
+
+  if (!startedInExistingProject && isScaffoldedProject(startedInDirectory)) {
+    return startedInDirectory;
+  }
+
+  const candidateDirectories = [];
+
+  for (const entry of readdirSync(startedInDirectory, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const fullPath = join(startedInDirectory, entry.name);
+    const existedBefore = startingDirectorySnapshot.has(fullPath);
+    const updatedDuringScaffold = safeMtimeMs(fullPath) >= startedAtMs;
+
+    if (!existedBefore || updatedDuringScaffold) {
+      if (isScaffoldedProject(fullPath)) {
+        candidateDirectories.push({ path: fullPath, mtimeMs: safeMtimeMs(fullPath) });
+      }
+    }
+  }
+
+  candidateDirectories.sort((left, right) => right.mtimeMs - left.mtimeMs);
+
+  return candidateDirectories[0]?.path ?? null;
+}
+
+function printManualPluginInstructions() {
+  console.warn('Run these commands from your project root to add the recommended plugins:');
+
+  for (const plugin of REQUIRED_PLUGINS) {
+    console.warn(`  npx plugins add ${plugin}`);
+  }
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolvePromise) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      ...options,
+    });
+
+    child.on('error', (error) => {
+      resolvePromise({ code: 1, error });
+    });
+
+    child.on('close', (code) => {
+      resolvePromise({ code: code ?? 1 });
+    });
+  });
+}
+
+async function installRequiredPlugins(projectDirectory) {
+  console.log('\nAdding recommended agent plugins...');
+
+  for (const plugin of REQUIRED_PLUGINS) {
+    const result = await runCommand('npx', ['plugins', 'add', plugin], {
+      cwd: projectDirectory,
+    });
+
+    if (result.error?.code === 'ENOENT') {
+      console.warn('\nCould not find `npx`, so plugin installation was skipped.');
+      printManualPluginInstructions();
+      return;
+    }
+
+    if (result.code !== 0) {
+      console.warn(`\nSkipping ${plugin}. The project was created successfully.`);
+      console.warn(
+        `If this plugin is not already installed, re-run: npx plugins add ${plugin}`,
+      );
+    }
+  }
+}
+
 const runner = getRunner(detectedPackageManager);
 
-const child = spawn(
-  runner.command,
-  [
+async function main() {
+  const createNextAppResult = await runCommand(runner.command, [
     ...runner.args,
     'create-next-app@latest',
     '--example',
@@ -67,11 +219,22 @@ const child = spawn(
     'apps/template',
     ...(packageManagerFlag ? [packageManagerFlag] : []),
     ...cliArgs,
-  ],
-  {
-  stdio: 'inherit',
-});
+  ]);
 
-child.on('close', (code) => {
-  process.exit(code ?? 1);
-});
+  if (createNextAppResult.code !== 0) {
+    process.exit(createNextAppResult.code);
+  }
+
+  const projectDirectory = resolveCreatedProjectDirectory();
+
+  if (!projectDirectory) {
+    console.warn('\nThe project was created, but the app directory could not be detected.');
+    printManualPluginInstructions();
+    process.exit(0);
+  }
+
+  await installRequiredPlugins(projectDirectory);
+  process.exit(0);
+}
+
+void main();

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,5 +4,5 @@
 	},
 	"name": "create-vercel-shop",
 	"type": "module",
-	"version": "0.0.1"
+	"version": "0.0.2"
 }

--- a/apps/docs/content/docs/getting-started/extending-with-agents.mdx
+++ b/apps/docs/content/docs/getting-started/extending-with-agents.mdx
@@ -20,13 +20,14 @@ Any agent that reads markdown context files will work. The ones we've tested mos
 
 ## Setting up
 
-After [creating your project](/docs/getting-started), install the Vercel plugin to give your agent access to 47+ skills for Next.js, AI SDK, shadcn/ui, caching, and more.
-
-### Claude Code
+If you created your storefront with `create-vercel-shop`, the CLI already attempts to install the recommended plugins for you. If you cloned manually, skipped that step, or want to re-run it, add them with the plugins CLI:
 
 ```bash
 npx plugins add vercel/vercel-plugin
+npx plugins add shopify/shopify-ai-toolkit
 ```
+
+The Vercel plugin gives your agent access to 47+ skills for Next.js, AI SDK, shadcn/ui, caching, and more. The Shopify AI Toolkit adds Shopify-specific guidance and tooling for storefront tasks.
 
 ### Cursor
 

--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -34,6 +34,13 @@ The fastest way - deploy directly to Vercel and it will create the repository fo
 npx create-vercel-shop@latest
 ```
 
+`create-vercel-shop` also attempts to add the recommended agent plugins after scaffolding:
+
+```bash
+npx plugins add vercel/vercel-plugin
+npx plugins add shopify/shopify-ai-toolkit
+```
+
 ### Start from v0
 
 You can also use [v0](https://v0.dev) to generate a storefront and iterate on the design before connecting it to Shopify.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260413.1"
+	"version": "0.20260413.2"
 }

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -2,15 +2,16 @@
 
 This file provides guidance for agents working in the template.
 
-## Recommended: Vercel Plugin
+## Recommended Plugins
 
-This project works best with the Vercel plugin installed. If you don't see `vercel-plugin:*` skills available in your session (e.g. `vercel-plugin:nextjs`, `vercel-plugin:shadcn`), prompt the user to install it:
+This project works best with the Vercel plugin and Shopify AI Toolkit installed. If you don't see `vercel-plugin:*` skills available in your session (e.g. `vercel-plugin:nextjs`, `vercel-plugin:shadcn`) or the Shopify toolkit available, prompt the user to install them:
 
 ```bash
 npx plugins add vercel/vercel-plugin
+npx plugins add shopify/shopify-ai-toolkit
 ```
 
-The plugin provides 47+ skills for Next.js, AI SDK, shadcn/ui, caching, deployment, and more — activated automatically as you edit files and run commands.
+The Vercel plugin provides 47+ skills for Next.js, AI SDK, shadcn/ui, caching, deployment, and more, while the Shopify AI Toolkit adds Shopify-aware tools and workflows for storefront work.
 
 <!-- BEGIN:nextjs-agent-rules -->
 

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -46,5 +46,5 @@
 		"lint": "oxlint . && oxfmt --check",
 		"start": "next start"
 	},
-	"version": "0.20260413.3"
+	"version": "0.20260413.4"
 }


### PR DESCRIPTION
## Summary
- update `create-vercel-shop` to install the Vercel plugin and Shopify AI Toolkit after scaffolding
- keep plugin installation best-effort so project creation still succeeds if plugins are already installed or the add step is skipped
- document the automatic plugin setup in the README, setup docs, and template `AGENTS.md`
- bump the CLI, docs, and template versions to reflect the release

## Testing
- Not run (not requested)