### PR TITLE
Sections primitive — vertical-spacing pilot on home & PDP

### DIFF
--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -63,11 +63,12 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 ### Spacing
 
-- Vertical spacing between sibling sections is **parent-owned**. Use `grid gap-*` on the parent (single implicit column unless `grid-cols-*` is set). Don't add `mb-*`, `mt-*`, `my-*`, or `space-y-*` to children.
-- `Container` provides `grid gap-10` by default, so direct children of `<Container>` need no wrapper.
+- `Container` provides horizontal padding and max-width only. It does **not** manage vertical spacing.
+- For vertical rhythm between sibling sections, wrap them in `<Sections>` (`components/ui/sections.tsx`). Default `gap-10`; override per page via `className` (e.g. `<Sections className="gap-5">`). `<Sections>` happily mixes full-bleed and contained children since each child can be a `<Container>`, a banner, or anything else.
+- Inside a single section, prefer `grid gap-*` on the immediate parent. Don't add `mb-*` / `mt-*` / `my-*` / `space-y-*` to children for inter-sibling spacing.
 - Canonical gap scale: `gap-2.5`, `gap-4`, `gap-5`, `gap-10`. Don't invent new values for the same job.
 - Padding *inside* a component (button, card, carousel breathing room via `py-*`) is fine. Negative-margin breakouts (`-mx-5`) are fine.
-- This convention is partially rolled out: home and PDP follow it; other pages convert page-by-page.
+- This convention is partially rolled out: home and PDP follow it; other pages still use `mb-*`/`space-y-*` patterns and that's OK in this transitional state.
 
 ### Tailwind & Styling
 

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -61,6 +61,14 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - Props interfaces: `{ComponentName}Props`
 - Constants: `SCREAMING_SNAKE_CASE`
 
+### Spacing
+
+- Vertical spacing between sibling sections is **parent-owned**. Use `grid gap-*` on the parent (single implicit column unless `grid-cols-*` is set). Don't add `mb-*`, `mt-*`, `my-*`, or `space-y-*` to children.
+- `Container` provides `grid gap-10` by default, so direct children of `<Container>` need no wrapper.
+- Canonical gap scale: `gap-2.5`, `gap-4`, `gap-5`, `gap-10`. Don't invent new values for the same job.
+- Padding *inside* a component (button, card, carousel breathing room via `py-*`) is fine. Negative-margin breakouts (`-mx-5`) are fine.
+- This convention is partially rolled out: home and PDP follow it; other pages convert page-by-page.
+
 ### Tailwind & Styling
 
 - Prefer `data-[attr=value]` selectors over conditional class assembly.

