### PR TITLE
Add content negotiation for collection and search pages

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -88,7 +88,7 @@ const HomePage = () => (
 				<CartDemo />
 			</OneTwoSection>
 			<OneTwoSection
-				description="Product pages serve structured markdown to LLM agents via Accept header — making your catalog AI-readable."
+				description="Product, collection, and search pages serve structured markdown to LLM agents via Accept header — making your storefront AI-readable."
 				title="Content negotiation"
 			>
 				<ContentNegotiationDemo />

--- a/apps/docs/content/docs/anatomy/content-negotiation.mdx
+++ b/apps/docs/content/docs/anatomy/content-negotiation.mdx
@@ -1,25 +1,29 @@
 ---
 title: Content Negotiation
-description: Product pages serve structured markdown to AI agents via Accept header content negotiation.
+description: Product, collection, and search pages serve structured markdown to AI agents via Accept header content negotiation.
 type: guide
 ---
 
 # Content Negotiation
 
-Product pages serve structured markdown when clients send `Accept: text/markdown`. Browsers continue to receive HTML; AI agents and crawlers get clean, parseable markdown from the same URL.
+Product, collection, and search pages serve structured markdown when clients send `Accept: text/markdown`. Browsers continue to receive HTML; AI agents and crawlers get clean, parseable markdown from the same URL.
 
 This is a built-in feature that requires no configuration.
 
 ## How it works
 
 ```
-GET /products/speaker  (Accept: text/markdown)
+GET /products/speaker        (Accept: text/markdown)
+GET /collections/speakers    (Accept: text/markdown)
+GET /search?q=speaker        (Accept: text/markdown)
     ↓
-next.config.ts rewrite  →  /products/md/speaker
+next.config.ts rewrite
     ↓
-app/products/md/[handle]/route.ts
+/products/md/[handle]
+/collections/md/[handle]
+/search/md
     ↓
-Response: text/markdown
+Route handler response: text/markdown
 ```
 
 Browsers that don't send `Accept: text/markdown` are unaffected — the rewrite only fires when the header matches.
@@ -29,6 +33,12 @@ Browsers that don't send `Accept: text/markdown` are unaffected — the rewrite 
 ```bash
 # Returns structured markdown
 curl -H "Accept: text/markdown" http://localhost:3000/products/speaker
+
+# Returns collection markdown with products, filters, and pagination
+curl -H "Accept: text/markdown" http://localhost:3000/collections/speakers
+
+# Returns search markdown with query, filters, and result summaries
+curl -H "Accept: text/markdown" "http://localhost:3000/search?q=speaker&sort=price-low-to-high"
 
 # Returns the normal HTML page
 curl http://localhost:3000/products/speaker
@@ -40,24 +50,24 @@ The `Vary: Accept` header ensures CDNs cache markdown and HTML responses separat
 
 The markdown representation includes:
 
-- **Product information** — handle, brand, category, availability
-- **Pricing** — current price, compare-at price, savings, price range
-- **Description** — plain text product description
-- **Options** — available options (e.g. Color, Size) with their values
-- **Variants** — full table of all variants with prices and availability
-- **Specifications** — metafield-based product specs
-- **Images** — direct URLs to product images
-- **Tags** and **SEO** metadata
+- **Product pages** — handle, brand, category, pricing, options, variants, specs, images, tags, and SEO metadata
+- **Collection pages** — collection metadata, description, applied filters, available filters, products, pagination, image, and SEO metadata
+- **Search pages** — query metadata, active collection filter, applied filters, available filters, products, and pagination state
 
 ## Key files
 
 | File | Purpose |
 |------|---------|
-| `next.config.ts` | Rewrite rule matching `Accept: text/markdown` |
-| `app/products/md/[handle]/route.ts` | Route handler returning markdown |
+| `next.config.ts` | Rewrite rules matching `Accept: text/markdown` |
+| `app/products/md/[handle]/route.ts` | Product markdown route handler |
+| `app/collections/md/[handle]/route.ts` | Collection markdown route handler |
+| `app/search/md/route.ts` | Search markdown route handler |
 | `lib/markdown/product.ts` | `productToMarkdown()` converter |
+| `lib/markdown/collection.ts` | `collectionToMarkdown()` converter |
+| `lib/markdown/search.ts` | `searchResultsToMarkdown()` converter |
+| `lib/markdown/catalog.ts` | Shared product/filter/pagination formatting helpers |
 | `lib/markdown/utils.ts` | Formatting helpers (prices, tables, escaping) |
 
 ## Multi-locale
 
-If you have enabled Shopify Markets, the rewrite fires before locale routing — no additional configuration is needed. Pass a `?locale=` query parameter to the markdown endpoint for locale-specific pricing.
+If you have enabled Shopify Markets, the rewrite fires before locale routing — no additional configuration is needed. Pass a `?locale=` query parameter to the markdown endpoint for locale-specific pricing and collection/search context.

--- a/apps/template/app/collections/md/[handle]/route.ts
+++ b/apps/template/app/collections/md/[handle]/route.ts
@@ -1,0 +1,80 @@
+import { RESULTS_PER_PAGE } from "@/lib/utils/product-card";
+import { defaultLocale, resolveLocale } from "@/lib/i18n";
+import { collectionToMarkdown } from "@/lib/markdown/collection";
+import { getCollection } from "@/lib/shopify/operations/collections";
+import {
+  buildProductFiltersFromParams,
+  getCollectionProducts,
+} from "@/lib/shopify/operations/products";
+import { transformShopifyFilters } from "@/lib/shopify/transforms/filters";
+import { parseFiltersFromSearchParams } from "@/lib/utils/filter-params";
+import { searchParamsToRecord } from "@/lib/utils/url-search-params";
+
+function markdownHeaders(cacheControl: string): HeadersInit {
+  return {
+    "Content-Type": "text/markdown; charset=utf-8",
+    "Cache-Control": cacheControl,
+    Vary: "Accept",
+    "X-Robots-Tag": "noindex",
+  };
+}
+
+export async function GET(request: Request, { params }: { params: Promise<{ handle: string }> }) {
+  const { handle } = await params;
+  const url = new URL(request.url);
+  const locale = resolveLocale(url.searchParams.get("locale") || defaultLocale);
+  const sort = url.searchParams.get("sort") ?? undefined;
+  const cursor = url.searchParams.get("cursor") ?? undefined;
+  const searchParams = searchParamsToRecord(url.searchParams);
+  const activeFilters = parseFiltersFromSearchParams(searchParams);
+  const shopifyFilters = buildProductFiltersFromParams(activeFilters);
+
+  try {
+    const [collection, result] = await Promise.all([
+      getCollection(handle, locale),
+      getCollectionProducts({
+        collection: handle,
+        sortKey: sort,
+        limit: RESULTS_PER_PAGE,
+        cursor,
+        filters: shopifyFilters,
+        locale,
+      }),
+    ]);
+
+    if (!collection) {
+      return new Response(
+        `# Collection Not Found\n\nThe collection with handle \`${handle}\` could not be found.`,
+        {
+          status: 404,
+          headers: markdownHeaders("public, max-age=3600, stale-while-revalidate=604800"),
+        },
+      );
+    }
+
+    const transformedFilters = transformShopifyFilters(result.filters, { activeFilters });
+    const hasPriceRange = result.filters.some((filter) => filter.type === "PRICE_RANGE");
+    const markdown = collectionToMarkdown({
+      collection,
+      products: result.products,
+      filters: transformedFilters.filters,
+      priceRange: hasPriceRange ? transformedFilters.priceRange : undefined,
+      activeFilters,
+      pageInfo: result.pageInfo,
+      locale,
+      sort,
+    });
+
+    return new Response(markdown, {
+      headers: markdownHeaders("public, max-age=86400, stale-while-revalidate=604800"),
+    });
+  } catch {
+    return new Response(
+      "# Server Error\n\nAn error occurred while retrieving the collection. Please try again later.",
+      {
+        status: 500,
+        headers: markdownHeaders("no-cache, no-store, must-revalidate"),
+      },
+    );
+  }
+}

