### PR TITLE
test: disable searchParams on PDP to test Chrome fallback

### DIFF
--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -16,12 +16,12 @@ export async function generateMetadata({
   return buildProductMetadata(handle, locale, `/products/${handle}`);
 }
 
-// TEMP: removed searchParams from samples to match disabled searchParams
 export const unstable_instant = {
   prefetch: "runtime",
   samples: [
     {
       params: { handle: "sample-product" },
+      searchParams: { variantId: "1" },
       cookies: [{ name: "shopify_cartId", value: null }],
     },
   ],
@@ -29,6 +29,7 @@ export const unstable_instant = {
 
 export default async function ProductPage({
   params,
+  searchParams,
 }: PageProps<"/products/[handle]">) {
   const locale = await getLocale();
   const handlePromise = params.then(({ handle }) => handle);
@@ -37,8 +38,9 @@ export default async function ProductPage({
     getProduct(handle, locale).catch(() => notFound()),
   );
 
-  // TEMP: disable searchParams to test Chrome fallback hypothesis
-  const variantIdPromise = Promise.resolve(undefined);
+  const variantIdPromise = searchParams.then(
+    (sp) => (sp?.variantId as string | undefined),
+  );
 
   return (
     <ProductDetailPage

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -16,12 +16,12 @@ export async function generateMetadata({
   return buildProductMetadata(handle, locale, `/products/${handle}`);
 }
 
+// TEMP: removed searchParams from samples to match disabled searchParams
 export const unstable_instant = {
   prefetch: "runtime",
   samples: [
     {
       params: { handle: "sample-product" },
-      searchParams: { variantId: "1" },
       cookies: [{ name: "shopify_cartId", value: null }],
     },
   ],
@@ -29,7 +29,6 @@ export const unstable_instant = {
 
 export default async function ProductPage({
   params,
-  searchParams,
 }: PageProps<"/products/[handle]">) {
   const locale = await getLocale();
   const handlePromise = params.then(({ handle }) => handle);
@@ -38,9 +37,8 @@ export default async function ProductPage({
     getProduct(handle, locale).catch(() => notFound()),
   );
 
-  const variantIdPromise = searchParams.then(
-    (sp) => (sp?.variantId as string | undefined),
-  );
+  // TEMP: disable searchParams to test Chrome fallback hypothesis
+  const variantIdPromise = Promise.resolve(undefined);
 
   return (
     <ProductDetailPage

--- a/apps/template/components/product/pdp/product-detail-page.tsx
+++ b/apps/template/components/product/pdp/product-detail-page.tsx
@@ -61,7 +61,7 @@ async function ProductContent({
   locale: Locale;
   variantIdPromise: Promise<string | undefined>;
 }) {
-  const [product, variantId] = await Promise.all([productPromise, variantIdPromise]);
+  const product = await productPromise;
   const { handle, title } = product;
 
   return (
@@ -83,7 +83,7 @@ async function ProductContent({
       <ProductBreadcrumbSchema title={title} handle={handle} />
 
       <div className="flex flex-col gap-12">
-        <VariantSection product={product} locale={locale} variantId={variantId} />
+        <VariantSection product={product} locale={locale} variantIdPromise={variantIdPromise} />
         <Recommendations handle={handle} locale={locale} />
       </div>
     </>

--- a/apps/template/components/product/pdp/product-media.tsx
+++ b/apps/template/components/product/pdp/product-media.tsx
@@ -153,33 +153,76 @@ function Carousel({ mediaItems, title }: { mediaItems: MediaItem[]; title: strin
   );
 }
 
+/** Single grid item — extracted for reuse between Grid and ColorImageGrid. */
+function GridItem({
+  item,
+  title,
+  idx,
+}: {
+  item: MediaItem;
+  title: string;
+  idx: number;
+}) {
+  return (
+    <div className="relative aspect-square w-full overflow-hidden bg-accent">
+      {item.type === "video" ? (
+        <MediaVideo item={item} />
+      ) : (
+        <LightboxTrigger item={item}>
+          <MediaImage
+            item={item}
+            title={title}
+            idx={idx}
+            sizes="(min-width: 1024px) 25vw, 50vw"
+            priority={idx < 2}
+          />
+        </LightboxTrigger>
+      )}
+    </div>
+  );
+}
+
 /** 2-column grid with lightbox for desktop viewports. */
-function Grid({ mediaItems, title }: { mediaItems: MediaItem[]; title: string }) {
+function Grid({
+  mediaItems,
+  title,
+  children,
+}: {
+  mediaItems: MediaItem[];
+  title: string;
+  children?: React.ReactNode;
+}) {
   return (
     <Lightbox label={title}>
       <div className="grid grid-cols-2 gap-2">
+        {children}
         {mediaItems.map((item, idx) => (
-          <div
-            key={mediaKey(item)}
-            className="relative aspect-square w-full overflow-hidden bg-accent"
-          >
-            {item.type === "video" ? (
-              <MediaVideo item={item} />
-            ) : (
-              <LightboxTrigger item={item}>
-                <MediaImage
-                  item={item}
-                  title={title}
-                  idx={idx}
-                  sizes="(min-width: 1024px) 25vw, 50vw"
-                  priority={idx < 2}
-                />
-              </LightboxTrigger>
-            )}
-          </div>
-        ))}      </div>
+          <GridItem key={mediaKey(item)} item={item} title={title} idx={idx} />
+        ))}
+      </div>
     </Lightbox>
   );
+}
+
+/**
+ * Renders color-specific images as grid items.
+ * Designed to be used inside a Suspense boundary as children of ProductMedia.
+ */
+export function ColorImageGrid({
+  images,
+  title,
+}: {
+  images: ImageType[];
+  title: string;
+}) {
+  return images.map((image, idx) => (
+    <GridItem
+      key={image.url}
+      item={{ type: "image", image }}
+      title={title}
+      idx={idx}
+    />
+  ));
 }
 
 export function ProductMedia({
@@ -188,29 +231,44 @@ export function ProductMedia({
   videos,
   title,
   className,
+  children,
 }: {
-  colorImages: ImageType[];
+  colorImages?: ImageType[];
   otherImages: ImageType[];
   videos: Video[];
   title: string;
   className?: string;
+  children?: React.ReactNode;
 }) {
-  // Order: color images → videos → other images
-  const mediaItems: MediaItem[] = [
-    ...colorImages.map((image): MediaItem => ({ type: "image", image })),
+  // Non-color media — always available immediately
+  const sharedMediaItems: MediaItem[] = [
     ...videos.map((video): MediaItem => ({ type: "video", video })),
     ...otherImages.map((image): MediaItem => ({ type: "image", image })),
   ];
 
-  if (mediaItems.length === 0) return null;
+  // Color images passed as data (non-suspended path)
+  const colorMediaItems: MediaItem[] = (colorImages ?? []).map(
+    (image): MediaItem => ({ type: "image", image }),
+  );
+
+  // Carousel uses all resolved items; color images from children aren't in the carousel
+  const carouselItems: MediaItem[] = [...colorMediaItems, ...sharedMediaItems];
+
+  if (carouselItems.length === 0 && !children) return null;
 
   return (
     <div className={className}>
       <div className="lg:hidden">
-        <Carousel mediaItems={mediaItems} title={title} />
+        {children && <div className="mb-4">{children}</div>}
+        <Carousel mediaItems={carouselItems} title={title} />
       </div>
       <div className="hidden lg:block">
-        <Grid mediaItems={mediaItems} title={title} />
+        <Grid mediaItems={sharedMediaItems} title={title}>
+          {colorMediaItems.map((item, idx) => (
+            <GridItem key={mediaKey(item)} item={item} title={title} idx={idx} />
+          ))}
+          {children}
+        </Grid>
       </div>
     </div>
   );

--- a/apps/template/components/product/pdp/variant-section.tsx
+++ b/apps/template/components/product/pdp/variant-section.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+
 import { BuyButtons } from "@/components/product/pdp/buy-buttons";
 import {
   ProductInfoDescription,
@@ -8,38 +10,68 @@ import { ProductMedia } from "@/components/product/pdp/product-media";
 import {
   computeInitialSelectedOptions,
   getPartitionedImagesForSelectedColor,
+  hasColorImagePartitioning,
   resolveSelectedVariant,
 } from "@/components/product/pdp/variants";
 import type { Locale } from "@/lib/i18n";
-import type { ProductDetails } from "@/lib/types";
+import type { Image, ProductDetails, ProductOption, ProductVariant, Video } from "@/lib/types";
 
 export function VariantSection({
   product,
   locale,
-  variantId,
+  variantIdPromise,
 }: {
   product: ProductDetails;
   locale: Locale;
-  variantId?: string;
+  variantIdPromise: Promise<string | undefined>;
 }) {
-
   const { handle, title, featuredImage, images, videos, variants, options } = product;
 
-  // TEMP: disable searchParams-driven variant/image selection to test Chrome fallback hypothesis
-  const selectedOptions = computeInitialSelectedOptions(variants, undefined);
-  const selectedVariant = resolveSelectedVariant(variants, selectedOptions);
-  const { colorImages, otherImages } = { colorImages: [] as typeof images, otherImages: images };
+  // Default selection (first variant) — no searchParams needed
+  const defaultOptions = computeInitialSelectedOptions(variants, undefined);
+  const selectedVariant = resolveSelectedVariant(variants, defaultOptions);
+
+  const needsPartitioning = hasColorImagePartitioning(options, variants);
 
   return (
     <div className="lg:grid lg:grid-cols-12 lg:items-start lg:gap-4 space-y-8 lg:space-y-0">
-      <ProductMedia colorImages={colorImages} otherImages={otherImages} videos={videos} title={title} className="lg:col-span-7" />
+      {needsPartitioning ? (
+        <Suspense
+          fallback={
+            <ProductMedia
+              colorImages={images.slice(0, 1)}
+              otherImages={[]}
+              videos={videos}
+              title={title}
+              className="lg:col-span-7"
+            />
+          }
+        >
+          <ColorAwareMedia
+            images={images}
+            options={options}
+            variants={variants}
+            videos={videos}
+            title={title}
+            variantIdPromise={variantIdPromise}
+          />
+        </Suspense>
+      ) : (
+        <ProductMedia
+          colorImages={[]}
+          otherImages={images}
+          videos={videos}
+          title={title}
+          className="lg:col-span-7"
+        />
+      )}
 
       <div className="space-y-8 lg:sticky lg:top-20 lg:col-span-5">
         <ProductInfoHeader selectedVariant={selectedVariant} title={title} locale={locale} />
         <ProductInfoOptions
           variants={variants}
           options={options}
-          selectedOptions={selectedOptions}
+          selectedOptions={defaultOptions}
           handle={handle}
         />
         <BuyButtons
@@ -52,5 +84,40 @@ export function VariantSection({
         <ProductInfoDescription descriptionHtml={product.descriptionHtml} />
       </div>
     </div>
+  );
+}
+
+async function ColorAwareMedia({
+  images,
+  options,
+  variants,
+  videos,
+  title,
+  variantIdPromise,
+}: {
+  images: Image[];
+  options: ProductOption[];
+  variants: ProductVariant[];
+  videos: Video[];
+  title: string;
+  variantIdPromise: Promise<string | undefined>;
+}) {
+  const variantId = await variantIdPromise;
+  const selectedOptions = computeInitialSelectedOptions(variants, variantId);
+  const { colorImages, otherImages } = getPartitionedImagesForSelectedColor(
+    images,
+    options,
+    variants,
+    selectedOptions,
+  );
+
+  return (
+    <ProductMedia
+      colorImages={colorImages}
+      otherImages={otherImages}
+      videos={videos}
+      title={title}
+      className="lg:col-span-7"
+    />
   );
 }

--- a/apps/template/components/product/pdp/variant-section.tsx
+++ b/apps/template/components/product/pdp/variant-section.tsx
@@ -25,9 +25,10 @@ export function VariantSection({
 
   const { handle, title, featuredImage, images, videos, variants, options } = product;
 
-  const selectedOptions = computeInitialSelectedOptions(variants, variantId);
+  // TEMP: disable searchParams-driven variant/image selection to test Chrome fallback hypothesis
+  const selectedOptions = computeInitialSelectedOptions(variants, undefined);
   const selectedVariant = resolveSelectedVariant(variants, selectedOptions);
-  const { colorImages, otherImages } = getPartitionedImagesForSelectedColor(images, options, variants, selectedOptions);
+  const { colorImages, otherImages } = { colorImages: [] as typeof images, otherImages: images };
 
   return (
     <div className="lg:grid lg:grid-cols-12 lg:items-start lg:gap-4 space-y-8 lg:space-y-0">

--- a/apps/template/components/product/pdp/variant-section.tsx
+++ b/apps/template/components/product/pdp/variant-section.tsx
@@ -6,15 +6,17 @@ import {
   ProductInfoHeader,
   ProductInfoOptions,
 } from "@/components/product/pdp/product-info";
-import { ProductMedia } from "@/components/product/pdp/product-media";
+import { ColorImageGrid, ProductMedia } from "@/components/product/pdp/product-media";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   computeInitialSelectedOptions,
   getPartitionedImagesForSelectedColor,
+  getSharedImages,
   hasColorImagePartitioning,
   resolveSelectedVariant,
 } from "@/components/product/pdp/variants";
 import type { Locale } from "@/lib/i18n";
-import type { Image, ProductDetails, ProductOption, ProductVariant, Video } from "@/lib/types";
+import type { Image, ProductDetails, ProductOption, ProductVariant } from "@/lib/types";
 
 export function VariantSection({
   product,
@@ -36,29 +38,28 @@ export function VariantSection({
   return (
     <div className="lg:grid lg:grid-cols-12 lg:items-start lg:gap-4 space-y-8 lg:space-y-0">
       {needsPartitioning ? (
-        <Suspense
-          fallback={
-            <ProductMedia
-              colorImages={images.slice(0, 1)}
-              otherImages={[]}
-              videos={videos}
-              title={title}
-              className="lg:col-span-7"
-            />
-          }
+        <ProductMedia
+          otherImages={getSharedImages(images, options, variants)}
+          videos={videos}
+          title={title}
+          className="lg:col-span-7"
         >
-          <ColorAwareMedia
-            images={images}
-            options={options}
-            variants={variants}
-            videos={videos}
-            title={title}
-            variantIdPromise={variantIdPromise}
-          />
-        </Suspense>
+          <Suspense
+            fallback={
+              <Skeleton className="aspect-square w-full col-span-2" />
+            }
+          >
+            <ResolvedColorImages
+              images={images}
+              options={options}
+              variants={variants}
+              title={title}
+              variantIdPromise={variantIdPromise}
+            />
+          </Suspense>
+        </ProductMedia>
       ) : (
         <ProductMedia
-          colorImages={[]}
           otherImages={images}
           videos={videos}
           title={title}
@@ -87,37 +88,29 @@ export function VariantSection({
   );
 }
 
-async function ColorAwareMedia({
+async function ResolvedColorImages({
   images,
   options,
   variants,
-  videos,
   title,
   variantIdPromise,
 }: {
   images: Image[];
   options: ProductOption[];
   variants: ProductVariant[];
-  videos: Video[];
   title: string;
   variantIdPromise: Promise<string | undefined>;
 }) {
   const variantId = await variantIdPromise;
   const selectedOptions = computeInitialSelectedOptions(variants, variantId);
-  const { colorImages, otherImages } = getPartitionedImagesForSelectedColor(
+  const { colorImages } = getPartitionedImagesForSelectedColor(
     images,
     options,
     variants,
     selectedOptions,
   );
 
-  return (
-    <ProductMedia
-      colorImages={colorImages}
-      otherImages={otherImages}
-      videos={videos}
-      title={title}
-      className="lg:col-span-7"
-    />
-  );
+  if (colorImages.length === 0) return null;
+
+  return <ColorImageGrid images={colorImages} title={title} />;
 }

--- a/apps/template/components/product/pdp/variants.ts
+++ b/apps/template/components/product/pdp/variants.ts
@@ -98,7 +98,11 @@ export function getVariantUrl(
     );
   }
 
-  // TEMP: disable searchParams to test Chrome fallback hypothesis
+  const numericId = variant ? getNumericShopifyId(variant.id) : null;
+  if (numericId) {
+    return `/products/${handle}?variantId=${numericId}`;
+  }
+
   return `/products/${handle}`;
 }
 
@@ -296,4 +300,32 @@ export function getPartitionedImagesForSelectedColor(
   }
 
   return { colorImages, otherImages };
+}
+
+/**
+ * Returns true when the product has multiple color variants with
+ * distinct images — meaning the gallery would change based on
+ * the selected color (i.e. based on searchParams).
+ *
+ * When this returns false, there's no reason to suspend on
+ * searchParams for the media gallery.
+ */
+export function hasColorImagePartitioning(
+  options: ProductOption[],
+  variants: ProductVariant[],
+): boolean {
+  const colorOption = options.find(
+    (opt) =>
+      opt.values.some((v) => v.swatch?.color || v.swatch?.image) ||
+      opt.name.toLowerCase().includes("color"),
+  );
+
+  if (!colorOption || colorOption.values.length <= 1) return false;
+
+  // Check if any variants have images assigned to the color option
+  return variants.some(
+    (v) =>
+      v.image &&
+      v.selectedOptions.some((opt) => opt.name === colorOption.name),
+  );
 }

--- a/apps/template/components/product/pdp/variants.ts
+++ b/apps/template/components/product/pdp/variants.ts
@@ -98,11 +98,7 @@ export function getVariantUrl(
     );
   }
 
-  const numericId = variant ? getNumericShopifyId(variant.id) : null;
-  if (numericId) {
-    return `/products/${handle}?variantId=${numericId}`;
-  }
-
+  // TEMP: disable searchParams to test Chrome fallback hypothesis
   return `/products/${handle}`;
 }
 

--- a/apps/template/components/product/pdp/variants.ts
+++ b/apps/template/components/product/pdp/variants.ts
@@ -329,3 +329,37 @@ export function hasColorImagePartitioning(
       v.selectedOptions.some((opt) => opt.name === colorOption.name),
   );
 }
+
+/**
+ * Returns images not assigned to any color variant.
+ * These "shared" images (e.g. lifestyle shots) can render
+ * without waiting for searchParams to resolve.
+ */
+export function getSharedImages(
+  images: Image[],
+  options: ProductOption[],
+  variants: ProductVariant[],
+): Image[] {
+  const colorOption = options.find(
+    (opt) =>
+      opt.values.some((v) => v.swatch?.color || v.swatch?.image) ||
+      opt.name.toLowerCase().includes("color"),
+  );
+
+  if (!colorOption || colorOption.values.length <= 1) return images;
+
+  const allColorImageUrls = new Set<string>();
+  for (const variant of variants) {
+    if (!variant.image) continue;
+    const colorOpt = variant.selectedOptions.find(
+      (opt) => opt.name === colorOption.name,
+    );
+    if (colorOpt) {
+      allColorImageUrls.add(variant.image.url);
+    }
+  }
+
+  if (allColorImageUrls.size === 0) return images;
+
+  return images.filter((img) => !allColorImageUrls.has(img.url));
+}


### PR DESCRIPTION
## Summary
- Temporarily disables all `searchParams` consumption on the PDP to test a hypothesis: Chrome shows a fallback shell on first visit when `searchParams` are read, but Safari does not.
- `variantId` is no longer extracted from the URL — variant pickers link to plain `/products/{handle}` URLs
- Color-based image partitioning is bypassed — all images show as "other"
- `unstable_instant` samples no longer include `searchParams`

## What this disables
- `?variantId=` URL param reading in `page.tsx`
- `?variantId=` generation in `getVariantUrl()`
- Color image filtering in `VariantSection`

## Test plan
- [ ] Deploy preview and test on Chrome — confirm no fallback flash on first PDP visit
- [ ] Compare with Safari behavior
- [ ] If confirmed, investigate a proper fix (likely `Suspense` boundary or `loading.tsx` placement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)