### PR TITLE
feat: reintroduce variant rewrite for PDP

### DIFF
--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -21,7 +21,6 @@ export const unstable_instant = {
   samples: [
     {
       params: { handle: "sample-product" },
-      searchParams: { variantId: "1" },
       cookies: [{ name: "shopify_cartId", value: null }],
     },
   ],
@@ -29,7 +28,6 @@ export const unstable_instant = {
 
 export default async function ProductPage({
   params,
-  searchParams,
 }: PageProps<"/products/[handle]">) {
   const locale = await getLocale();
   const handlePromise = params.then(({ handle }) => handle);
@@ -38,15 +36,10 @@ export default async function ProductPage({
     getProduct(handle, locale).catch(() => notFound()),
   );
 
-  const variantIdPromise = searchParams.then(
-    (sp) => (sp?.variantId as string | undefined),
-  );
-
   return (
     <ProductDetailPage
       productPromise={productPromise}
       locale={locale}
-      variantIdPromise={variantIdPromise}
     />
   );
 }

--- a/apps/template/app/products/[handle]/variants/[variantId]/page.tsx
+++ b/apps/template/app/products/[handle]/variants/[variantId]/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { ProductDetailPage } from "@/components/product/pdp/product-detail-page";
+import { getLocale } from "@/lib/params";
+import { getProduct } from "@/lib/shopify/operations/products";
+
+import { buildProductMetadata } from "../../shared";
+
+type Params = { handle: string; variantId: string };
+type Props = { params: Promise<Params> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const [{ handle, variantId }, locale] = await Promise.all([
+    params,
+    getLocale(),
+  ]);
+
+  return buildProductMetadata(
+    handle,
+    locale,
+    `/products/${handle}?variantId=${variantId}`,
+  );
+}
+
+export default async function ProductVariantPage({ params }: Props) {
+  const locale = await getLocale();
+  const handlePromise = params.then(({ handle }) => handle);
+
+  const productPromise = handlePromise.then((handle) =>
+    getProduct(handle, locale).catch(() => notFound()),
+  );
+
+  const variantIdPromise = params.then(({ variantId }) => variantId);
+
+  return (
+    <ProductDetailPage
+      productPromise={productPromise}
+      locale={locale}
+      variantIdPromise={variantIdPromise}
+    />
+  );
+}

--- a/apps/template/components/product/pdp/product-detail-page.tsx
+++ b/apps/template/components/product/pdp/product-detail-page.tsx
@@ -55,13 +55,13 @@ function ProductPageFallback() {
 async function ProductContent({
   productPromise,
   locale,
-  variantIdPromise,
+  variantId,
 }: {
   productPromise: Promise<ProductDetails>;
   locale: Locale;
-  variantIdPromise: Promise<string | undefined>;
+  variantId?: string;
 }) {
-  const [product, variantId] = await Promise.all([productPromise, variantIdPromise]);
+  const product = await productPromise;
   const { handle, title } = product;
 
   return (
@@ -97,12 +97,14 @@ export async function ProductDetailPage({
 }: {
   productPromise: Promise<ProductDetails>;
   locale: Locale;
-  variantIdPromise: Promise<string | undefined>;
+  variantIdPromise?: Promise<string | undefined>;
 }) {
+  const variantId = await variantIdPromise;
+
   return (
     <Container className="bg-background pt-0 lg:pt-8">
       <Suspense fallback={<ProductPageFallback />}>
-        <ProductContent productPromise={productPromise} locale={locale} variantIdPromise={variantIdPromise} />
+        <ProductContent productPromise={productPromise} locale={locale} variantId={variantId} />
       </Suspense>
     </Container>
   );

--- a/apps/template/components/product/pdp/product-detail-page.tsx
+++ b/apps/template/components/product/pdp/product-detail-page.tsx
@@ -55,13 +55,16 @@ function ProductPageFallback() {
 async function ProductContent({
   productPromise,
   locale,
-  variantId,
+  variantIdPromise,
 }: {
   productPromise: Promise<ProductDetails>;
   locale: Locale;
-  variantId?: string;
+  variantIdPromise?: Promise<string | undefined>;
 }) {
-  const product = await productPromise;
+  const [product, variantId] = await Promise.all([
+    productPromise,
+    variantIdPromise,
+  ]);
   const { handle, title } = product;
 
   return (
@@ -90,7 +93,7 @@ async function ProductContent({
   );
 }
 
-export async function ProductDetailPage({
+export function ProductDetailPage({
   productPromise,
   locale,
   variantIdPromise,
@@ -99,12 +102,10 @@ export async function ProductDetailPage({
   locale: Locale;
   variantIdPromise?: Promise<string | undefined>;
 }) {
-  const variantId = await variantIdPromise;
-
   return (
     <Container className="bg-background pt-0 lg:pt-8">
       <Suspense fallback={<ProductPageFallback />}>
-        <ProductContent productPromise={productPromise} locale={locale} variantId={variantId} />
+        <ProductContent productPromise={productPromise} locale={locale} variantIdPromise={variantIdPromise} />
       </Suspense>
     </Container>
   );

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -30,7 +30,15 @@ const nextConfig: NextConfig = {
           has: [{ type: "header", key: "accept", value: "(.*)text/markdown(.*)" }],
         },
       ],
-      afterFiles: [],
+      afterFiles: [
+        {
+          source: "/products/:handle",
+          has: [
+            { type: "query", key: "variantId", value: "(?<variantId>.+)" },
+          ],
+          destination: "/products/:handle/variants/:variantId",
+        },
+      ],
       fallback: [],
     };
   },


### PR DESCRIPTION
## Summary
- Reintroduces the `next.config.ts` rewrite approach for variant selection on the PDP, replacing `searchParams`
- `searchParams` on the PDP causes Chrome to show a fallback skeleton on first visit (confirmed in #122) — Safari doesn't exhibit this behavior
- The rewrite maps `/products/:handle?variantId=X` → `/products/:handle/variants/:variantId`, a hidden ISR route
- Base `/products/[handle]` page no longer reads `searchParams` at all — fully static
- Each variant URL gets its own ISR-cached page via the hidden route

## Changes
- **next.config.ts**: add `afterFiles` rewrite for `?variantId` query → `/variants/:variantId` sub-route
- **products/[handle]/page.tsx**: remove `searchParams` from signature, no more `variantIdPromise`
- **products/[handle]/variants/[variantId]/page.tsx**: new hidden route, reads `variantId` from `params`
- **product-detail-page.tsx**: resolves optional `variantIdPromise` at the top, passes string to content

## Test plan
- [ ] Visit `/products/{handle}` on Chrome — no fallback flash
- [ ] Visit `/products/{handle}?variantId=X` on Chrome — correct variant renders, no fallback flash  
- [ ] Click variant pickers — soft navigation (no hard reload), URL updates with `?variantId=`
- [ ] Compare Chrome vs Safari behavior — should be identical now
- [ ] Verify ISR caching: second visit to same `?variantId=` URL should be instant

🤖 Generated with [Claude Code](https://claude.com/claude-code)