--- a/apps/template/app/search/md/route.ts
+++ b/apps/template/app/search/md/route.ts
@@ -1,0 +1,70 @@
+import { RESULTS_PER_PAGE } from "@/lib/utils/product-card";
+import { defaultLocale, resolveLocale } from "@/lib/i18n";
+import { searchResultsToMarkdown } from "@/lib/markdown/search";
+import {
+  buildProductFiltersFromParams,
+  getProducts,
+} from "@/lib/shopify/operations/products";
+import { transformShopifyFilters } from "@/lib/shopify/transforms/filters";
+import { parseFiltersFromSearchParams } from "@/lib/utils/filter-params";
+import { searchParamsToRecord } from "@/lib/utils/url-search-params";
+
+function markdownHeaders(cacheControl: string): HeadersInit {
+  return {
+    "Content-Type": "text/markdown; charset=utf-8",
+    "Cache-Control": cacheControl,
+    Vary: "Accept",
+    "X-Robots-Tag": "noindex",
+  };
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const locale = resolveLocale(url.searchParams.get("locale") || defaultLocale);
+  const query = url.searchParams.get("q") ?? undefined;
+  const collection = url.searchParams.get("collection") ?? undefined;
+  const sort = url.searchParams.get("sort") ?? undefined;
+  const cursor = url.searchParams.get("cursor") ?? undefined;
+  const searchParams = searchParamsToRecord(url.searchParams);
+  const activeFilters = parseFiltersFromSearchParams(searchParams);
+  const shopifyFilters = buildProductFiltersFromParams(activeFilters);
+
+  try {
+    const result = await getProducts({
+      query,
+      collection,
+      sortKey: sort,
+      limit: RESULTS_PER_PAGE,
+      cursor,
+      filters: shopifyFilters,
+      locale,
+    });
+
+    const transformedFilters = transformShopifyFilters(result.filters, { activeFilters });
+    const hasPriceRange = result.filters.some((filter) => filter.type === "PRICE_RANGE");
+    const markdown = searchResultsToMarkdown({
+      query,
+      collection,
+      products: result.products,
+      total: result.total,
+      filters: transformedFilters.filters,
+      priceRange: hasPriceRange ? transformedFilters.priceRange : undefined,
+      activeFilters,
+      pageInfo: result.pageInfo,
+      locale,
+      sort,
+    });
+
+    return new Response(markdown, {
+      headers: markdownHeaders("public, max-age=86400, stale-while-revalidate=604800"),
+    });
+  } catch {
+    return new Response(
+      "# Server Error\n\nAn error occurred while retrieving the search results. Please try again later.",
+      {
+        status: 500,
+        headers: markdownHeaders("no-cache, no-store, must-revalidate"),
+      },
+    );
+  }
+}

