### PR TITLE
Suspend home featured products + share grid skeleton

### DIFF
--- a/apps/template/README.md
+++ b/apps/template/README.md
@@ -64,13 +64,13 @@ See [vercel.shop/docs/getting-started](https://vercel.shop/docs/getting-started)
 
 Vercel Shop includes a `vercel-shop` plugin with skills for extending the storefront with common commerce patterns. In Claude Code, these are exposed as `/vercel-shop:<skill>` commands:
 
-| Skill | Description |
-|-------|-------------|
-| `add-locale-url-prefix` | Locale-prefixed URL routing with next-intl |
-| `enable-analytics` | Add Vercel Analytics, Speed Insights, and Google Tag Manager |
-| `enable-shopify-cms` | Wire Shopify metaobjects as a CMS for homepage and marketing pages |
-| `enable-shopify-markets` | Multi-locale support with Shopify Markets and next-intl |
-| `enable-shopify-menus` | Replace hardcoded nav/footer with Shopify-powered menus, optional megamenu |
+| Skill                    | Description                                                                |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `add-locale-url-prefix`  | Locale-prefixed URL routing with next-intl                                 |
+| `enable-analytics`       | Add Vercel Analytics, Speed Insights, and Google Tag Manager               |
+| `enable-shopify-cms`     | Wire Shopify metaobjects as a CMS for homepage and marketing pages         |
+| `enable-shopify-markets` | Multi-locale support with Shopify Markets and next-intl                    |
+| `enable-shopify-menus`   | Replace hardcoded nav/footer with Shopify-powered menus, optional megamenu |
 
 ## Documentation
 

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -1,14 +1,13 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
-import { ProductsGrid } from "@/components/product/products-grid";
+import { FeaturedProducts } from "@/components/product/products-grid";
 import { BannerSection } from "@/components/sections/banner-section";
 import { Container } from "@/components/ui/container";
 import { Sections } from "@/components/ui/sections";
 import { siteConfig } from "@/lib/config";
 import { getLocale } from "@/lib/params";
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
-import { getProducts } from "@/lib/shopify/operations/products";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("seo");
@@ -30,7 +29,6 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function HomePage() {
   const [locale, t] = await Promise.all([getLocale(), getTranslations("content.homepage")]);
-  const featuredProductsResult = await getProducts({ limit: 8, locale });
 
   return (
     <Sections>
@@ -48,14 +46,12 @@ export default async function HomePage() {
       />
 
       <Container className="pb-10">
-        {featuredProductsResult.products.length > 0 && (
-          <ProductsGrid
-            title={t("featuredProducts.title")}
-            products={featuredProductsResult.products}
-            locale={locale}
-            collectionUrl="/search"
-          />
-        )}
+        <FeaturedProducts
+          title={t("featuredProducts.title")}
+          limit={8}
+          locale={locale}
+          collectionUrl="/search"
+        />
       </Container>
     </Sections>
   );

--- a/apps/template/components/collections/results-grid.tsx
+++ b/apps/template/components/collections/results-grid.tsx
@@ -1,25 +1,21 @@
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
-import { ProductCard, ProductCardSkeleton } from "@/components/product-card/product-card";
+import { ProductCard } from "@/components/product-card/product-card";
+import { ProductsGridSkeleton } from "@/components/product/products-grid";
 import { loadMoreCollectionProducts } from "@/lib/collections/action";
 import type { CollectionResultsData } from "@/lib/collections/server";
 import type { Locale } from "@/lib/i18n";
+import { RESULTS_PER_PAGE } from "@/lib/utils";
 
 import { InfiniteProductGrid } from "./infinite-product-grid";
 
-const RESULTS_SKELETON_KEYS = Array.from(
-  { length: 15 },
-  (_, index) => `collection-results-skeleton-${index}`,
-);
-
 function Fallback() {
   return (
-    <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-      {RESULTS_SKELETON_KEYS.map((key) => (
-        <ProductCardSkeleton key={key} />
-      ))}
-    </div>
+    <ProductsGridSkeleton
+      count={RESULTS_PER_PAGE}
+      className="sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+    />
   );
 }
 

--- a/apps/template/components/collections/results.tsx
+++ b/apps/template/components/collections/results.tsx
@@ -4,33 +4,28 @@ import { Suspense } from "react";
 
 import { FilterSidebarSheet } from "@/components/collections/filter-sidebar-sheet";
 import { CollectionsSortSelect } from "@/components/collections/sort-select";
-import { ProductCardSkeleton } from "@/components/product-card/product-card";
+import { ProductsGridSkeleton } from "@/components/product/products-grid";
 import {
   type CollectionResultsData,
   getExactCollectionResultCount,
 } from "@/lib/collections/server";
 import type { Locale } from "@/lib/i18n";
 import { getActiveFilterBadges } from "@/lib/shopify/transforms/filters";
+import { RESULTS_PER_PAGE } from "@/lib/utils";
 
 import { FilterPendingScope } from "./filter-pending-context";
 import { CollectionFilters } from "./filters";
 import { CollectionResultsGrid } from "./results-grid";
 import { CollectionToolbar, CollectionToolbarSkeleton } from "./toolbar";
 
-const FALLBACK_SKELETON_KEYS = Array.from(
-  { length: 15 },
-  (_, index) => `collection-section-skeleton-${index}`,
-);
-
 function Fallback() {
   return (
     <>
       <CollectionToolbarSkeleton />
-      <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-        {FALLBACK_SKELETON_KEYS.map((key) => (
-          <ProductCardSkeleton key={key} />
-        ))}
-      </div>
+      <ProductsGridSkeleton
+        count={RESULTS_PER_PAGE}
+        className="sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+      />
     </>
   );
 }

--- a/apps/template/components/product/products-grid.tsx
+++ b/apps/template/components/product/products-grid.tsx
@@ -1,19 +1,42 @@
 import { getTranslations } from "next-intl/server";
 import Link from "next/link";
+import { Suspense } from "react";
 
-import { ProductCard } from "@/components/product-card/product-card";
+import { ProductCard, ProductCardSkeleton } from "@/components/product-card/product-card";
 import type { Locale } from "@/lib/i18n";
-import type { ProductCard as ProductCardType } from "@/lib/types";
+import { getProducts } from "@/lib/shopify/operations/products";
+import { cn } from "@/lib/utils";
 
-interface ProductsGridProps {
+interface ProductsGridSkeletonProps {
+  count: number;
+  className?: string;
+}
+
+export function ProductsGridSkeleton({ count, className }: ProductsGridSkeletonProps) {
+  return (
+    <div className={cn("grid grid-cols-2 gap-5 lg:grid-cols-4", className)}>
+      {Array.from({ length: count }, (_, index) => (
+        <ProductCardSkeleton key={index} />
+      ))}
+    </div>
+  );
+}
+
+interface FeaturedProductsProps {
   title: string;
-  products: ProductCardType[];
+  limit: number;
   locale: Locale;
   collectionUrl?: string;
 }
 
-export async function ProductsGrid({ title, products, locale, collectionUrl }: ProductsGridProps) {
+export async function FeaturedProducts({
+  title,
+  limit,
+  locale,
+  collectionUrl,
+}: FeaturedProductsProps) {
   const t = await getTranslations("product");
+
   return (
     <div className="grid gap-4">
       <div className="flex items-center justify-between">
@@ -27,16 +50,36 @@ export async function ProductsGrid({ title, products, locale, collectionUrl }: P
           </Link>
         )}
       </div>
-      <div className="grid grid-cols-2 gap-5 lg:grid-cols-4">
-        {products.map((product) => (
-          <ProductCard
-            key={product.id}
-            product={product}
-            locale={locale}
-            outOfStockText={t("outOfStock")}
-          />
-        ))}
-      </div>
+      <Suspense fallback={<ProductsGridSkeleton count={limit} />}>
+        <FeaturedProductsGrid limit={limit} locale={locale} outOfStockText={t("outOfStock")} />
+      </Suspense>
+    </div>
+  );
+}
+
+async function FeaturedProductsGrid({
+  limit,
+  locale,
+  outOfStockText,
+}: {
+  limit: number;
+  locale: Locale;
+  outOfStockText: string;
+}) {
+  const { products } = await getProducts({ limit, locale });
+
+  if (products.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-2 gap-5 lg:grid-cols-4">
+      {products.map((product) => (
+        <ProductCard
+          key={product.id}
+          product={product}
+          locale={locale}
+          outOfStockText={outOfStockText}
+        />
+      ))}
     </div>
   );
 }

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -7,7 +7,8 @@ import {
 } from "@/components/collections/filter-pending-context";
 import { InfiniteProductGrid } from "@/components/collections/infinite-product-grid";
 import { CollectionToolbarSkeleton } from "@/components/collections/toolbar";
-import { ProductCard, ProductCardSkeleton } from "@/components/product-card/product-card";
+import { ProductCard } from "@/components/product-card/product-card";
+import { ProductsGridSkeleton } from "@/components/product/products-grid";
 import type { Locale } from "@/lib/i18n";
 import { loadMoreSearchProducts } from "@/lib/search/action";
 import { buildProductFiltersFromParams, getProducts } from "@/lib/shopify/operations/products";
@@ -17,20 +18,14 @@ import type { ProductFilter } from "@/lib/shopify/types/filters";
 import type { PageInfo, ProductCard as ProductCardType } from "@/lib/types";
 import { RESULTS_PER_PAGE } from "@/lib/utils";
 
-const RESULTS_SKELETON_KEYS = Array.from(
-  { length: 15 },
-  (_, index) => `search-results-skeleton-${index}`,
-);
-
 export function ResultsSkeleton() {
   return (
     <>
       <CollectionToolbarSkeleton />
-      <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-        {RESULTS_SKELETON_KEYS.map((key) => (
-          <ProductCardSkeleton key={key} />
-        ))}
-      </div>
+      <ProductsGridSkeleton
+        count={RESULTS_PER_PAGE}
+        className="sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+      />
     </>
   );
 }
@@ -93,11 +88,10 @@ export async function SearchResultsGrid({
   return (
     <Suspense
       fallback={
-        <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-          {RESULTS_SKELETON_KEYS.map((key) => (
-            <ProductCardSkeleton key={key} />
-          ))}
-        </div>
+        <ProductsGridSkeleton
+          count={RESULTS_PER_PAGE}
+          className="sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+        />
       }
     >
       <SearchResultsGridRender

--- a/apps/template/lib/i18n/messages/en.d.json.ts
+++ b/apps/template/lib/i18n/messages/en.d.json.ts
@@ -5,6 +5,21 @@ declare const messages: {
   "accessibility": {
     "skipToContent": "Skip to content"
   },
+  "account": {
+    "addresses": "Addresses",
+    "addressesDescription": "Manage your saved addresses",
+    "email": "Email",
+    "name": "Name",
+    "noAddresses": "You have no saved addresses yet.",
+    "noOrders": "You have no orders yet.",
+    "order": "Order",
+    "orderDetailPlaceholder": "Order details will appear here once customer operations are connected.",
+    "orders": "Orders",
+    "ordersDescription": "View your order history",
+    "profile": "Profile",
+    "profileDescription": "Your account information",
+    "signOut": "Sign out"
+  },
   "agent": {
     "assistantLabel": "Shopping assistant",
     "clearChat": "Clear chat",
@@ -113,6 +128,9 @@ declare const messages: {
     "error": "Something went wrong",
     "errorDesc": "An unexpected error occurred. Please try again.",
     "goHome": "Go back to the home page",
+    "loginClickHere": "Click here",
+    "loginNotRedirected": "Not redirected?",
+    "loginRedirecting": "Redirecting to sign in...",
     "notFound": "Page Not Found",
     "notFoundDesc": "The link may be incorrect, or the page has been removed.",
     "tryAgain": "Try again"
@@ -178,6 +196,8 @@ declare const messages: {
     "setAddress": "Set address",
     "shoppingAddress": "Shipping address",
     "showAllCategory": "Show all {category}",
+    "signIn": "Sign in",
+    "signOut": "Sign out",
     "switchLanguage": "Switch language",
     "toggleAiSearch": "Toggle AI Search",
     "zipCode": "ZIP code"
@@ -311,6 +331,7 @@ declare const messages: {
     "titleSubtext": "Showing results for your search query"
   },
   "seo": {
+    "accountTitle": "Account",
     "collectionFallbackDescription": "Browse collection products.",
     "collectionFallbackTitle": "Collection",
     "collectionsDescription": "Browse all product collections.",
@@ -318,6 +339,7 @@ declare const messages: {
     "defaultDescription": "Shop premium products, curated collections, and latest offers from Vercel Shop.",
     "homeDescription": "Explore featured products, curated collections, and seasonal campaigns.",
     "homeTitle": "Home",
+    "loginTitle": "Sign In",
     "searchDescription": "Search for products in our store",
     "searchDescriptionQuery": "Find products matching \"{query}\"",
     "searchTitle": "Search",


### PR DESCRIPTION
## Summary

- Home page no longer blocks on `getProducts` — the featured-products fetch lives in its own Suspense boundary so the banner and section header stream immediately. The route is now Partial Prerender (◐) instead of fully dynamic.
- New `ProductsGridSkeleton({ count, className })` in `components/product/products-grid.tsx` drives fallbacks from the same number used to fetch — home passes `8`, search/collections pass `RESULTS_PER_PAGE` (24, up from a hardcoded 15).
- Title/view-all link render eagerly outside Suspense; only the grid wall is in the fallback.

## Test plan

- [ ] `pnpm dev`, load `/`. Banner + featured-products header render before the grid; an 8-card 2/4-col skeleton briefly shows, then swaps to real cards with no layout shift.
- [ ] Throttle to "Slow 3G" to make the swap visible.
- [ ] Load `/search` and `/collections/<handle>`. Fallback now shows ~24 skeleton cards in the 5-col grid layout.
- [ ] `pnpm build` — verified locally; `/` is `◐` (PPR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)