### PR TITLE
Add Open Graph images to the docs site

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Installer } from "@/components/fromsrc/installer";
 import { Button } from "@/components/ui/button";
 import { nav } from "@/lib/constants";
+import { homeDescription, siteName } from "@/lib/site";
 import { AgentDemo } from "./components/agent-demo";
 import { AssistantDemo } from "./components/assistant-demo";
 import { CartDemo } from "./components/cart-demo";
@@ -10,18 +12,36 @@ import { CTA } from "./components/cta";
 import { FakeBrowser } from "./components/fake-browser";
 import { ContentNegotiationDemo } from "./components/content-negotiation-demo";
 import { Hero } from "./components/hero";
-import { OneTwoSection } from "./components/one-two-section";
-import { Installer } from "@/components/fromsrc/installer";
 import { PromptCopy } from "./components/prompt-copy";
+import { OneTwoSection } from "./components/one-two-section";
 
-const title = "Vercel Shop";
-const description =
-	"Ship a production-ready Shopify storefront in days. Customize everything with AI agents. Built on Next.js.";
+const title = siteName;
+const description = homeDescription;
 const agentCommand = "npx plugins add vercel/shop";
 
 export const metadata: Metadata = {
 	title,
 	description,
+	openGraph: {
+		title,
+		description,
+		type: "website",
+		url: "/",
+		siteName,
+		images: [
+			{
+				url: "/opengraph-image",
+				width: 1200,
+				height: 628,
+			},
+		],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title,
+		description,
+		images: ["/opengraph-image"],
+	},
 };
 
 const HomePage = () => (

--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -7,6 +7,7 @@ import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import { docs } from "@/lib/fromsrc/content";
 import { mdxComponents } from "@/lib/fromsrc/mdx-components";
+import { docsDescription, siteName } from "@/lib/site";
 import { MobileToc } from "../mobiletoc";
 import { Outline } from "../outline";
 
@@ -148,8 +149,32 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     notFound();
   }
 