--- a/apps/template/lib/markdown/catalog.ts
+++ b/apps/template/lib/markdown/catalog.ts
@@ -1,0 +1,163 @@
+import { getCurrencyCode } from "@/lib/i18n";
+import type { Filter, PageInfo, PriceRange, ProductCard } from "@/lib/types";
+import { getActiveFilterBadges } from "@/lib/shopify/transforms/filters";
+
+import { createTable, escapeMarkdown, formatPrice } from "./utils";
+
+const SORT_LABELS: Record<string, string> = {
+  "best-matches": "Best matches",
+  "price-low-to-high": "Price: low to high",
+  "price-high-to-low": "Price: high to low",
+  "product-name-ascending": "Product name: A to Z",
+  "product-name-descending": "Product name: Z to A",
+  BEST_SELLING: "Best selling",
+  COLLECTION_DEFAULT: "Collection default",
+  CREATED: "Newest first",
+  ID: "ID",
+  MANUAL: "Manual",
+  PRICE: "Price",
+  RELEVANCE: "Relevance",
+  TITLE: "Title",
+};
+
+function getSingleValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function formatPriceRange(priceRange: PriceRange, locale: string): string {
+  const currencyCode = getCurrencyCode(locale);
+
+  return `${formatPrice({ amount: priceRange.min.toString(), currencyCode }, locale)} - ${formatPrice(
+    { amount: priceRange.max.toString(), currencyCode },
+    locale,
+  )}`;
+}
+
+export function formatSortLabel(sort?: string): string {
+  if (!sort) return SORT_LABELS["best-matches"];
+  return SORT_LABELS[sort] ?? sort;
+}
+
+export function appendAppliedFiltersSection(
+  sections: string[],
+  {
+    activeFilters,
+    filters,
+  }: {
+    activeFilters: Record<string, string | string[] | undefined>;
+    filters: Filter[];
+  },
+): void {
+  const appliedFilters: string[] = getActiveFilterBadges(filters, activeFilters).map(
+    (badge) => `- **${escapeMarkdown(badge.filterLabel)}**: ${escapeMarkdown(badge.label)}`,
+  );
+
+  const availability = getSingleValue(activeFilters["filter.v.availability"]);
+  if (availability === "1") {
+    appliedFilters.push("- **Availability**: In stock");
+  } else if (availability === "0") {
+    appliedFilters.push("- **Availability**: Out of stock");
+  }
+
+  const minPrice = getSingleValue(activeFilters["filter.v.price.gte"]);
+  const maxPrice = getSingleValue(activeFilters["filter.v.price.lte"]);
+  if (minPrice || maxPrice) {
+    const constraints: string[] = [];
+    if (minPrice) constraints.push(`min ${escapeMarkdown(minPrice)}`);
+    if (maxPrice) constraints.push(`max ${escapeMarkdown(maxPrice)}`);
+    appliedFilters.push(`- **Price**: ${constraints.join(", ")}`);
+  }
+
+  if (appliedFilters.length === 0) {
+    return;
+  }
+
+  sections.push("## Applied Filters");
+  sections.push("");
+  sections.push(...appliedFilters);
+  sections.push("");
+}
+
+export function appendAvailableFiltersSection(
+  sections: string[],
+  {
+    filters,
+    priceRange,
+    locale,
+  }: {
+    filters: Filter[];
+    priceRange?: PriceRange;
+    locale: string;
+  },
+): void {
+  if (filters.length === 0 && !priceRange) {
+    return;
+  }
+
+  sections.push("## Available Filters");
+  sections.push("");
+
+  if (priceRange) {
+    sections.push(`- **Price Range**: ${formatPriceRange(priceRange, locale)}`);
+  }
+
+  for (const filter of filters) {
+    const values = filter.values
+      .slice(0, 10)
+      .map((value) => `${escapeMarkdown(value.label)} (${value.count})`)
+      .join(", ");
+
+    const suffix = filter.values.length > 10 ? ", ..." : "";
+    sections.push(`- **${escapeMarkdown(filter.label)}**: ${values}${suffix}`);
+  }
+
+  sections.push("");
+}
+
+export function appendPaginationSection(sections: string[], pageInfo: PageInfo): void {
+  sections.push("## Pagination");
+  sections.push("");
+  sections.push(`- **Has Previous Page**: ${pageInfo.hasPreviousPage ? "Yes" : "No"}`);
+  sections.push(`- **Has Next Page**: ${pageInfo.hasNextPage ? "Yes" : "No"}`);
+  if (pageInfo.startCursor) {
+    sections.push(`- **Start Cursor**: \`${pageInfo.startCursor}\``);
+  }
+  if (pageInfo.endCursor) {
+    sections.push(`- **End Cursor**: \`${pageInfo.endCursor}\``);
+  }
+  sections.push("");
+}
+
+export function appendProductsSection(
+  sections: string[],
+  {
+    products,
+    locale,
+  }: {
+    products: ProductCard[];
+    locale: string;
+  },
+): void {
+  sections.push("## Products");
+  sections.push("");
+
+  if (products.length === 0) {
+    sections.push("_No products matched the current selection._");
+    sections.push("");
+    return;
+  }
+
+  const headers = ["Title", "Handle", "Price", "Compare At", "Available", "Brand", "URL"];
+  const rows = products.map((product) => [
+    escapeMarkdown(product.title),
+    escapeMarkdown(product.handle),
+    formatPrice(product.price, locale),
+    product.compareAtPrice ? formatPrice(product.compareAtPrice, locale) : "-",
+    product.availableForSale ? "Yes" : "No",
+    escapeMarkdown(product.vendor ?? "-"),
+    `/products/${product.handle}`,
+  ]);
+
+  sections.push(createTable(headers, rows));
+  sections.push("");
+}