--- a/apps/template/app/about/page.tsx
+++ b/apps/template/app/about/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function AboutPage() {
   return (
-    <Container className="max-w-2xl">
+    <Container className="max-w-2xl py-10">
       <article className="prose prose-neutral prose-headings:font-semibold prose-headings:tracking-tight">
         <h1>About Vercel Shop</h1>
         <p>

--- a/apps/template/app/account/(authenticated)/layout.tsx
+++ b/apps/template/app/account/(authenticated)/layout.tsx
@@ -23,7 +23,7 @@ export default function AccountLayout({ children }: { children: React.ReactNode 
   if (!isAuthEnabled) notFound();
 
   return (
-    <Container className="flex flex-1 flex-col gap-6 md:flex-row md:gap-10">
+    <Container className="py-10 flex flex-1 flex-col gap-6 md:flex-row md:gap-10">
       <aside className="hidden w-52 shrink-0 md:block">
         <div className="sticky top-24 flex flex-col gap-6">
           <Suspense fallback={<UserInfoSkeleton />}>

--- a/apps/template/app/cart/page.tsx
+++ b/apps/template/app/cart/page.tsx
@@ -47,7 +47,7 @@ async function CartContent({ locale }: { locale: Locale }) {
         {!cart || cart.totalQuantity === 0 ? (
           <Empty />
         ) : (
-          <Container>
+          <Container className="py-10">
             <Header />
             <div className="lg:grid lg:grid-cols-12 lg:gap-10">
               <div className="lg:col-span-9">

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -47,16 +47,14 @@ export default async function HomePage() {
       />
 
       <Container>
-        <div className="flex flex-col gap-10">
-          {featuredProductsResult.products.length > 0 && (
-            <ProductsGrid
-              title={t("featuredProducts.title")}
-              products={featuredProductsResult.products}
-              locale={locale}
-              collectionUrl="/search"
-            />
-          )}
-        </div>
+        {featuredProductsResult.products.length > 0 && (
+          <ProductsGrid
+            title={t("featuredProducts.title")}
+            products={featuredProductsResult.products}
+            locale={locale}
+            collectionUrl="/search"
+          />
+        )}
       </Container>
     </>
   );

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -47,7 +47,7 @@ export default async function HomePage() {
         }}
       />
 
-      <Container>
+      <Container className="pb-10">
         {featuredProductsResult.products.length > 0 && (
           <ProductsGrid
             title={t("featuredProducts.title")}

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from "next-intl/server";
 import { ProductsGrid } from "@/components/product/products-grid";
 import { BannerSection } from "@/components/sections/banner-section";
 import { Container } from "@/components/ui/container";
+import { Sections } from "@/components/ui/sections";
 import { siteConfig } from "@/lib/config";
 import { getLocale } from "@/lib/params";
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
@@ -32,7 +33,7 @@ export default async function HomePage() {
   const featuredProductsResult = await getProducts({ limit: 8, locale });
 
   return (
-    <>
+    <Sections>
       {/* To use a custom hero image, pass a backgroundImage prop:
           backgroundImage: { url: "https://...", alt: "...", width: 1920, height: 1080 }
           or import a local image: import myHero from "@/public/my-hero.jpg" */}
@@ -56,6 +57,6 @@ export default async function HomePage() {
           />
         )}
       </Container>
-    </>
+    </Sections>
   );
 }

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -81,7 +81,7 @@ export default async function SearchPage({ searchParams }: PageProps<"/search">)
   const [locale, t] = await Promise.all([getLocale(), getTranslations("search")]);
 
   return (
-    <Container className="pt-2.5 md:pt-10">
+    <Container className="pt-2.5 md:pt-10 pb-10">
       <FilterTransitionProvider>
         <div className="mb-6">
           <h1 className="text-3xl sm:text-4xl md:text-5xl font-semibold tracking-tight">

--- a/apps/template/components/collections/collection-page.tsx
+++ b/apps/template/components/collections/collection-page.tsx
@@ -32,7 +32,7 @@ export function CollectionDetailPage({
 
   return (
     <FilterTransitionProvider>
-      <Container className="pt-2.5 md:pt-10">
+      <Container className="pt-2.5 md:pt-10 pb-10">
         <CollectionStructuredData
           locale={locale}
           handlePromise={handlePromise}

--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -26,7 +26,7 @@ export function ColorPicker({
   ...props
 }: ColorPickerProps) {
   return (
-    <div className={cn("space-y-2.5", className)} {...props}>
+    <div className={cn("grid gap-2.5", className)} {...props}>
       <p className="text-sm font-medium text-foreground/70">
         {option.name}: <span className="text-foreground">{selectedValue}</span>
       </p>

--- a/apps/template/components/product-detail/option-picker.tsx
+++ b/apps/template/components/product-detail/option-picker.tsx
@@ -23,7 +23,7 @@ export function OptionPicker({
   ...props
 }: OptionPickerProps) {
   return (
-    <div className={cn("space-y-2.5", className)} {...props}>
+    <div className={cn("grid gap-2.5", className)} {...props}>
       <p className="text-sm font-medium text-foreground/70">
         {option.name}: <span className="text-foreground">{selectedValue}</span>
       </p>

--- a/apps/template/components/product-detail/product-detail-page.tsx
+++ b/apps/template/components/product-detail/product-detail-page.tsx
@@ -24,11 +24,11 @@ function ProductBreadcrumbSchema({ title, handle }: { title: string; handle: str
 
 function ProductPageFallback() {
   return (
-    <div className="space-y-10">
-      <div className="lg:grid lg:grid-cols-10 lg:items-start lg:gap-5 space-y-10 lg:space-y-0">
+    <div className="grid gap-10">
+      <div className="grid gap-10 lg:grid-cols-10 lg:items-start lg:gap-5">
         <div className="lg:col-span-6">
           {/* Mobile: single full-bleed square + pagination space */}
-          <div className="space-y-5 lg:hidden -mx-5">
+          <div className="grid gap-5 lg:hidden -mx-5">
             <Skeleton className="aspect-square w-full" />
             <div className="h-1.5" />
           </div>
@@ -40,12 +40,12 @@ function ProductPageFallback() {
             <Skeleton className="aspect-square w-full" />
           </div>
         </div>
-        <div className="space-y-10 lg:sticky lg:top-20 lg:col-span-4">
-          <div>
+        <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
+          <div className="grid gap-2.5">
             <Skeleton className="h-8 w-3/4" />
             <Skeleton className="h-6 w-24" />
           </div>
-          <div className="space-y-2.5">
+          <div className="grid gap-2.5">
             <Skeleton className="h-4 w-20" />
             <div className="grid grid-cols-5 gap-2.5">
               {["a", "b", "c", "d"].map((k) => (
@@ -93,7 +93,7 @@ async function ProductContent({
       />
       <ProductBreadcrumbSchema title={title} handle={handle} />
 
-      <div className="flex flex-col gap-10">
+      <div className="grid gap-10">
         <ProductDetailSection
           product={product}
           locale={locale}

--- a/apps/template/components/product-detail/product-detail-page.tsx
+++ b/apps/template/components/product-detail/product-detail-page.tsx
@@ -116,7 +116,7 @@ export async function ProductDetailPage({
   variantIdPromise: Promise<string | undefined>;
 }) {
   return (
-    <Container className="bg-background pt-0">
+    <Container className="bg-background pt-0 pb-10">
       <Suspense fallback={<ProductPageFallback />}>
         <ProductContent
           productPromise={productPromise}

--- a/apps/template/components/product-detail/product-detail-page.tsx
+++ b/apps/template/components/product-detail/product-detail-page.tsx
@@ -4,6 +4,7 @@ import { ProductSchema } from "@/components/product-detail/schema";
 import { RelatedProductsSection } from "@/components/product/related-products-section";
 import { BreadcrumbSchema } from "@/components/schema/breadcrumb-schema";
 import { Container } from "@/components/ui/container";
+import { Sections } from "@/components/ui/sections";
 import { Skeleton } from "@/components/ui/skeleton";
 import { siteConfig } from "@/lib/config";
 import type { Locale } from "@/lib/i18n";
@@ -24,7 +25,7 @@ function ProductBreadcrumbSchema({ title, handle }: { title: string; handle: str
 
 function ProductPageFallback() {
   return (
-    <div className="grid gap-10">
+    <Sections>
       <div className="grid gap-10 lg:grid-cols-10 lg:items-start lg:gap-5">
         <div className="lg:col-span-6">
           {/* Mobile: single full-bleed square + pagination space */}
@@ -41,7 +42,7 @@ function ProductPageFallback() {
           </div>
         </div>
         <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
-          <div className="grid gap-2.5">
+          <div>
             <Skeleton className="h-8 w-3/4" />
             <Skeleton className="h-6 w-24" />
           </div>
@@ -59,7 +60,7 @@ function ProductPageFallback() {
           </div>
         </div>
       </div>
-    </div>
+    </Sections>
   );
 }
 
@@ -93,14 +94,14 @@ async function ProductContent({
       />
       <ProductBreadcrumbSchema title={title} handle={handle} />
 
-      <div className="grid gap-10">
+      <Sections>
         <ProductDetailSection
           product={product}
           locale={locale}
           variantIdPromise={variantIdPromise}
         />
         <RelatedProductsSection handle={handle} locale={locale} />
-      </div>
+      </Sections>
     </>
   );
 }

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -61,7 +61,7 @@ export async function ProductDetailSection({
   const allInStock = variants[0]?.availableForSale ?? true;
 
   return (
-    <div className="lg:grid lg:grid-cols-10 lg:items-start lg:gap-5 space-y-10 lg:space-y-0">
+    <div className="grid gap-10 lg:grid-cols-10 lg:items-start lg:gap-5">
       {needsPartitioning ? (
         <ProductMedia
           otherImages={getSharedImages(images, options, variants)}
@@ -115,8 +115,8 @@ export async function ProductDetailSection({
         />
       )}
 
-      <div className="space-y-10 lg:sticky lg:top-20 lg:col-span-4">
-        <div data-slot="product-info-header">
+      <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
+        <div data-slot="product-info-header" className="grid gap-2.5">
           <h1 className="font-semibold text-foreground tracking-tight text-3xl">{title}</h1>
           {uniformPrice ? (
             variants[0] && (

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -116,7 +116,7 @@ export async function ProductDetailSection({
       )}
 
       <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
-        <div data-slot="product-info-header" className="grid gap-2.5">
+        <div data-slot="product-info-header">
           <h1 className="font-semibold text-foreground tracking-tight text-3xl">{title}</h1>
           {uniformPrice ? (
             variants[0] && (

--- a/apps/template/components/product-detail/product-info.tsx
+++ b/apps/template/components/product-detail/product-info.tsx
@@ -23,7 +23,7 @@ function ProductInfoHeader({
   ...props
 }: ProductInfoHeaderProps) {
   return (
-    <div data-slot="product-info-header" className={className} {...props}>
+    <div data-slot="product-info-header" className={cn("grid gap-2.5", className)} {...props}>
       <h1 className={cn("font-semibold text-foreground tracking-tight", "text-3xl")}>{title}</h1>
 
       {selectedVariant && (
@@ -32,7 +32,6 @@ function ProductInfoHeader({
           currencyCode={selectedVariant.price.currencyCode}
           compareAtAmount={selectedVariant.compareAtPrice?.amount}
           locale={locale}
-          className="mt-3"
         />
       )}
     </div>
@@ -67,7 +66,7 @@ function ProductInfoOptions({
 
   return (
     <div data-slot="product-info-options" className={className} {...props}>
-      <div className="space-y-10">
+      <div className="grid gap-10">
         {/* Color Pickers (with images or swatches) */}
         {colorOptions.map((colorOption) => (
           <ColorPicker

--- a/apps/template/components/product-detail/product-info.tsx
+++ b/apps/template/components/product-detail/product-info.tsx
@@ -23,7 +23,7 @@ function ProductInfoHeader({
   ...props
 }: ProductInfoHeaderProps) {
   return (
-    <div data-slot="product-info-header" className={cn("grid gap-2.5", className)} {...props}>
+    <div data-slot="product-info-header" className={className} {...props}>
       <h1 className={cn("font-semibold text-foreground tracking-tight", "text-3xl")}>{title}</h1>
 
       {selectedVariant && (

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -120,7 +120,7 @@ function Carousel({
   }, [mediaItems.length]);
 
   return (
-    <div className="space-y-5">
+    <div className="grid gap-5">
       <div
         ref={scrollContainerRef}
         className="relative overflow-x-auto flex snap-x snap-mandatory overscroll-x-contain scrollbar-hide -mx-5 w-[calc(100%+2.5rem)]"

--- a/apps/template/components/product/products-grid.tsx
+++ b/apps/template/components/product/products-grid.tsx
@@ -15,8 +15,8 @@ interface ProductsGridProps {
 export async function ProductsGrid({ title, products, locale, collectionUrl }: ProductsGridProps) {
   const t = await getTranslations("product");
   return (
-    <div>
-      <div className="flex items-center justify-between mb-4">
+    <div className="grid gap-4">
+      <div className="flex items-center justify-between">
         <h2 className="text-2xl sm:text-3xl font-semibold tracking-tighter">{title}</h2>
         {collectionUrl && (
           <Link

--- a/apps/template/components/product/related-products-section.tsx
+++ b/apps/template/components/product/related-products-section.tsx
@@ -10,16 +10,16 @@ import { getProductRecommendations } from "@/lib/shopify/operations/products";
 function Fallback({ title }: { title: string }) {
   return (
     <div className="overflow-x-clip py-5">
-      <div className="mx-auto min-w-0">
-        <h2 className="text-2xl sm:text-3xl font-semibold tracking-tighter mb-4">{title}</h2>
+      <div className="mx-auto min-w-0 grid gap-4">
+        <h2 className="text-2xl sm:text-3xl font-semibold tracking-tighter">{title}</h2>
         <div className="grid grid-flow-col gap-5 relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen max-w-none auto-cols-[58.33vw] px-5 sm:left-auto sm:right-auto sm:mx-0 sm:w-full sm:max-w-full sm:auto-cols-[calc((100%-1rem)/2)] sm:px-0 lg:auto-cols-[calc((100%-2rem)/3)] xl:auto-cols-[calc((100%-3rem)/4)]">
           {["a", "b", "c", "d"].map((key) => (
             <div key={key}>
               <Skeleton className="aspect-square" />
-              <div className="py-2.5 h-18 box-content">
+              <div className="py-2.5 h-18 box-content grid gap-2">
                 <Skeleton className="h-4 w-full" />
-                <Skeleton className="h-4 w-3/4 mt-2" />
-                <Skeleton className="h-4 w-16 mt-2" />
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-16" />
               </div>
             </div>
           ))}

--- a/apps/template/components/ui/container.tsx
+++ b/apps/template/components/ui/container.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 
 export function Container({ children, className, ...props }: ComponentPropsWithRef<"section">) {
   return (
-    <section className={cn("mx-auto w-full grid gap-10 px-5 py-10 lg:px-10", className)} {...props}>
+    <section className={cn("mx-auto w-full px-5 py-10 lg:px-10", className)} {...props}>
       {children}
     </section>
   );

--- a/apps/template/components/ui/container.tsx
+++ b/apps/template/components/ui/container.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 
 export function Container({ children, className, ...props }: ComponentPropsWithRef<"section">) {
   return (
-    <section className={cn("mx-auto w-full px-5 py-10 lg:px-10", className)} {...props}>
+    <section className={cn("mx-auto w-full grid gap-10 px-5 py-10 lg:px-10", className)} {...props}>
       {children}
     </section>
   );

--- a/apps/template/components/ui/container.tsx
+++ b/apps/template/components/ui/container.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 
 export function Container({ children, className, ...props }: ComponentPropsWithRef<"section">) {
   return (
-    <section className={cn("mx-auto w-full px-5 py-10 lg:px-10", className)} {...props}>
+    <section className={cn("mx-auto w-full max-w-[96rem] px-5 lg:px-10", className)} {...props}>
       {children}
     </section>
   );

--- a/apps/template/components/ui/sections.tsx
+++ b/apps/template/components/ui/sections.tsx
@@ -1,0 +1,11 @@
+import type { ComponentPropsWithRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function Sections({ children, className, ...props }: ComponentPropsWithRef<"div">) {
+  return (
+    <div className={cn("grid gap-10", className)} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/packages/plugin/template-rollout-log/2026-04-25-grid-gap-pilot.md
+++ b/packages/plugin/template-rollout-log/2026-04-25-grid-gap-pilot.md
@@ -1,0 +1,64 @@
+---
+title: Vertical-spacing pilot — home + PDP on grid+gap
+changeKey: grid-gap-pilot-home-pdp
+introducedOn: 2026-04-25
+changeType: refactor
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/components/ui/container.tsx
+  - apps/template/app/page.tsx
+  - apps/template/components/product/products-grid.tsx
+  - apps/template/components/product/related-products-section.tsx
+  - apps/template/components/product-detail/product-detail-page.tsx
+  - apps/template/components/product-detail/product-detail-section.tsx
+  - apps/template/components/product-detail/product-info.tsx
+  - apps/template/components/product-detail/color-picker.tsx
+  - apps/template/components/product-detail/option-picker.tsx
+  - apps/template/components/product-detail/product-media.tsx
+  - apps/template/AGENTS.md
+---
+
+## Summary
+
+The template's vertical-spacing model is shifting away from child-side margins (`mb-*`, `mt-*`) and `space-y-*` (which is still margin-based under the hood) toward **parent-owned** spacing using `display: grid` with a single implicit column and `gap-*`. This entry rolls out the convention to the home page and the PDP. Other pages convert in follow-up PRs.
+
+Concrete changes:
+
+- `Container` now sets `grid gap-10` by default, so its direct children get the canonical vertical rhythm with no extra wrapper.
+- Home page (`app/page.tsx`) drops its inner `<div className="flex flex-col gap-10">` wrapper; `ProductsGrid` is now a direct Container child.
+- `ProductsGrid`'s outer `<div>` becomes `grid gap-4`; `mb-4` removed from its title row.
+- All `space-y-*` on the PDP (page shell, fallback, options, color/option pickers, media) become `grid gap-*` with the same numeric value.
+- The `mt-3` between the product title and price moves into the wrapper as `grid gap-2.5`.
+- AGENTS.md gains a `Spacing` subsection codifying the convention and the canonical gap scale (`gap-2.5 / 4 / 5 / 10`).
+
+## Why it matters
+
+- Predictable layout: child components no longer push each other around, so reordering or reusing a component doesn't change the rhythm.
+- Eliminates margin-collapse and `space-y-*`-vs-grid surprises.
+- The 5-column language used by search, the nav megamenu, and the footer all assume CSS gap; this pilot brings the page-level scaffolding in line.
+
+## Apply when
+
+- The storefront still uses the original `Container`, `ProductsGrid`, or PDP components and hasn't customized spacing.
+- The storefront wants a single, predictable spacing convention as more pages migrate.
+
+## Safe to skip when
+
+- The storefront has heavily customized the home or PDP layouts and has its own spacing convention.
+- The storefront overrides `Container` to disable padding/sizing — the new `gap-10` default will only apply between direct children, so the override may already be a no-op, but verify.
+
+## Validation
+
+1. `pnpm --filter template dev`. Visit `/`. Visual diff against `main`: banner sits flush, products grid below with the same rhythm. Mobile and desktop unchanged.
+2. Visit `/products/[handle]`:
+   - Loaded state: title → price (gap-2.5), pickers (gap-10 between groups), buy buttons, description, then RelatedProductsSection. Same rhythm as before.
+   - Suspense fallback: skeleton shell mirrors the loaded state's rhythm.
+3. DevTools: confirm direct children of `<Container>`, the PDP grid wrapper, and the product-info column have no inline `margin-top` / `margin-bottom`.
+4. Lint and format clean: `pnpm --filter template lint` / `pnpm --filter template format --check`.
+
+## Follow-ups
+
+- Apply the same convention to search, account, cart, and footer body in subsequent PRs (one page per PR keeps blast radius small).
+- After the majority of pages convert, consider adding an oxlint rule banning `\bmb-`, `\bmt-`, `\bspace-y-` in JSX `className` strings (with carve-outs for compound-component internals like `ScrollCarousel`).

--- a/packages/plugin/template-rollout-log/2026-04-25-grid-gap-pilot.md
+++ b/packages/plugin/template-rollout-log/2026-04-25-grid-gap-pilot.md
@@ -1,6 +1,6 @@
 ---
-title: Vertical-spacing pilot — home + PDP on grid+gap
-changeKey: grid-gap-pilot-home-pdp
+title: Sections primitive — vertical-spacing pilot on home & PDP
+changeKey: sections-pilot-home-pdp
 introducedOn: 2026-04-25
 changeType: refactor
 defaultAction: review
@@ -8,6 +8,7 @@ appliesTo:
   - all
 paths:
   - apps/template/components/ui/container.tsx
+  - apps/template/components/ui/sections.tsx
   - apps/template/app/page.tsx
   - apps/template/components/product/products-grid.tsx
   - apps/template/components/product/related-products-section.tsx
@@ -22,22 +23,25 @@ paths:
 
 ## Summary
 
-The template's vertical-spacing model is shifting away from child-side margins (`mb-*`, `mt-*`) and `space-y-*` (which is still margin-based under the hood) toward **parent-owned** spacing using `display: grid` with a single implicit column and `gap-*`. This entry rolls out the convention to the home page and the PDP. Other pages convert in follow-up PRs.
+Vertical rhythm between page sections moves from child-side margins (`mb-*`, `mt-*`) and `space-y-*` to a small parent primitive: **`Sections`** (`components/ui/sections.tsx`). It's a `<div className="grid gap-10">` wrapper that overrides cleanly via `className`. `Container` keeps its narrow role — horizontal padding + max-width — and no longer carries any vertical opinion.
+
+This entry rolls out the convention to the home page and the PDP. Other pages stay on prior patterns until follow-up PRs.
 
 Concrete changes:
 
-- `Container` now sets `grid gap-10` by default, so its direct children get the canonical vertical rhythm with no extra wrapper.
-- Home page (`app/page.tsx`) drops its inner `<div className="flex flex-col gap-10">` wrapper; `ProductsGrid` is now a direct Container child.
-- `ProductsGrid`'s outer `<div>` becomes `grid gap-4`; `mb-4` removed from its title row.
-- All `space-y-*` on the PDP (page shell, fallback, options, color/option pickers, media) become `grid gap-*` with the same numeric value.
-- The `mt-3` between the product title and price moves into the wrapper as `grid gap-2.5`.
-- AGENTS.md gains a `Spacing` subsection codifying the convention and the canonical gap scale (`gap-2.5 / 4 / 5 / 10`).
+- New `<Sections>` primitive, default `grid gap-10`, override via `className`.
+- `app/page.tsx` wraps banner + Container in `<Sections>` so full-bleed and constrained children compose freely.
+- PDP `ProductContent` and the Suspense fallback shell use `<Sections>` for inter-section rhythm. Inner column layouts (sticky right column with title → options → buy → description) use plain `grid gap-*`.
+- The product title and price sit flush, matching production. The pilot's earlier accidental `gap-2.5` between them is removed.
+- `space-y-*` and `flex flex-col gap-*` inside the PDP files (color/option pickers, product-media, related-products skeleton) are normalized to `grid gap-*` — internal layout improvements that don't affect inter-section rhythm.
+- `products-grid` outer becomes `grid gap-4`; the `mb-4` on the title row is gone.
+- AGENTS.md gains a `Spacing` subsection codifying the rule and the canonical scale (`gap-2.5 / 4 / 5 / 10`).
 
 ## Why it matters
 
-- Predictable layout: child components no longer push each other around, so reordering or reusing a component doesn't change the rhythm.
-- Eliminates margin-collapse and `space-y-*`-vs-grid surprises.
-- The 5-column language used by search, the nav megamenu, and the footer all assume CSS gap; this pilot brings the page-level scaffolding in line.
+- Predictable layout: child components no longer push each other around, so reordering or reusing them doesn't change the rhythm.
+- `Container` and `Sections` have orthogonal responsibilities. A page can interleave full-bleed sections (a hero strip, a marketing banner) with constrained `<Container>` children inside the same `<Sections>`.
+- Per-page rhythm is a one-prop override (`<Sections className="gap-5">`) rather than a Container API negotiation.
 
 ## Apply when
 
@@ -47,18 +51,22 @@ Concrete changes:
 ## Safe to skip when
 
 - The storefront has heavily customized the home or PDP layouts and has its own spacing convention.
-- The storefront overrides `Container` to disable padding/sizing — the new `gap-10` default will only apply between direct children, so the override may already be a no-op, but verify.
 
 ## Validation
 
-1. `pnpm --filter template dev`. Visit `/`. Visual diff against `main`: banner sits flush, products grid below with the same rhythm. Mobile and desktop unchanged.
+1. `pnpm --filter template dev`. Visit `/`. Visual diff against `main`: banner + featured products grid, same rhythm. Mobile and desktop unchanged.
 2. Visit `/products/[handle]`:
-   - Loaded state: title → price (gap-2.5), pickers (gap-10 between groups), buy buttons, description, then RelatedProductsSection. Same rhythm as before.
-   - Suspense fallback: skeleton shell mirrors the loaded state's rhythm.
-3. DevTools: confirm direct children of `<Container>`, the PDP grid wrapper, and the product-info column have no inline `margin-top` / `margin-bottom`.
-4. Lint and format clean: `pnpm --filter template lint` / `pnpm --filter template format --check`.
+   - Title and price flush — no extra gap between them.
+   - Sticky right column rhythm matches production (title-price → options → buy → description).
+   - RelatedProductsSection sits below ProductDetailSection with `gap-10`.
+   - Suspense fallback mirrors loaded rhythm.
+3. Visit `/collections/[handle]` and `/search?q=beds`. Rhythm matches `main` — Container is back to horizontal-only, so pages that haven't migrated keep their original spacing.
+4. DevTools:
+   - `<Container>` has no `display: grid` and no inline gap.
+   - `<Sections>` instances have `display: grid; gap: 40px;` (or override).
+5. Lint and format clean: `pnpm --filter template lint` / `pnpm --filter template format --check`.
 
 ## Follow-ups
 
-- Apply the same convention to search, account, cart, and footer body in subsequent PRs (one page per PR keeps blast radius small).
-- After the majority of pages convert, consider adding an oxlint rule banning `\bmb-`, `\bmt-`, `\bspace-y-` in JSX `className` strings (with carve-outs for compound-component internals like `ScrollCarousel`).
+- Apply `<Sections>` to search, collection, account, cart, footer body in subsequent PRs (one page per PR keeps blast radius small). Each page gets to pick its own gap (`gap-5` for collection's filter→grid pairing, etc.).
+- After the majority of pages convert, consider an oxlint rule banning `\bmb-`, `\bmt-`, `\bspace-y-` in JSX `className` strings (with carve-outs for compound-component internals like `ScrollCarousel`).


### PR DESCRIPTION
## Summary

Vertical rhythm between page sections moves from child-side margins (`mb-*`, `mt-*`) and `space-y-*` to a small parent primitive: **`Sections`**. `Container` keeps its narrow role (horizontal padding + max-width) and no longer carries any vertical opinion.

This started as a pilot that baked `grid gap-10` into `Container` directly. That doubled spacing on pages that still carried their own margins (collection title→toolbar jumped from 24px to 64px) and accidentally introduced a 10px gap between the PDP title and price that doesn't exist in production. v2 fixes both by extracting the spacing into a separate primitive.

## Pattern

```tsx
<Sections>                       {/* grid gap-10 default; className overrides */}
  <BannerSection />              {/* full-bleed, edge-to-edge */}
  <Container>                    {/* constrained, horizontal padding */}
    <FeaturedProducts />
  </Container>
  <FullBleedQuote />              {/* mix of full-bleed and contained, freely */}
  <Container><Newsletter /></Container>
</Sections>
```

`Sections` is a `<div className=\"grid gap-10\">` wrapper. Per-page tightening: `<Sections className=\"gap-5\">`.

## Concrete changes

- `components/ui/sections.tsx` — new primitive.
- `components/ui/container.tsx` — reverted to `mx-auto w-full px-5 py-10 lg:px-10`. No vertical opinion.
- `app/page.tsx` — banner + Container wrapped in `<Sections>`.
- `components/product-detail/product-detail-page.tsx` — `<Sections>` in both the live `ProductContent` and the Suspense fallback shell.
- `components/product-detail/product-detail-section.tsx` and `product-info.tsx` — title and price flush (drop the introduced `grid gap-2.5`).
- Internal layout improvements from v1 (color/option pickers, product-media, related-products skeleton: `space-y-*` → `grid gap-*`) are retained. Those don't affect inter-section rhythm and are independent of the Container/Sections debate.
- `apps/template/AGENTS.md` — Spacing subsection rewritten: `Container` is horizontal-only; `Sections` owns vertical rhythm. Canonical scale `gap-2.5/4/5/10`.

## Out of scope

- Collection / search / cart / account / footer body migration to `<Sections>`. Reverting Container restores their production rhythm; per-page migrations land in follow-ups.
- An oxlint rule banning `mb-`/`mt-`/`space-y-` — defer until the majority of pages convert.

## Test plan

- [ ] `/` renders identically to `main`: banner + featured products grid with the same vertical rhythm.
- [ ] `/products/[handle]` loaded state: title and price flush (no extra gap), sticky right column rhythm matches production, RelatedProductsSection sits below ProductDetailSection with `gap-10`.
- [ ] `/products/[handle]` Suspense fallback: skeleton shell mirrors loaded rhythm.
- [ ] `/collections/[handle]` and `/search?q=beds` rhythm matches `main` — Container is back to horizontal-only, so unmigrated pages keep their original spacing.
- [ ] DevTools: `<Container>` has no `display: grid`; `<Sections>` instances do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)