### PR TITLE
Add cursor-pointer to interactive elements

### DIFF
--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -67,6 +67,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - Use `cn()` (from `@/lib/utils`) when classes must be conditional.
 - Use `data-slot` attributes as stable styling hooks on compound components.
 - Use CVA (`cva`) for multi-variant component APIs.
+- Interactive elements (buttons, clickable links, CTAs) must use `cursor-pointer`. Disabled interactive elements must use `cursor-not-allowed`.
 
 ### Exports
 

--- a/apps/template/components/ui/button.tsx
+++ b/apps/template/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3 aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-all cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3 aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

- Add `cursor-pointer` and `disabled:cursor-not-allowed` to Button CVA base styles, replacing `disabled:pointer-events-none` so disabled buttons show the not-allowed cursor
- Add cursor design rule to AGENTS.md: interactive elements must use `cursor-pointer`, disabled elements must use `cursor-not-allowed`
- Global CSS in `globals.css` already covers `button` and `[role="button"]` as a safety net

## Test plan

- [ ] Buttons show pointer cursor on hover
- [ ] Disabled buttons show not-allowed cursor on hover
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)