### PR TITLE
Add a no-template CLI mode for agent-only plugin installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ The scaffold also installs these project-scoped agent plugins:
 - `vercel-plugin`
 - `shopify-ai-toolkit`
 
+To install only the agent plugins into an existing project, run this from that project's root:
+
+```sh
+npx create-vercel-shop@latest --no-template
+```
+
 2. In Shopify admin, create a storefront token in **Settings → Apps and sales channels → Headless**, enable the required Storefront API permissions, then add your Shopify credentials:
 
 ```sh

--- a/apps/cli/index.mjs
+++ b/apps/cli/index.mjs
@@ -1,17 +1,24 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { resolve, join } from 'node:path';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-const userAgent = process.env.npm_config_user_agent ?? '';
-const execPath = process.env.npm_execpath ?? '';
-const cliArgs = process.argv.slice(2);
+export const NO_TEMPLATE_FLAG = '--no-template';
 
-const hasExplicitPackageManagerFlag = cliArgs.some((arg) =>
-  ['--use-pnpm', '--use-npm', '--use-yarn', '--use-bun'].includes(arg),
-);
+const PACKAGE_MANAGER_FLAGS = ['--use-pnpm', '--use-npm', '--use-yarn', '--use-bun'];
+const flagsWithValues = new Set(['--import-alias']);
+const pluginInstalls = [
+  ['vercel/shop', '--scope', 'project', '--yes'],
+  ['vercel/vercel-plugin', '--scope', 'project', '--yes'],
+  ['Shopify/shopify-ai-toolkit', '--scope', 'project', '--yes'],
+];
 
-function detectPackageManager() {
+export function hasExplicitPackageManagerFlag(args) {
+  return args.some((arg) => PACKAGE_MANAGER_FLAGS.includes(arg));
+}
+
+export function detectPackageManager({ userAgent = '', execPath = '' } = {}) {
   if (userAgent.startsWith('pnpm/')) return 'pnpm';
   if (userAgent.startsWith('bun/')) return 'bun';
   if (userAgent.startsWith('yarn/')) return 'yarn';
@@ -25,22 +32,23 @@ function detectPackageManager() {
   return null;
 }
 
-const detectedPackageManager = hasExplicitPackageManagerFlag
-  ? null
-  : detectPackageManager();
-
-const packageManagerFlag =
-  detectedPackageManager === 'pnpm'
+export function getPackageManagerFlag(packageManager) {
+  return packageManager === 'pnpm'
     ? '--use-pnpm'
-    : detectedPackageManager === 'bun'
+    : packageManager === 'bun'
       ? '--use-bun'
-      : detectedPackageManager === 'yarn'
+      : packageManager === 'yarn'
         ? '--use-yarn'
-        : detectedPackageManager === 'npm'
+        : packageManager === 'npm'
           ? '--use-npm'
           : null;
+}
 
-function getRunner(packageManager) {
+export function stripInternalArgs(args) {
+  return args.filter((arg) => arg !== NO_TEMPLATE_FLAG);
+}
+
+export function getRunner(packageManager) {
   if (packageManager === 'pnpm') {
     return { command: 'pnpm', args: ['dlx'] };
   }
@@ -56,11 +64,7 @@ function getRunner(packageManager) {
   return { command: 'npx', args: [] };
 }
 
-const runner = getRunner(detectedPackageManager);
-const templateVersion = await readTemplateVersion();
-
-function findProjectDir(args) {
-  const flagsWithValues = new Set(['--import-alias']);
+export function findProjectDir(args, cwd = process.cwd()) {
   let skipNext = false;
 
   for (const arg of args) {
@@ -79,21 +83,67 @@ function findProjectDir(args) {
     }
 
     if (!arg.startsWith('-')) {
-      return resolve(process.cwd(), arg);
+      return resolve(cwd, arg);
     }
   }
 
-  return process.cwd();
+  return cwd;
 }
 
-async function readTemplateVersion() {
-  const packageJson = new URL('./package.json', import.meta.url);
+export function getScaffoldArgs({ cliArgs, packageManagerFlag, runnerArgs = [] }) {
+  return [
+    ...runnerArgs,
+    'create-next-app@latest',
+    '--example',
+    'https://github.com/vercel/shop',
+    '--example-path',
+    'apps/template',
+    ...(packageManagerFlag ? [packageManagerFlag] : []),
+    ...cliArgs,
+  ];
+}
+
+export function createExecutionPlan({
+  cliArgs,
+  cwd = process.cwd(),
+  execPath = process.env.npm_execpath ?? '',
+  userAgent = process.env.npm_config_user_agent ?? '',
+} = {}) {
+  const forwardedArgs = stripInternalArgs(cliArgs);
+  const explicitPackageManager = hasExplicitPackageManagerFlag(cliArgs);
+  const detectedPackageManager = explicitPackageManager
+    ? null
+    : detectPackageManager({ userAgent, execPath });
+  const packageManagerFlag = getPackageManagerFlag(detectedPackageManager);
+  const runner = getRunner(detectedPackageManager);
+  const noTemplate = cliArgs.includes(NO_TEMPLATE_FLAG);
+  const projectDir = findProjectDir(forwardedArgs, cwd);
+
+  return {
+    detectedPackageManager,
+    forwardedArgs,
+    noTemplate,
+    packageManagerFlag,
+    projectDir,
+    runner,
+    scaffoldArgs: noTemplate
+      ? null
+      : getScaffoldArgs({
+          cliArgs: forwardedArgs,
+          packageManagerFlag,
+          runnerArgs: runner.args,
+        }),
+  };
+}
+
+export async function readTemplateVersion(importMetaUrl = import.meta.url) {
+  const packageJson = new URL('./package.json', importMetaUrl);
   const raw = await readFile(packageJson, 'utf8');
   const pkg = JSON.parse(raw);
   return pkg.shopTemplateVersion;
 }
 
-function runCommand(command, args, options = {}) {
+export function runCommand(command, args, options = {}) {
   return new Promise((resolveRun) => {
     const child = spawn(command, args, {
       stdio: 'inherit',
@@ -110,7 +160,11 @@ function runCommand(command, args, options = {}) {
   });
 }
 
-async function writeBootstrapMetadata(projectDir) {
+export async function ensureProjectDir(projectDir) {
+  await mkdir(projectDir, { recursive: true });
+}
+
+export async function writeBootstrapMetadata(projectDir, templateVersion) {
   const metadataDir = join(projectDir, '.vercel-shop');
   const metadataPath = join(metadataDir, 'bootstrap.json');
 
@@ -122,17 +176,11 @@ async function writeBootstrapMetadata(projectDir) {
   );
 }
 
-async function installProjectPlugins(projectDir) {
-  const installs = [
-    ['vercel/shop', '--scope', 'project', '--yes'],
-    ['vercel/vercel-plugin', '--scope', 'project', '--yes'],
-    ['Shopify/shopify-ai-toolkit', '--scope', 'project', '--yes'],
-  ];
-
+export async function installProjectPlugins(projectDir, run = runCommand) {
   const failures = [];
 
-  for (const args of installs) {
-    const code = await runCommand('npx', ['plugins', 'add', ...args], {
+  for (const args of pluginInstalls) {
+    const code = await run('npx', ['plugins', 'add', ...args], {
       cwd: projectDir,
     });
 
@@ -144,42 +192,64 @@ async function installProjectPlugins(projectDir) {
   return failures;
 }
 
-function printRetryCommands(projectDir) {
-  console.warn('\nVercel Shop scaffolded successfully, but one or more plugin installs failed.');
+export function printRetryCommands(projectDir, { scaffolded = true } = {}) {
+  if (scaffolded) {
+    console.warn('\nVercel Shop scaffolded successfully, but one or more plugin installs failed.');
+  } else {
+    console.warn('\nProject plugin installation failed.');
+  }
+
   console.warn(`Retry from ${projectDir}:`);
   console.warn('  npx plugins add vercel/shop --scope project --yes');
   console.warn('  npx plugins add vercel/vercel-plugin --scope project --yes');
   console.warn('  npx plugins add Shopify/shopify-ai-toolkit --scope project --yes');
 }
 
-const scaffoldCode = await runCommand(runner.command, [
-  ...runner.args,
-  'create-next-app@latest',
-  '--example',
-  'https://github.com/vercel/shop',
-  '--example-path',
-  'apps/template',
-  ...(packageManagerFlag ? [packageManagerFlag] : []),
-  ...cliArgs,
-]);
+export async function main({
+  cliArgs = process.argv.slice(2),
+  cwd = process.cwd(),
+  execPath = process.env.npm_execpath ?? '',
+  importMetaUrl = import.meta.url,
+  run = runCommand,
+  userAgent = process.env.npm_config_user_agent ?? '',
+} = {}) {
+  const plan = createExecutionPlan({
+    cliArgs,
+    cwd,
+    execPath,
+    userAgent,
+  });
 
-if (scaffoldCode !== 0) {
-  process.exit(scaffoldCode);
+  if (!plan.noTemplate) {
+    const scaffoldCode = await run(plan.runner.command, plan.scaffoldArgs);
+
+    if (scaffoldCode !== 0) {
+      return scaffoldCode;
+    }
+
+    try {
+      const templateVersion = await readTemplateVersion(importMetaUrl);
+      await writeBootstrapMetadata(plan.projectDir, templateVersion);
+    } catch (error) {
+      console.warn('\nScaffold completed, but bootstrap metadata could not be written.');
+      console.warn(error instanceof Error ? error.message : String(error));
+      printRetryCommands(plan.projectDir);
+      return 0;
+    }
+  } else {
+    await ensureProjectDir(plan.projectDir);
+  }
+
+  const failedPlugins = await installProjectPlugins(plan.projectDir, run);
+
+  if (failedPlugins.length > 0) {
+    printRetryCommands(plan.projectDir, { scaffolded: !plan.noTemplate });
+  }
+
+  return 0;
 }
 
-const projectDir = findProjectDir(cliArgs);
-
-try {
-  await writeBootstrapMetadata(projectDir);
-} catch (error) {
-  console.warn('\nScaffold completed, but bootstrap metadata could not be written.');
-  console.warn(error instanceof Error ? error.message : String(error));
-  printRetryCommands(projectDir);
-  process.exit(0);
-}
-
-const failedPlugins = await installProjectPlugins(projectDir);
-
-if (failedPlugins.length > 0) {
-  printRetryCommands(projectDir);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const exitCode = await main();
+  process.exit(exitCode);
 }

--- a/apps/cli/index.test.mjs
+++ b/apps/cli/index.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+
+import { createExecutionPlan, main, readTemplateVersion } from './index.mjs';
+
+test('createExecutionPlan removes internal flags and targets cwd by default for --no-template', () => {
+  const cwd = '/tmp/workspace';
+  const plan = createExecutionPlan({
+    cliArgs: ['--no-template', '--use-pnpm'],
+    cwd,
+    userAgent: 'pnpm/10.0.0',
+  });
+
+  assert.equal(plan.noTemplate, true);
+  assert.deepEqual(plan.forwardedArgs, ['--use-pnpm']);
+  assert.equal(plan.projectDir, cwd);
+  assert.equal(plan.scaffoldArgs, null);
+});
+
+test('createExecutionPlan finds the project directory after option values', () => {
+  const cwd = '/tmp/workspace';
+  const plan = createExecutionPlan({
+    cliArgs: ['--import-alias', '@/*', 'my-store', '--no-template'],
+    cwd,
+  });
+
+  assert.equal(plan.projectDir, join(cwd, 'my-store'));
+  assert.deepEqual(plan.forwardedArgs, ['--import-alias', '@/*', 'my-store']);
+});
+
+test('main skips scaffolding and only installs plugins with --no-template', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const projectDir = join(tempRoot, 'existing-project');
+  const calls = [];
+
+  try {
+    const exitCode = await main({
+      cliArgs: ['--no-template', projectDir],
+      cwd: tempRoot,
+      run: async (command, args, options = {}) => {
+        calls.push({ command, args, options });
+        return 0;
+      },
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(calls.length, 3);
+    assert.ok(calls.every(({ command }) => command === 'npx'));
+    assert.ok(
+      calls.every(({ args }) => args[0] === 'plugins' && args[1] === 'add'),
+    );
+    assert.ok(calls.every(({ options }) => options.cwd === projectDir));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('main scaffolds the template and writes bootstrap metadata by default', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const projectName = 'my-store';
+  const projectDir = join(tempRoot, projectName);
+  const calls = [];
+
+  try {
+    const exitCode = await main({
+      cliArgs: [projectName],
+      cwd: tempRoot,
+      run: async (command, args, options = {}) => {
+        calls.push({ command, args, options });
+        return 0;
+      },
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(calls.length, 4);
+    assert.equal(calls[0].command, 'npx');
+    assert.ok(calls[0].args.includes('create-next-app@latest'));
+    assert.ok(calls[0].args.includes(projectName));
+
+    const bootstrapMetadata = JSON.parse(
+      await readFile(join(projectDir, '.vercel-shop', 'bootstrap.json'), 'utf8'),
+    );
+
+    assert.equal(bootstrapMetadata.templateVersion, await readTemplateVersion());
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});

--- a/apps/docs/app/(home)/components/one-two-section.tsx
+++ b/apps/docs/app/(home)/components/one-two-section.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 interface OneTwoSectionProps {
   children?: ReactNode;
-  description: string;
+  description: ReactNode;
   reverse?: boolean;
   title: string;
 }
@@ -18,9 +18,9 @@ export const OneTwoSection = ({
       <h2 className="font-sans font-semibold text-xl tracking-tight dark:text-white sm:text-2xl md:text-3xl">
         {title}
       </h2>
-      <p className="mt-2 text-balance text-lg text-muted-foreground">
+      <div className="mt-2 text-balance text-lg text-muted-foreground">
         {description}
-      </p>
+      </div>
     </div>
     <div className="sm:col-span-2 sm:p-12">{children}</div>
   </div>

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -52,7 +52,20 @@ const HomePage = () => (
 				<FakeBrowser />
 			</CenteredSection>
 			<OneTwoSection
-				description="The vercel-shop plugin and template recipes let agents extend your store with a single command. Add markets, CMS, auth, and more."
+				description={
+					<>
+						<p>
+							The vercel-shop plugin and template recipes let agents extend your
+							store with a single command. Add markets, CMS, auth, and more.
+						</p>
+						<div className="mt-4 max-w-[22rem]">
+							<Installer
+								className="w-full"
+								command="npx create-vercel-shop@latest --no-template"
+							/>
+						</div>
+					</>
+				}
 				title="Agentic development"
 				reverse
 			>

--- a/apps/docs/content/docs/getting-started/extending-with-agents.mdx
+++ b/apps/docs/content/docs/getting-started/extending-with-agents.mdx
@@ -26,6 +26,14 @@ After [creating your project](/docs/getting-started), `create-vercel-shop` insta
 - `vercel-plugin` for generic Vercel and Next.js guidance
 - `shopify-ai-toolkit` for Shopify-aware tooling and schema access
 
+If you already have a project and only want the agent setup, run this from the project root instead:
+
+```bash
+npx create-vercel-shop@latest --no-template
+```
+
+That skips the storefront scaffold and only installs the expected project-scoped plugins.
+
 If any of them are missing, rerun:
 
 ```bash

