### PR TITLE
Fix search page fallback: contained skeleton + correct h1

### DIFF
--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -83,26 +83,43 @@ export default async function SearchPage({ searchParams }: PageProps<"/search">)
   return (
     <Container className="pt-2.5 md:pt-10">
       <FilterTransitionProvider>
-        <Suspense fallback={<ResultsSkeleton title={t("title")} />}>
-          <SearchContent
-            locale={locale}
-            searchParamsPromise={searchParams}
-            defaultTitle={t("title")}
-          />
+        <div className="mb-6">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-semibold tracking-tight">
+            <Link href="/search">{t("title")}</Link>
+            <Suspense fallback={null}>
+              <SearchQueryLabel searchParamsPromise={searchParams} />
+            </Suspense>
+          </h1>
+        </div>
+        <Suspense fallback={<ResultsSkeleton />}>
+          <SearchContent locale={locale} searchParamsPromise={searchParams} />
         </Suspense>
       </FilterTransitionProvider>
     </Container>
   );
 }
 
+async function SearchQueryLabel({
+  searchParamsPromise,
+}: {
+  searchParamsPromise: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [resolvedSearchParams, t] = await Promise.all([
+    searchParamsPromise,
+    getTranslations("search"),
+  ]);
+  const raw = resolvedSearchParams.q;
+  const query = Array.isArray(raw) ? raw[0] : raw;
+  if (!query) return null;
+  return t("forQuery", { query });
+}
+
 async function SearchContent({
   locale,
   searchParamsPromise,
-  defaultTitle,
 }: {
   locale: Locale;
   searchParamsPromise: Promise<Record<string, string | string[] | undefined>>;
-  defaultTitle: string;
 }) {
   const [resolvedSearchParams, t] = await Promise.all([
     searchParamsPromise,
@@ -122,12 +139,6 @@ async function SearchContent({
 
   return (
     <>
-      <div className="mb-6">
-        <h1 className="text-3xl sm:text-4xl md:text-5xl font-semibold tracking-tight">
-          <Link href="/search">{q ? t("titleQuery", { query: q }) : defaultTitle}</Link>
-        </h1>
-      </div>
-
       <Suspense fallback={<CollectionToolbarSkeleton />}>
         <SearchToolbar
           locale={locale}

--- a/apps/template/components/layout/nav/search-modal.tsx
+++ b/apps/template/components/layout/nav/search-modal.tsx
@@ -122,7 +122,7 @@ function SearchDialogContent({ onClose }: { onClose: () => void }) {
           requestAnimationFrame(() => inputRef.current?.focus());
         }}
       >
-        <div className="w-full max-w-lg h-fit">
+        <div className="w-full max-w-xl h-fit">
           <DialogTitle className="sr-only">{t("search")}</DialogTitle>
           <div className="bg-background rounded-xl shadow-lg overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 duration-200">
             {/* Search input */}

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -22,12 +22,9 @@ const RESULTS_SKELETON_KEYS = Array.from(
   (_, index) => `search-results-skeleton-${index}`,
 );
 
-export function ResultsSkeleton({ title }: { title: string }) {
+export function ResultsSkeleton() {
   return (
     <>
-      <div className="mb-6">
-        <h1 className="text-3xl sm:text-4xl md:text-5xl font-semibold tracking-tight">{title}</h1>
-      </div>
       <CollectionToolbarSkeleton />
       <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
         {RESULTS_SKELETON_KEYS.map((key) => (

--- a/apps/template/components/ui/container.tsx
+++ b/apps/template/components/ui/container.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 
 export function Container({ children, className, ...props }: ComponentPropsWithRef<"section">) {
   return (
-    <section className={cn("mx-auto px-5 py-10 lg:px-10", className)} {...props}>
+    <section className={cn("mx-auto w-full px-5 py-10 lg:px-10", className)} {...props}>
       {children}
     </section>
   );

--- a/apps/template/lib/i18n/messages/en.d.json.ts
+++ b/apps/template/lib/i18n/messages/en.d.json.ts
@@ -272,6 +272,7 @@ declare const messages: {
     "clearFilters": "Clear all filters",
     "filter": "Filter",
     "filters": "Filters",
+    "forQuery": " for \"{query}\"",
     "loadingMore": "Loading more products...",
     "noResults": "No products found",
     "noResultsAvailable": "No products available",
@@ -306,8 +307,7 @@ declare const messages: {
       "priceLowToHigh": "Price: Low to High"
     },
     "sortBy": "Sort",
-    "title": "All Products",
-    "titleQuery": "Search results for \"{query}\"",
+    "title": "Search",
     "titleSubtext": "Showing results for your search query"
   },
   "seo": {

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -289,6 +289,7 @@
     "clearFilters": "Clear all filters",
     "filter": "Filter",
     "filters": "Filters",
+    "forQuery": " for \"{query}\"",
     "loadingMore": "Loading more products...",
     "noResults": "No products found",
     "noResultsAvailable": "No products available",
@@ -323,8 +324,7 @@
       "priceLowToHigh": "Price: Low to High"
     },
     "sortBy": "Sort",
-    "title": "All Products",
-    "titleQuery": "Search results for \"{query}\"",
+    "title": "Search",
     "titleSubtext": "Showing results for your search query"
   },
   "seo": {

--- a/packages/plugin/template-rollout-log/2026-04-25-container-fills-flex-parent.md
+++ b/packages/plugin/template-rollout-log/2026-04-25-container-fills-flex-parent.md
@@ -1,0 +1,33 @@
+---
+title: Container always fills its flex parent
+changeKey: container-w-full
+introducedOn: 2026-04-25
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/ui/container.tsx
+---
+
+## Summary
+
+`Container` (`components/ui/container.tsx`) now sets `w-full` alongside `mx-auto`. Previously, when `Container` was used inside a flex column (e.g. the root `<main className="flex flex-1 flex-col min-w-0">`), the auto margins overrode the default `align-items: stretch` and the section shrank to fit its children's intrinsic width.
+
+## Why it matters
+
+With real product cards, images forced the grid wide enough that the bug was invisible. The Suspense fallback skeleton has no intrinsic min-width, so on routes like `/search?q=...` the entire skeleton (toolbar + 5-column grid) collapsed into a narrow strip on the right of the page during the loading state.
+
+## Apply when
+
+- The storefront still uses `components/ui/container.tsx` with `mx-auto` and no width class.
+- The storefront has Suspense fallbacks containing low-intrinsic-width skeletons (e.g. `ProductCardSkeleton`).
+
+## Safe to skip when
+
+- `Container` has already been customized to set its own width or has been replaced.
+
+## Validation
+
+- Open `/search?q=beds` (or any collection) and confirm the loading skeleton spans the full container width with the configured grid columns, not a narrow strip.
+- Confirm the loaded state still renders identically.

--- a/packages/plugin/template-rollout-log/2026-04-25-container-fills-flex-parent.md
+++ b/packages/plugin/template-rollout-log/2026-04-25-container-fills-flex-parent.md
@@ -1,6 +1,6 @@
 ---
-title: Container always fills its flex parent
-changeKey: container-w-full
+title: Search page skeleton fix and Container fills flex parent
+changeKey: search-skeleton-and-container-w-full
 introducedOn: 2026-04-25
 changeType: fix
 defaultAction: adopt
@@ -8,26 +8,34 @@ appliesTo:
   - all
 paths:
   - apps/template/components/ui/container.tsx
+  - apps/template/app/search/page.tsx
+  - apps/template/components/search/results.tsx
+  - apps/template/lib/i18n/messages/en.json
 ---
 
 ## Summary
 
-`Container` (`components/ui/container.tsx`) now sets `w-full` alongside `mx-auto`. Previously, when `Container` was used inside a flex column (e.g. the root `<main className="flex flex-1 flex-col min-w-0">`), the auto margins overrode the default `align-items: stretch` and the section shrank to fit its children's intrinsic width.
+Two related fixes for the `/search` loading state:
+
+1. `Container` (`components/ui/container.tsx`) now sets `w-full` alongside `mx-auto`. Previously, when `Container` was used inside a flex column (e.g. the root `<main className="flex flex-1 flex-col min-w-0">`), the auto margins overrode the default `align-items: stretch` and the section shrank to fit its children's intrinsic width. Real product cards forced the grid wide via image intrinsics, hiding the bug — but Suspense fallback skeletons have no intrinsic width, so the entire skeleton collapsed into a narrow strip.
+2. The search page's h1 is now hoisted out of the Suspense boundary. The static prefix ("Search") renders immediately, and a nested `<Suspense fallback={null}>` resolves the search-params promise to append ` for "{query}"`. This means the page never flashes "All Products" before settling on the real title. `ResultsSkeleton` no longer takes a `title` prop. New i18n key `search.forQuery` replaces the now-removed `search.titleQuery`; `search.title` was also retitled from "All Products" to "Search".
 
 ## Why it matters
 
-With real product cards, images forced the grid wide enough that the bug was invisible. The Suspense fallback skeleton has no intrinsic min-width, so on routes like `/search?q=...` the entire skeleton (toolbar + 5-column grid) collapsed into a narrow strip on the right of the page during the loading state.
+The previous fallback rendered "All Products" as the h1 even when a query was present, then snapped to "Search results for \"…\"" once data resolved. The skeleton beneath also collapsed because of the Container bug. After the fix, the title is consistent across loading and loaded states, and the skeleton fills the full grid.
 
 ## Apply when
 
 - The storefront still uses `components/ui/container.tsx` with `mx-auto` and no width class.
-- The storefront has Suspense fallbacks containing low-intrinsic-width skeletons (e.g. `ProductCardSkeleton`).
+- The storefront still uses the original `/search` page structure where the h1 lives inside the outer Suspense boundary.
 
 ## Safe to skip when
 
-- `Container` has already been customized to set its own width or has been replaced.
+- `Container` has been customized to set its own width or has been replaced.
+- The search page has already been restructured or replaced with a different layout that doesn't share these issues.
 
 ## Validation
 
-- Open `/search?q=beds` (or any collection) and confirm the loading skeleton spans the full container width with the configured grid columns, not a narrow strip.
-- Confirm the loaded state still renders identically.
+- Visit `/search?q=beds` and confirm the loading skeleton spans the full container width with the configured grid columns.
+- Confirm the loaded h1 reads `Search for "beds"` and `/search` (no query) reads `Search`.
+- Confirm the loaded grid still renders identically.


### PR DESCRIPTION
## Summary

Two related fixes for the `/search` loading state.

### 1. Container collapsing inside flex parents

`Container` used `mx-auto` with no width. Inside a flex column (`<main class=\"flex flex-1 flex-col min-w-0\">`), auto margins override `align-items: stretch` and the section shrinks to fit its children. Real product cards forced the grid wide via image intrinsics, hiding the bug. The Suspense fallback skeleton has no intrinsic width, so on `/search?q=...` the entire skeleton (toolbar + 5-column grid) collapsed into a narrow strip on the right of the page.

Added `w-full` to `Container` so it always fills its parent regardless of child intrinsic sizes.

### 2. h1 fallback strategy

The outer `<Suspense fallback={<ResultsSkeleton title={t(\"title\")} />}>` rendered the h1 with `t(\"title\")` = \"All Products\", which then snapped to `Search results for \"{query}\"` once data resolved. Every query-search flashed a wrong title.

Restructured so the h1 lives outside the Suspense boundary:

```tsx
<h1>
  <Link href=\"/search\">{t(\"title\")}</Link>
  <Suspense fallback={null}>
    <SearchQueryLabel searchParamsPromise={searchParams} />
  </Suspense>
</h1>
```

`SearchQueryLabel` awaits the params promise and emits ` for \"{query}\"` when there's a query, otherwise nothing. So:

- `/search` → `Search`
- `/search?q=beds` → `Search` while params pending → `Search for \"beds\"` once resolved

`ResultsSkeleton` no longer takes a title prop. i18n: `search.title` retitled `\"All Products\"` → `\"Search\"`; `search.titleQuery` removed; new `search.forQuery` = `\" for \\\"{query}\\\"\"`.

### Rollout log

Updated `packages/plugin/template-rollout-log/2026-04-25-container-fills-flex-parent.md` to cover both fixes.

## Test plan

- [ ] Visit `/search?q=beds`. Loading skeleton fills the full grid (5 columns), and the h1 reads `Search` then becomes `Search for \"beds\"` (no \"All Products\" flash).
- [ ] Visit `/search` with no query. h1 reads just `Search` and stays that way.
- [ ] Confirm the loaded results render identically to before (no spacing/column regression).
- [ ] Spot-check other pages that use `Container` (home, product, account) — layout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)