### PR TITLE
PLP: use "Item" label, fix search sort options

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/plp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/plp.mdx
@@ -29,13 +29,15 @@ On mobile, filters are accessible through a sheet overlay rather than a persiste
 
 ## Sorting
 
-A select dropdown offers five sort options:
+A select dropdown offers sort options. Collection pages support all five:
 
 - Best Matches (default)
 - Price: Low to High
 - Price: High to Low
 - Name: A to Z
 - Name: Z to A
+
+The search page only shows Best Matches and the two price sorts because Shopify's `SearchSortKeys` does not support sorting by title.
 
 Sort changes use `useTransition` for non-blocking navigation. On mobile, the sort control renders as a bottom sheet.
 

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -186,7 +186,11 @@ async function SearchToolbar({
           </FilterPendingScope>
         </FilterSidebarSheet>
       }
-      sortSelect={<CollectionsSortSelect />}
+      sortSelect={
+        <CollectionsSortSelect
+          exclude={["product-name-ascending", "product-name-descending"]}
+        />
+      }
     />
   );
 }

--- a/apps/template/components/collections/sort-select.tsx
+++ b/apps/template/components/collections/sort-select.tsx
@@ -14,13 +14,14 @@ const SORT_OPTIONS = [
   { value: "product-name-descending", key: "nameDescending" },
 ] as const;
 
-export function CollectionsSortSelect() {
+export function CollectionsSortSelect({ exclude }: { exclude?: string[] } = {}) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const tSort = useTranslations("search.sort");
   const tSearch = useTranslations("search");
   const [isPending, startTransition] = useTransition();
 
+  const options = exclude ? SORT_OPTIONS.filter((o) => !exclude.includes(o.value)) : SORT_OPTIONS;
   const currentSort = searchParams.get("sort") || "best-matches";
 
   const handleSortChange = (value: string) => {
@@ -43,7 +44,7 @@ export function CollectionsSortSelect() {
         <span>{tSearch("sortBy")}</span>
       </SelectTrigger>
       <SelectContent>
-        {SORT_OPTIONS.map((option) => (
+        {options.map((option) => (
           <SelectItem key={option.value} value={option.value}>
             {tSort(option.key)}
           </SelectItem>

--- a/apps/template/lib/i18n/messages/en.d.json.ts
+++ b/apps/template/lib/i18n/messages/en.d.json.ts
@@ -158,7 +158,7 @@ declare const messages: {
     "noResults": "No products found",
     "noResultsQuery": "We couldn't find any products matching \"{query}\"",
     "noResultsAvailable": "No products available",
-    "resultCount": "{count, plural, one {# Result} other {# Results}}",
+    "resultCount": "{count, plural, one {# Item} other {# Items}}",
     "resultRange": "(showing {start}-{end})",
     "priceUpTo": "up to",
     "title": "All Products",

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -155,7 +155,7 @@
     "noResults": "No products found",
     "noResultsQuery": "We couldn't find any products matching \"{query}\"",
     "noResultsAvailable": "No products available",
-    "resultCount": "{count, plural, one {# Result} other {# Results}}",
+    "resultCount": "{count, plural, one {# Item} other {# Items}}",
     "resultRange": "(showing {start}-{end})",
     "priceUpTo": "up to",
     "title": "All Products",

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -111,14 +111,11 @@ const PRODUCTS_SEARCH_QUERY = `
 `;
 
 // SearchSortKeys only supports PRICE and RELEVANCE.
-// TITLE is not a valid SearchSortKeys value, so name-based sorts fall back to RELEVANCE.
+// Name-based sort options are excluded from the search UI.
 const SEARCH_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolean }> = {
   "best-matches": { sortKey: "RELEVANCE", reverse: false },
   "price-low-to-high": { sortKey: "PRICE", reverse: false },
   "price-high-to-low": { sortKey: "PRICE", reverse: true },
-  "product-name-ascending": { sortKey: "RELEVANCE", reverse: false },
-  "product-name-descending": { sortKey: "RELEVANCE", reverse: false },
-  TITLE: { sortKey: "RELEVANCE", reverse: false },
   PRICE: { sortKey: "PRICE", reverse: false },
   RELEVANCE: { sortKey: "RELEVANCE", reverse: false },
 };


### PR DESCRIPTION
## Summary
- Rename "Result/Results" to "Item/Items" in the PLP toolbar count
- Remove Name A-Z / Z-A sort options from the search page — Shopify's `SearchSortKeys` only supports `RELEVANCE` and `PRICE`, so these silently did nothing
- Collection pages keep all five sort options (`ProductCollectionSortKeys` supports `TITLE`)
- Clean up dead entries from `SEARCH_SORT_KEY_MAP`
- Update PLP docs to document the search sort limitation

## Test plan
- [ ] Visit `/search` — sort dropdown should show 3 options (Best Matches, Price Low→High, Price High→Low)
- [ ] Visit `/collections/[handle]` — sort dropdown should show all 5 options including Name A-Z / Z-A
- [ ] Verify price sort works on `/search?sort=price-low-to-high`
- [ ] Verify name sort works on a collection page with `?sort=product-name-ascending`
- [ ] Confirm toolbar shows "X Items" instead of "X Results"

🤖 Generated with [Claude Code](https://claude.com/claude-code)