--- a/apps/template/lib/markdown/collection.ts
+++ b/apps/template/lib/markdown/collection.ts
@@ -1,0 +1,82 @@
+import type { Collection, Filter, PageInfo, PriceRange, ProductCard } from "@/lib/types";
+
+import {
+  appendAppliedFiltersSection,
+  appendAvailableFiltersSection,
+  appendPaginationSection,
+  appendProductsSection,
+  formatSortLabel,
+} from "./catalog";
+import { escapeMarkdown } from "./utils";
+
+export function collectionToMarkdown({
+  collection,
+  products,
+  filters,
+  priceRange,
+  activeFilters,
+  pageInfo,
+  locale,
+  sort,
+}: {
+  collection: Collection;
+  products: ProductCard[];
+  filters: Filter[];
+  priceRange?: PriceRange;
+  activeFilters: Record<string, string | string[] | undefined>;
+  pageInfo: PageInfo;
+  locale: string;
+  sort?: string;
+}): string {
+  const sections: string[] = [];
+
+  sections.push(`# ${escapeMarkdown(collection.title)}`);
+  sections.push("");
+
+  sections.push("## Collection Information");
+  sections.push("");
+  sections.push(`- **Handle**: ${collection.handle}`);
+  sections.push(`- **Path**: ${collection.path}`);
+  sections.push(`- **Sort**: ${escapeMarkdown(formatSortLabel(sort))}`);
+  sections.push(`- **Products In This Page**: ${products.length}`);
+  sections.push(`- **Has More Results**: ${pageInfo.hasNextPage ? "Yes" : "No"}`);
+  sections.push("");
+
+  if (collection.description) {
+    sections.push("## Description");
+    sections.push("");
+    sections.push(escapeMarkdown(collection.description));
+    sections.push("");
+  }
+
+  appendAppliedFiltersSection(sections, { activeFilters, filters });
+  appendAvailableFiltersSection(sections, { filters, priceRange, locale });
+  appendProductsSection(sections, { products, locale });
+  appendPaginationSection(sections, pageInfo);
+
+  if (collection.image?.url) {
+    sections.push("## Image");
+    sections.push("");
+    sections.push(`- ${collection.image.url}`);
+    sections.push("");
+  }
+
+  if (collection.seo.title || collection.seo.description) {
+    sections.push("## SEO");
+    sections.push("");
+    if (collection.seo.title) {
+      sections.push(`- **Title**: ${escapeMarkdown(collection.seo.title)}`);
+    }
+    if (collection.seo.description) {
+      sections.push(`- **Description**: ${escapeMarkdown(collection.seo.description)}`);
+    }
+    sections.push("");
+  }
+
+  sections.push("---");
+  sections.push("");
+  sections.push(`*Last updated: ${collection.updatedAt}*`);
+  sections.push(`*Locale: ${locale}*`);
+
+  return sections.join("\n");
+}

