### PR TITLE
Add count badges to cart and filter slideover headers

### DIFF
--- a/apps/template/components/cart/overlay.tsx
+++ b/apps/template/components/cart/overlay.tsx
@@ -9,6 +9,17 @@ import { useMediaQuery } from "@/hooks/use-media-query";
 import { useCart } from "./context";
 import { OverlayContent } from "./overlay-content";
 
+function CartCountBadge() {
+  const { cartWithPending } = useCart();
+  const count = cartWithPending?.totalQuantity ?? 0;
+  if (count === 0) return null;
+  return (
+    <span className="flex size-5 items-center justify-center rounded-full bg-foreground text-xs text-background">
+      {count}
+    </span>
+  );
+}
+
 interface CartOverlayProps {
   locale: string;
 }
@@ -22,8 +33,9 @@ export function CartOverlay({ locale }: CartOverlayProps) {
     return (
       <Sheet open={isOverlayOpen} onOpenChange={setOverlayOpen}>
         <SheetContent side="right" className="w-full max-w-md p-0 gap-0">
-          <div className="flex h-16 shrink-0 items-center px-5">
+          <div className="flex h-16 shrink-0 items-center gap-2 px-5">
             <SheetTitle className="text-lg font-semibold">{t("shoppingCart")}</SheetTitle>
+            <CartCountBadge />
           </div>
           <SheetDescription className="sr-only">{t("reviewCartDescription")}</SheetDescription>
           <OverlayContent locale={locale} />
@@ -35,8 +47,9 @@ export function CartOverlay({ locale }: CartOverlayProps) {
   return (
     <Drawer open={isOverlayOpen} onOpenChange={setOverlayOpen}>
       <DrawerContent className="max-h-[85vh]">
-        <div className="flex h-16 shrink-0 items-center px-5">
+        <div className="flex h-16 shrink-0 items-center gap-2 px-5">
           <DrawerTitle className="text-lg font-semibold">{t("shoppingCart")}</DrawerTitle>
+          <CartCountBadge />
         </div>
         <DrawerDescription className="sr-only">{t("reviewCartDescription")}</DrawerDescription>
         <OverlayContent locale={locale} />

--- a/apps/template/components/collections/filter-sidebar-sheet.tsx
+++ b/apps/template/components/collections/filter-sidebar-sheet.tsx
@@ -44,13 +44,13 @@ export function FilterSidebarSheet({
         side="left"
         className="gap-0 px-5 pb-5 overflow-y-auto [&_[data-slot=filter-sidebar-scroll-fade]]:hidden [&_[data-slot=filter-sidebar]]:overflow-y-visible [&_[data-slot=filter-sidebar]>div]:!pb-0 [&_[data-slot=filter-sidebar-header]]:hidden"
       >
-        <div className="flex h-16 shrink-0 items-center">
-          <SheetTitle className="text-lg font-semibold">
-            {label}
-            {activeCount !== undefined && activeCount > 0 && (
-              <span className="ml-1">({activeCount})</span>
-            )}
-          </SheetTitle>
+        <div className="flex h-16 shrink-0 items-center gap-2">
+          <SheetTitle className="text-lg font-semibold">{label}</SheetTitle>
+          {activeCount !== undefined && activeCount > 0 && (
+            <span className="flex size-5 items-center justify-center rounded-full bg-foreground text-xs text-background">
+              {activeCount}
+            </span>
+          )}
         </div>
         {children}
       </SheetContent>


### PR DESCRIPTION
## Summary
- Add item count badge to Shopping Cart sheet/drawer title (matches filter trigger button style)
- Add active filter count badge to Filters sheet title (replaces parenthetical count)
- Badge style: `size-5 rounded-full bg-foreground text-xs text-background` — consistent across filter button, filter sheet, and cart sheet

## Test plan
- [ ] Open cart with items → verify count badge appears next to "Shopping Cart"
- [ ] Open cart with no items → verify no badge shown
- [ ] Add/remove items → verify badge updates
- [ ] Open filters sheet with active filters → verify count badge appears
- [ ] Clear all filters → verify badge disappears
- [ ] Test on mobile (drawer) and desktop (sheet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)