### PR TITLE
Fix PDP lightbox a11y: add hidden DialogTitle and opt out of Description

### DIFF
--- a/apps/template/components/product-detail/lightbox.tsx
+++ b/apps/template/components/product-detail/lightbox.tsx
@@ -27,11 +27,13 @@ export function Lightbox({ label, children }: { label: string; children: ReactNo
           <DialogPrimitive.Overlay className="fixed inset-0 z-60 bg-black/30 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
           <DialogPrimitive.Content
             className="fixed inset-0 z-60 flex items-center justify-center p-10 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
-            aria-label={`${label} enlarged`}
+            aria-describedby={undefined}
             onClick={(e) => {
               if (e.target === e.currentTarget) close();
             }}
           >
+            <DialogPrimitive.Title className="sr-only">{`${label} enlarged`}</DialogPrimitive.Title>
+
             <DialogPrimitive.Close className="pointer-events-auto absolute top-4 right-4 z-10 rounded-full bg-black/50 p-2 text-white transition-opacity hover:opacity-80 focus:ring-2 focus:ring-white focus:outline-hidden">
               <XIcon className="size-5" />
               <span className="sr-only">Close</span>

--- a/packages/plugin/template-rollout-log/2026-04-25-pdp-lightbox-dialog-title.md
+++ b/packages/plugin/template-rollout-log/2026-04-25-pdp-lightbox-dialog-title.md
@@ -1,0 +1,42 @@
+---
+title: PDP lightbox — add hidden DialogTitle to satisfy Radix a11y
+changeKey: pdp-lightbox-dialog-title
+introducedOn: 2026-04-25
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-detail/lightbox.tsx
+---
+
+## Summary
+
+Opening the PDP lightbox triggered two Radix Dialog console messages:
+
+> `DialogContent` requires a `DialogTitle` for the component to be accessible for screen reader users.
+
+> Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.
+
+Radix expects an actual `Dialog.Title` element (not just `aria-label`) and either a `Dialog.Description` or an explicit opt-out via `aria-describedby={undefined}`.
+
+Fix: add a visually-hidden `<DialogPrimitive.Title className="sr-only">{label} enlarged</DialogPrimitive.Title>` inside `DialogContent`, drop the redundant `aria-label`, and set `aria-describedby={undefined}` since the lightbox has no descriptive text beyond the title.
+
+## Why it matters
+
+- Removes accessibility warnings that show up for any user opening browser dev tools on a PDP.
+- Gives screen-reader users a real heading for the lightbox instead of a synthetic accessible-name.
+
+## Apply when
+
+- The storefront still uses `components/product-detail/lightbox.tsx` largely as shipped (Radix Dialog primitives, no wrapper around Title/Description).
+
+## Safe to skip when
+
+- The storefront has replaced the lightbox with a different modal/lightbox library that handles the a11y contract differently.
+
+## Validation
+
+1. `pnpm --filter template dev`. Open a PDP, click an image to open the lightbox.
+2. Browser console: confirm there is no longer a Radix Dialog title or description warning.
+3. Screen-reader spot-check (VoiceOver or NVDA): confirm the lightbox announces "{product title} enlarged" when it opens.


### PR DESCRIPTION
## Summary

Opening the PDP lightbox logged two Radix Dialog warnings:

> \`DialogContent\` requires a \`DialogTitle\` for the component to be accessible for screen reader users.

> Missing \`Description\` or \`aria-describedby={undefined}\` for {DialogContent}.

Radix expects an actual \`Dialog.Title\` element (not just \`aria-label\`) and either a \`Dialog.Description\` or an explicit opt-out via \`aria-describedby={undefined}\`.

- Replace the \`aria-label={\\\`\${label} enlarged\\\`}\` on \`DialogPrimitive.Content\` with a visually-hidden \`DialogPrimitive.Title\` carrying the same string.
- Add \`aria-describedby={undefined}\` since the lightbox has no descriptive text beyond the title.

Includes a \`template-rollout-log\` entry — downstream storefronts using the lightbox have the same warning.

## Test plan

- [ ] \`pnpm --filter template dev\`. Open a PDP, click an image to open the lightbox. Console has no Radix Dialog warnings.
- [ ] Screen-reader spot-check (VoiceOver / NVDA): the lightbox announces "{product title} enlarged" when it opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)