--- a/apps/template/lib/markdown/search.ts
+++ b/apps/template/lib/markdown/search.ts
@@ -1,0 +1,62 @@
+import type { Filter, PageInfo, PriceRange, ProductCard } from "@/lib/types";
+
+import {
+  appendAppliedFiltersSection,
+  appendAvailableFiltersSection,
+  appendPaginationSection,
+  appendProductsSection,
+  formatSortLabel,
+} from "./catalog";
+import { escapeMarkdown } from "./utils";
+
+export function searchResultsToMarkdown({
+  query,
+  collection,
+  products,
+  total,
+  filters,
+  priceRange,
+  activeFilters,
+  pageInfo,
+  locale,
+  sort,
+}: {
+  query?: string;
+  collection?: string;
+  products: ProductCard[];
+  total: number;
+  filters: Filter[];
+  priceRange?: PriceRange;
+  activeFilters: Record<string, string | string[] | undefined>;
+  pageInfo: PageInfo;
+  locale: string;
+  sort?: string;
+}): string {
+  const sections: string[] = [];
+
+  const title = query ? `Search Results for "${escapeMarkdown(query)}"` : "Search Results";
+  sections.push(`# ${title}`);
+  sections.push("");
+
+  sections.push("## Search Information");
+  sections.push("");
+  sections.push(`- **Query**: ${query ? escapeMarkdown(query) : "None"}`);
+  if (collection) {
+    sections.push(`- **Collection Filter**: ${escapeMarkdown(collection)}`);
+  }
+  sections.push(`- **Sort**: ${escapeMarkdown(formatSortLabel(sort))}`);
+  sections.push(`- **Total Matching Products**: ${total}`);
+  sections.push(`- **Products In This Page**: ${products.length}`);
+  sections.push("");
+
+  appendAppliedFiltersSection(sections, { activeFilters, filters });
+  appendAvailableFiltersSection(sections, { filters, priceRange, locale });
+  appendProductsSection(sections, { products, locale });
+  appendPaginationSection(sections, pageInfo);
+
+  sections.push("---");
+  sections.push("");
+  sections.push(`*Locale: ${locale}*`);
+
+  return sections.join("\n");
+}

