### PR TITLE
Codify comment style; strip restating and decorative comments

### DIFF
--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -103,6 +103,28 @@ Avoid the word "client" in a filename to mean an HTTP/SDK client wrapper — tha
 - Named exports only in component files. Pages use default exports per Next.js convention.
 - Alphabetize specifiers in export statements.
 
+### Comments
+
+Default to writing none. Well-named identifiers, types, and tests already document WHAT the code does. Add a comment only when removing it would leave a future reader genuinely confused — and the reason is something they couldn't recover by reading the surrounding code.
+
+A comment earns its place when it captures one of:
+
+- A hidden constraint (e.g. "cookies can't be set during stream").
+- A workaround for a specific upstream/library bug.
+- A non-obvious algorithmic choice or invariant.
+- A cross-system quirk (e.g. "Shopify's `productFilters` only affects facet counts, not results").
+
+Don't write:
+
+- JSDoc that restates the function name (`/** Verify webhook signature */` over `verifyWebhook()`). Either drop it or replace it with the WHY.
+- Inline comments that narrate the next line (`// fetch products` above `fetchProducts()`).
+- References to current work (`// added for cart refactor`, `// part of issue #123`, `// new`). That belongs in the PR description.
+- File-top banner comments and `// ── Section ──`-style dividers. If a file is large enough that you reach for one, split the file instead.
+- Bare `// TODO` without an owner or actionable reason. Either write `// TODO(handle): explain blocker` or fix the thing now.
+- Multi-paragraph docstrings on simple functions. If the JSDoc fits on one line, inline it; if you reach for multiple paragraphs, that's a signal to split or rename, not to write more prose.
+
+Keep `// eslint-disable-*`, `// @ts-expect-error`, `// biome-ignore`, and other tooling directives — those are not prose comments.
+
 <!-- END:vercel-shop-style -->
 
 ## Overview

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -13,9 +13,6 @@ import { createCartWithoutCookie } from "@/lib/shopify/operations/cart";
 import { getCollection } from "@/lib/shopify/operations/collections";
 import { getProduct } from "@/lib/shopify/operations/products";
 
-/**
- * Parse referer URL to extract locale and path segments.
- */
 function parseReferer(referer: string | null): {
   locale: Locale;
   segments: string[];
@@ -34,10 +31,7 @@ function parseReferer(referer: string | null): {
   }
 }
 
-/**
- * Resolve page context from URL segments.
- * Fetches trusted data from the database.
- */
+/** Fetches trusted data from the database — never trusts client-supplied context. */
 async function resolvePageContext(
   segments: string[],
   locale: Locale,
@@ -47,7 +41,7 @@ async function resolvePageContext(
     return { type: "home" };
   }
 
-  // segments[0] = page type, segments[1] = handle/id
+  // segments[0] = page type, segments[1] = handle/id.
   const pageType = segments[0];
 
   if (pageType === "products" && segments.length >= 2) {
@@ -56,7 +50,7 @@ async function resolvePageContext(
       const product = await getProduct(handle, locale);
       return { type: "product", product };
     } catch {
-      // Product not found
+      // Product not found — fall through to other branches.
     }
   }
 
@@ -68,7 +62,7 @@ async function resolvePageContext(
         return { type: "collection", handle, title: collection.title };
       }
     } catch {
-      // Collection not found
+      // Collection not found — fall through to other branches.
     }
   }
 
