### PR TITLE
Update docs demo link to template.vercel.shop

### DIFF
--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -10,7 +10,7 @@ export const nav = [
   },
   {
     label: "Demo",
-    href: "https://shop-template.labs.vercel.dev",
+    href: "https://template.vercel.shop",
     target: "_blank",
   },
   {


### PR DESCRIPTION
## Summary
- change the docs navigation Demo link to `https://template.vercel.shop`
- remove the old `shop-template.labs.vercel.dev` target from the docs nav config

## Testing
- Not run (not requested)