### PR TITLE
Bump Next.js to 16.3.0-canary.1

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -25,7 +25,7 @@
 		"lucide-react": "1.8.0",
 		"motion": "12.38.0",
 		"nanoid": "5.1.9",
-		"next": "16.3.0-canary.0",
+		"next": "16.3.0-canary.1",
 		"next-mdx-remote": "6.0.0",
 		"next-themes": "0.4.6",
 		"postcss": "8.5.10",

--- a/apps/template/app/collections/[handle]/page.tsx
+++ b/apps/template/app/collections/[handle]/page.tsx
@@ -75,7 +75,6 @@ export async function generateMetadata({
 }
 
 export const unstable_instant = {
-  prefetch: "runtime",
   samples: [
     {
       params: { handle: "__placeholder__" },
@@ -87,7 +86,7 @@ export const unstable_instant = {
   ],
 };
 
-export const unstable_prefetch = "runtime";
+export const unstable_prefetch = "force-runtime";
 
 export default async function CollectionPage({
   params,

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -64,7 +64,6 @@ export async function generateMetadata({
 }
 
 export const unstable_instant = {
-  prefetch: "runtime",
   samples: [
     {
       params: { handle: "__placeholder__" },
@@ -74,7 +73,7 @@ export const unstable_instant = {
   ],
 };
 
-export const unstable_prefetch = "runtime";
+export const unstable_prefetch = "force-runtime";
 
 export default async function ProductPage({
   params,

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -62,7 +62,6 @@ export async function generateMetadata({ searchParams }: PageProps<"/search">): 
 }
 
 export const unstable_instant = {
-  prefetch: "runtime",
   samples: [
     {
       searchParams: {
@@ -75,7 +74,7 @@ export const unstable_instant = {
   ],
 };
 
-export const unstable_prefetch = "runtime";
+export const unstable_prefetch = "force-runtime";
 
 export default async function SearchPage({ searchParams }: PageProps<"/search">) {
   const [locale, t] = await Promise.all([getLocale(), getTranslations("search")]);

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -28,7 +28,7 @@
     "lucide-react": "1.8.0",
     "motion": "12.38.0",
     "nanoid": "5.1.9",
-    "next": "16.3.0-canary.0",
+    "next": "16.3.0-canary.1",
     "next-intl": "4.9.1",
     "oxfmt": "0.45.0",
     "oxlint": "1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,10 +52,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.1(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vue@3.5.30(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.0(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.168
         version: 6.0.168(zod@4.3.6)
@@ -79,10 +79,10 @@ importers:
         version: 5.2.0
       fromsrc:
         specifier: 0.0.31
-        version: 0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       geist:
         specifier: 1.7.0
-        version: 1.7.0(next@16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 1.7.0(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       jotai:
         specifier: 2.19.1
         version: 2.19.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.5)
@@ -96,8 +96,8 @@ importers:
         specifier: 5.1.9
         version: 5.1.9
       next:
-        specifier: 16.3.0-canary.0
-        version: 16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 16.3.0-canary.1
+        version: 16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-mdx-remote:
         specifier: 6.0.0
         version: 6.0.0(@types/react@19.2.14)(react@19.2.5)
@@ -204,11 +204,11 @@ importers:
         specifier: 5.1.9
         version: 5.1.9
       next:
-        specifier: 16.3.0-canary.0
-        version: 16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 16.3.0-canary.1
+        version: 16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-intl:
         specifier: 4.9.1
-        version: 4.9.1(next@16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        version: 4.9.1(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       oxfmt:
         specifier: 0.45.0
         version: 0.45.0
@@ -811,57 +811,57 @@ packages:
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
 
-  '@next/env@16.3.0-canary.0':
-    resolution: {integrity: sha512-5LymuiNITdsZLlxny2qP3UGX1LF4tWIx4qLExa4i5E3Zag4blhTF5n3al4CNDQV/yzETCXYmlck2AV1XcHi8Iw==}
+  '@next/env@16.3.0-canary.1':
+    resolution: {integrity: sha512-TgUDvA5bmzteb7GvC9kX4BqdWCdMhRWGcBg+zhlrwRykVMeHN54/YhShLy9UIFeObJcf/LU6VRfKCnMbZk627g==}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.0':
-    resolution: {integrity: sha512-dN4OyNiUsG9z0YjcVmXKgEa06m9FmOYUbtiKF10XFVeO+LCKlPVUKDIGyVVcexw5BWNxFACZcMqWapAB4cDV8Q==}
+  '@next/swc-darwin-arm64@16.3.0-canary.1':
+    resolution: {integrity: sha512-oprUsiW1/mDxYu2lYloBN0MISydr0+KCUzhgdiBcfrDutYWikMJxeawqy3h0cisaGXUU6wd0Zg+5orFw02jy0w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.3.0-canary.0':
-    resolution: {integrity: sha512-xlVOEs16GpWgqVNAKy6QzPpuf0K8AG6lto7gDAFz1QthOAcq9x2JlcRwukPeRKcKOdi5GJIbJI+O2ymAPdlgiA==}
+  '@next/swc-darwin-x64@16.3.0-canary.1':
+    resolution: {integrity: sha512-pWQCu7+DiB0xeTHIPthHhfEOIo8c1iJi/U85UCE24U9m0G37wXaizAuzmAOIR4eQpXi8LxZcMciSdiFrfLuzSw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.0':
-    resolution: {integrity: sha512-MRaQXhUZyvYwIIa4KfhULqgR8xqBM0WNYTaVO92/aZDXLKyYHNh+OXuDjFB7rIHZwufnmrWY87m/j4FKtwpQrA==}
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.1':
+    resolution: {integrity: sha512-mxE9diHw5K8LOgKIS8pE7Jo0CBft0nX2Pi67IsDVD+SujgEvjTFUzo4TNKLgdJMvJNg1P0J0Ao5KAPhB8LbVVw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.0':
-    resolution: {integrity: sha512-lR4X4WEPOZM4XFGdbrDuGJbxxTFck8koMYxoTW7ZJIKBHuWQKD3ewputFdal+EgsOdAs6g2jJNaoDOAJVdUyxQ==}
+  '@next/swc-linux-arm64-musl@16.3.0-canary.1':
+    resolution: {integrity: sha512-O7xwizzkU/X9TQBsBsKRHieXSZoP8mucMod7cYRlrqZJkXzx2h8Z+J2L8Xj+/pchI3yldT/SyICN9qhHDeq85w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.0':
-    resolution: {integrity: sha512-btU37LpQ2cf0IPOreVfwtfpunjnZlOIjsKjqgRy++GNAt6Y9e6QMYNe17e4rV+KZ/1WZ1g/9HL7M0Wb8nP9B3A==}
+  '@next/swc-linux-x64-gnu@16.3.0-canary.1':
+    resolution: {integrity: sha512-6N49YsPhhvvAuTMPBwmOSm/KhcsPmeF6J053SvSKNkkjzDDXtGT/grB8qwxH51H1A9OLh9mPsi/anUngcGjhOA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.0':
-    resolution: {integrity: sha512-NitKjr7MnmK+n2mmZPLSxBGUMJR/XnjmA8wjtXo+B4Er7qFtb4AQWidoyA5PQp/876Tu3IzbWdV5u086QehZ6A==}
+  '@next/swc-linux-x64-musl@16.3.0-canary.1':
+    resolution: {integrity: sha512-TGEb0gx6uHOjM6HmqTIh1nqfLkaT/8srvAIvvEqVbOHYboS5cIsP2UBuQqC167g9yIsLEqHu/1tQFkLOtu5usA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.0':
-    resolution: {integrity: sha512-/J8/MivQuzYlRCtJmAQoTlwVILQ+ItxHTYxtTPjjJ17wKxFJLfTHYbXERvCSvuq8tw26Pt4gF/nIu2BhERX2vg==}
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.1':
+    resolution: {integrity: sha512-BaEEil5UMuyciyvsdsZJ7Z+NT6QoNhhLGpaKY62XFt95P8B+Sy3yefqNaKoleforgVSb5tvzt6jsPAERbLMLiw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.0':
-    resolution: {integrity: sha512-hXizrwbaTRDsNoVT/l1mYCGkbvBJUzzpE9DttDAvP9ryJTn+TIRSBA7/AGzQIvprmPUuAvq4Fx+bCwNDZ9Aheg==}
+  '@next/swc-win32-x64-msvc@16.3.0-canary.1':
+    resolution: {integrity: sha512-9E16XXHORi213//iw/42mTVJCq7U3yQXkl0vYN9HID3aNEE1Fi6OFl4Jzt3lriPfOF5bFE5gbv50va8BFy2Mlw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -4077,8 +4077,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.3.0-canary.0:
-    resolution: {integrity: sha512-lVPNjDEgH53zm9VaCNR/pIh6vUjmKbvCRn5qfhKRxznG1l94f5njzPq1kVw3zbAPayUIqEnQOhUfrf33s3aC0g==}
+  next@16.3.0-canary.1:
+    resolution: {integrity: sha512-3Vo3Yx2Hef0HVuX2M9UYSSg36l0W9UhQJyMq1PzAB7N9J+r3Km53OaxFlxhttHGPl/9XCotuXwy/hnnRrWbszA==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5783,30 +5783,30 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@next/env@16.3.0-canary.0': {}
+  '@next/env@16.3.0-canary.1': {}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.0':
+  '@next/swc-darwin-arm64@16.3.0-canary.1':
     optional: true
 
-  '@next/swc-darwin-x64@16.3.0-canary.0':
+  '@next/swc-darwin-x64@16.3.0-canary.1':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.0':
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.1':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.0':
+  '@next/swc-linux-arm64-musl@16.3.0-canary.1':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.0':
+  '@next/swc-linux-x64-gnu@16.3.0-canary.1':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.0':
+  '@next/swc-linux-x64-musl@16.3.0-canary.1':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.0':
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.1':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.0':
+  '@next/swc-win32-x64-msvc@16.3.0-canary.1':
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -7176,17 +7176,17 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(next@16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       vue: 3.5.30(typescript@6.0.3)
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       vue: 3.5.30(typescript@6.0.3)
 
@@ -8039,13 +8039,13 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fromsrc@0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+  fromsrc@0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@shikijs/rehype': 3.23.0
       '@shikijs/transformers': 3.23.0
       gray-matter: 4.0.3
-      next: 16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-mdx-remote: 6.0.0(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       remark-gfm: 4.0.1
@@ -8081,9 +8081,9 @@ snapshots:
 
   fuzzysort@3.1.0: {}
 
-  geist@1.7.0(next@16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
+  geist@1.7.0(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
     dependencies:
-      next: 16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   gensync@1.0.0-beta.2: {}
 
@@ -9140,14 +9140,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.9.1: {}
 
-  next-intl@4.9.1(next@16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@6.0.3):
+  next-intl@4.9.1(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.18
       icu-minify: 4.9.1
       negotiator: 1.0.0
-      next: 16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-intl-swc-plugin-extractor: 4.9.1
       po-parser: 2.1.1
       react: 19.2.5
@@ -9176,9 +9176,9 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  next@16.3.0-canary.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@next/env': 16.3.0-canary.0
+      '@next/env': 16.3.0-canary.1
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.7
       caniuse-lite: 1.0.30001778
@@ -9187,14 +9187,14 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.3.0-canary.0
-      '@next/swc-darwin-x64': 16.3.0-canary.0
-      '@next/swc-linux-arm64-gnu': 16.3.0-canary.0
-      '@next/swc-linux-arm64-musl': 16.3.0-canary.0
-      '@next/swc-linux-x64-gnu': 16.3.0-canary.0
-      '@next/swc-linux-x64-musl': 16.3.0-canary.0
-      '@next/swc-win32-arm64-msvc': 16.3.0-canary.0
-      '@next/swc-win32-x64-msvc': 16.3.0-canary.0
+      '@next/swc-darwin-arm64': 16.3.0-canary.1
+      '@next/swc-darwin-x64': 16.3.0-canary.1
+      '@next/swc-linux-arm64-gnu': 16.3.0-canary.1
+      '@next/swc-linux-arm64-musl': 16.3.0-canary.1
+      '@next/swc-linux-x64-gnu': 16.3.0-canary.1
+      '@next/swc-linux-x64-musl': 16.3.0-canary.1
+      '@next/swc-win32-arm64-msvc': 16.3.0-canary.1
+      '@next/swc-win32-x64-msvc': 16.3.0-canary.1
       '@opentelemetry/api': 1.9.0
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5


### PR DESCRIPTION
## Summary
- Bump `next` from `16.3.0-canary.0` to `16.3.0-canary.1` in both `apps/template` and `apps/docs`
- Adapt to breaking config changes:
  - `unstable_prefetch`: `"runtime"` renamed to `"force-runtime"`
  - `unstable_instant`: `prefetch` field removed (now controlled solely by the separate `unstable_prefetch` export)

## Test plan
- [ ] `pnpm build` succeeds for template and docs
- [ ] Verify instant navigation still works on product, collection, and search pages
- [ ] Verify runtime prefetching behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)