### PR TITLE
Fix CLS on search and collection pages

### DIFF
--- a/apps/template/app/collections/[handle]/page.tsx
+++ b/apps/template/app/collections/[handle]/page.tsx
@@ -74,6 +74,24 @@ export async function generateMetadata({
   };
 }
 
+export const unstable_instant = {
+  prefetch: "runtime",
+  samples: [
+    {
+      params: { handle: "__placeholder__" },
+      searchParams: {
+        sort: null,
+        cursor: null,
+        "filter.v.price.gte": null,
+        "filter.v.price.lte": null,
+      },
+      cookies: [{ name: "shopify_cartId", value: null }],
+    },
+  ],
+};
+
+export const unstable_prefetch = "runtime";
+
 export default async function CollectionPage({
   params,
   searchParams,

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -66,7 +66,14 @@ export const unstable_instant = {
   prefetch: "runtime",
   samples: [
     {
-      searchParams: { q: "__placeholder__", collection: null, sort: null, cursor: null },
+      searchParams: {
+        q: "__placeholder__",
+        collection: null,
+        sort: null,
+        cursor: null,
+        "filter.v.price.gte": null,
+        "filter.v.price.lte": null,
+      },
       cookies: [{ name: "shopify_cartId", value: null }],
     },
   ],

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -62,6 +62,18 @@ export async function generateMetadata({ searchParams }: PageProps<"/search">): 
   };
 }
 
+export const unstable_instant = {
+  prefetch: "runtime",
+  samples: [
+    {
+      searchParams: { q: "__placeholder__" },
+      cookies: [{ name: "shopify_cartId", value: null }],
+    },
+  ],
+};
+
+export const unstable_prefetch = "runtime";
+
 export default async function SearchPage({ searchParams }: PageProps<"/search">) {
   const locale = await getLocale();
 
@@ -93,8 +105,6 @@ async function SearchHeader({
   ]);
   const q = resolvedSearchParams.q as string | undefined;
   const activeFilters = parseFiltersFromSearchParams(resolvedSearchParams);
-
-  const collection = resolvedSearchParams.collection as string | undefined;
 
   return (
     <>

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -199,7 +199,7 @@ function SearchHeaderSkeleton() {
   return (
     <>
       <MobileFilterSortBarSkeleton />
-      <Skeleton className="mt-4 md:mt-0 mb-8 h-10 w-72" />
+      <Skeleton className="mt-4 md:mt-0 mb-6 h-10 w-72" />
     </>
   );
 }

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -66,7 +66,7 @@ export const unstable_instant = {
   prefetch: "runtime",
   samples: [
     {
-      searchParams: { q: "__placeholder__" },
+      searchParams: { q: "__placeholder__", collection: null, sort: null, cursor: null },
       cookies: [{ name: "shopify_cartId", value: null }],
     },
   ],

--- a/apps/template/components/collections/results-grid.tsx
+++ b/apps/template/components/collections/results-grid.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
-import { ProductCard } from "@/components/product-card";
+import { ProductCard, ProductCardSkeleton } from "@/components/product-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Locale } from "@/lib/i18n";
 
@@ -20,7 +20,7 @@ function Fallback() {
       <Skeleton className="mb-6 h-4 w-40" />
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 xl:grid-cols-4">
         {RESULTS_SKELETON_KEYS.map((key) => (
-          <Skeleton key={key} className="h-80 rounded-md" />
+          <ProductCardSkeleton key={key} />
         ))}
       </div>
     </>

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -7,7 +7,7 @@ import {
 import { CollectionsPagination } from "@/components/collections/pagination";
 import { CollectionFilterSidebarClient } from "@/components/collections/filter-sidebar";
 import { CollectionFilterSidebarSkeleton } from "@/components/collections/filter-sidebar-skeleton";
-import { ProductCard } from "@/components/product-card";
+import { ProductCard, ProductCardSkeleton } from "@/components/product-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Locale } from "@/lib/i18n";
 import { buildProductFiltersFromParams, getProducts } from "@/lib/shopify/operations/products";
@@ -30,7 +30,7 @@ export function ResultsSkeleton() {
         <Skeleton className="mb-6 h-4 w-40" />
         <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 gap-4">
           {RESULTS_SKELETON_KEYS.map((key) => (
-            <Skeleton key={key} className="h-80 rounded-md" />
+            <ProductCardSkeleton key={key} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replaced fixed-height `h-80` (320px) skeleton blocks with `ProductCardSkeleton` in both search results and collection results grids. The existing `ProductCardSkeleton` uses `aspect-square` + structured text placeholders that match real card dimensions, eliminating the upward shift when streamed content replaces the fallback.
- Fixed search header skeleton margin mismatch (`mb-8` → `mb-6`) to match the real header.

## Test plan
- [ ] Visit `/search` on the preview deployment and confirm no visible layout shift when results stream in
- [ ] Visit a collection page and confirm the same
- [ ] Verify skeleton appearance still looks good (aspect-square image placeholder + text lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)