### PR TITLE
PDP: generate static shell from real product handle

### DIFF
--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -4,22 +4,19 @@ import { notFound } from "next/navigation";
 import { ProductDetailPage } from "@/components/pdp/product-detail-page";
 import { getLocale } from "@/lib/params";
 
-import { getProduct } from "@/lib/shopify/operations/products";
+import { getFirstProductHandle, getProduct } from "@/lib/shopify/operations/products";
 
 import { buildProductMetadata } from "./shared";
 
-const PLACEHOLDER_HANDLE = "__placeholder__";
-
 export async function generateStaticParams() {
-  return [{ handle: PLACEHOLDER_HANDLE }];
+  const handle = await getFirstProductHandle();
+  return handle ? [{ handle }] : [];
 }
 
 export async function generateMetadata({
   params,
 }: PageProps<"/products/[handle]">): Promise<Metadata> {
   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
-
-  if (handle === PLACEHOLDER_HANDLE) return {};
 
   return buildProductMetadata(handle, locale, `/products/${handle}`);
 }
@@ -28,7 +25,7 @@ export const unstable_instant = {
   prefetch: "runtime",
   samples: [
     {
-      params: { handle: "__placeholder__" },
+      params: { handle: "sample-product" },
       searchParams: { variantId: "1" },
       cookies: [{ name: "shopify_cartId", value: null }],
     },
@@ -40,10 +37,7 @@ export default async function ProductPage({
   searchParams,
 }: PageProps<"/products/[handle]">) {
   const locale = await getLocale();
-  const handlePromise = params.then(({ handle }) => {
-    if (handle === PLACEHOLDER_HANDLE) notFound();
-    return handle;
-  });
+  const handlePromise = params.then(({ handle }) => handle);
 
   const productPromise = handlePromise.then((handle) =>
     getProduct(handle, locale).catch(() => notFound()),

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({
 }
 
 export const unstable_instant = {
-  prefetch: "runtime",
+  prefetch: "static",
   samples: [
     {
       params: { handle: "sample-product" },

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -616,3 +616,31 @@ export async function getProductsByHandles(
 
   return shopifyProducts.map(transformShopifyProductCard);
 }
+
+const GET_FIRST_PRODUCT_HANDLE_QUERY = `
+  query getFirstProductHandle {
+    products(first: 1) {
+      edges {
+        node {
+          handle
+        }
+      }
+    }
+  }
+`;
+
+export async function getFirstProductHandle(): Promise<string | null> {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("products");
+
+  const data = await shopifyFetch<{
+    products: { edges: Array<{ node: { handle: string } }> };
+  }>({
+    operation: "getFirstProductHandle",
+    query: GET_FIRST_PRODUCT_HANDLE_QUERY,
+    variables: {},
+  });
+
+  return data.products.edges[0]?.node.handle ?? null;
+}


### PR DESCRIPTION
## Summary
- Adds `getFirstProductHandle()` — a lightweight cached function that fetches the first product handle from Shopify
- `generateStaticParams` now uses a real product handle instead of `__placeholder__`, producing a static shell with actual product data
- Removes the placeholder fast-fail `notFound()` logic that was previously needed

## Test plan
- [ ] Verify `pnpm build` succeeds and the PDP static shell contains real product data
- [ ] Confirm navigating to `/products/<handle>` renders correctly
- [ ] Confirm navigating to a non-existent product still 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)