### PR TITLE
Diagnostic: AI summary section on PDP for ISR observation

### DIFF
--- a/apps/template/components/product-detail/product-detail-page.tsx
+++ b/apps/template/components/product-detail/product-detail-page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 
+import { ProductSummarySection } from "@/components/product-detail/product-summary-section";
 import { ProductSchema } from "@/components/product-detail/schema";
 import { RelatedProductsSection } from "@/components/product/related-products-section";
 import { BreadcrumbSchema } from "@/components/schema/breadcrumb-schema";
@@ -87,6 +88,7 @@ async function ProductContent({
           locale={locale}
           variantIdPromise={variantIdPromise}
         />
+        <ProductSummarySection description={product.description} handle={handle} title={title} />
         <RelatedProductsSection handle={handle} locale={locale} />
       </Sections>
     </>

--- a/apps/template/components/product-detail/product-summary-section.tsx
+++ b/apps/template/components/product-detail/product-summary-section.tsx
@@ -1,0 +1,49 @@
+import { generateText } from "ai";
+import { cacheLife, cacheTag } from "next/cache";
+import { Suspense } from "react";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+const SUMMARY_LIMIT = 140;
+
+async function generateSummary(handle: string, title: string, description: string) {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag(`product-summary-${handle}`);
+
+  const { text } = await generateText({
+    model: "anthropic/claude-haiku-4.5",
+    prompt: `Summarize this product in ${SUMMARY_LIMIT} characters or fewer. Plain prose, no markdown, no quotes.\n\nTitle: ${title}\nDescription: ${description}`,
+  });
+
+  return text.trim().slice(0, SUMMARY_LIMIT);
+}
+
+async function Render({
+  handle,
+  title,
+  description,
+}: {
+  handle: string;
+  title: string;
+  description: string;
+}) {
+  const summary = await generateSummary(handle, title, description);
+  return <p className="text-sm text-muted-foreground">{summary}</p>;
+}
+
+export function ProductSummarySection({
+  description,
+  handle,
+  title,
+}: {
+  description: string;
+  handle: string;
+  title: string;
+}) {
+  return (
+    <Suspense fallback={<Skeleton className="h-5 w-3/4" />}>
+      <Render handle={handle} title={title} description={description} />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary
- Pure diagnostic PR — **do not merge**. Used to confirm ISR / Runtime Cache behavior.
- Adds a server-only section between the product detail and the related products carousel on the PDP.
- Calls Claude Haiku 4.5 through the Vercel AI Gateway to generate a 140-character product summary.
- Generation is wrapped in `"use cache: remote"` with `cacheLife("max")` and a per-handle `cacheTag` so the result is stored in the Vercel Runtime Cache and the section participates in ISR.

## How to observe
- Hit the PDP for a product, note the summary text.
- Refresh — same text on cache hit.
- Tag-invalidate (`vercel cache invalidate --tag product-summary-<handle>`) or wait for revalidation, then refresh — text should regenerate (a different summary).

## Test plan
- [ ] Verify build passes
- [ ] Verify `VERCEL_OIDC_TOKEN` is provisioned in preview env (AI Gateway auth)
- [ ] Visit a PDP on the preview deployment, confirm summary renders
- [ ] Refresh and confirm identical text (cache hit)
- [ ] Invalidate the tag and confirm a fresh summary on next request

🤖 Generated with [Claude Code](https://claude.com/claude-code)