### PR TITLE
feat: Adding relevant project links in template's `/about` page

### DIFF
--- a/apps/template/app/about/page.tsx
+++ b/apps/template/app/about/page.tsx
@@ -31,6 +31,12 @@ export default function AboutPage() {
           The code is yours. Change the layout, pull out components, restyle things, wire in a
           different CMS. It's written to be read and modified, not worked around.
         </p>
+        <p>
+          Read the{" "}
+          <a href="https://shop-docs.labs.vercel.dev/docs">documentation</a>, browse the{" "}
+          <a href="https://github.com/vercel/shop">source on GitHub</a>, or visit the{" "}
+          <a href="https://shop-docs.labs.vercel.dev">docs site</a> for the full picture.
+        </p>
       </article>
     </Container>
   );

--- a/apps/template/app/about/page.tsx
+++ b/apps/template/app/about/page.tsx
@@ -35,7 +35,7 @@ export default function AboutPage() {
           Read the{" "}
           <a href="https://shop-docs.labs.vercel.dev/docs">documentation</a>, browse the{" "}
           <a href="https://github.com/vercel/shop">source on GitHub</a>, or visit the{" "}
-          <a href="https://shop-docs.labs.vercel.dev">docs site</a> for the full picture.
+          <a href="https://shop-docs.labs.vercel.dev">project's landing page</a> for an overview.
         </p>
       </article>
     </Container>


### PR DESCRIPTION
<img width="700" height="611" alt="Screenshot 2026-04-16 at 9 59 14 AM" src="https://github.com/user-attachments/assets/57af4db2-894b-41ac-a52e-e28e7d811f66" />

Figured these are worth including. Hardcoded directly into the about page - didn't see a need to create exportable constants since these are contained within the template that will get ripped / stripped upon forking etc. 