@@ -118,7 +112,6 @@ export async function POST(request: Request) {
   if (!cartId) {
     const newCart = await createCartWithoutCookie(locale);
     cartId = newCart.id;
-    // Build Set-Cookie header value for the new cart
     const secure = process.env.NODE_ENV === "production";
     const maxAge = 60 * 60 * 24 * 7; // 7 days
     newCartCookie = `shopify_cartId=${cartId}; Path=/; HttpOnly; SameSite=Strict; Max-Age=${maxAge}${secure ? "; Secure" : ""}`;

--- a/apps/template/app/api/webhooks/shopify/route.ts
+++ b/apps/template/app/api/webhooks/shopify/route.ts
@@ -6,9 +6,6 @@ import { getNumericShopifyId } from "@/lib/shopify/utils";
 
 const SHOPIFY_WEBHOOK_SECRET = process.env.SHOPIFY_WEBHOOK_SECRET;
 
-/**
- * Verify Shopify webhook HMAC signature
- */
 async function verifyWebhook(body: string, hmacHeader: string | null): Promise<boolean> {
   if (!SHOPIFY_WEBHOOK_SECRET || !hmacHeader) {
     return false;
@@ -23,21 +20,15 @@ async function verifyWebhook(body: string, hmacHeader: string | null): Promise<b
 }
 
 /**
- * Shopify webhook handler for cache invalidation
- *
- * Supported topics:
- * - products/create, products/update, products/delete
- * - collections/create, collections/update, collections/delete
- *
- * Configure these webhooks in Shopify Admin:
- * Settings > Notifications > Webhooks
+ * Cache invalidation handler. Configure topics in Shopify Admin →
+ * Settings → Notifications → Webhooks. Supported: `products/*`,
+ * `collections/*`, `inventory_levels/*`, `metaobjects/*`.
  */
 export async function POST(request: Request) {
   const body = await request.text();
   const hmacHeader = request.headers.get("x-shopify-hmac-sha256");
   const topic = request.headers.get("x-shopify-topic");
 
-  // Verify webhook signature in production
   if (SHOPIFY_WEBHOOK_SECRET) {
     const isValid = await verifyWebhook(body, hmacHeader);
     if (!isValid) {
@@ -54,11 +45,10 @@ export async function POST(request: Request) {
 
   const tagsInvalidated: string[] = [];
 
-  // Product-related webhooks
   if (topic.startsWith("products/")) {
     const productTags = ["products", "collections"];
 
-    // Parse body to get specific product handle/id for targeted invalidation
+    // Pull handle/id from the payload for targeted invalidation.
     try {
       const payload = JSON.parse(body);
       if (payload.handle) {
@@ -74,7 +64,7 @@ export async function POST(request: Request) {
         productTags.push(`product-${payload.id}`);
       }
     } catch {
-      // If parsing fails, just invalidate generic tags
+      // Parse failure: fall through and invalidate the generic tags.
     }
 
     for (const tag of productTags) {
@@ -83,18 +73,16 @@ export async function POST(request: Request) {
     }
   }
 
-  // Collection-related webhooks
   if (topic.startsWith("collections/")) {
     const collectionTags = ["collections", "products", "menus"];
 
-    // Parse body to get specific collection handle
     try {
       const payload = JSON.parse(body);
       if (payload.handle) {
         collectionTags.push(`collection-${payload.handle}`);
       }
     } catch {
-      // If parsing fails, just invalidate generic tags
+      // Parse failure: fall through and invalidate the generic tags.
     }
 
     for (const tag of collectionTags) {
@@ -103,7 +91,6 @@ export async function POST(request: Request) {
     }
   }
 
-  // Inventory-related webhooks (product availability changes)
   if (topic.startsWith("inventory_levels/")) {
     const inventoryTags = ["products", "collections"];
 
@@ -113,7 +100,6 @@ export async function POST(request: Request) {
     }
   }
 
-  // Metaobject-related webhooks (CMS)
   if (topic.startsWith("metaobjects/")) {
     const cmsTags = ["cms:all"];
 
@@ -136,7 +122,7 @@ export async function POST(request: Request) {
         cmsTags.push("cms:pages", "cms:homepage");
       }
     } catch {
-      // If parsing fails, just invalidate base CMS tag
+      // Parse failure: fall through and invalidate the base CMS tag only.
     }
 
     for (const tag of cmsTags) {

--- a/apps/template/app/collections/[handle]/page.tsx
+++ b/apps/template/app/collections/[handle]/page.tsx
@@ -7,10 +7,6 @@ import { getLocale } from "@/lib/params";
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
 import { getCollection } from "@/lib/shopify/operations/collections";
 
-// export async function generateStaticParams() {
-//   return [{ handle: "__placeholder__" }];
-// }
-
 export async function generateMetadata({
   params,
 }: PageProps<"/collections/[handle]">): Promise<Metadata> {

--- a/apps/template/components/agent/cart-reconciler.tsx
+++ b/apps/template/components/agent/cart-reconciler.tsx
@@ -43,7 +43,6 @@ export function CartReconciler({ messages }: { messages: UIMessage[] }) {
       if (message.role !== "assistant") continue;
 
       for (const part of message.parts) {
-        // Check if this part is a cart-modifying tool call
         const toolName =
           part.type === "dynamic-tool" && "toolName" in part
             ? (part.toolName as string)

--- a/apps/template/components/cart/context.tsx
+++ b/apps/template/components/cart/context.tsx
@@ -17,7 +17,6 @@ import type { Cart, CartLine } from "@/lib/types";
 
 const DEBOUNCE_MS = 400;
 
-// Internal utility functions (moved from utils.ts)
 function createOptimisticCart(cart: Cart, lineId: string, newQuantity: number): Cart {
   const currentLine = cart.lines.find((l) => l.id === lineId);
   if (!currentLine) return cart;
@@ -63,12 +62,10 @@ function computeCartWithPending(
   pendingLines: CartLine[],
 ): Cart | null {
   if (cart) {
-    // Merge pending lines into existing cart lines
     const mergedLines = [...cart.lines];
     for (const pl of pendingLines) {
       const existingIndex = mergedLines.findIndex((l) => l.merchandise.id === pl.merchandise.id);
       if (existingIndex >= 0) {
-        // Increment quantity on existing line
         const existing = mergedLines[existingIndex];
         const unitPrice = parseFloat(existing.cost.totalAmount.amount) / existing.quantity;
         const newQty = existing.quantity + pl.quantity;
@@ -169,13 +166,11 @@ type CartContextType = {
     productInfo?: OptimisticProductInfo,
   ) => Promise<boolean>;
   pendingQuantity: number;
-  // Update/remove line items - quantity=0 removes the item
+  /** quantity=0 removes the item. */
   updateItemOptimistic: (lineId: string, quantity: number) => void;
-  // True when any update/remove operation is in-flight
   isUpdatingCart: boolean;
 };
 
-// Type for tracking pending line operations
 type LineOperation = {
   originalCart: Cart | null;
   targetQuantity: number;
@@ -209,32 +204,28 @@ export function CartProvider({
   const [cart, setCartInternal] = useState<Cart | null>(initialCart);
   const [, startTransition] = useTransition();
 
-  // Overlay state
   const [isOverlayOpen, setOverlayOpen] = useState(false);
   const [isAddingToCart, setIsAddingToCart] = useState(false);
   const [pendingQuantity, setPendingQuantity] = useState(0);
   const [pendingLines, setPendingLines] = useState<CartLine[]>([]);
 
-  // Track in-flight update/remove operations
   const [isUpdatingCart, setIsUpdatingCart] = useState(false);
   const inFlightCountRef = useRef(0);
 
   const openOverlay = useCallback(() => setOverlayOpen(true), []);
 
-  // Debounce state for add-to-cart
   const addToCartDebounceRef = useRef({
     pending: new Map<string, number>(),
     timer: null as ReturnType<typeof setTimeout> | null,
   });
   const addToCartResolversRef = useRef<Map<string, Array<(success: boolean) => void>>>(new Map());
 
-  // Track overlay state for timeout callback
   const isOverlayOpenRef = useRef(isOverlayOpen);
   isOverlayOpenRef.current = isOverlayOpen;
 
-  // Track pending line item operations (for update/remove with leading-edge debounce)
+  // Pending line item ops use leading-edge debounce.
   const lineOpsRef = useRef<Map<string, LineOperation>>(new Map());
-  // Per-line request versioning to ignore stale responses that return out of order
+  // Per-line request versioning ignores stale responses that return out of order.
   const latestLineRequestIdRef = useRef<Map<string, number>>(new Map());
 
   const nextLineRequestId = (lineId: string) => {
@@ -244,10 +235,8 @@ export function CartProvider({
   };
 
   const displayCart = applyPendingLineOperations(cart, lineOpsRef.current);
-  // Compute cart with pending quantity and optimistic lines
   const cartWithPending = computeCartWithPending(displayCart, pendingQuantity, pendingLines);
 
-  // Build an optimistic CartLine from product info
   const buildOptimisticLine = (
     variantId: string,
     qty: number,
@@ -276,10 +265,9 @@ export function CartProvider({
     },
   });
 
-  // Ref to track product info for each variant (used when building optimistic lines)
   const pendingProductInfoRef = useRef<Map<string, OptimisticProductInfo>>(new Map());
 
-  // Add to cart with debouncing - accumulates rapid clicks into a single request
+  /** Debounced — accumulates rapid clicks into a single request per variant. */
   const addToCartOptimistic = (
     variantId: string,
     quantity: number,
@@ -292,20 +280,16 @@ export function CartProvider({
       addToCartResolversRef.current.set(variantId, resolvers);
     });
 
-    // Store product info if provided
     if (productInfo) {
       pendingProductInfoRef.current.set(variantId, productInfo);
     }
 
-    // Accumulate quantity for this variant
     const current = debounce.pending.get(variantId) || 0;
     debounce.pending.set(variantId, current + quantity);
 
-    // Update pending quantity display
     const totalPending = Array.from(debounce.pending.values()).reduce((sum, q) => sum + q, 0);
     setPendingQuantity(totalPending);
 
-    // Build optimistic pending lines from all accumulated variants
     const nextPendingLines: CartLine[] = [];
     for (const [vid, qty] of debounce.pending) {
       const info = pendingProductInfoRef.current.get(vid);
@@ -315,18 +299,15 @@ export function CartProvider({
     }
     setPendingLines(nextPendingLines);
 
-    // Open overlay on first addition
     if (!isOverlayOpenRef.current) {
       setIsAddingToCart(true);
       setOverlayOpen(true);
     }
 
-    // Reset debounce timer
     if (debounce.timer !== null) {
       clearTimeout(debounce.timer);
     }
 
-    // Flush pending items after debounce period
     debounce.timer = setTimeout(() => {
       debounce.timer = null;
 
@@ -342,7 +323,6 @@ export function CartProvider({
         addToCartResolversRef.current.delete(vid);
       }
 
-      // Make one request per variant (usually just one)
       for (const [vid, qty] of items) {
         startTransition(async () => {
           let success = false;
@@ -363,7 +343,7 @@ export function CartProvider({
             }
           }
 
-          // Only clear pending state if no new items have been queued while we were in-flight
+          // Only clear pending state if nothing was queued while in-flight.
           if (debounce.pending.size === 0) {
             setIsAddingToCart(false);
             setPendingQuantity(0);
@@ -376,7 +356,6 @@ export function CartProvider({
     return requestPromise;
   };
 
-  // Track start/end of in-flight requests
   const trackInFlight = () => {
     inFlightCountRef.current++;
     setIsUpdatingCart(true);
@@ -389,7 +368,6 @@ export function CartProvider({
     };
   };
 
-  // Send update request to server
   const fireUpdateRequest = (lineId: string, quantity: number, originalCart: Cart | null) => {
     const requestId = nextLineRequestId(lineId);
     const endTracking = trackInFlight();
@@ -405,19 +383,17 @@ export function CartProvider({
       const pending = lineOpsRef.current.get(lineId);
 
       if (result.success && result.cart) {
-        // If user changed quantity during request, keep optimistic state
-        // (the debounce timer will fire the final request)
+        // If the user changed quantity during the request, keep the optimistic
+        // state — the debounce timer will fire the final request.
         if (!pending || pending.targetQuantity === quantity) {
           setCartInternal(result.cart);
           lineOpsRef.current.delete(lineId);
         }
       } else if (originalCart) {
         setCartInternal(originalCart);
-        // Check if more changes came in during request
-        if (pending && pending.targetQuantity !== quantity) {
-          // User changed quantity again, keep pending for retry
-          // The debounce timer will fire the final request
-        } else {
+        // If quantity changed again during the request, leave the pending
+        // entry so the debounce timer will retry.
+        if (!pending || pending.targetQuantity === quantity) {
           lineOpsRef.current.delete(lineId);
         }
       }
@@ -426,20 +402,20 @@ export function CartProvider({
     });
   };
 
-  // Update/remove line items with leading-edge debounce
-  // quantity > 0: update quantity (first update instant, subsequent debounced)
-  // quantity === 0: remove item (always immediate)
+  /**
+   * quantity > 0: update with leading-edge debounce (first instant, rest debounced).
+   * quantity === 0: remove immediately, no debounce.
+   */
   const updateItemOptimistic = (lineId: string, quantity: number) => {
     if (quantity < 0 || quantity > 99 || !cart) return;
 
-    // REMOVE: quantity === 0 (immediate, no debounce)
     if (quantity === 0) {
       const pending = lineOpsRef.current.get(lineId);
       if (pending?.timer) clearTimeout(pending.timer);
 
       const originalCart = pending?.originalCart ?? cart;
       lineOpsRef.current.delete(lineId);
-      // Invalidate any in-flight quantity update responses for this line.
+      // Invalidate in-flight quantity-update responses for this line.
       nextLineRequestId(lineId);
 
       setCartInternal(createOptimisticCartWithoutItem(cart, lineId));
@@ -457,7 +433,6 @@ export function CartProvider({
       return;
     }
 
-    // UPDATE: quantity > 0
     let pending = lineOpsRef.current.get(lineId);
 
     if (!pending) {
@@ -472,20 +447,17 @@ export function CartProvider({
 
     pending.targetQuantity = quantity;
 
-    // Optimistic UI update (always instant)
     setCartInternal(createOptimisticCart(cart, lineId, quantity));
 
-    // Clear existing debounce timer
     if (pending.timer) clearTimeout(pending.timer);
 
-    // Leading-edge: first update fires immediately
+    // Leading edge — first update fires immediately, the rest are debounced.
     if (!pending.hasFiredInitial) {
       pending.hasFiredInitial = true;
       fireUpdateRequest(lineId, quantity, pending.originalCart);
       return;
     }
 
-    // Trailing-edge: subsequent updates are debounced
     pending.timer = setTimeout(() => {
       const p = lineOpsRef.current.get(lineId);
       if (!p) return;
@@ -493,16 +465,13 @@ export function CartProvider({
     }, DEBOUNCE_MS);
   };
 
-  // Cleanup timers on unmount
   useEffect(() => {
     const debounce = addToCartDebounceRef.current;
     return () => {
-      // Clear add-to-cart debounce timer
       if (debounce.timer !== null) {
         clearTimeout(debounce.timer);
       }
 
-      // Clear all pending line operation timers
       for (const [, pending] of lineOpsRef.current) {
         if (pending.timer !== null) {
           clearTimeout(pending.timer);
@@ -512,8 +481,7 @@ export function CartProvider({
     };
   }, []);
 
-  // Cleanup stale line operations when cart changes
-  // (handles edge case: cart revalidates, line no longer exists)
+  // Drop pending ops for lines the revalidated cart no longer contains.
   useEffect(() => {
     const lineIds = new Set(cart?.lines.map((l) => l.id) ?? []);
     for (const [lineId, pending] of lineOpsRef.current) {

--- a/apps/template/components/cart/overlay-summary.tsx
+++ b/apps/template/components/cart/overlay-summary.tsx
@@ -14,7 +14,7 @@ export function OverlaySummary({ cart, locale }: OverlaySummaryProps) {
   const t = useTranslations("cart");
   const currencyCode = cart.cost.subtotalAmount.currencyCode;
 
-  // Calculate subtotal from line items for accurate real-time display
+  // Sum line totals locally — Shopify's `subtotalAmount` lags during optimistic updates.
   const subtotal = cart.lines.reduce(
     (sum, line) => sum + parseFloat(line.cost.totalAmount.amount),
     0,

--- a/apps/template/components/product-detail/buy-buttons.tsx
+++ b/apps/template/components/product-detail/buy-buttons.tsx
@@ -79,7 +79,6 @@ export function BuyButtons({
 
   const isOutOfStock = !selectedVariant.availableForSale;
 
-  // Button text logic
   const getButtonText = () => {
     if (pendingQuantity > 0) return t("addingQuantity", { quantity: String(pendingQuantity) });
     if (isAddingToCart) return t("addingToCart");

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -56,7 +56,6 @@ export async function ProductDetailSection({
     ? resolveSelectedVariant(variants, eagerSelectedOptions)
     : null;
 
-  // Translations for stock-aware buy button fallback
   const t = uniformStock && !singleVariant ? await getTranslations("product") : null;
   const allInStock = variants[0]?.availableForSale ?? true;
 

--- a/apps/template/components/product-detail/product-info.tsx
+++ b/apps/template/components/product-detail/product-info.tsx
@@ -55,7 +55,6 @@ function ProductInfoOptions({
   className,
   ...props
 }: ProductInfoOptionsProps) {
-  // Separate color/swatch options from other options.
   const isColorOption = (opt: ProductOption) =>
     opt.values.some((v) => v.swatch?.color || v.swatch?.image) ||
     opt.name.toLowerCase().includes("color");

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -168,7 +168,6 @@ function Carousel({
   );
 }
 
-/** Single grid item — extracted for reuse. */
 function GridItem({ item, title, idx }: { item: MediaItem; title: string; idx: number }) {
   return (
     <div className="relative aspect-square w-full overflow-hidden bg-accent">

--- a/apps/template/components/schema/site-schema.tsx
+++ b/apps/template/components/schema/site-schema.tsx
@@ -1,6 +1,5 @@
 import { siteConfig } from "@/lib/config";
 
-// TODO: Skill
 function buildSiteSchema(locale: string) {
   return [
     {

--- a/apps/template/hooks/use-controllable-state.ts
+++ b/apps/template/hooks/use-controllable-state.ts
@@ -1,9 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 
-/**
- * A hook for managing controlled/uncontrolled component state.
- * Replaces @radix-ui/react-use-controllable-state.
- */
+/** Replaces `@radix-ui/react-use-controllable-state`. */
 export function useControllableState<T>({
   prop,
   defaultProp,

--- a/apps/template/lib/agent/server.ts
+++ b/apps/template/lib/agent/server.ts
@@ -15,14 +15,12 @@ import { removeFromCartTool } from "./tools/remove-from-cart";
 import { searchProductsTool } from "./tools/search-products";
 import { updateCartItemTool } from "./tools/update-cart-item";
 
-// ── Context ──────────────────────────────────────────────────────────
-
 export type User = {
   type: "guest";
   locale: Locale;
 };
 
-// Page context resolved from Referer header with trusted data
+/** Resolved server-side from the Referer header with trusted data. */
 export type PageContext =
   | { type: "home" }
   | { type: "product"; product: ProductDetails }
@@ -31,8 +29,6 @@ export type PageContext =
   | { type: "cart" }
   | null;
 
-// We can track context in here like current user or current page
-// so we can adapt the agent's behavior to the context, like having order tools for logged in users etc
 export interface AgentContext {
   chatId: string;
   user: User;
@@ -60,8 +56,6 @@ export function getAgentContext() {
   }
   return ctx;
 }
-
-// ── Prompt ───────────────────────────────────────────────────────────
 
 /** Strip common leading whitespace from a tagged template literal. */
 function dedent(strings: TemplateStringsArray, ...values: unknown[]): string {
@@ -186,8 +180,6 @@ function getSystemPrompt() {
   const ctx = getAgentContext();
   return createSystemPrompt(ctx);
 }
-
-// ── Agent ────────────────────────────────────────────────────────────
 
 const defaults: ToolLoopAgentSettings = {
   model: "anthropic/claude-sonnet-4.6",

--- a/apps/template/lib/agent/tools/add-to-cart.ts
+++ b/apps/template/lib/agent/tools/add-to-cart.ts
@@ -38,7 +38,6 @@ If there are multiple variants (sizes, colors), ask the user which one they want
           user.locale,
         );
 
-        // Include product title in response if we have context
         let productInfo = "";
         if (page?.type === "product") {
           const { product } = page;

--- a/apps/template/lib/cart/action.ts
+++ b/apps/template/lib/cart/action.ts
@@ -158,11 +158,7 @@ export async function addToCartAction(
   }
 }
 
-/**
- * Sync cart buyer identity with the current locale
- * This ensures the cart uses the correct country/currency for the locale
- * Should be called when the locale changes or on initial page load
- */
+/** Aligns cart country/currency with the locale; call on locale change or initial page load. */
 export async function syncCartLocaleAction(locale: string): Promise<CartActionResult> {
   if (!isEnabledLocale(locale)) {
     return {
@@ -174,8 +170,8 @@ export async function syncCartLocaleAction(locale: string): Promise<CartActionRe
   try {
     const cart = await updateCartBuyerIdentity(locale);
 
+    // No cart exists yet — nothing to sync, treat as success.
     if (!cart) {
-      // No cart exists, that's fine
       return { success: true };
     }
 
@@ -216,11 +212,7 @@ export async function updateCartNoteAction(note: string): Promise<CartActionResu
   }
 }
 
-/**
- * Build a Shop Pay checkout URL for the given variant.
- * Uses Shopify's cart permalink format (`/cart/{numericId}:{qty}`)
- * so no cart needs to be created via the API.
- */
+/** Uses Shopify's cart permalink format (`/cart/{numericId}:{qty}`) — no API cart is created. */
 export async function buyNowAction(
   merchandiseId: string,
   quantity: number = 1,
@@ -257,10 +249,6 @@ export async function buyNowAction(
   return { checkoutUrl };
 }
 
-/**
- * Return the checkout URL for the current cart.
- * Called before redirecting to Shopify checkout.
- */
 export async function prepareCheckoutAction(): Promise<{
   checkoutUrl: string | null;
 }> {

--- a/apps/template/lib/i18n/index.ts
+++ b/apps/template/lib/i18n/index.ts
@@ -8,9 +8,6 @@ export const defaultLocale: Locale = "en-US";
 export const enabledLocales: readonly Locale[] = [defaultLocale];
 export const localeSwitchingEnabled = enabledLocales.length > 1;
 
-/**
- * Type guard to check if a string is a valid locale
- */
 export function isLocale(value: string): value is Locale {
   return locales.includes(value as Locale);
 }
@@ -19,22 +16,15 @@ export function isEnabledLocale(value: string): value is Locale {
   return enabledLocales.includes(value as Locale);
 }
 
-/**
- * Safely convert a string to a supported locale.
- */
 export function asLocale(value: string): Locale {
   return isLocale(value) ? value : defaultLocale;
 }
 
-/**
- * Resolve a locale for the current deployment. Unsupported or disabled values
- * fall back to the configured default locale.
- */
+/** Unsupported or disabled values fall back to `defaultLocale`. */
 export function resolveLocale(value: string | null | undefined): Locale {
   return value && isEnabledLocale(value) ? value : defaultLocale;
 }
 
-// Currency data per locale
 const localeCurrency: Record<Locale, { currency: string; symbol: string }> = {
   "en-US": { currency: "USD", symbol: "$" },
 };
@@ -52,11 +42,10 @@ export function getLocaleData(locale: string): LocaleData {
   const [lang, country] = locale.split("-");
   const currencyData = localeCurrency[locale as Locale] ?? localeCurrency[defaultLocale];
 
-  // Get native language name (e.g., "Deutsch" for de-DE)
+  // Native language name (e.g., "Deutsch" for de-DE).
   const languageNames = new Intl.DisplayNames([locale], { type: "language" });
   const languageName = languageNames.of(lang) ?? lang;
 
-  // Get currency name in the locale's language
   const currencyNames = new Intl.DisplayNames([locale], { type: "currency" });
   const currencyName = currencyNames.of(currencyData.currency) ?? currencyData.currency;
 

--- a/apps/template/lib/markdown/product.ts
+++ b/apps/template/lib/markdown/product.ts
@@ -2,18 +2,13 @@ import type { ProductDetails } from "@/lib/types";
 
 import { createTable, escapeMarkdown, formatPrice } from "./utils";
 
-/**
- * Convert a ProductDetails object to a Markdown string.
- * Designed for agent/crawler consumption with structured, parseable output.
- */
+/** Output is consumed by agents/crawlers, so structure must stay parseable. */
 export function productToMarkdown(product: ProductDetails, locale: string): string {
   const sections: string[] = [];
 
-  // Title
   sections.push(`# ${escapeMarkdown(product.title)}`);
   sections.push("");
 
-  // Product Information
   sections.push("## Product Information");
   sections.push("");
   sections.push(`- **Handle**: ${product.handle}`);
@@ -30,7 +25,6 @@ export function productToMarkdown(product: ProductDetails, locale: string): stri
   sections.push(`- **Available**: ${product.availableForSale ? "Yes" : "No"}`);
   sections.push("");
 
-  // Pricing
   sections.push("## Pricing");
   sections.push("");
   sections.push(`- **Price**: ${formatPrice(product.price, locale)}`);
@@ -54,7 +48,6 @@ export function productToMarkdown(product: ProductDetails, locale: string): stri
   }
   sections.push("");
 
-  // Description
   if (product.description) {
     sections.push("## Description");
     sections.push("");
@@ -62,7 +55,6 @@ export function productToMarkdown(product: ProductDetails, locale: string): stri
     sections.push("");
   }
 
-  // Options (compact summary)
   if (product.options.length > 0) {
     sections.push("## Options");
     sections.push("");
@@ -73,7 +65,6 @@ export function productToMarkdown(product: ProductDetails, locale: string): stri
     sections.push("");
   }
 
-  // Variants (full table)
   if (product.variants.length > 0) {
     sections.push("## Variants");
     sections.push("");
@@ -98,7 +89,6 @@ export function productToMarkdown(product: ProductDetails, locale: string): stri
     sections.push("");
   }
 
-  // Specifications
   if (product.metafields && product.metafields.length > 0) {
     sections.push("## Specifications");
     sections.push("");
@@ -113,7 +103,6 @@ export function productToMarkdown(product: ProductDetails, locale: string): stri
     sections.push("");
   }
 
-  // Images (as plain URLs)
   if (product.images.length > 0) {
     sections.push("## Images");
     sections.push("");
@@ -123,7 +112,6 @@ export function productToMarkdown(product: ProductDetails, locale: string): stri
     sections.push("");
   }
 
-  // Tags
   if (product.tags.length > 0) {
     sections.push("## Tags");
     sections.push("");
@@ -131,7 +119,6 @@ export function productToMarkdown(product: ProductDetails, locale: string): stri
     sections.push("");
   }
 
-  // SEO
   if (product.seo.title || product.seo.description) {
     sections.push("## SEO");
     sections.push("");
@@ -144,7 +131,6 @@ export function productToMarkdown(product: ProductDetails, locale: string): stri
     sections.push("");
   }
 
-  // Footer metadata
   sections.push("---");
   sections.push("");
   sections.push(`*Last updated: ${product.updatedAt}*`);

--- a/apps/template/lib/markdown/utils.ts
+++ b/apps/template/lib/markdown/utils.ts
@@ -1,8 +1,5 @@
 import type { Money } from "@/lib/types";
 
-/**
- * Format a Money object to a localized price string.
- */
 export function formatPrice(money: Money, locale: string): string {
   const amount = Number.parseFloat(money.amount);
   return new Intl.NumberFormat(locale, {
@@ -12,10 +9,7 @@ export function formatPrice(money: Money, locale: string): string {
   }).format(amount);
 }
 
-/**
- * Escape special markdown characters in text.
- * Handles: | (table pipes), * (bold/italic), _ (italic), ` (code), # (headers)
- */
+/** Handles: | (table pipes), * (bold/italic), _ (italic), ` (code), # (headers). */
 export function escapeMarkdown(text: string): string {
   return text
     .replace(/\|/g, "\\|")
@@ -25,11 +19,7 @@ export function escapeMarkdown(text: string): string {
     .replace(/^#/gm, "\\#");
 }
 
-/**
- * Create a markdown table from headers and rows.
- * Validates that all rows have the same number of cells as headers.
- * Empty rows are filtered out. Rows with mismatched cell counts are padded with empty cells.
- */
+/** Empty rows are dropped; mismatched cell counts are truncated or padded with empty cells. */
 export function createTable(headers: string[], rows: string[][]): string {
   if (headers.length === 0 || rows.length === 0) return "";
 

--- a/apps/template/lib/product.ts
+++ b/apps/template/lib/product.ts
@@ -1,14 +1,9 @@
 import { getNumericShopifyId } from "@/lib/shopify/utils";
 import type { Image, Money, ProductOption, ProductVariant, SelectedOption } from "@/lib/types";
 
-// ── Variant selection ────────────────────────────────────────────────
-
 export type SelectedOptions = Record<string, string>;
 
-/**
- * Compute initial selected options based on variantId and available variants.
- * Called server-side so the initial HTML matches hydrated state (zero CLS).
- */
+/** Called server-side so the initial HTML matches hydrated state (zero CLS). */
 export function computeInitialSelectedOptions(
   variants: ProductVariant[],
   initialVariantId?: string,
@@ -52,11 +47,6 @@ export function resolveSelectedVariant(
   );
 }
 
-/**
- * Compute the URL for selecting a given option value.
- * Finds the variant matching the updated options and returns
- * `/products/{handle}?variantId={numericId}`.
- */
 export function getVariantUrl(
   handle: string,
   variants: ProductVariant[],
@@ -66,12 +56,10 @@ export function getVariantUrl(
 ): string {
   const newOptions = { ...currentOptions, [optionName]: optionValue };
 
-  // Try exact match first
   let variant = variants.find((v) =>
     v.selectedOptions.every((opt) => newOptions[opt.name] === opt.value),
   );
 
-  // Fall back to first variant with this option value
   if (!variant) {
     variant = variants.find((v) =>
       v.selectedOptions.some((opt) => opt.name === optionName && opt.value === optionValue),
@@ -86,18 +74,9 @@ export function getVariantUrl(
   return `/products/${handle}`;
 }
 
-// ── Color image partitioning ─────────────────────────────────────────
-
 /**
- * Returns filtered images for the currently selected color variant.
- *
- * Collects variant images assigned to other colors and excludes them,
- * keeping the selected color's variant image and all shared/unassigned images.
- *
- * Falls back to all product images when:
- * - No color option exists on the product
- * - Only one color is available
- * - No variant images are assigned
+ * Falls back to all product images when no color option exists, only one color
+ * is available, or no variant images are assigned.
  */
 export function getImagesForSelectedColor(
   images: Image[],
@@ -121,7 +100,6 @@ export function getImagesForSelectedColor(
   // Only one color means all images belong to it
   if (colorOption.values.length <= 1) return images;
 
-  // Collect variant image URLs for each color
   const colorToImageUrls = new Map<string, Set<string>>();
   for (const variant of variants) {
     if (!variant.image) continue;
@@ -136,10 +114,8 @@ export function getImagesForSelectedColor(
     urls.add(variant.image.url);
   }
 
-  // No variant images assigned — show all
   if (colorToImageUrls.size === 0) return images;
 
-  // Collect image URLs belonging to other colors (not the selected one)
   const otherColorImageUrls = new Set<string>();
   for (const [color, urls] of colorToImageUrls) {
     if (color !== selectedColor) {
@@ -149,7 +125,7 @@ export function getImagesForSelectedColor(
     }
   }
 
-  // Don't exclude images that are shared with the selected color
+  // Images shared with the selected color must not be excluded.
   const selectedColorUrls = colorToImageUrls.get(selectedColor);
   if (selectedColorUrls) {
     for (const url of selectedColorUrls) {
@@ -161,7 +137,6 @@ export function getImagesForSelectedColor(
 
   if (filtered.length === 0) return images;
 
-  // Partition: color-specific images first, then shared/unassigned images
   const colorImages: typeof filtered = [];
   const sharedImages: typeof filtered = [];
 
@@ -173,7 +148,6 @@ export function getImagesForSelectedColor(
     }
   }
 
-  // Within color images, move the selected variant's image to the front
   const selectedVariant = resolveSelectedVariant(variants, selectedOptions);
   const variantImageUrl = selectedVariant?.image?.url;
 
@@ -188,13 +162,6 @@ export function getImagesForSelectedColor(
   return [...colorImages, ...sharedImages];
 }
 
-/**
- * Returns partitioned images for the currently selected color variant.
- *
- * Returns an object with:
- * - colorImages: Images specific to the selected color variant
- * - otherImages: Shared/unassigned images
- */
 export function getPartitionedImagesForSelectedColor(
   images: Image[],
   options: ProductOption[],
@@ -214,10 +181,8 @@ export function getPartitionedImagesForSelectedColor(
   const selectedColor = selectedOptions[colorOption.name];
   if (!selectedColor) return { colorImages: [], otherImages: images };
 
-  // Only one color means all images belong to it
   if (colorOption.values.length <= 1) return { colorImages: images, otherImages: [] };
 
-  // Collect variant image URLs for each color
   const colorToImageUrls = new Map<string, Set<string>>();
   for (const variant of variants) {
     if (!variant.image) continue;
@@ -232,10 +197,8 @@ export function getPartitionedImagesForSelectedColor(
     urls.add(variant.image.url);
   }
 
-  // No variant images assigned — all are "other"
   if (colorToImageUrls.size === 0) return { colorImages: [], otherImages: images };
 
-  // Collect image URLs belonging to other colors (not the selected one)
   const otherColorImageUrls = new Set<string>();
   for (const [color, urls] of colorToImageUrls) {
     if (color !== selectedColor) {
@@ -245,7 +208,7 @@ export function getPartitionedImagesForSelectedColor(
     }
   }
 
-  // Don't exclude images that are shared with the selected color
+  // Images shared with the selected color must not be excluded.
   const selectedColorUrls = colorToImageUrls.get(selectedColor);
   if (selectedColorUrls) {
     for (const url of selectedColorUrls) {
@@ -257,7 +220,6 @@ export function getPartitionedImagesForSelectedColor(
 
   if (filtered.length === 0) return { colorImages: [], otherImages: images };
 
-  // Partition: color-specific images vs shared/unassigned images
   const colorImages: Image[] = [];
   const otherImages: Image[] = [];
 
@@ -269,7 +231,6 @@ export function getPartitionedImagesForSelectedColor(
     }
   }
 
-  // Within color images, move the selected variant's image to the front
   const selectedVariant = resolveSelectedVariant(variants, selectedOptions);
   const variantImageUrl = selectedVariant?.image?.url;
 
@@ -284,11 +245,7 @@ export function getPartitionedImagesForSelectedColor(
   return { colorImages, otherImages };
 }
 
-/**
- * Returns true when all variants share the same price and compareAtPrice.
- * When true, we can render the price immediately without waiting for
- * searchParams to resolve the selected variant.
- */
+/** When true, the price renders without waiting for searchParams to resolve the variant. */
 export function hasUniformPricing(variants: ProductVariant[]): boolean {
   if (variants.length <= 1) return true;
   const first = variants[0];
@@ -300,22 +257,14 @@ export function hasUniformPricing(variants: ProductVariant[]): boolean {
   );
 }
 
-/**
- * Returns true when every variant shares the same availableForSale value.
- * When true, we can eagerly show the correct buy-button labels in the
- * Suspense fallback without waiting for variant resolution.
- */
+/** When true, buy-button labels can render in the Suspense fallback without variant resolution. */
 export function hasUniformStock(variants: ProductVariant[]): boolean {
   if (variants.length <= 1) return true;
   const first = variants[0];
   return variants.every((v) => v.availableForSale === first.availableForSale);
 }
 
-/**
- * Returns true when the product has multiple color variants with
- * distinct images — meaning the gallery would change based on
- * the selected color (i.e. based on searchParams).
- */
+/** True when the gallery depends on selected color (i.e. on searchParams). */
 export function hasColorImagePartitioning(
   options: ProductOption[],
   variants: ProductVariant[],
@@ -333,10 +282,7 @@ export function hasColorImagePartitioning(
   );
 }
 
-/**
- * Returns images not assigned to any color variant.
- * These "shared" images can render without waiting for searchParams.
- */
+/** Images not assigned to any color variant — can render without waiting for searchParams. */
 export function getSharedImages(
   images: Image[],
   options: ProductOption[],
@@ -364,9 +310,6 @@ export function getSharedImages(
   return images.filter((img) => !allColorImageUrls.has(img.url));
 }
 
-// ── Optimistic cart info ─────────────────────────────────────────────
-
-// Product info needed to construct an optimistic CartLine
 export type OptimisticProductInfo = {
   variantTitle: string;
   productTitle: string;
@@ -376,7 +319,7 @@ export type OptimisticProductInfo = {
   selectedOptions: SelectedOption[];
 };
 
-// Build OptimisticProductInfo from a ProductCard (grid/carousel quick-add)
+/** From a ProductCard (grid/carousel quick-add). */
 export function productCardToOptimisticInfo(product: {
   title: string;
   handle: string;
@@ -400,7 +343,7 @@ export function productCardToOptimisticInfo(product: {
   };
 }
 
-// Build OptimisticProductInfo from a PDP variant + product
+/** From a PDP variant + product. */
 export function variantToOptimisticInfo(
   variant: {
     title: string;

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -116,8 +116,7 @@ export async function getCart(cartId?: string): Promise<Cart | undefined> {
 }
 
 /**
- * Create a cart without setting cookies.
- * Use this in streaming contexts (e.g., AI agent) where cookies().set() won't work.
+ * Use in streaming contexts (e.g., the AI agent) where `cookies().set()` won't work.
  * The caller is responsible for setting the cookie via response headers.
  */
 export async function createCartWithoutCookie(locale: string = defaultLocale): Promise<Cart> {
@@ -155,7 +154,6 @@ export async function createCartWithoutCookie(locale: string = defaultLocale): P
 export async function createCart(locale: string = defaultLocale): Promise<Cart> {
   const cart = await createCartWithoutCookie(locale);
 
-  // Store cart ID in HTTP-only cookie (server-side only)
   if (cart.id) {
     (await cookies()).set("shopify_cartId", cart.id, {
       httpOnly: true,
@@ -178,7 +176,6 @@ export async function addToCart(
     cartId = (await cookies()).get("shopify_cartId")?.value;
   }
 
-  // No cart exists, create one with the current locale's country
   if (!cartId) {
     const cart = await createCart(locale);
     cartId = cart.id;

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -14,18 +14,11 @@ import {
 import type { ProductFilter, ShopifyFilter } from "../types/filters";
 import { getNumericShopifyId } from "../utils";
 
-/**
- * Generate a `product-{numericId}` cache tag for a Shopify product GID.
- * Returns `null` if the numeric ID cannot be extracted.
- */
 function productIdTag(gid: string): string | null {
   const numericId = getNumericShopifyId(gid);
   return numericId ? `product-${numericId}` : null;
 }
 
-/**
- * Call `cacheTag` for each product in a list, using their numeric Shopify IDs.
- */
 function tagProducts(products: Array<{ id: string }>): void {
   for (const product of products) {
     const tag = productIdTag(product.id);
@@ -528,10 +521,6 @@ const GET_PRODUCTS_BY_IDS_QUERY = `
   }
 `;
 
-/**
- * Decode a Shopify ID from base64 to GID format if needed.
- * Handles both base64-encoded IDs and raw GIDs.
- */
 function decodeShopifyId(id: string): string {
   if (id.startsWith("gid://")) {
     return id;
@@ -539,9 +528,6 @@ function decodeShopifyId(id: string): string {
   return Buffer.from(id, "base64").toString("utf-8");
 }
 
-/**
- * Fetch a single product by its Shopify ID (GID or base64-encoded).
- */
 export async function getProductById(
   id: string,
   locale: string = defaultLocale,
@@ -570,10 +556,7 @@ export async function getProductById(
   return transformShopifyProductDetails(product);
 }
 
-/**
- * Fetch multiple products by their Shopify IDs (GID or base64-encoded) in a single request.
- * Results are returned in the same order as the input IDs.
- */
+/** Results are returned in the same order as the input IDs. */
 export async function getProductsByIds(
   ids: string[],
   locale: string = defaultLocale,
@@ -603,11 +586,7 @@ export async function getProductsByIds(
   return shopifyProducts.map(transformShopifyProductCard);
 }
 
-/**
- * Fetch multiple products by their handles in a single request.
- * Uses Shopify's products query with handle filter.
- * Results are reordered to match the input handle order.
- */
+/** Results are reordered to match the input handle order. */
 export async function getProductsByHandles(
   handles: string[],
   locale: string = defaultLocale,
@@ -634,13 +613,11 @@ export async function getProductsByHandles(
     variables: { query: searchQuery, first: handles.length, country, language },
   });
 
-  // Create a map for O(1) lookup by handle
   const productMap = new Map<string, ShopifyProductCard>();
   for (const edge of data.products.edges) {
     productMap.set(edge.node.handle, edge.node);
   }
 
-  // Return products in the original handle order, filtering out missing
   const shopifyProducts = handles
     .map((handle) => productMap.get(handle))
     .filter((product): product is ShopifyProductCard => product !== undefined);

--- a/apps/template/lib/shopify/transforms/collection.ts
+++ b/apps/template/lib/shopify/transforms/collection.ts
@@ -43,5 +43,4 @@ export function transformShopifyCollections(collections: ShopifyCollection[]): C
   return collections.map(transformShopifyCollection);
 }
 
-// Re-export Shopify types for use in operations
 export type { ShopifyCollection };

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -235,7 +235,6 @@ function transformSwatch(swatch: ShopifyOptionValueSwatch | null): OptionValueSw
 }
 
 function transformOption(option: ShopifyOption): ProductOption {
-  // Build a lookup from optionValues for swatch data
   const swatchLookup = new Map<string, OptionValueSwatch | undefined>();
   if (option.optionValues) {
     for (const ov of option.optionValues) {
@@ -256,7 +255,6 @@ function transformOption(option: ShopifyOption): ProductOption {
   };
 }
 
-// Map metafield keys to display labels
 const METAFIELD_LABELS: Record<string, string> = {
   material: "Material",
   dimensions: "Dimensions",
@@ -282,15 +280,11 @@ function transformMetafields(
     }));
 }
 
-// Convert snake_case or kebab-case to Title Case
 function formatKey(key: string): string {
   return key.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-/**
- * Filter product images to exclude variant-specific images (e.g. color swatches)
- * while keeping product-level images and the default variant's image.
- */
+/** Excludes variant-specific images (e.g. color swatches); keeps the default variant's image. */
 function filterVariantImages(product: ShopifyProductCard): Image[] {
   if (!product.images) return [];
 

--- a/apps/template/lib/shopify/utils.ts
+++ b/apps/template/lib/shopify/utils.ts
@@ -4,17 +4,10 @@ export function flattenEdges<T>(connection: ShopifyEdges<T>): T[] {
   return connection.edges.map((edge) => edge.node);
 }
 
-/**
- * Extract the numeric ID from a Shopify GID string.
- * e.g. "gid://shopify/Product/1234567890" → "1234567890"
- *
- * Handles both raw GID strings and base64-encoded GIDs.
- * Returns `null` if the ID cannot be extracted.
- */
+/** "gid://shopify/Product/1234567890" → "1234567890". Accepts raw or base64-encoded GIDs. */
 export function getNumericShopifyId(gid: string): string | null {
   let decoded = gid;
 
-  // If it doesn't look like a GID, try base64 decoding
   if (!decoded.startsWith("gid://")) {
     try {
       decoded = Buffer.from(decoded, "base64").toString("utf-8");

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -6,10 +6,6 @@ export type SearchParamsPromise = Promise<Record<string, string | string[] | und
 
 export type NormalizedSearchParams = Record<string, string | undefined>;
 
-/**
- * Normalize search params by taking the first value of any arrays.
- * Use this to convert raw Next.js searchParams to a clean string map.
- */
 export function normalizeSearchParams(
   params: Record<string, string | string[] | undefined>,
 ): NormalizedSearchParams {
@@ -18,13 +14,8 @@ export function normalizeSearchParams(
   );
 }
 
-/**
- * Core types for the commerce template
- *
- * These types define the contract between data sources and components.
- * Each integration (Shopify, Algolia, etc.) transforms their API responses
- * into these types.
- */
+// These types are the contract between data sources and components. Each
+// integration (Shopify, Algolia, etc.) transforms its API responses into these.
 
 export interface Money {
   amount: string;
@@ -50,10 +41,6 @@ export interface SEO {
   description: string;
 }
 
-/**
- * Minimal product data for cards in grids/carousels
- * Used by: ProductCard, search results, category listings
- */
 export interface ProductCard {
   id: string;
   handle: string;
@@ -69,10 +56,6 @@ export interface ProductCard {
   defaultVariantSelectedOptions?: SelectedOption[];
 }
 
-/**
- * Extended product data for product detail pages
- * Used by: PDP components (Info, Images, Variants, Details)
- */
 export interface ProductDetails extends ProductCard {
   description: string;
   descriptionHtml: string;
@@ -171,9 +154,6 @@ export interface CartMerchandise {
   product: CartProduct;
 }
 
-/**
- * Minimal product data within cart context
- */
 export interface CartProduct {
   id: string;
   handle: string;
@@ -237,10 +217,6 @@ export interface ProductListResult {
   subcategories?: CategoryNavItem[];
 }
 
-/**
- * Lightweight product data for predictive search results.
- * Subset of ProductCard for predictive search results.
- */
 export interface PredictiveSearchProduct {
   id: string;
   handle: string;


### PR DESCRIPTION
## Summary
- Add a **Comments** subsection to `apps/template/AGENTS.md` inside the existing `<!-- BEGIN:vercel-shop-style -->` block. Default is no comments; JSDoc only when WHY is non-obvious; ban restating, PR/task references, banner dividers, and bare `// TODO`. Tooling directives (`// eslint-disable-*`, `// @ts-expect-error`, etc.) are explicitly preserved.
- Aggressive cleanup pass across `apps/template/{app,lib,components,hooks}` (skipping vendored `components/ui/*` and `components/ai-elements/*`). 26 files, −300 / +79 lines.

## What was kept
Shopify API quirks (e.g. `productFilters` facet-only behavior), streaming/cookie boundaries in the chat route, locale-agnostic swatch matching, `@deprecated` tags, oxlint-disable directives with explanations, and example-bearing JSDoc like `getNumericShopifyId`'s GID format.

## What was stripped
- JSDoc that just restated the function name (`/** Verify Shopify webhook HMAC signature */` over `verifyWebhook`).
- Inline comments narrating the next line (`// Verify webhook signature in production`, `// Build a lookup from optionValues for swatch data`).
- `// Title` / `// Pricing` / `// SEO` style dividers in `lib/markdown/product.ts` (a single function with `## Section` push() calls right next to them).
- `// ── Section ──` dividers in `lib/product.ts` and `lib/agent/server.ts` — function names already cluster, and `hasUniformPricing` doesn't actually belong under "Color image partitioning."
- `// Used by:` annotations on type definitions (rot risk, low value).
- Vague `// TODO: Skill` and the commented-out `generateStaticParams` block in `app/collections/[handle]/page.tsx`.

## Test plan
- [ ] `pnpm lint` from `apps/template` — pre-existing 5 warnings + 2 format issues, unchanged by this PR (verified by stashing the diff and rerunning on baseline).
- [ ] Spot-check that `// eslint-disable-*` and `@ts-expect-error` directives still apply (none were touched).
- [ ] `pnpm dev` and click through PDP / cart / agent panel — behavior should be identical (only one logic-equivalent simplification: the empty `if`/`else` branch in `cart/context.tsx` `fireUpdateRequest` was inverted to drop the empty body; semantics preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)