### PR TITLE
Polish UI copy and reduce CLS in recommendations fallback

### DIFF
--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -57,7 +57,7 @@ export default async function HomePage() {
               title={t("featuredProducts.title")}
               products={featuredProductsResult.products}
               locale={locale}
-              collectionUrl="/collections/all-products"
+              collectionUrl="/search"
             />
           )}
         </div>

--- a/apps/template/components/pdp/product-detail-page.tsx
+++ b/apps/template/components/pdp/product-detail-page.tsx
@@ -27,7 +27,13 @@ function ProductPageFallback() {
     <div className="space-y-8">
       <div className="lg:grid lg:grid-cols-12 lg:items-start lg:gap-4 space-y-8 lg:space-y-0">
         <div className="lg:col-span-7">
-          <div className="grid grid-cols-2 gap-2">
+          {/* Mobile: single full-bleed square + pagination space */}
+          <div className="space-y-4 lg:hidden -mx-4">
+            <Skeleton className="aspect-square w-full" />
+            <div className="h-1.5" />
+          </div>
+          {/* Desktop: 2×2 grid */}
+          <div className="hidden lg:grid grid-cols-2 gap-2">
             <Skeleton className="aspect-square w-full" />
             <Skeleton className="aspect-square w-full" />
             <Skeleton className="aspect-square w-full" />

--- a/apps/template/components/pdp/product-media.tsx
+++ b/apps/template/components/pdp/product-media.tsx
@@ -141,8 +141,8 @@ function Carousel({
         ))}
       </div>
 
-      {/* Dot indicators */}
-      <div className="flex justify-center gap-2">
+      {/* Dot indicators – reserve space but hide when there's only one image */}
+      <div className={cn("flex justify-center gap-2", mediaItems.length <= 1 && "invisible")}>
         {mediaItems.map((item, idx) => (
           <button
             type="button"

--- a/apps/template/components/pdp/recommendations.tsx
+++ b/apps/template/components/pdp/recommendations.tsx
@@ -8,11 +8,11 @@ import { getProductRecommendations } from "@/lib/shopify/operations/products";
 
 import { ProductsCarousel } from "@/components/product/products-carousel";
 
-function Fallback() {
+function Fallback({ title }: { title: string }) {
   return (
     <div className="overflow-x-clip py-4">
       <div className="mx-auto min-w-0">
-        <Skeleton className="h-9 w-64 mb-4" />
+        <h2 className="text-2xl sm:text-3xl font-semibold tracking-tighter mb-4">{title}</h2>
         <div className="grid grid-flow-col gap-4 relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen max-w-none auto-cols-[58.33vw] px-4 sm:left-auto sm:right-auto sm:mx-0 sm:w-full sm:max-w-full sm:auto-cols-[calc((100%-1rem)/2)] sm:px-0 lg:auto-cols-[calc((100%-2rem)/3)] xl:auto-cols-[calc((100%-3rem)/4)]">
           {["a", "b", "c", "d"].map((key) => (
             <div key={key}>
@@ -49,8 +49,9 @@ async function Render({ handle, locale }: { handle: string; locale: Locale }) {
 }
 
 export async function Recommendations({ handle, locale }: { handle: string; locale: Locale }) {
+  const t = await getTranslations("product");
   return (
-    <Suspense fallback={<Fallback />}>
+    <Suspense fallback={<Fallback title={t("recommendations")} />}>
       <Render handle={handle} locale={locale} />
     </Suspense>
   );

--- a/apps/template/components/ui/product-card-slideshow.tsx
+++ b/apps/template/components/ui/product-card-slideshow.tsx
@@ -65,7 +65,7 @@ export function ProductCardSlideshow({
     <div
       data-slot="product-card-slideshow"
       className={cn(
-        "absolute inset-0 opacity-0 [@media(hover:hover)]:group-hover/image:opacity-100 transition-opacity duration-200",
+        "absolute inset-0 hidden lg:block opacity-0 [@media(hover:hover)]:group-hover/image:opacity-100 transition-opacity duration-200",
         className,
       )}
     >

--- a/apps/template/lib/i18n/messages/en.d.json.ts
+++ b/apps/template/lib/i18n/messages/en.d.json.ts
@@ -227,7 +227,7 @@ declare const messages: {
         "title": "From {collectionTitle}"
       },
       "featuredProducts": {
-        "title": "Featured products"
+        "title": "Featured Products"
       }
     }
   },

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -47,7 +47,7 @@
     "selectVariantLabel": "Select {name}: {value}",
     "viewImage": "View image {current} of {total}",
     "goToImage": "Go to image {number}",
-    "viewAll": "View all",
+    "viewAll": "View All",
     "recommendations": "You May Also Like",
     "inStock": "In Stock",
     "buyNow": "Buy now",
@@ -224,7 +224,7 @@
         "title": "From {collectionTitle}"
       },
       "featuredProducts": {
-        "title": "Featured products"
+        "title": "Featured Products"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Hide single-image pagination dots on mobile PDP (preserves space to prevent layout shift)
- Capitalize "Featured Products" and "View All" in locale strings
- Link "View All" to `/search` instead of `/collections/all-products`
- Show real heading text in recommendations Suspense fallback instead of a skeleton bar, reducing visible skeleton area and CLS

## Test plan
- [ ] Open a PDP with a single image on mobile — pagination dots should be invisible but space preserved
- [ ] Open a PDP with multiple images — pagination dots work as before
- [ ] Home page shows "Featured Products" (capital P) and "View All" (capital A) linking to `/search`
- [ ] Recommendations section shows "You May Also Like" heading immediately while products load

🤖 Generated with [Claude Code](https://claude.com/claude-code)