### PR TITLE
Add template rollout log and upgrade planning guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ The docs app is in apps/docs using [fromsrc](https://www.fromsrc.com). It is lin
 
 * The main app in this monorepo is apps/template, which is a template/reference architecture for using Shopify and Next.js. Learn more by reading the AGENTS.md in the directory. It is linked to the vercel-labs/shop-template project on Vercel.
 * You MUST check if a feature being updated in the template is documented in the docs application. If so, also update the documentation.
+* When a template change is something downstream storefronts may want to adopt later, add an entry to `packages/plugin/template-rollout-log/` so agents can reason about change-level rollout instead of only template versions.
 
 ## Skills
 

--- a/apps/cli/index.mjs
+++ b/apps/cli/index.mjs
@@ -164,14 +164,18 @@ export async function ensureProjectDir(projectDir) {
   await mkdir(projectDir, { recursive: true });
 }
 
-export async function writeBootstrapMetadata(projectDir, templateVersion) {
+export async function writeBootstrapMetadata(
+  projectDir,
+  templateVersion,
+  scaffoldedAt = new Date().toISOString(),
+) {
   const metadataDir = join(projectDir, '.vercel-shop');
   const metadataPath = join(metadataDir, 'bootstrap.json');
 
   await mkdir(metadataDir, { recursive: true });
   await writeFile(
     metadataPath,
-    `${JSON.stringify({ templateVersion }, null, 2)}\n`,
+    `${JSON.stringify({ scaffoldedAt, templateVersion }, null, 2)}\n`,
     'utf8',
   );
 }

--- a/apps/cli/index.test.mjs
+++ b/apps/cli/index.test.mjs
@@ -85,6 +85,8 @@ test('main scaffolds the template and writes bootstrap metadata by default', asy
     );
 
     assert.equal(bootstrapMetadata.templateVersion, await readTemplateVersion());
+    assert.equal(typeof bootstrapMetadata.scaffoldedAt, 'string');
+    assert.ok(Number.isFinite(Date.parse(bootstrapMetadata.scaffoldedAt)));
   } finally {
     await rm(tempRoot, { force: true, recursive: true });
   }

--- a/apps/docs/content/docs/getting-started/extending-with-agents.mdx
+++ b/apps/docs/content/docs/getting-started/extending-with-agents.mdx
@@ -22,7 +22,7 @@ Any agent that reads markdown context files will work. The ones we've tested mos
 
 After [creating your project](/docs/getting-started), `create-vercel-shop` installs the project plugins that the template expects:
 
-- `vercel-shop` for storefront skills and bootstrap/drift commands
+- `vercel-shop` for storefront skills plus bootstrap, drift, and upgrade-planning commands
 - `vercel-plugin` for generic Vercel and Next.js guidance
 - `shopify-ai-toolkit` for Shopify-aware tooling and schema access
 
@@ -43,6 +43,8 @@ npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 ```
 
 The combined plugin setup gives Claude Code both storefront-specific skills and the broader Vercel/Next.js guidance used across the stack.
+
+For upgrade work, the `vercel-shop` plugin also carries a template rollout log. That gives agents change-level context about template updates that downstream storefronts may want to adopt, instead of forcing them to guess from a single scaffold version. New scaffolds also record bootstrap metadata so agents can compare rollout entries against when a project was created.
 
 ## What are skills?
 

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -30,6 +30,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 2. **New user-visible strings go in ALL locale files** (`en.json`, etc.) so the documented multi-locale upgrade path stays mechanical.
 3. **Components in `ui/` must NOT import domain types**. Accept primitive props only and never call `useTranslations`.
 4. **Always verify Shopify GraphQL fields against the live schema via `shopify-ai-toolkit` or `/vercel-shop:shopify-graphql-reference`**. Never guess Shopify field names.
+5. **If a template change should be considered for existing storefronts, add a rollout entry in `packages/plugin/template-rollout-log/`**. Do not rely on the template version number alone.
 
 ## Overview
 
@@ -75,6 +76,16 @@ Common entry points:
 - Shopify metaobject CMS: `/vercel-shop:enable-shopify-cms`
 - Navigation menus: `/vercel-shop:enable-shopify-menus`
 - Analytics: `/vercel-shop:enable-analytics`
+
+## Template Rollout Log
+
+The `vercel-shop` plugin includes a template rollout log in `packages/plugin/template-rollout-log/` for downstream adoption work.
+
+- Add one append-only markdown entry for each template change that downstream storefronts may want to review or adopt.
+- Keep entries change-scoped. Do not batch unrelated work into one log item.
+- Include what changed, why it matters, when it applies, safe skip cases, and validation steps.
+- Prefer `changeKey`, `introducedOn`, and any bootstrap `scaffoldedAt` metadata over version math when reasoning about rollout order.
+- Treat the log as the source of truth for rollout planning. The template version is only a hint.
 
 ## Shopify GraphQL Workflow
 

--- a/packages/plugin/commands/vercel-shop-plan-upgrade.md
+++ b/packages/plugin/commands/vercel-shop-plan-upgrade.md
@@ -1,0 +1,54 @@
+---
+description: Plan which template updates should be rolled into an existing Vercel Shop project by combining scaffold metadata, the template rollout log, and the current project state.
+---
+
+# Plan a Vercel Shop upgrade
+
+Use this command in an existing Vercel Shop project when the user wants to know which template updates are worth carrying forward into a customized storefront.
+
+## Read these inputs
+
+1. `.vercel-shop/bootstrap.json` in the project root if it exists
+2. `template-version.json` from this plugin
+3. every markdown entry in `template-rollout-log/` from this plugin except `README.md`
+4. `AGENTS.md`
+5. `.claude/settings.json` if present
+6. the current project structure and any obviously relevant files mentioned by matching rollout entries
+
+## Core rule
+
+Do not treat the template version as a complete migration plan. Use the rollout log to reason about individual changes because downstream projects may intentionally adopt only some of them. If bootstrap metadata includes `scaffoldedAt`, use that timestamp as the primary hint for which rollout entries are likely new to the project.
+
+## What to do
+
+1. Identify the original scaffold version if bootstrap metadata exists.
+2. Identify the scaffold timestamp if bootstrap metadata includes `scaffoldedAt`.
+3. Read the rollout log entries that are likely newer than the project based on `scaffoldedAt`, file dates, or version hints, plus any older entries that still look applicable from the current project state.
+4. For each relevant entry, decide one of:
+   - adopt now
+   - review manually
+   - not applicable
+   - already present
+5. Validate each decision against the current codebase. Do not assume a change is missing just because the version is old.
+6. Call out uncertainty when a project has heavily diverged from template conventions.
+
+## Report format
+
+Return a concise upgrade plan with:
+
+- original scaffold version if known
+- scaffold timestamp if known
+- current recommended template version
+- a short note on overall drift
+- `Adopt now` entries
+- `Review manually` entries
+- `Already present` entries
+- `Not applicable` entries
+- follow-up commands or skills to use for the selected work
+
+## Important behavior
+
+- This is a planning pass. Do not edit files unless the user explicitly asks you to apply selected updates.
+- Prefer rollout log evidence over broad version assumptions.
+- If `.vercel-shop/bootstrap.json` is missing, say the project predates bootstrap metadata and continue with a best-effort audit.
+- If the rollout log has no applicable entries, say so explicitly instead of inventing upgrade work.

--- a/packages/plugin/template-rollout-log/README.md
+++ b/packages/plugin/template-rollout-log/README.md
@@ -1,0 +1,79 @@
+# Template Rollout Log
+
+This directory is the change-level rollout log for the shop template.
+
+Use it when a template update may need to be reviewed or selectively adopted by existing storefronts. A template version alone is too coarse because downstream apps often take only part of the template over time.
+
+## Rules
+
+- Add one new markdown file per rollout-worthy template change.
+- Keep the log append-only. Do not rewrite old entries unless they are factually wrong.
+- Keep entries narrow. One entry should describe one change or one tightly related set of edits.
+- Prefer concrete file paths, behavior changes, and validation steps over vague summaries.
+- Note when a change is optional, only applies with another feature, or is safe to skip.
+
+## File naming
+
+Use a date-first slug so entries sort naturally:
+
+```text
+YYYY-MM-DD-short-change-name.md
+```
+
+## Suggested entry shape
+
+```md
+---
+title: Short change title
+changeKey: locale-routing-alternates
+introducedInVersion: 0.1.0
+introducedOn: 2026-04-14
+changeType: feature | fix | breaking | refactor | dependency | docs | meta
+defaultAction: adopt | review | ignore
+appliesTo:
+  - all
+paths:
+  - app/example/page.tsx
+relatedSkills:
+  - /vercel-shop:enable-shopify-markets
+---
+
+## Summary
+
+What changed in the template.
+
+## Why it matters
+
+Why a downstream storefront might want this.
+
+## Apply when
+
+Signals that the change is relevant.
+
+## Safe to skip when
+
+Cases where the change should not be rolled out.
+
+## Validation
+
+Concrete checks an agent can run after applying it.
+```
+
+## Frontmatter guidance
+
+- `changeKey`: stable identifier for the rollout item
+- `introducedInVersion`: optional template version that first included the change
+- `introducedOn`: optional calendar date the change landed in the template
+- `changeType`: categorize the change for triage
+- `defaultAction`: the default recommendation for downstream projects
+- `appliesTo`: use `all` or a short list such as `markets-enabled`, `auth-enabled`, `cms-enabled`
+- `paths`: relevant template files or directories
+- `relatedSkills`: optional plugin commands or skills that help apply the change
+
+Agents should prefer `introducedOn` and the bootstrap `scaffoldedAt` timestamp when ordering rollout candidates. Versions are only hints.
+
+## Scope
+
+Only log changes that downstream storefronts may reasonably want to compare, adopt, or consciously skip.
+
+Do not add entries for every docs-only tweak, typo fix, or purely local maintenance task unless it changes rollout guidance for downstream projects.


### PR DESCRIPTION
## Summary
- add a `vercel-shop-plan-upgrade` command to plan selective template rollouts for existing storefronts
- introduce a template rollout log format for recording change-level adoption guidance
- record `scaffoldedAt` in bootstrap metadata so agents can compare rollout entries against project creation time
- update repo, template, and docs guidance to treat rollout entries as the source of truth over version math

## Testing
- `node --test apps/cli/index.test.mjs`
- `git diff --check`