--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -36,6 +36,16 @@ npx create-vercel-shop@latest my-store
 
 `create-vercel-shop` also installs the `vercel-shop`, `vercel-plugin`, and `shopify-ai-toolkit` plugins in project scope so a coding agent can start working with the project immediately.
 
+### Add the agent setup to an existing project
+
+If you already have a repo and only want the project-scoped agent plugins, run this from the project root:
+
+```bash
+npx create-vercel-shop@latest --no-template
+```
+
+This skips the storefront scaffold and only installs the `vercel-shop`, `vercel-plugin`, and `shopify-ai-toolkit` plugins in project scope.
+
 ### Start from v0
 
 You can also use [v0](https://v0.dev) to generate a storefront and iterate on the design before connecting it to Shopify.
@@ -54,7 +64,7 @@ You can find the storefront token in **Settings → Apps and sales channels → 
 
 ## Step 4: Run locally
 
-`create-vercel-shop` uses the package manager you used to scaffold the project. Start the dev server with the matching command:
+If you scaffolded the storefront, `create-vercel-shop` uses the package manager you used to scaffold the project. Start the dev server with the matching command:
 
 ```bash
 pnpm dev

--- a/apps/docs/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/content/docs/reference/troubleshooting.mdx
@@ -74,7 +74,13 @@ Coding agents rely on `AGENTS.md` in the project root plus the expected project-
 - Verify you cloned from the correct template (`vercel/shop`, `apps/template` path)
 - The `AGENTS.md` file should be at the project root, not nested in a subdirectory
 - Check that `.claude/settings.json` exists and that the project plugins are enabled
-- Rerun the project plugin installs if needed:
+- Rerun the project plugin setup from the project root if needed:
+
+```bash
+npx create-vercel-shop@latest --no-template
+```
+
+If that still fails, rerun the plugin installs individually:
 
 ```bash
 npx plugins add vercel/shop --scope project --yes


### PR DESCRIPTION
## Summary
- add `--no-template` to `create-vercel-shop` so existing projects can install Vercel Shop agent plugins without scaffolding the template
- refactor the CLI into testable helpers and add `node:test` coverage for both scaffolded and plugin-only flows
- update the README, getting started docs, troubleshooting guide, and homepage agent section to point agent-only setup to `npx create-vercel-shop@latest --no-template`

## Testing
- `node --test apps/cli/index.test.mjs`
- `pnpm --filter docs typecheck` (fails in this worktree because docs dependencies are unavailable)