### PR TITLE
Refactor hero to use static image import

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/home.mdx
+++ b/apps/docs/content/docs/anatomy/pages/home.mdx
@@ -12,6 +12,8 @@ The home page is a server component that renders a hero banner, a featured produ
 
 A full-width banner with a background image, gradient overlay, headline, subheadline, and a CTA link. The hero scales responsively - 300px tall on mobile, 400px on small screens, and 500px on medium and up.
 
+By default the hero uses a statically imported image from `public/hero.jpg`, which enables automatic blur placeholders and prevents layout shift. To use a custom image, pass a `backgroundImage` prop — either a static import (`import myHero from "@/public/my-hero.jpg"`) or a remote URL object (`{ url: "https://...", alt: "...", width: 1920, height: 1080 }`).
+
 The headline and CTA are configurable through the `HeroSection` type. By default the CTA links to `/search` to browse the catalog.
 
 On mobile, the subheadline and CTA text are hidden to keep the banner compact.
@@ -39,7 +41,7 @@ Products are fetched server-side with `getProducts({ limit: 10, locale })`, whic
 | File | Purpose |
 |------|---------|
 | `app/page.tsx` | Root page, metadata generation, product fetch |
-| `components/cms/hero-section.tsx` | Full-width hero banner with image, headline, CTA |
+| `components/hero-section.tsx` | Full-width hero banner with image, headline, CTA |
 | `components/cms/blocks/top-products-carousel.tsx` | Horizontally scrollable product carousel |
 | `components/product-card.tsx` | Product card with image, price, quick-add |
 | `lib/shopify/operations/products.ts` | Shopify product fetching with caching |

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -36,6 +36,9 @@ export default async function HomePage() {
 
   return (
     <>
+      {/* To use a custom hero image, pass a backgroundImage prop:
+          backgroundImage: { url: "https://...", alt: "...", width: 1920, height: 1080 }
+          or import a local image: import myHero from "@/public/my-hero.jpg" */}
       <HeroSection
         hero={{
           id: "homepage-hero",
@@ -44,12 +47,6 @@ export default async function HomePage() {
             "A production-ready, agent-friendly Shopify storefront built on Next.js.",
           ctaText: "Browse the Catalog",
           ctaLink: "/search",
-          backgroundImage: {
-            url: "/hero.jpg",
-            alt: "Hero background",
-            width: 1920,
-            height: 1080,
-          },
         }}
       />
 

--- a/apps/template/components/hero-section.tsx
+++ b/apps/template/components/hero-section.tsx
@@ -1,7 +1,9 @@
+import type { StaticImageData } from "next/image";
 import Image from "next/image";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+import heroDefault from "@/public/hero.jpg";
 import type { HeroSection as HeroSectionType } from "@/lib/types";
 
 interface HeroSectionProps {
@@ -9,21 +11,39 @@ interface HeroSectionProps {
 }
 
 export function HeroSection({ hero }: HeroSectionProps) {
+  const image = hero.backgroundImage ?? heroDefault;
+  const isStatic = typeof image === "object" && "src" in image;
+
   return (
     <section className="relative w-full overflow-hidden">
       <div className="relative h-75 sm:h-100 md:h-125 bg-linear-to-b from-black via-neutral-950 to-neutral-900">
-        {hero.backgroundImage && (
+        {isStatic ? (
           <>
             <Image
-              src={hero.backgroundImage.url}
-              alt={hero.backgroundImage.alt}
+              src={image as StaticImageData}
+              alt="Hero background"
               fill
               className="object-cover"
+              placeholder="blur"
               priority
               sizes="100vw"
             />
             <div className="absolute inset-0 bg-linear-to-t from-black/60 via-transparent to-transparent" />
           </>
+        ) : (
+          image && (
+            <>
+              <Image
+                src={(image as { url: string }).url}
+                alt={(image as { alt: string }).alt}
+                fill
+                className="object-cover"
+                priority
+                sizes="100vw"
+              />
+              <div className="absolute inset-0 bg-linear-to-t from-black/60 via-transparent to-transparent" />
+            </>
+          )
         )}
 
         <div className="absolute inset-0 flex items-center justify-center px-4 lg:px-8">

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -1,3 +1,5 @@
+import type { StaticImageData } from "next/image";
+
 import type { Locale } from "@/lib/i18n";
 
 export type SearchParamsPromise = Promise<Record<string, string | string[] | undefined>>;
@@ -276,7 +278,7 @@ export interface HeroSection {
   id: string;
   headline: string;
   subheadline: string | null;
-  backgroundImage?: MarketingImage | null;
+  backgroundImage?: MarketingImage | StaticImageData | null;
   ctaText: string | null;
   ctaLink: string | null;
 }


### PR DESCRIPTION
## Summary
- Hero component now imports `public/hero.jpg` as a static import by default, enabling automatic blur placeholders and zero layout shift
- `backgroundImage` prop is optional — omit it to use the default, or pass a static import / remote URL to override
- Updated docs to explain the default image behavior and override options
- Fixed stale file path in docs (`components/cms/hero-section.tsx` → `components/hero-section.tsx`)

## Test plan
- [ ] Hero renders with blur placeholder on initial load
- [ ] No CLS on the hero section
- [ ] Passing a custom `backgroundImage` prop still works
- [ ] Docs page reflects the new default image behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)