### PR TITLE
Update package versions to 0.1.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -3,7 +3,7 @@
 		"create-vercel-shop": "index.mjs"
 	},
 	"name": "create-vercel-shop",
-	"shopTemplateVersion": "0.20260414.0",
+	"shopTemplateVersion": "0.1.0",
 	"type": "module",
-	"version": "0.0.2"
+	"version": "0.1.0"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -52,5 +52,5 @@
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},
-	"version": "0.20260414.2"
+	"version": "0.1.0"
 }

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -46,5 +46,5 @@
 		"lint": "oxlint . && oxfmt --check",
 		"start": "next start"
 	},
-	"version": "0.20260414.2"
+	"version": "0.1.0"
 }

--- a/packages/plugin/template-version.json
+++ b/packages/plugin/template-version.json
@@ -1,3 +1,3 @@
 {
-  "templateVersion": "0.20260414.0"
+  "templateVersion": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- replace date-based template version values with `0.1.0`
- align the CLI package version and `shopTemplateVersion` with the same `0.1.0` release
- update plugin template version metadata to match the template and docs packages

## Testing
- Not run (not requested)