+  const description = doc.description ?? docsDescription;
+  const image = doc.slug ? `/og/${doc.slug}/image.png` : "/og/image.png";
+  const url = doc.slug ? `/docs/${doc.slug}` : "/docs";
+
   return {
     title: doc.title,
-    description: doc.description,
+    description,
+    openGraph: {
+      title: doc.title,
+      description,
+      siteName,
+      type: "website",
+      url,
+      images: [
+        {
+          url: image,
+          width: 1200,
+          height: 628,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: doc.title,
+      description,
+      images: [image],
+    },
   };
 }

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -2,6 +2,7 @@ import "./global.css";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { AdapterProvider, nextAdapter } from "fromsrc/client";
+import type { Metadata } from "next";
 import { ThemeProvider } from "next-themes";
 import type { ReactNode } from "react";
 import { Chat } from "@/components/fromsrc/chat";
@@ -10,12 +11,32 @@ import { Search } from "@/components/fromsrc/search";
 import { Toaster } from "@/components/ui/sonner";
 import { docs } from "@/lib/fromsrc/content";
 import { mono, pixel, pixelSquare, pixelTriangle, sans } from "@/lib/geistdocs/fonts";
+import { docsDescription, docsTitle, getBaseUrl, siteName } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
-export const metadata = {
-  title: "Vercel Shop Documentation",
-  description:
-    "Documentation for Vercel Shop — an agent-native, fast-by-default Shopify storefront built on Next.js.",
+export const metadata: Metadata = {
+  metadataBase: getBaseUrl(),
+  title: docsTitle,
+  description: docsDescription,
+  openGraph: {
+    title: docsTitle,
+    description: docsDescription,
+    siteName,
+    type: "website",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 628,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: docsTitle,
+    description: docsDescription,
+    images: ["/opengraph-image"],
+  },
 };
 
 function flatitems(items: unknown[]): { title: string; href: string }[] {

--- a/apps/docs/app/og/[...slug]/route.tsx
+++ b/apps/docs/app/og/[...slug]/route.tsx
@@ -1,8 +1,8 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-import { ImageResponse } from "next/og";
 import type { NextRequest } from "next/server";
 import { docs } from "@/lib/fromsrc/content";
+import { createOgImageResponse } from "@/lib/og";
+
+export const runtime = "nodejs";
 
 export async function GET(
   _request: NextRequest,
@@ -19,60 +19,7 @@ export async function GET(
 
   const { title, description } = doc;
 
-  const regularFont = await readFile(
-    join(process.cwd(), "app/og/[...slug]/geist-sans-regular.ttf")
-  );
-
-  const semiboldFont = await readFile(
-    join(process.cwd(), "app/og/[...slug]/geist-sans-semibold.ttf")
-  );
-
-  const backgroundImage = await readFile(
-    join(process.cwd(), "app/og/[...slug]/background.png")
-  );
-
-  const backgroundImageData = backgroundImage.buffer.slice(
-    backgroundImage.byteOffset,
-    backgroundImage.byteOffset + backgroundImage.byteLength
-  );
-
-  return new ImageResponse(
-    <div style={{ fontFamily: "Geist" }} tw="flex h-full w-full bg-black">
-      {/** biome-ignore lint/performance/noImgElement: "Required for Satori" */}
-      <img
-        alt="Vercel OpenGraph Background"
-        height={628}
-        src={backgroundImageData as never}
-        width={1200}
-      />
-      <div tw="flex flex-col absolute h-full w-[750px] justify-center left-[50px] pr-[50px] pt-[116px] pb-[86px]">
-        <div
-          style={{ textWrap: "balance" }}
-          tw="text-5xl font-medium text-white tracking-tight flex leading-[1.1] mb-4"
-        >
-          {title}
-        </div>
-        <div
-          style={{
-            color: "#8B8B8B",
-            lineHeight: "44px",
-            textWrap: "balance",
-          }}
-          tw="text-[32px]"
-        >
-          {description}
-        </div>
-      </div>
-    </div>,
-    {
-      width: 1200,
-      height: 628,
-      fonts: [
-        { name: "Geist", data: regularFont, weight: 400 },
-        { name: "Geist", data: semiboldFont, weight: 500 },
-      ],
-    }
-  );
+  return createOgImageResponse({ title, description });
 }
 
 export async function generateStaticParams() {

--- a/apps/docs/app/opengraph-image.tsx
+++ b/apps/docs/app/opengraph-image.tsx
@@ -1,0 +1,17 @@
+import { createOgImageResponse, ogImageContentType, ogImageSize } from "@/lib/og";
+import { homeDescription, siteName } from "@/lib/site";
+
+export const runtime = "nodejs";
+
+export const alt = `${siteName} preview image`;
+
+export const size = ogImageSize;
+
+export const contentType = ogImageContentType;
+
+export default function OpenGraphImage() {
+  return createOgImageResponse({
+    title: siteName,
+    description: homeDescription,
+  });
+}

--- a/apps/docs/lib/og.tsx
+++ b/apps/docs/lib/og.tsx
@@ -1,0 +1,76 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { ImageResponse } from "next/og";
+
+const ogAssetDir = join(process.cwd(), "app/og/[...slug]");
+
+const ogAssets = Promise.all([
+  readFile(join(ogAssetDir, "geist-sans-regular.ttf")),
+  readFile(join(ogAssetDir, "geist-sans-semibold.ttf")),
+  readFile(join(ogAssetDir, "background.png")),
+]).then(([regularFont, semiboldFont, backgroundImage]) => ({
+  regularFont,
+  semiboldFont,
+  backgroundImageData: backgroundImage.buffer.slice(
+    backgroundImage.byteOffset,
+    backgroundImage.byteOffset + backgroundImage.byteLength
+  ),
+}));
+
+export const ogImageSize = {
+  width: 1200,
+  height: 628,
+} as const;
+
+export const ogImageContentType = "image/png";
+
+interface OgImageContent {
+  title: string;
+  description?: string | null;
+}
+
+export async function createOgImageResponse({
+  title,
+  description,
+}: OgImageContent) {
+  const { backgroundImageData, regularFont, semiboldFont } = await ogAssets;
+
+  return new ImageResponse(
+    <div style={{ fontFamily: "Geist" }} tw="flex h-full w-full bg-black">
+      {/** biome-ignore lint/performance/noImgElement: Satori requires img */}
+      <img
+        alt="Vercel Shop Open Graph Background"
+        height={ogImageSize.height}
+        src={backgroundImageData as never}
+        width={ogImageSize.width}
+      />
+      <div tw="absolute left-[50px] flex h-full w-[750px] flex-col justify-center pt-[116px] pr-[50px] pb-[86px]">
+        <div
+          style={{ textWrap: "balance" }}
+          tw="mb-4 flex text-5xl leading-[1.1] font-medium tracking-tight text-white"
+        >
+          {title}
+        </div>
+        {description ? (
+          <div
+            style={{
+              color: "#8B8B8B",
+              lineHeight: "44px",
+              textWrap: "balance",
+            }}
+            tw="text-[32px]"
+          >
+            {description}
+          </div>
+        ) : null}
+      </div>
+    </div>,
+    {
+      ...ogImageSize,
+      fonts: [
+        { name: "Geist", data: regularFont, weight: 400 },
+        { name: "Geist", data: semiboldFont, weight: 500 },
+      ],
+    }
+  );
+}

--- a/apps/docs/lib/site.ts
+++ b/apps/docs/lib/site.ts
@@ -1,0 +1,17 @@
+export const siteName = "Vercel Shop";
+
+export const homeDescription =
+  "Ship a production-ready Shopify storefront in days. Customize everything with AI agents. Built on Next.js.";
+
+export const docsTitle = "Vercel Shop Documentation";
+
+export const docsDescription =
+  "Documentation for Vercel Shop — an agent-native, fast-by-default Shopify storefront built on Next.js.";
+
+export function getBaseUrl() {
+  const host =
+    process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL || "localhost:3000";
+  const protocol = host.includes("localhost") ? "http" : "https";
+
+  return new URL(`${protocol}://${host}`);
+}


### PR DESCRIPTION
## Summary
- add a shared Open Graph image renderer for the docs site using the existing Geist-style assets
- add a root `opengraph-image` route and default site metadata for Open Graph and Twitter cards
- update docs page metadata to point each page at its generated `/og/.../image.png` image
- centralize site titles, descriptions, and base URL helpers for reuse across metadata

## Testing
- `pnpm --dir apps/docs exec tsc --noEmit --ignoreDeprecations 6.0`
- `pnpm --dir apps/docs exec next build` stalled after starting the production build