### PR TITLE
Remove motion in favor of Tailwind transitions

### DIFF
--- a/apps/template/app/globals.css
+++ b/apps/template/app/globals.css
@@ -52,6 +52,17 @@
   --radius-xl: calc(var(--radius) + 4px);
 
   --shadow-line: 0 1px 0 0 #0000001a;
+
+  --animate-shimmer: shimmer var(--shimmer-duration, 2s) linear infinite;
+
+  @keyframes shimmer {
+    from {
+      background-position: 100% center;
+    }
+    to {
+      background-position: 0% center;
+    }
+  }
 }
 
 :root {

--- a/apps/template/components/action-bar/predictive-search-results.tsx
+++ b/apps/template/components/action-bar/predictive-search-results.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Search, Tag } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
 import { useLocale, useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -14,8 +13,6 @@ import type {
   SearchSuggestion,
 } from "@/lib/types";
 import { cn } from "@/lib/utils";
-
-const easing = [0.32, 0.72, 0, 1] as const;
 
 interface PredictiveSearchPanelProps {
   results: PredictiveSearchResult | null;
@@ -42,23 +39,25 @@ export function PredictiveSearchPanel({
   const show = query.trim().length > 0 && (results !== null || isLoading);
 
   return (
-    <AnimatePresence>
+    <div
+      data-state={show ? "open" : "closed"}
+      role="listbox"
+      id="predictive-search-results"
+      aria-label={t("suggestions")}
+      className={cn(
+        "absolute left-0 right-0 z-50 overflow-hidden bg-popover/90 backdrop-blur-xl border border-border/50 shadow-lg",
+        "transition-[opacity,transform,display] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] transition-discrete",
+        "data-[state=open]:opacity-100 data-[state=open]:translate-y-0",
+        "data-[state=closed]:opacity-0 data-[state=closed]:hidden",
+        position === "above" &&
+          "bottom-full mb-2 starting:translate-y-2 data-[state=closed]:translate-y-2",
+        position === "below" &&
+          "top-full mt-2 starting:-translate-y-2 data-[state=closed]:-translate-y-2",
+        className,
+      )}
+    >
       {show && (
-        <motion.div
-          initial={{ opacity: 0, y: position === "above" ? 8 : -8 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: position === "above" ? 8 : -8 }}
-          transition={{ duration: 0.2, ease: easing }}
-          className={cn(
-            "absolute left-0 right-0 z-50 overflow-hidden bg-popover/90 backdrop-blur-xl border border-border/50 shadow-lg",
-            position === "above" && "bottom-full mb-2",
-            position === "below" && "top-full mt-2",
-            className,
-          )}
-          role="listbox"
-          id="predictive-search-results"
-          aria-label={t("suggestions")}
-        >
+        <>
           {isLoading && !results && (
             <div className="px-5 py-2.5">
               <LoadingSkeleton />
@@ -125,9 +124,9 @@ export function PredictiveSearchPanel({
               )}
             </div>
           )}
-        </motion.div>
+        </>
       )}
-    </AnimatePresence>
+    </div>
   );
 }
 

--- a/apps/template/components/agent/agent-panel.tsx
+++ b/apps/template/components/agent/agent-panel.tsx
@@ -29,7 +29,6 @@ import {
   UploadIcon,
   XIcon,
 } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
 import { nanoid } from "nanoid";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
@@ -67,7 +66,6 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "../ui/hover-card"
 import { CartReconciler } from "./cart-reconciler";
 import { registry } from "./registry";
 
-const easing = [0.32, 0.72, 0, 1] as const;
 const AUTO_CLOSE_DELAY = 1000;
 const AGENT_CHAT_STORAGE_KEY = "template-agent-chat:v1";
 
@@ -564,115 +562,108 @@ export function AgentPanel({ open, onOpenChange, triggerRef }: AgentPanelProps) 
   return (
     <>
       <CartReconciler messages={messages} />
-      <AnimatePresence>
-        {open && (
-          <motion.div
-            ref={panelRef}
-            role="dialog"
-            aria-label={t("assistantLabel")}
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 10 }}
-            onAnimationComplete={scrollMessagesToBottom}
-            transition={{ duration: 0.35, ease: easing }}
-            className="fixed right-5 bottom-20 z-40 flex max-h-[min(40rem,80vh)] w-[calc(100vw-2rem)] max-w-160 flex-col overflow-hidden rounded-2xl bg-background/95 shadow-[0px_2px_4px_0px_rgba(90,90,90,0.30)] outline -outline-offset-1 outline-border/35 backdrop-blur-sm"
-          >
-            {/* Drag overlay */}
-            {isDragging && (
-              <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-primary/50 bg-primary/5 backdrop-blur-sm">
-                <UploadIcon className="size-8 text-primary/60" />
-                <p className="font-medium text-primary/80 text-sm">{t("dropFiles")}</p>
-              </div>
-            )}
-
-            {/* Header */}
-            <div className="flex shrink-0 items-center justify-between border-b border-border/35 px-5 py-2.5">
-              <div className="flex items-center gap-2">
-                <span className="font-semibold text-sm">{t("name")}</span>
-                {t("title") && <span className="text-muted-foreground text-sm">{t("title")}</span>}
-              </div>
-              <div className="flex items-center gap-1">
-                <button
-                  type="button"
-                  onClick={handleClear}
-                  disabled={!canClear}
-                  className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
-                  aria-label={t("clearChat")}
-                >
-                  <Trash2Icon className="size-4" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => onOpenChange(false)}
-                  className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                  aria-label={t("minimizeAssistant")}
-                >
-                  <MinusIcon className="size-4" />
-                </button>
-              </div>
-            </div>
-
-            {/* Messages */}
-            <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain" data-slot="messages">
-              <Conversation>
-                <ConversationContent>
-                  {messages.length === 0 && (
-                    <div className="flex items-start gap-2.5">
-                      <BotMessageSquareIcon className="size-5 shrink-0 text-primary mt-0.5" />
-                      <p className="pt-2 text-sm text-foreground">{t("greeting")}</p>
-                    </div>
-                  )}
-                  {messages.map((message, messageIndex) => (
-                    <ChatMessage
-                      key={message.id}
-                      message={message}
-                      isLastAssistant={messageIndex === lastAssistantIndex}
-                      status={status}
-                      messages={messages}
-                      regenerate={regenerate}
-                    />
-                  ))}
-                </ConversationContent>
-              </Conversation>
-            </div>
-
-            {/* Input */}
-            <PromptInput
-              onSubmit={handleSubmit}
-              className="px-5 py-2.5 **:data-[slot=input-group]:h-auto **:data-[slot=input-group]:flex-col **:data-[slot=input-group]:rounded-2xl **:data-[slot=input-group]:border-0 **:data-[slot=input-group]:bg-input **:data-[slot=input-group]:shadow-none"
-              globalDrop
-              multiple
-            >
-              <AttachmentChips />
-              <div className="flex w-full items-center">
-                <AttachButton />
-                <PromptInputBody>
-                  <PromptInputTextarea
-                    autoFocus
-                    className="min-h-0 py-2.5 text-sm"
-                    onChange={(e) => setInput(e.target.value)}
-                    value={input}
-                  />
-                </PromptInputBody>
-                <SpeechInput
-                  type="button"
-                  size="icon-sm"
-                  variant="ghost"
-                  className="shrink-0 bg-transparent text-foreground/50 hover:bg-transparent hover:text-foreground"
-                  onTranscriptionChange={(text) => {
-                    setInput((prev) => (prev ? `${prev} ${text}` : text));
-                  }}
-                />
-                <PromptInputSubmit
-                  className="mr-1.5"
-                  disabled={!input && !status}
-                  status={status}
-                />
-              </div>
-            </PromptInput>
-          </motion.div>
+      <div
+        ref={panelRef}
+        data-state={open ? "open" : "closed"}
+        role="dialog"
+        aria-label={t("assistantLabel")}
+        onTransitionEnd={(e) => {
+          if (e.target === e.currentTarget && e.propertyName === "opacity" && open) {
+            scrollMessagesToBottom();
+          }
+        }}
+        className="fixed right-5 bottom-20 z-40 flex max-h-[min(40rem,80vh)] w-[calc(100vw-2rem)] max-w-160 flex-col overflow-hidden rounded-2xl bg-background/95 shadow-[0px_2px_4px_0px_rgba(90,90,90,0.30)] outline -outline-offset-1 outline-border/35 backdrop-blur-sm transition-[opacity,transform,display] duration-[350ms] ease-[cubic-bezier(0.32,0.72,0,1)] transition-discrete data-[state=open]:opacity-100 data-[state=open]:translate-y-0 data-[state=closed]:opacity-0 data-[state=closed]:translate-y-2.5 data-[state=closed]:hidden starting:opacity-0 starting:translate-y-2.5"
+      >
+        {/* Drag overlay */}
+        {isDragging && (
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-primary/50 bg-primary/5 backdrop-blur-sm">
+            <UploadIcon className="size-8 text-primary/60" />
+            <p className="font-medium text-primary/80 text-sm">{t("dropFiles")}</p>
+          </div>
         )}
-      </AnimatePresence>
+
+        {/* Header */}
+        <div className="flex shrink-0 items-center justify-between border-b border-border/35 px-5 py-2.5">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-sm">{t("name")}</span>
+            {t("title") && <span className="text-muted-foreground text-sm">{t("title")}</span>}
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={handleClear}
+              disabled={!canClear}
+              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+              aria-label={t("clearChat")}
+            >
+              <Trash2Icon className="size-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              aria-label={t("minimizeAssistant")}
+            >
+              <MinusIcon className="size-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Messages */}
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain" data-slot="messages">
+          <Conversation>
+            <ConversationContent>
+              {messages.length === 0 && (
+                <div className="flex items-start gap-2.5">
+                  <BotMessageSquareIcon className="size-5 shrink-0 text-primary mt-0.5" />
+                  <p className="pt-2 text-sm text-foreground">{t("greeting")}</p>
+                </div>
+              )}
+              {messages.map((message, messageIndex) => (
+                <ChatMessage
+                  key={message.id}
+                  message={message}
+                  isLastAssistant={messageIndex === lastAssistantIndex}
+                  status={status}
+                  messages={messages}
+                  regenerate={regenerate}
+                />
+              ))}
+            </ConversationContent>
+          </Conversation>
+        </div>
+
+        {/* Input */}
+        <PromptInput
+          onSubmit={handleSubmit}
+          className="px-5 py-2.5 **:data-[slot=input-group]:h-auto **:data-[slot=input-group]:flex-col **:data-[slot=input-group]:rounded-2xl **:data-[slot=input-group]:border-0 **:data-[slot=input-group]:bg-input **:data-[slot=input-group]:shadow-none"
+          globalDrop
+          multiple
+        >
+          <AttachmentChips />
+          <div className="flex w-full items-center">
+            <AttachButton />
+            <PromptInputBody>
+              <PromptInputTextarea
+                autoFocus
+                className="min-h-0 py-2.5 text-sm"
+                onChange={(e) => setInput(e.target.value)}
+                value={input}
+              />
+            </PromptInputBody>
+            <SpeechInput
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              className="shrink-0 bg-transparent text-foreground/50 hover:bg-transparent hover:text-foreground"
+              onTranscriptionChange={(text) => {
+                setInput((prev) => (prev ? `${prev} ${text}` : text));
+              }}
+            />
+            <PromptInputSubmit className="mr-1.5" disabled={!input && !status} status={status} />
+          </div>
+        </PromptInput>
+      </div>
     </>
   );
 }

--- a/apps/template/components/ai-elements/shimmer.tsx
+++ b/apps/template/components/ai-elements/shimmer.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { motion } from "motion/react";
-import { type CSSProperties, type ElementType, type JSX, memo, useMemo } from "react";
+import { type CSSProperties, type ElementType, memo, useMemo } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -20,34 +19,27 @@ const ShimmerComponent = ({
   duration = 2,
   spread = 2,
 }: TextShimmerProps) => {
-  const MotionComponent = motion.create(Component as keyof JSX.IntrinsicElements);
-
   const dynamicSpread = useMemo(() => (children?.length ?? 0) * spread, [children, spread]);
 
   return (
-    <MotionComponent
-      animate={{ backgroundPosition: "0% center" }}
+    <Component
       className={cn(
         "relative inline-block bg-[length:250%_100%,auto] bg-clip-text text-transparent",
         "[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),var(--color-background),#0000_calc(50%+var(--spread)))] [background-repeat:no-repeat,padding-box]",
+        "animate-shimmer",
         className,
       )}
-      initial={{ backgroundPosition: "100% center" }}
       style={
         {
           "--spread": `${dynamicSpread}px`,
+          "--shimmer-duration": `${duration}s`,
           backgroundImage:
             "var(--bg), linear-gradient(var(--color-muted-foreground), var(--color-muted-foreground))",
         } as CSSProperties
       }
-      transition={{
-        repeat: Number.POSITIVE_INFINITY,
-        duration,
-        ease: "linear",
-      }}
     >
       {children}
-    </MotionComponent>
+    </Component>
   );
 };
 

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -26,7 +26,6 @@
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
     "lucide-react": "1.11.0",
-    "motion": "12.38.0",
     "nanoid": "5.1.9",
     "next": "16.3.0-canary.1",
     "next-intl": "4.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,9 +200,6 @@ importers:
       lucide-react:
         specifier: 1.11.0
         version: 1.11.0(react@19.2.5)
-      motion:
-        specifier: 12.38.0
-        version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       nanoid:
         specifier: 5.1.9
         version: 5.1.9


### PR DESCRIPTION
## Summary
Drops the `motion` dependency. Three usages, all converted to Tailwind 4 / `tw-animate-css` syntax:

- `ai-elements/shimmer` — `motion.create` + animated `backgroundPosition` → `@keyframes shimmer` in `globals.css` + `animate-shimmer`. Duration is fed in via a `--shimmer-duration` CSS var on the element so the prop still works.
- `action-bar/predictive-search-results` — `AnimatePresence` + `motion.div` enter/exit → always-mounted `<div>` with `data-state`, `starting:*` for entry, `data-[state=closed]:*` for exit, and `transition-discrete` so `display` waits for opacity/transform to finish. The `position` prop swaps `translate-y-2` ↔ `-translate-y-2` exactly like before.
- `agent/agent-panel` — same pattern as predictive-search (350ms instead of 200ms). `onAnimationComplete={scrollMessagesToBottom}` is replaced by `onTransitionEnd` filtered by `propertyName === "opacity"` and current `open` state, so the scroll still fires once at the end of the entrance.

The custom easing `[0.32, 0.72, 0, 1]` is preserved verbatim via `ease-[cubic-bezier(0.32,0.72,0,1)]`.

Targets `2026-04-27-cleanup`.

## Test plan
- [ ] `pnpm install` clean (lockfile updated)
- [ ] `pnpm build` in apps/template
- [ ] Open the search action-bar — popup fades/slides in on type, fades/slides out on clear
- [ ] Open the agent panel — fades/slides in, scrolls to bottom after the entrance animation
- [ ] Loading shimmer text continues to animate

🤖 Generated with [Claude Code](https://claude.com/claude-code)