### PR TITLE
Tighten conventions: directive-suffix split, interface Props, React.ComponentProps

### DIFF
--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -51,14 +51,15 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 - Keep sub-components in the same file as their consumer when they share the same directive (or lack one). Only split into a separate file when the components need different directives (e.g., one is `"use client"` and the other is a server component) or when the file becomes unwieldy.
 - A single file per logical component is preferred.
-- When a split is necessary, name the file by its role: `components.tsx` for directive-free sub-components, `client-components.tsx` for `"use client"` sub-components, `server-components.tsx` for server-only sub-components.
+- When a directive split is necessary, suffix the carved-out file with the directive: `foo.tsx` (the entry, typically a server component) is paired with `foo-client.tsx` for `"use client"` sub-components — e.g. `sidebar.tsx` + `sidebar-client.tsx`, `mobile-tabs.tsx` + `mobile-tabs-client.tsx`. Use `foo-server.tsx` symmetrically if a server-only piece needs to be carved out of an otherwise-client file. The suffix keeps the pair adjacent in the directory listing.
 
 ### Naming
 
 - Files: `kebab-case.tsx`
 - Components: `PascalCase`
 - Server actions: verb + `Action` suffix (`addToCartAction`)
-- Props interfaces: `{ComponentName}Props`
+- Props interfaces: `{ComponentName}Props`. Use `interface` (not `type`) so consumers can extend or augment.
+- Native-element prop pass-through: use `React.ComponentProps<"div">` (with `import type * as React from "react"`), not `ComponentPropsWithoutRef`. Refs are regular props in React 19, so the extra type is unnecessary noise.
 - Constants: `SCREAMING_SNAKE_CASE`
 
 ### Spacing

