### PR TITLE
Simplify price filter to manual min/max only

### DIFF
--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -41,7 +41,7 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
       >
         <a
           href="#main-content"
-          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-5 focus:z-100 focus:rounded-md focus:bg-background focus:px-5 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:ring-2 focus:ring-foreground focus:outline-none"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-100 focus:rounded-md focus:bg-background focus:px-5 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:ring-2 focus:ring-foreground focus:outline-none"
         >
           {t("skipToContent")}
         </a>

--- a/apps/template/components/collections/filter-sidebar.tsx
+++ b/apps/template/components/collections/filter-sidebar.tsx
@@ -12,7 +12,6 @@ import {
   FilterBadge,
   FilterOption,
   FilterOptionList,
-  FilterPricePreset,
   FilterPriceRange,
   FilterSection,
   FilterSectionContent,
@@ -32,13 +31,6 @@ interface CollectionFilterSidebarClientProps {
 }
 
 type FilterState = Record<string, string | string[] | undefined>;
-
-const PRICE_PRESETS = [
-  { label: "Under $50", min: 0, max: 50 },
-  { label: "$50 - $100", min: 50, max: 100 },
-  { label: "$100 - $200", min: 100, max: 200 },
-  { label: "Over $200", min: 200, max: undefined },
-];
 
 function formatPriceRangeLabel(min: number | null, max: number | null): string {
   if (min !== null && max !== null) {
@@ -178,12 +170,6 @@ export function CollectionFilterSidebarClient({
     });
   };
 
-  const applyPricePreset = (min: number, max: number | undefined) => {
-    setMinInput(min.toString());
-    setMaxInput(max?.toString() ?? "");
-    applyPriceRange(min.toString(), max?.toString() ?? "");
-  };
-
   const removePriceRange = () => {
     const params = new URLSearchParams(searchParams.toString());
     params.delete("filter.v.price.gte");
@@ -248,27 +234,7 @@ export function CollectionFilterSidebarClient({
                 onMinChange={setMinInput}
                 onMaxChange={setMaxInput}
                 onApply={applyPriceRange}
-              >
-                <FilterOptionList>
-                  {PRICE_PRESETS.map((preset) => {
-                    const isSelected =
-                      urlPriceMin === preset.min &&
-                      (preset.max === undefined
-                        ? urlPriceMax === null
-                        : urlPriceMax === preset.max);
-
-                    return (
-                      <FilterPricePreset
-                        key={preset.label}
-                        selected={isSelected}
-                        onClick={() => applyPricePreset(preset.min, preset.max)}
-                      >
-                        {preset.label}
-                      </FilterPricePreset>
-                    );
-                  })}
-                </FilterOptionList>
-              </FilterPriceRange>
+              />
             </FilterSectionContent>
           </FilterSection>
         )}

--- a/apps/template/components/pdp/lightbox.tsx
+++ b/apps/template/components/pdp/lightbox.tsx
@@ -32,7 +32,7 @@ export function Lightbox({ label, children }: { label: string; children: ReactNo
               if (e.target === e.currentTarget) close();
             }}
           >
-            <DialogPrimitive.Close className="pointer-events-auto absolute top-5 right-4 z-10 rounded-full bg-black/50 p-2 text-white transition-opacity hover:opacity-80 focus:ring-2 focus:ring-white focus:outline-hidden">
+            <DialogPrimitive.Close className="pointer-events-auto absolute top-4 right-4 z-10 rounded-full bg-black/50 p-2 text-white transition-opacity hover:opacity-80 focus:ring-2 focus:ring-white focus:outline-hidden">
               <XIcon className="size-5" />
               <span className="sr-only">Close</span>
             </DialogPrimitive.Close>

--- a/apps/template/components/ui/dialog.tsx
+++ b/apps/template/components/ui/dialog.tsx
@@ -61,7 +61,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-5 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>

--- a/apps/template/components/ui/dropdown-menu.tsx
+++ b/apps/template/components/ui/dropdown-menu.tsx
@@ -61,7 +61,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-10 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -79,7 +79,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-10 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -110,7 +110,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-10 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -136,7 +136,7 @@ function DropdownMenuLabel({
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
-      className={cn("px-2 py-1.5 text-sm font-medium data-[inset]:pl-10", className)}
+      className={cn("px-2 py-1.5 text-sm font-medium data-[inset]:pl-8", className)}
       {...props}
     />
   );
@@ -182,7 +182,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-10 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/apps/template/components/ui/filter-sidebar.tsx
+++ b/apps/template/components/ui/filter-sidebar.tsx
@@ -267,74 +267,43 @@ function FilterPriceRange({
   onApply,
   currencySymbol = "$",
   className,
-  children,
   ...props
 }: FilterPriceRangeProps) {
   return (
-    <div data-slot="filter-price-range" className={cn("flex flex-col gap-2.5", className)} {...props}>
-      <div className="flex items-center gap-2">
-        <div className="flex flex-1 items-center rounded-full bg-input px-2.5 h-8">
-          <span className="text-sm text-muted-foreground">{currencySymbol}</span>
-          <Input
-            type="number"
-            step="0.01"
-            min="0"
-            placeholder="From"
-            value={minValue}
-            onChange={(e) => onMinChange?.(e.target.value)}
-            className="h-auto border-0 bg-transparent px-1 text-sm shadow-none outline-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-          />
-        </div>
-        <span className="text-muted-foreground">–</span>
-        <div className="flex flex-1 items-center rounded-full bg-input px-2.5 h-8">
-          <span className="text-sm text-muted-foreground">{currencySymbol}</span>
-          <Input
-            type="number"
-            step="0.01"
-            min="0"
-            placeholder="To"
-            value={maxValue}
-            onChange={(e) => onMaxChange?.(e.target.value)}
-            className="h-auto border-0 bg-transparent px-1 text-sm shadow-none outline-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-          />
-        </div>
-        <button
-          type="button"
-          onClick={() => onApply?.(minValue, maxValue)}
-          className="flex size-8 items-center justify-center rounded-full bg-foreground text-background transition-colors hover:bg-foreground/90"
-        >
-          <CheckIcon className="size-4" />
-        </button>
+    <div data-slot="filter-price-range" className={cn("flex items-center gap-2", className)} {...props}>
+      <div className="flex flex-1 items-center rounded-lg bg-input px-2.5 h-8">
+        <span className="text-sm text-muted-foreground">{currencySymbol}</span>
+        <Input
+          type="number"
+          step="0.01"
+          min="0"
+          placeholder="From"
+          value={minValue}
+          onChange={(e) => onMinChange?.(e.target.value)}
+          className="h-auto border-0 bg-transparent px-1 text-sm shadow-none outline-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        />
       </div>
-      {children}
+      <span className="text-muted-foreground">–</span>
+      <div className="flex flex-1 items-center rounded-lg bg-input px-2.5 h-8">
+        <span className="text-sm text-muted-foreground">{currencySymbol}</span>
+        <Input
+          type="number"
+          step="0.01"
+          min="0"
+          placeholder="To"
+          value={maxValue}
+          onChange={(e) => onMaxChange?.(e.target.value)}
+          className="h-auto border-0 bg-transparent px-1 text-sm shadow-none outline-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        />
+      </div>
+      <button
+        type="button"
+        onClick={() => onApply?.(minValue, maxValue)}
+        className="flex size-8 items-center justify-center rounded-lg bg-foreground text-background transition-colors hover:bg-foreground/90"
+      >
+        <CheckIcon className="size-4" />
+      </button>
     </div>
-  );
-}
-
-interface FilterPricePresetProps extends React.ComponentProps<"button"> {
-  selected?: boolean;
-}
-
-function FilterPricePreset({
-  selected = false,
-  className,
-  children,
-  ...props
-}: FilterPricePresetProps) {
-  return (
-    <button
-      type="button"
-      data-slot="filter-price-preset"
-      data-selected={selected}
-      className={cn(
-        "text-left text-sm text-muted-foreground transition-colors hover:text-foreground",
-        "data-[selected=true]:font-medium",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </button>
   );
 }
 
@@ -443,7 +412,6 @@ export {
   FilterOptionList,
   FilterOption,
   FilterPriceRange,
-  FilterPricePreset,
   FilterSidebarCategories,
   FilterSidebarCategoryBack,
   FilterSidebarCategoryItem,

--- a/apps/template/components/ui/scroll-carousel.tsx
+++ b/apps/template/components/ui/scroll-carousel.tsx
@@ -152,8 +152,8 @@ function ScrollCarouselContent({ className, children, ...props }: React.Componen
       className={cn(
         "grid grid-flow-col gap-5 overflow-x-auto overscroll-x-contain snap-x snap-mandatory scrollbar-hide",
         "relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen max-w-none auto-cols-[58.33vw] px-5 scroll-px-5",
-        "sm:left-auto sm:right-auto sm:mx-0 sm:w-full sm:max-w-full sm:auto-cols-[calc((100%-1rem)/2)] sm:px-0 sm:scroll-px-0",
-        "lg:auto-cols-[calc((100%-2rem)/3)] xl:auto-cols-[calc((100%-3rem)/4)] 2xl:auto-cols-[calc((100%-4rem)/5)] 3xl:auto-cols-[calc((100%-5rem)/6)] 4xl:auto-cols-[calc((100%-7rem)/8)]",
+        "sm:left-auto sm:right-auto sm:mx-0 sm:w-full sm:max-w-full sm:auto-cols-[calc((100%-1.25rem)/2)] sm:px-0 sm:scroll-px-0",
+        "lg:auto-cols-[calc((100%-2.5rem)/3)] xl:auto-cols-[calc((100%-3.75rem)/4)] 2xl:auto-cols-[calc((100%-5rem)/5)] 3xl:auto-cols-[calc((100%-6.25rem)/6)] 4xl:auto-cols-[calc((100%-8.75rem)/8)]",
         className,
       )}
       {...props}

--- a/apps/template/components/ui/select.tsx
+++ b/apps/template/components/ui/select.tsx
@@ -100,7 +100,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-10 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/apps/template/components/ui/sheet.tsx
+++ b/apps/template/components/ui/sheet.tsx
@@ -66,7 +66,7 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-5 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>


### PR DESCRIPTION
## Summary
- Remove preset price range buttons (Under $50, $50-$100, etc.)
- Keep only manual min/max inputs for price filtering
- Switch input and apply button rounding from `rounded-full` to `rounded-lg` to match CTA button styling

## Test plan
- [ ] Price filter shows only min/max input fields, no preset buttons
- [ ] Input fields and apply button have `rounded-lg` rounding
- [ ] Entering min/max values and clicking apply filters products correctly
- [ ] Price filter badge appears in active filters and can be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)