### PR TITLE
Hide search result count while count is unreliable

### DIFF
--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -167,7 +167,7 @@ async function SearchToolbar({
   searchResultsDataPromise: Promise<SearchResultsData>;
   filtersLabel: string;
 }) {
-  const [data, t] = await Promise.all([searchResultsDataPromise, getTranslations("search")]);
+  const data = await searchResultsDataPromise;
 
   const activeFilterCount = Object.values(data.activeFilters).reduce((count, v) => {
     if (!v) return count;
@@ -176,7 +176,6 @@ async function SearchToolbar({
 
   return (
     <CollectionToolbar
-      resultCount={data.total > 0 ? t("resultCount", { count: data.total }) : undefined}
       filterSheet={
         <FilterSidebarSheet
           label={filtersLabel}


### PR DESCRIPTION
## Summary
- Temporarily stop rendering the result count in the search toolbar — the displayed total is currently incorrect and needs investigation.
- Total is still computed and passed through `SearchResultsData`, so re-enabling is just adding the `resultCount` prop back once the underlying count is fixed.

## Test plan
- [ ] Visit `/search?q=...` and confirm the toolbar no longer shows a result count
- [ ] Confirm filters, sort, and the product grid all still work
- [ ] Confirm collection pages (which share the toolbar component) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)