### PR TITLE
Restyle not-found page and convert empty-cart to RSC

### DIFF
--- a/apps/template/app/not-found.tsx
+++ b/apps/template/app/not-found.tsx
@@ -1,25 +1,27 @@
-import { FileQuestionIcon } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 
 import { Container } from "@/components/layout/container";
-import { Button } from "@/components/ui/button";
 
 export default async function NotFoundError() {
   const t = await getTranslations("common");
 
   return (
-    <Container className="flex flex-col items-center justify-center py-10 text-center lg:py-10">
-      <div className="mb-6 flex justify-center">
-        <div className="rounded-full bg-muted p-5">
-          <FileQuestionIcon className="h-12 w-12 text-muted-foreground" />
-        </div>
+    <Container className="flex flex-1 flex-col items-center justify-center py-10 text-center lg:py-10">
+      <div className="flex flex-col items-center text-center gap-2.5">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl font-semibold tracking-tight">
+          {t("notFound")}
+        </h1>
+        <p className="text-sm md:text-base text-muted-foreground max-w-xl">
+          {t("notFoundDesc")}
+        </p>
+        <Link
+          href="/search"
+          className="inline-flex items-center justify-center h-12 px-8 rounded-lg text-sm font-medium bg-foreground text-background hover:bg-foreground/90 transition-colors"
+        >
+          {t("continueShopping")}
+        </Link>
       </div>
-      <h1 className="mb-2 text-2xl font-semibold tracking-tight lg:text-3xl">{t("notFound")}</h1>
-      <p className="mb-8 max-w-md text-muted-foreground">{t("notFoundDesc")}</p>
-      <Button asChild>
-        <Link href="/">{t("goHome")}</Link>
-      </Button>
     </Container>
   );
 }

--- a/apps/template/components/cart-page/empty-cart.tsx
+++ b/apps/template/components/cart-page/empty-cart.tsx
@@ -1,10 +1,8 @@
-"use client";
-
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 
-export function Empty() {
-  const t = useTranslations("cart");
+export async function Empty() {
+  const t = await getTranslations("cart");
 
   return (
     <div className="flex flex-col items-center justify-center py-10 lg:py-10 px-5">

--- a/apps/template/lib/i18n/messages/en.d.json.ts
+++ b/apps/template/lib/i18n/messages/en.d.json.ts
@@ -237,9 +237,10 @@ declare const messages: {
     }
   },
   "common": {
-    "notFound": "Not Found",
-    "notFoundDesc": "The page you are looking for does not exist.",
+    "notFound": "Page Not Found",
+    "notFoundDesc": "The link may be incorrect, or the page has been removed.",
     "goHome": "Go back to the home page",
+    "continueShopping": "Continue Shopping",
     "error": "Something went wrong",
     "errorDesc": "An unexpected error occurred. Please try again.",
     "tryAgain": "Try again"

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -234,9 +234,10 @@
     }
   },
   "common": {
-    "notFound": "Not Found",
-    "notFoundDesc": "The page you are looking for does not exist.",
+    "notFound": "Page Not Found",
+    "notFoundDesc": "The link may be incorrect, or the page has been removed.",
     "goHome": "Go back to the home page",
+    "continueShopping": "Continue Shopping",
     "error": "Something went wrong",
     "errorDesc": "An unexpected error occurred. Please try again.",
     "tryAgain": "Try again"


### PR DESCRIPTION
## Summary
- **Not-found page**: Removed icon, consistent h1 sizing (`text-3xl sm:text-4xl md:text-5xl`), banner-style content stack, "Continue Shopping" CTA linking to `/search` with checkout button styling, updated description copy
- **Empty cart**: Converted from client to server component (`useTranslations` → `getTranslations`)

## Test plan
- [ ] Visit a non-existent URL (e.g. `/nonexistent`) — should show restyled not-found page
- [ ] Click "Continue Shopping" — should navigate to `/search`
- [ ] Visit `/cart` with empty cart — should still render correctly as RSC

🤖 Generated with [Claude Code](https://claude.com/claude-code)