### PR TITLE
Fix cart image fallback for single-variant products

### DIFF
--- a/apps/template/lib/product/index.ts
+++ b/apps/template/lib/product/index.ts
@@ -415,7 +415,7 @@ export function variantToOptimisticInfo(
     productTitle: product.title,
     productHandle: product.handle,
     price: variant.price,
-    image: variant.image ||
+    image: (variant.image?.url ? variant.image : null) ||
       product.featuredImage || {
         url: "",
         altText: product.title,

--- a/apps/template/lib/shopify/transforms/cart.ts
+++ b/apps/template/lib/shopify/transforms/cart.ts
@@ -84,7 +84,7 @@ function transformCartLine(line: ShopifyCartLine): CartLine {
     merchandise: {
       id: line.merchandise.id,
       title: line.merchandise.title,
-      image: line.merchandise.image ? transformImage(line.merchandise.image) : undefined,
+      image: line.merchandise.image?.url ? transformImage(line.merchandise.image) : undefined,
       price: line.merchandise.price,
       selectedOptions: line.merchandise.selectedOptions,
       product: transformCartProduct(line.merchandise.product),


### PR DESCRIPTION
## Summary
- Single-variant products may return a variant image object with an empty URL from Shopify, bypassing the `product.featuredImage` fallback
- Check for a truthy `image.url` before using the variant image in both:
  - `lib/shopify/transforms/cart.ts` — server response path
  - `lib/product/index.ts` (`variantToOptimisticInfo`) — optimistic add path

## Test plan
- [ ] Add a single-variant product to cart → verify product featured image loads (not a broken image)
- [ ] Add a multi-variant product to cart → verify variant-specific image still loads correctly
- [ ] Check both cart overlay and /cart page

🤖 Generated with [Claude Code](https://claude.com/claude-code)