### PR TITLE
Test: cached timestamp with tag invalidation

### DIFF
--- a/apps/template/app/api/invalidate-tmp/route.ts
+++ b/apps/template/app/api/invalidate-tmp/route.ts
@@ -1,0 +1,6 @@
+import { revalidateTag } from "next/cache";
+
+export async function POST() {
+  revalidateTag("tmp", "max");
+  return Response.json({ revalidated: true });
+}

--- a/apps/template/components/layout/nav/cached-timestamp.tsx
+++ b/apps/template/components/layout/nav/cached-timestamp.tsx
@@ -9,5 +9,5 @@ async function getTimestamp() {
 
 export async function CachedTimestamp() {
   const timestamp = await getTimestamp();
-  return <span className="text-xs text-muted-foreground">{timestamp}</span>;
+  return <span className="text-sm">{timestamp}</span>;
 }

--- a/apps/template/components/layout/nav/cached-timestamp.tsx
+++ b/apps/template/components/layout/nav/cached-timestamp.tsx
@@ -1,0 +1,13 @@
+import { cacheLife, cacheTag } from "next/cache";
+
+async function getTimestamp() {
+  "use cache";
+  cacheLife("max");
+  cacheTag("tmp");
+  return new Date().toISOString();
+}
+
+export async function CachedTimestamp() {
+  const timestamp = await getTimestamp();
+  return <span className="text-xs text-muted-foreground">{timestamp}</span>;
+}

--- a/apps/template/components/layout/nav/index.tsx
+++ b/apps/template/components/layout/nav/index.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Suspense } from "react";
 
+import { CachedTimestamp } from "./cached-timestamp";
 import { CartIcon, CartIconFallback } from "./cart";
 import { MobileMenu } from "./mobile-menu";
 import { QuickLinks } from "./quick-links";
@@ -19,6 +20,9 @@ export function Nav({ locale }: { locale: string }) {
         </Link>
 
         <QuickLinks />
+        <Suspense>
+          <CachedTimestamp />
+        </Suspense>
 
         <div className="flex items-center gap-5 ml-auto">
           <Suspense fallback={<CartIconFallback />}>


### PR DESCRIPTION
## Summary
- Adds a `use cache` timestamp in the nav (next to About) with `cacheLife("max")` and `cacheTag("tmp")`
- Adds `POST /api/invalidate-tmp` route to revalidate the tag — no secret required

**Test branch — do not merge to main.**

## Usage
```bash
curl -X POST https://<deploy-url>/api/invalidate-tmp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)