--- a/apps/template/components/product-detail/about-item.tsx
+++ b/apps/template/components/product-detail/about-item.tsx
@@ -1,8 +1,8 @@
-import type { ComponentPropsWithoutRef } from "react";
+import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-interface AboutItemProps extends ComponentPropsWithoutRef<"div"> {
+interface AboutItemProps extends React.ComponentProps<"div"> {
   descriptionHtml: string;
 }
 

--- a/apps/template/components/product-detail/auto-play-video.tsx
+++ b/apps/template/components/product-detail/auto-play-video.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import Image from "next/image";
-import { type ComponentPropsWithoutRef, useEffect, useRef, useState } from "react";
+import type * as React from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { Image as ImageType } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-type AutoPlayVideoProps = Omit<ComponentPropsWithoutRef<"video">, "autoPlay" | "ref"> & {
+interface AutoPlayVideoProps extends Omit<React.ComponentProps<"video">, "autoPlay" | "ref"> {
   previewImage?: ImageType | null;
   sizes?: string;
   priorityImage?: boolean;
-};
+}
 
 /**
  * A video element that autoplays when visible and pauses when off-screen.

--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -1,12 +1,12 @@
 import Image from "next/image";
 import Link from "next/link";
-import type { ComponentPropsWithoutRef } from "react";
+import type * as React from "react";
 
 import { type SelectedOptions, getVariantUrl } from "@/lib/product";
 import type { ProductOption, ProductVariant } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-interface ColorPickerProps extends ComponentPropsWithoutRef<"div"> {
+interface ColorPickerProps extends React.ComponentProps<"div"> {
   option: ProductOption;
   selectedValue: string;
   variants: ProductVariant[];

--- a/apps/template/components/product-detail/option-picker.tsx
+++ b/apps/template/components/product-detail/option-picker.tsx
@@ -1,11 +1,11 @@
 import Link from "next/link";
-import type { ComponentPropsWithoutRef } from "react";
+import type * as React from "react";
 
 import { type SelectedOptions, getVariantUrl } from "@/lib/product";
 import type { ProductOption, ProductVariant } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-interface OptionPickerProps extends ComponentPropsWithoutRef<"div"> {
+interface OptionPickerProps extends React.ComponentProps<"div"> {
   option: ProductOption;
   selectedValue: string;
   variants: ProductVariant[];

--- a/apps/template/components/product-detail/product-info.tsx
+++ b/apps/template/components/product-detail/product-info.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef } from "react";
+import type * as React from "react";
 
 import type { SelectedOptions } from "@/lib/product";
 import type { ProductOption, ProductVariant } from "@/lib/types";
@@ -9,7 +9,7 @@ import { ColorPicker } from "./color-picker";
 import { OptionPicker } from "./option-picker";
 import { ProductPrice } from "./product-price";
 
-interface ProductInfoHeaderProps extends ComponentPropsWithoutRef<"div"> {
+interface ProductInfoHeaderProps extends React.ComponentProps<"div"> {
   selectedVariant: ProductVariant | undefined;
   title: string;
   locale: string;
@@ -38,7 +38,7 @@ function ProductInfoHeader({
   );
 }
 
-interface ProductInfoOptionsProps extends ComponentPropsWithoutRef<"div"> {
+interface ProductInfoOptionsProps extends React.ComponentProps<"div"> {
   variants: ProductVariant[];
   options: ProductOption[];
   selectedOptions: SelectedOptions;
@@ -98,7 +98,7 @@ function ProductInfoOptions({
   );
 }
 
-interface ProductInfoDescriptionProps extends ComponentPropsWithoutRef<"div"> {
+interface ProductInfoDescriptionProps extends React.ComponentProps<"div"> {
   descriptionHtml: string;
 }
 

--- a/apps/template/components/product-detail/product-price.tsx
+++ b/apps/template/components/product-detail/product-price.tsx
@@ -1,10 +1,10 @@
-import type { ComponentPropsWithoutRef } from "react";
+import type * as React from "react";
 
 import { DiscountBadge } from "@/components/product/discount-badge";
 import { Price } from "@/components/product/price";
 import { cn } from "@/lib/utils";
 
-interface ProductPriceProps extends ComponentPropsWithoutRef<"div"> {
+interface ProductPriceProps extends React.ComponentProps<"div"> {
   amount: string;
   currencyCode: string;
   compareAtAmount?: string;

--- a/apps/template/components/product/discount-badge.tsx
+++ b/apps/template/components/product/discount-badge.tsx
@@ -1,8 +1,8 @@
-import type { ComponentPropsWithoutRef } from "react";
+import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-interface DiscountBadgeProps extends ComponentPropsWithoutRef<"span"> {
+interface DiscountBadgeProps extends React.ComponentProps<"span"> {
   percent: number;
   variant?: "green" | "blue";
 }

--- a/apps/template/components/product/price.tsx
+++ b/apps/template/components/product/price.tsx
@@ -1,9 +1,9 @@
-import type { ComponentPropsWithoutRef } from "react";
+import type * as React from "react";
 
 import { defaultLocale } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
 
-interface PriceProps extends ComponentPropsWithoutRef<"span"> {
+interface PriceProps extends React.ComponentProps<"span"> {
   amount: string;
   currencyCode: string;
   locale?: string;

--- a/apps/template/components/ui/country-flag.tsx
+++ b/apps/template/components/ui/country-flag.tsx
@@ -18,11 +18,11 @@ const COUNTRY_CODES: Record<string, string> = {
   "ru-RU": "RU",
 };
 
-type CountryFlagProps = {
+interface CountryFlagProps {
   locale: string;
   className?: string;
   size?: "sm" | "md" | "lg";
-};
+}
 
 const SIZE_DIMENSIONS = {
   sm: { width: 20, height: 16 },

--- a/packages/plugin/template-rollout-log/2026-04-25-tighten-conventions.md
+++ b/packages/plugin/template-rollout-log/2026-04-25-tighten-conventions.md
@@ -32,7 +32,7 @@ Three small convention tightenings, no behavior changes.
 
 3. **`React.ComponentProps<"X">` everywhere (was: `ComponentPropsWithoutRef<"X">` in product/product-detail).** Refs are regular props in React 19, so the `WithoutRef` distinction is no longer meaningful, and the rest of the codebase (`components/ui/*`) already uses the `React.ComponentProps` form via `import type * as React from "react"`. Converted 7 files in `components/product/*` and `components/product-detail/*`. AGENTS.md now states this under Naming.
 
-`components/ui/drawer.tsx` is intentionally left on `React.ComponentPropsWithoutRef`. It's the older shadcn `forwardRef` + `React.ElementRef` pattern; converting it requires a wider rewrite of every `forwardRef` block, which is out of scope here and worth doing as a coordinated drawer-modernization PR.
+`components/ui/drawer.tsx` was deliberately scoped out of this PR (it's the older shadcn `forwardRef` + `React.ElementRef` pattern that needed a wider rewrite). It was modernized separately in `drawer-modernize-no-forwardref` (PR #194) and is now on the same `React.ComponentProps` form as the rest of `components/ui/`.
 
 ## Why it matters
 
@@ -53,7 +53,7 @@ Three small convention tightenings, no behavior changes.
 ## Validation
 
 1. `pnpm --filter template build` — clean (the pre-existing i18n typecheck errors on main are unrelated).
-2. `git grep "ComponentPropsWithoutRef" apps/template/components` returns only `components/ui/drawer.tsx` (the deliberate exclusion) and `components/ai-elements/*` (vendored).
+2. `git grep "ComponentPropsWithoutRef" apps/template/components` returns only `components/ai-elements/*` (vendored).
 3. `git grep "type [A-Z][a-zA-Z]*Props =" apps/template/components` returns only files in `components/ai-elements/*` (vendored).
 4. `git grep "client-components\.tsx\|server-components\.tsx" apps/template` returns no results.
 5. PDP renders normally (color picker, option picker, price, discount badge, autoplay video, lightbox).

--- a/packages/plugin/template-rollout-log/2026-04-25-tighten-conventions.md
+++ b/packages/plugin/template-rollout-log/2026-04-25-tighten-conventions.md
@@ -1,0 +1,59 @@
+---
+title: Tighten conventions — directive-suffix split, interface Props, React.ComponentProps
+changeKey: tighten-conventions-props-and-splits
+introducedOn: 2026-04-25
+changeType: refactor
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/AGENTS.md
+  - apps/template/components/ui/country-flag.tsx
+  - apps/template/components/product-detail/auto-play-video.tsx
+  - apps/template/components/product-detail/about-item.tsx
+  - apps/template/components/product-detail/color-picker.tsx
+  - apps/template/components/product-detail/option-picker.tsx
+  - apps/template/components/product-detail/product-info.tsx
+  - apps/template/components/product-detail/product-price.tsx
+  - apps/template/components/product/discount-badge.tsx
+  - apps/template/components/product/price.tsx
+---
+
+## Summary
+
+Three small convention tightenings, no behavior changes.
+
+1. **AGENTS.md split-files rule rewritten to match what's actually shipped.** The prior text prescribed `client-components.tsx` / `server-components.tsx` / `components.tsx` filenames for directive splits. The codebase already uses the `*-client.tsx` suffix everywhere (`sidebar.tsx` + `sidebar-client.tsx`, `mobile-tabs.tsx` + `mobile-tabs-client.tsx`, `cart.tsx` + `cart-client.tsx`). AGENTS.md now codifies the suffix form and notes the symmetric `*-server.tsx` for the inverse case.
+
+2. **`interface FooProps` everywhere (was: two stragglers using `type`).**
+   - `components/ui/country-flag.tsx`: `type CountryFlagProps = { ... }` → `interface CountryFlagProps { ... }`
+   - `components/product-detail/auto-play-video.tsx`: `type AutoPlayVideoProps = Omit<...> & { ... }` → `interface AutoPlayVideoProps extends Omit<...> { ... }`
+   - AGENTS.md now states this explicitly under Naming.
+
+3. **`React.ComponentProps<"X">` everywhere (was: `ComponentPropsWithoutRef<"X">` in product/product-detail).** Refs are regular props in React 19, so the `WithoutRef` distinction is no longer meaningful, and the rest of the codebase (`components/ui/*`) already uses the `React.ComponentProps` form via `import type * as React from "react"`. Converted 7 files in `components/product/*` and `components/product-detail/*`. AGENTS.md now states this under Naming.
+
+`components/ui/drawer.tsx` is intentionally left on `React.ComponentPropsWithoutRef`. It's the older shadcn `forwardRef` + `React.ElementRef` pattern; converting it requires a wider rewrite of every `forwardRef` block, which is out of scope here and worth doing as a coordinated drawer-modernization PR.
+
+## Why it matters
+
+- Convention docs match reality, so an agent reading AGENTS.md doesn't try to introduce a third filename pattern that no file uses.
+- One `Props` declaration form across the codebase (interface), so consumers can declaration-merge or extend without hitting the `type` vs `interface` mismatch.
+- One `ComponentProps` form, so future grepping for native-element pass-through is consistent.
+
+## Apply when
+
+- The storefront still uses the affected files largely as shipped.
+- The storefront is happy to align with the modern React 19 `ComponentProps` form.
+
+## Safe to skip when
+
+- The storefront has its own conventions document and prefers to keep `type`-style Props or `ComponentPropsWithoutRef`.
+- The storefront has restructured `components/product*` such that the listed files no longer exist.
+
+## Validation
+
+1. `pnpm --filter template build` — clean (the pre-existing i18n typecheck errors on main are unrelated).
+2. `git grep "ComponentPropsWithoutRef" apps/template/components` returns only `components/ui/drawer.tsx` (the deliberate exclusion) and `components/ai-elements/*` (vendored).
+3. `git grep "type [A-Z][a-zA-Z]*Props =" apps/template/components` returns only files in `components/ai-elements/*` (vendored).
+4. `git grep "client-components\.tsx\|server-components\.tsx" apps/template` returns no results.
+5. PDP renders normally (color picker, option picker, price, discount badge, autoplay video, lightbox).


### PR DESCRIPTION
## Summary

Audit follow-up #3 + #7 + #8. Three small convention fixes in \`apps/template\`, no behavior changes.

### 1. AGENTS.md split-files rule rewritten to match reality
The prior text prescribed \`client-components.tsx\` / \`server-components.tsx\` / \`components.tsx\` for directive splits. The codebase already uses the \`*-client.tsx\` suffix everywhere (\`sidebar.tsx\` + \`sidebar-client.tsx\`, \`mobile-tabs.tsx\` + \`mobile-tabs-client.tsx\`, \`cart.tsx\` + \`cart-client.tsx\`). AGENTS.md now codifies the suffix form (and the symmetric \`*-server.tsx\`).

### 2. \`interface FooProps\` everywhere
Two stragglers used \`type FooProps = { ... }\`:
- \`components/ui/country-flag.tsx\`
- \`components/product-detail/auto-play-video.tsx\` (now \`interface AutoPlayVideoProps extends Omit<React.ComponentProps<"video">, "autoPlay" | "ref"> { ... }\`)

AGENTS.md states the rule under Naming.

### 3. \`React.ComponentProps<"X">\` everywhere
Refs are regular props in React 19, so the \`WithoutRef\` distinction is no longer meaningful, and \`components/ui/*\` already uses the \`React.ComponentProps\` form. Converted 7 files in \`components/product/\` and \`components/product-detail/\` from \`ComponentPropsWithoutRef\`. AGENTS.md states the rule under Naming.

\`components/ui/drawer.tsx\` was deliberately scoped out of this PR (legacy \`forwardRef\` + \`React.ElementRef\` pattern needed a wider rewrite). Modernized separately in #194 — now merged — so after this PR lands, no \`ComponentPropsWithoutRef\` usage remains in \`apps/template/components\` outside vendored \`ai-elements/\`.

## Test plan

- [ ] \`pnpm --filter template build\` — clean (the pre-existing i18n typecheck errors on main are unrelated).
- [ ] \`git grep "ComponentPropsWithoutRef" apps/template/components\` returns only \`components/ai-elements/*\`.
- [ ] \`git grep "type [A-Z][a-zA-Z]*Props =" apps/template/components\` returns only \`components/ai-elements/*\`.
- [ ] PDP renders normally — color picker, option picker, price, discount badge, autoplay video, lightbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)