### PR TITLE
Design cleanup

### DIFF
--- a/apps/template/components/pdp/product-detail-page.tsx
+++ b/apps/template/components/pdp/product-detail-page.tsx
@@ -26,8 +26,13 @@ function ProductPageFallback() {
   return (
     <div className="space-y-8">
       <div className="lg:grid lg:grid-cols-12 lg:items-start lg:gap-4 space-y-8 lg:space-y-0">
-        <div className="space-y-2 lg:col-span-7">
-          <Skeleton className="aspect-square w-full" />
+        <div className="lg:col-span-7">
+          <div className="grid grid-cols-2 gap-2">
+            <Skeleton className="aspect-square w-full" />
+            <Skeleton className="aspect-square w-full" />
+            <Skeleton className="aspect-square w-full" />
+            <Skeleton className="aspect-square w-full" />
+          </div>
         </div>
         <div className="space-y-8 lg:sticky lg:top-20 lg:col-span-5">
           <div>

--- a/apps/template/components/pdp/recommendations.tsx
+++ b/apps/template/components/pdp/recommendations.tsx
@@ -17,9 +17,9 @@ function Fallback() {
           {["a", "b", "c", "d"].map((key) => (
             <div key={key}>
               <Skeleton className="aspect-square" />
-              <div className="py-3 space-y-2">
+              <div className="py-3 h-18 box-content">
                 <Skeleton className="h-4 w-full" />
-                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-3/4 mt-2" />
                 <Skeleton className="h-4 w-16 mt-2" />
               </div>
             </div>

--- a/apps/template/components/pdp/variant-section.tsx
+++ b/apps/template/components/pdp/variant-section.tsx
@@ -42,7 +42,7 @@ export function VariantSection({
           title={title}
           className="lg:col-span-7"
           desktopSlot={
-            <Suspense fallback={<Skeleton className="aspect-square w-full" />}>
+            <Suspense fallback={<><Skeleton className="aspect-square w-full" /><Skeleton className="aspect-square w-full" /><Skeleton className="aspect-square w-full" /><Skeleton className="aspect-square w-full" /></>}>
               <ResolvedColorImages
                 images={images}
                 options={options}

--- a/apps/template/components/ui/product-card.tsx
+++ b/apps/template/components/ui/product-card.tsx
@@ -124,7 +124,7 @@ function ProductCardTitle({ className, children, ...props }: React.ComponentProp
     <h3
       data-slot="product-card-title"
       className={cn(
-        "text-base font-semibold text-main-foreground line-clamp-2 leading-tight",
+        "text-base font-semibold text-main-foreground line-clamp-2",
         className,
       )}
       {...props}
@@ -194,10 +194,10 @@ function ProductCardSkeleton({ className }: { className?: string }) {
       className={cn("flex flex-col overflow-hidden", className)}
     >
       <div className="aspect-square bg-muted animate-pulse" />
-      <div className="py-3">
+      <div className="py-3 h-18 box-content">
         <div className="h-4 w-full bg-muted rounded animate-pulse" />
-        <div className="h-4 w-3/4 bg-muted rounded animate-pulse mt-1" />
-        <div className="h-4 w-12 bg-muted rounded animate-pulse mt-1" />
+        <div className="h-4 w-3/4 bg-muted rounded animate-pulse mt-2" />
+        <div className="h-4 w-12 bg-muted rounded animate-pulse mt-2" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Align PDP fallback skeleton with the actual image grid layout — show a 2×2 grid of squares on desktop instead of one large square

## Test plan
- [ ] Load a PDP with throttled network to see the skeleton state
- [ ] Verify the 2×2 grid matches the gap and sizing of the real image grid
- [ ] Check mobile still shows the single-square carousel fallback


🤖 Generated with [Claude Code](https://claude.com/claude-code)