### PR TITLE
PDP: eager variant preselection and stock-aware fallbacks

### DIFF
--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -60,6 +60,7 @@ export default async function HomePage() {
               title={t("featuredProducts.title")}
               products={featuredProductsResult.products}
               locale={locale}
+              collectionUrl="/collections/all-products"
             />
           )}
         </div>

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { HeroSection } from "@/components/hero-section";
-import { ProductsCarousel } from "@/components/product/products-carousel";
+import { ProductsGrid } from "@/components/product/products-grid";
 import { Container } from "@/components/layout/container";
 import { siteConfig } from "@/lib/config";
 import { getLocale } from "@/lib/params";
@@ -32,7 +32,7 @@ export default async function HomePage() {
     getLocale(),
     getTranslations("content.homepage"),
   ]);
-  const featuredProductsResult = await getProducts({ limit: 10, locale });
+  const featuredProductsResult = await getProducts({ limit: 8, locale });
 
   return (
     <>
@@ -56,7 +56,7 @@ export default async function HomePage() {
       <Container>
         <div className="flex flex-col gap-12">
           {featuredProductsResult.products.length > 0 && (
-            <ProductsCarousel
+            <ProductsGrid
               title={t("featuredProducts.title")}
               products={featuredProductsResult.products}
               locale={locale}

--- a/apps/template/components/pdp/product-detail-page.tsx
+++ b/apps/template/components/pdp/product-detail-page.tsx
@@ -37,7 +37,7 @@ function ProductPageFallback() {
         <div className="space-y-8 lg:sticky lg:top-20 lg:col-span-5">
           <div>
             <Skeleton className="h-8 w-3/4" />
-            <Skeleton className="h-6 w-24 mt-3" />
+            <Skeleton className="h-6 w-24" />
           </div>
           <div className="space-y-3">
             <Skeleton className="h-4 w-20" />

--- a/apps/template/components/pdp/variant-section.tsx
+++ b/apps/template/components/pdp/variant-section.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
 import { BuyButtons } from "@/components/pdp/buy-buttons";
@@ -5,21 +6,24 @@ import {
   ProductInfoDescription,
   ProductInfoOptions,
 } from "@/components/pdp/product-info";
+import { ShopLogo } from "@/components/pdp/shop-logo";
 import { ColorImageCarouselItems, ColorImageGrid, ProductMedia } from "@/components/pdp/product-media";
 import { ProductPrice } from "@/components/pdp/product-price";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 import {
   computeInitialSelectedOptions,
   getPartitionedImagesForSelectedColor,
   getSharedImages,
   hasColorImagePartitioning,
   hasUniformPricing,
+  hasUniformStock,
   resolveSelectedVariant,
 } from "@/lib/product";
 import type { Locale } from "@/lib/i18n";
 import type { Image as ImageType, ProductDetails, ProductOption, ProductVariant } from "@/lib/types";
 
-export function VariantSection({
+export async function VariantSection({
   product,
   locale,
   variantIdPromise,
@@ -32,6 +36,20 @@ export function VariantSection({
 
   const needsPartitioning = hasColorImagePartitioning(options, variants);
   const uniformPrice = hasUniformPricing(variants);
+  const singleVariant = variants.length === 1;
+  const uniformStock = hasUniformStock(variants);
+
+  // Pre-resolve for single-variant products (no searchParam needed)
+  const eagerSelectedOptions = singleVariant
+    ? computeInitialSelectedOptions(variants, undefined)
+    : null;
+  const eagerSelectedVariant = eagerSelectedOptions
+    ? resolveSelectedVariant(variants, eagerSelectedOptions)
+    : null;
+
+  // Translations for stock-aware buy button fallback
+  const t = uniformStock && !singleVariant ? await getTranslations("product") : null;
+  const allInStock = variants[0]?.availableForSale ?? true;
 
   return (
     <div className="lg:grid lg:grid-cols-12 lg:items-start lg:gap-4 space-y-8 lg:space-y-0">
@@ -98,41 +116,77 @@ export function VariantSection({
             </Suspense>
           )}
         </div>
-        <Suspense
-          fallback={
-            <ProductInfoOptions
-              variants={variants}
-              options={options}
-              selectedOptions={{}}
-              handle={handle}
-              hideImages
-            />
-          }
-        >
-          <ResolvedOptions
+        {singleVariant && eagerSelectedOptions ? (
+          <ProductInfoOptions
             variants={variants}
             options={options}
+            selectedOptions={eagerSelectedOptions}
             handle={handle}
-            variantIdPromise={variantIdPromise}
           />
-        </Suspense>
-        <Suspense
-          fallback={
-            <div className="grid grid-cols-2 gap-2">
-              <div className="h-12 rounded-lg bg-shop" />
-              <div className="h-12 rounded-lg bg-foreground" />
-            </div>
-          }
-        >
-          <ResolvedBuyButtons
-            variants={variants}
+        ) : (
+          <Suspense
+            fallback={
+              <ProductInfoOptions
+                variants={variants}
+                options={options}
+                selectedOptions={{}}
+                handle={handle}
+                hideImages
+              />
+            }
+          >
+            <ResolvedOptions
+              variants={variants}
+              options={options}
+              handle={handle}
+              variantIdPromise={variantIdPromise}
+            />
+          </Suspense>
+        )}
+        {singleVariant && eagerSelectedVariant ? (
+          <BuyButtons
+            selectedVariant={eagerSelectedVariant}
             title={title}
             handle={handle}
             featuredImage={featuredImage}
             availableForSale={product.availableForSale}
-            variantIdPromise={variantIdPromise}
           />
-        </Suspense>
+        ) : (
+          <Suspense
+            fallback={
+              t ? (
+                <div className="grid grid-cols-2 gap-2">
+                  <div
+                    className={cn(
+                      "flex items-center justify-center gap-1.5 rounded-lg h-12 bg-shop text-white",
+                      !allInStock && "invisible",
+                    )}
+                  >
+                    <span className="text-sm font-medium">{t("buyWithShop")}</span>
+                    <ShopLogo className="h-4 w-auto" />
+                  </div>
+                  <div className="flex items-center justify-center rounded-lg h-12 bg-foreground text-background text-sm font-medium">
+                    {allInStock ? t("addToCart") : t("outOfStock")}
+                  </div>
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="h-12 rounded-lg bg-shop" />
+                  <div className="h-12 rounded-lg bg-foreground" />
+                </div>
+              )
+            }
+          >
+            <ResolvedBuyButtons
+              variants={variants}
+              title={title}
+              handle={handle}
+              featuredImage={featuredImage}
+              availableForSale={product.availableForSale}
+              variantIdPromise={variantIdPromise}
+            />
+          </Suspense>
+        )}
         <ProductInfoDescription descriptionHtml={product.descriptionHtml} />
       </div>
     </div>

--- a/apps/template/components/pdp/variant-section.tsx
+++ b/apps/template/components/pdp/variant-section.tsx
@@ -107,11 +107,10 @@ export async function VariantSection({
                 currencyCode={variants[0].price.currencyCode}
                 compareAtAmount={variants[0].compareAtPrice?.amount}
                 locale={locale}
-                className="mt-3"
               />
             )
           ) : (
-            <Suspense fallback={<Skeleton className="h-6 w-24 mt-3" />}>
+            <Suspense fallback={<Skeleton className="h-6 w-24" />}>
               <ResolvedPrice variants={variants} locale={locale} variantIdPromise={variantIdPromise} />
             </Suspense>
           )}
@@ -268,7 +267,6 @@ async function ResolvedPrice({
       currencyCode={selectedVariant.price.currencyCode}
       compareAtAmount={selectedVariant.compareAtPrice?.amount}
       locale={locale}
-      className="mt-3"
     />
   );
 }

--- a/apps/template/components/product/products-grid.tsx
+++ b/apps/template/components/product/products-grid.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
 import { ProductCard } from "@/components/product-card";
@@ -8,13 +9,24 @@ interface ProductsGridProps {
   title: string;
   products: ProductCardType[];
   locale: Locale;
+  collectionUrl?: string;
 }
 
-export async function ProductsGrid({ title, products, locale }: ProductsGridProps) {
+export async function ProductsGrid({ title, products, locale, collectionUrl }: ProductsGridProps) {
   const t = await getTranslations("product");
   return (
     <div>
-      <h2 className="text-2xl sm:text-3xl font-semibold tracking-tighter mb-4">{title}</h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-2xl sm:text-3xl font-semibold tracking-tighter">{title}</h2>
+        {collectionUrl && (
+          <Link
+            href={collectionUrl}
+            className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {t("viewAll")}
+          </Link>
+        )}
+      </div>
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         {products.map((product) => (
           <ProductCard

--- a/apps/template/components/product/products-grid.tsx
+++ b/apps/template/components/product/products-grid.tsx
@@ -1,0 +1,30 @@
+import { getTranslations } from "next-intl/server";
+
+import { ProductCard } from "@/components/product-card";
+import type { Locale } from "@/lib/i18n";
+import type { ProductCard as ProductCardType } from "@/lib/types";
+
+interface ProductsGridProps {
+  title: string;
+  products: ProductCardType[];
+  locale: Locale;
+}
+
+export async function ProductsGrid({ title, products, locale }: ProductsGridProps) {
+  const t = await getTranslations("product");
+  return (
+    <div>
+      <h2 className="text-2xl sm:text-3xl font-semibold tracking-tighter mb-4">{title}</h2>
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {products.map((product) => (
+          <ProductCard
+            key={product.id}
+            product={product}
+            locale={locale}
+            outOfStockText={t("outOfStock")}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/template/lib/i18n/messages/en.d.json.ts
+++ b/apps/template/lib/i18n/messages/en.d.json.ts
@@ -50,6 +50,7 @@ declare const messages: {
     "selectVariantLabel": "Select {name}: {value}",
     "viewImage": "View image {current} of {total}",
     "goToImage": "Go to image {number}",
+    "viewAll": "View all",
     "recommendations": "You May Also Like",
     "inStock": "In Stock",
     "buyNow": "Buy now",

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -47,6 +47,7 @@
     "selectVariantLabel": "Select {name}: {value}",
     "viewImage": "View image {current} of {total}",
     "goToImage": "Go to image {number}",
+    "viewAll": "View all",
     "recommendations": "You May Also Like",
     "inStock": "In Stock",
     "buyNow": "Buy now",

--- a/apps/template/lib/product/index.ts
+++ b/apps/template/lib/product/index.ts
@@ -301,6 +301,17 @@ export function hasUniformPricing(variants: ProductVariant[]): boolean {
 }
 
 /**
+ * Returns true when every variant shares the same availableForSale value.
+ * When true, we can eagerly show the correct buy-button labels in the
+ * Suspense fallback without waiting for variant resolution.
+ */
+export function hasUniformStock(variants: ProductVariant[]): boolean {
+  if (variants.length <= 1) return true;
+  const first = variants[0];
+  return variants.every((v) => v.availableForSale === first.availableForSale);
+}
+
+/**
  * Returns true when the product has multiple color variants with
  * distinct images — meaning the gallery would change based on
  * the selected color (i.e. based on searchParams).


### PR DESCRIPTION
## Summary
- Single-variant products render options and buy buttons immediately without waiting for URL searchParams
- Multi-variant products with uniform stock show labeled button fallbacks ("Buy with Shop" / "Add to Cart" or "Out of Stock") instead of empty placeholder divs
- New `hasUniformStock` utility mirrors the existing `hasUniformPricing` pattern

## Test plan
- [ ] Load a single-variant product — options and buy buttons should render instantly (no skeleton flash)
- [ ] Load a multi-variant product where all variants are in stock — fallback shows "Buy with Shop" / "Add to Cart" labels
- [ ] Load a multi-variant product with mixed stock — fallback shows plain colored placeholder divs (unchanged)
- [ ] Verify no regressions on variant selection and add-to-cart flow


🤖 Generated with [Claude Code](https://claude.com/claude-code)