--- a/apps/template/lib/utils/url-search-params.ts
+++ b/apps/template/lib/utils/url-search-params.ts
@@ -1,0 +1,17 @@
+export function searchParamsToRecord(
+  searchParams: URLSearchParams,
+): Record<string, string | string[] | undefined> {
+  const record: Record<string, string | string[] | undefined> = {};
+
+  for (const key of new Set(searchParams.keys())) {
+    const values = searchParams.getAll(key);
+
+    if (values.length === 0) {
+      continue;
+    }
+
+    record[key] = values.length === 1 ? values[0] : values;
+  }
+
+  return record;
+}

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -26,8 +26,18 @@ const nextConfig: NextConfig = {
     return {
       beforeFiles: [
         {
+          source: "/collections/:handle",
+          destination: "/collections/md/:handle",
+          has: [{ type: "header", key: "accept", value: "(.*)text/markdown(.*)" }],
+        },
+        {
           source: "/products/:handle",
           destination: "/products/md/:handle",
+          has: [{ type: "header", key: "accept", value: "(.*)text/markdown(.*)" }],
+        },
+        {
+          source: "/search",
+          destination: "/search/md",
           has: [{ type: "header", key: "accept", value: "(.*)text/markdown(.*)" }],
         },
       ],


### PR DESCRIPTION
## Summary
- add `Accept: text/markdown` rewrites for collection and search routes alongside the existing product flow
- add markdown route handlers and shared formatters for collection/search results, filters, pagination, and product summaries
- update docs and homepage copy to describe content negotiation across product, collection, and search pages

## Testing
- Not run (not requested)