### PR TITLE
Fix /search missing products + re-enable count + BEST_SELLING default

### DIFF
--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import { ProductDetailPage } from "@/components/product-detail/product-detail-page";
 import { getLocale } from "@/lib/params";
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
-import { getProduct, getProducts } from "@/lib/shopify/operations/products";
+import { getCatalogProducts, getProduct } from "@/lib/shopify/operations/products";
 
 const PLACEHOLDER_HANDLE = "__placeholder__";
 
@@ -48,7 +48,7 @@ async function buildProductMetadata(
 }
 
 export async function generateStaticParams() {
-  const { products } = await getProducts({ limit: 1 });
+  const { products } = await getCatalogProducts({ limit: 1 });
   const first = products[0];
   return first ? [{ handle: first.handle }] : [];
 }

--- a/apps/template/app/search/md/route.ts
+++ b/apps/template/app/search/md/route.ts
@@ -1,6 +1,10 @@
 import { defaultLocale, resolveLocale } from "@/lib/i18n";
 import { searchResultsToMarkdown } from "@/lib/markdown/search";
-import { buildProductFiltersFromParams, getProducts } from "@/lib/shopify/operations/products";
+import {
+  buildProductFiltersFromParams,
+  getCatalogProducts,
+  getSearchFacets,
+} from "@/lib/shopify/operations/products";
 import { transformShopifyFilters } from "@/lib/shopify/transforms/filters";
 import { RESULTS_PER_PAGE, parseFiltersFromSearchParams, searchParamsToRecord } from "@/lib/utils";
 
@@ -25,27 +29,30 @@ export async function GET(request: Request) {
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
 
   try {
-    const result = await getProducts({
-      query,
-      collection,
-      sortKey: sort,
-      limit: RESULTS_PER_PAGE,
-      cursor,
-      filters: shopifyFilters,
-      locale,
-    });
+    const [catalog, facets] = await Promise.all([
+      getCatalogProducts({
+        query,
+        collection,
+        sortKey: sort,
+        limit: RESULTS_PER_PAGE,
+        cursor,
+        filters: shopifyFilters,
+        locale,
+      }),
+      getSearchFacets({ query, collection, filters: shopifyFilters, locale }),
+    ]);
 
-    const transformedFilters = transformShopifyFilters(result.filters, { activeFilters });
-    const hasPriceRange = result.filters.some((filter) => filter.type === "PRICE_RANGE");
+    const transformedFilters = transformShopifyFilters(facets.filters, { activeFilters });
+    const hasPriceRange = facets.filters.some((filter) => filter.type === "PRICE_RANGE");
     const markdown = searchResultsToMarkdown({
       query,
       collection,
-      products: result.products,
-      total: result.total,
+      products: catalog.products,
+      total: facets.total,
       filters: transformedFilters.filters,
       priceRange: hasPriceRange ? transformedFilters.priceRange : undefined,
       activeFilters,
-      pageInfo: result.pageInfo,
+      pageInfo: catalog.pageInfo,
       locale,
       sort,
     });

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -167,7 +167,7 @@ async function SearchToolbar({
   searchResultsDataPromise: Promise<SearchResultsData>;
   filtersLabel: string;
 }) {
-  const data = await searchResultsDataPromise;
+  const [data, t] = await Promise.all([searchResultsDataPromise, getTranslations("search")]);
 
   const activeFilterCount = Object.values(data.activeFilters).reduce((count, v) => {
     if (!v) return count;
@@ -176,6 +176,7 @@ async function SearchToolbar({
 
   return (
     <CollectionToolbar
+      resultCount={data.total > 0 ? t("resultCount", { count: data.total }) : undefined}
       filterSheet={
         <FilterSidebarSheet
           label={filtersLabel}

--- a/apps/template/components/product/products-grid.tsx
+++ b/apps/template/components/product/products-grid.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 
 import { ProductCard, ProductCardSkeleton } from "@/components/product-card/product-card";
 import type { Locale } from "@/lib/i18n";
-import { getProducts } from "@/lib/shopify/operations/products";
+import { getCatalogProducts } from "@/lib/shopify/operations/products";
 import { cn } from "@/lib/utils";
 
 interface ProductsGridSkeletonProps {
@@ -66,7 +66,7 @@ async function FeaturedProductsGrid({
   locale: Locale;
   outOfStockText: string;
 }) {
-  const { products } = await getProducts({ limit, locale });
+  const { products } = await getCatalogProducts({ limit, locale });
 
   if (products.length === 0) return null;
 

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -11,7 +11,11 @@ import { ProductCard } from "@/components/product-card/product-card";
 import { ProductsGridSkeleton } from "@/components/product/products-grid";
 import type { Locale } from "@/lib/i18n";
 import { loadMoreSearchProducts } from "@/lib/search/action";
-import { buildProductFiltersFromParams, getProducts } from "@/lib/shopify/operations/products";
+import {
+  buildProductFiltersFromParams,
+  getCatalogProducts,
+  getSearchFacets,
+} from "@/lib/shopify/operations/products";
 import { transformShopifyFilters } from "@/lib/shopify/transforms/filters";
 import type { TransformedFilters } from "@/lib/shopify/transforms/filters";
 import type { ProductFilter } from "@/lib/shopify/types/filters";
@@ -56,20 +60,23 @@ export async function getSearchResultsData({
   activeFilters: Record<string, string | string[] | undefined>;
 }): Promise<SearchResultsData> {
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
-  const result = await getProducts({
-    query,
-    collection,
-    sortKey: sort,
-    limit: RESULTS_PER_PAGE,
-    filters: shopifyFilters,
-    locale,
-  });
+  const [catalog, facets] = await Promise.all([
+    getCatalogProducts({
+      query,
+      collection,
+      sortKey: sort,
+      limit: RESULTS_PER_PAGE,
+      filters: shopifyFilters,
+      locale,
+    }),
+    getSearchFacets({ query, collection, filters: shopifyFilters, locale }),
+  ]);
 
   return {
-    products: result.products,
-    total: result.total,
-    pageInfo: result.pageInfo,
-    transformedFilters: transformShopifyFilters(result.filters, { activeFilters }),
+    products: catalog.products,
+    total: facets.total,
+    pageInfo: catalog.pageInfo,
+    transformedFilters: transformShopifyFilters(facets.filters, { activeFilters }),
     activeFilters,
     filters: shopifyFilters,
     query,

--- a/apps/template/lib/agent/tools/search-products.ts
+++ b/apps/template/lib/agent/tools/search-products.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 
-import { getProducts } from "@/lib/shopify/operations/products";
+import { searchIndexProducts } from "@/lib/shopify/operations/products";
 
 import { getAgentContext } from "../server";
 
@@ -21,7 +21,7 @@ Returns a list of matching products with titles, prices, and availability.`,
       const { user } = getAgentContext();
 
       try {
-        const { products, total } = await getProducts({
+        const { products, total } = await searchIndexProducts({
           query,
           sortKey,
           limit,

--- a/apps/template/lib/search/action.ts
+++ b/apps/template/lib/search/action.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getProducts } from "@/lib/shopify/operations/products";
+import { getCatalogProducts } from "@/lib/shopify/operations/products";
 import { predictiveSearch } from "@/lib/shopify/operations/search";
 import type { ProductFilter } from "@/lib/shopify/types/filters";
 import type { PageInfo, PredictiveSearchResult, ProductCard } from "@/lib/types";
@@ -23,8 +23,8 @@ export async function loadMoreSearchProducts(params: {
   sortKey?: string;
   filters?: ProductFilter[];
   locale: string;
-}): Promise<{ products: ProductCard[]; pageInfo: PageInfo; total: number }> {
-  const result = await getProducts({
+}): Promise<{ products: ProductCard[]; pageInfo: PageInfo }> {
+  const result = await getCatalogProducts({
     query: params.query,
     collection: params.collection,
     cursor: params.cursor,
@@ -36,6 +36,5 @@ export async function loadMoreSearchProducts(params: {
   return {
     products: result.products,
     pageInfo: result.pageInfo,
-    total: result.total,
   };
 }

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -61,17 +61,39 @@ export async function getProduct(handle: string, locale: string = defaultLocale)
   return transformShopifyProductDetails(data.productByHandle);
 }
 
-const PRODUCTS_SEARCH_QUERY = `
+const CATALOG_PRODUCTS_QUERY = `
   ${PRODUCT_CARD_FRAGMENT}
-  query searchProducts($query: String!, $first: Int!, $after: String, $sortKey: SearchSortKeys, $reverse: Boolean, $productFilters: [ProductFilter!], $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
-    search(
-      query: $query
+  query catalogProducts($first: Int!, $after: String, $query: String, $sortKey: ProductSortKeys, $reverse: Boolean, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    products(
       first: $first
       after: $after
+      query: $query
       sortKey: $sortKey
       reverse: $reverse
+    ) {
+      edges {
+        cursor
+        node {
+          ...ProductCardFields
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+    }
+  }
+`;
+
+const SEARCH_FACETS_QUERY = `
+  query searchFacets($query: String!, $productFilters: [ProductFilter!], $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    search(
+      query: $query
       productFilters: $productFilters
       types: PRODUCT
+      first: 1
     ) {
       totalCount
       productFilters {
@@ -85,6 +107,22 @@ const PRODUCTS_SEARCH_QUERY = `
           input
         }
       }
+    }
+  }
+`;
+
+const PRODUCTS_SEARCH_QUERY = `
+  ${PRODUCT_CARD_FRAGMENT}
+  query searchProducts($query: String!, $first: Int!, $after: String, $sortKey: SearchSortKeys, $reverse: Boolean, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    search(
+      query: $query
+      first: $first
+      after: $after
+      sortKey: $sortKey
+      reverse: $reverse
+      types: PRODUCT
+    ) {
+      totalCount
       edges {
         cursor
         node {
@@ -103,52 +141,88 @@ const PRODUCTS_SEARCH_QUERY = `
   }
 `;
 
-// SearchSortKeys only supports PRICE and RELEVANCE.
-// Name-based sort options are excluded from the search UI.
+// QueryRoot.products(sortKey: ProductSortKeys) — used for the catalog browse path.
+const CATALOG_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolean }> = {
+  "best-matches": { sortKey: "RELEVANCE", reverse: false },
+  "best-selling": { sortKey: "BEST_SELLING", reverse: false },
+  "date-new-to-old": { sortKey: "CREATED_AT", reverse: true },
+  "date-old-to-new": { sortKey: "CREATED_AT", reverse: false },
+  "price-high-to-low": { sortKey: "PRICE", reverse: true },
+  "price-low-to-high": { sortKey: "PRICE", reverse: false },
+  "product-name-ascending": { sortKey: "TITLE", reverse: false },
+  "product-name-descending": { sortKey: "TITLE", reverse: true },
+  BEST_SELLING: { sortKey: "BEST_SELLING", reverse: false },
+  CREATED_AT: { sortKey: "CREATED_AT", reverse: false },
+  ID: { sortKey: "ID", reverse: false },
+  PRICE: { sortKey: "PRICE", reverse: false },
+  PRODUCT_TYPE: { sortKey: "PRODUCT_TYPE", reverse: false },
+  RELEVANCE: { sortKey: "RELEVANCE", reverse: false },
+  TITLE: { sortKey: "TITLE", reverse: false },
+  UPDATED_AT: { sortKey: "UPDATED_AT", reverse: false },
+  VENDOR: { sortKey: "VENDOR", reverse: false },
+};
+
+// SearchSortKeys only supports PRICE and RELEVANCE — used by the AI agent text-search path.
 const SEARCH_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolean }> = {
   "best-matches": { sortKey: "RELEVANCE", reverse: false },
-  "price-low-to-high": { sortKey: "PRICE", reverse: false },
   "price-high-to-low": { sortKey: "PRICE", reverse: true },
+  "price-low-to-high": { sortKey: "PRICE", reverse: false },
   PRICE: { sortKey: "PRICE", reverse: false },
   RELEVANCE: { sortKey: "RELEVANCE", reverse: false },
 };
 
-/**
- * Shopify's search query `productFilters` only affects facet counts, not actual
- * results. Apply filters in memory after fetching to match collection behavior.
- */
-function applyFiltersInMemory(products: ProductCard[], filters: ProductFilter[]): ProductCard[] {
-  return products.filter((product) => {
-    for (const filter of filters) {
-      if (filter.price) {
-        const price = Number.parseFloat(product.price.amount);
-        if (filter.price.min !== undefined && price < filter.price.min) return false;
-        if (filter.price.max !== undefined && price > filter.price.max) return false;
-      }
-      if (filter.productVendor && product.vendor !== filter.productVendor) {
-        return false;
-      }
-      if (filter.available !== undefined && product.availableForSale !== filter.available) {
-        return false;
-      }
-    }
-    return true;
-  });
+function escapeProductQuery(value: string): string {
+  return value.replace(/'/g, "\\'");
 }
 
-function buildShopifySearchQuery(query?: string, collection?: string): string {
-  const queryParts: string[] = [];
+function joinOr(field: string, values: string[]): string {
+  const expressions = values.map((v) => `${field}:'${escapeProductQuery(v)}'`);
+  return expressions.length > 1 ? `(${expressions.join(" OR ")})` : expressions[0];
+}
 
-  if (query?.trim()) {
-    queryParts.push(query.trim());
+// Translates ProductFilter[] (from URL params) into Shopify's product-query syntax.
+// `productFilters` on Search only affects facet counts; QueryRoot.products has no
+// equivalent arg, so structured filters are encoded into the `query` string instead.
+// variantOption / productMetafield filters have no product-query syntax and are dropped.
+function buildCatalogQuery(args: {
+  query?: string;
+  collection?: string;
+  filters: ProductFilter[];
+}): string {
+  const parts: string[] = [];
+
+  if (args.query?.trim()) {
+    parts.push(args.query.trim());
   }
 
-  if (collection) {
-    const safeCollection = collection.replace(/'/g, "\\'");
-    queryParts.push(`collection:'${safeCollection}'`);
+  if (args.collection) {
+    parts.push(`collection:'${escapeProductQuery(args.collection)}'`);
   }
 
-  return queryParts.length > 0 ? queryParts.join(" AND ") : "*";
+  const vendors: string[] = [];
+  const types: string[] = [];
+  const tags: string[] = [];
+  let available: boolean | undefined;
+  let priceMin: number | undefined;
+  let priceMax: number | undefined;
+
+  for (const f of args.filters) {
+    if (f.productVendor) vendors.push(f.productVendor);
+    if (f.productType) types.push(f.productType);
+    if (f.tag) tags.push(f.tag);
+    if (f.available !== undefined) available = f.available;
+    if (f.price?.min !== undefined) priceMin = f.price.min;
+    if (f.price?.max !== undefined) priceMax = f.price.max;
+  }
+
+  if (vendors.length) parts.push(joinOr("vendor", vendors));
+  if (types.length) parts.push(joinOr("product_type", types));
+  if (tags.length) parts.push(joinOr("tag", tags));
+  if (available !== undefined) parts.push(`available_for_sale:${available}`);
+  if (priceMin !== undefined) parts.push(`variants.price:>=${priceMin}`);
+  if (priceMax !== undefined) parts.push(`variants.price:<=${priceMax}`);
+
+  return parts.join(" AND ");
 }
 
 function toArray(value: string | string[] | undefined): string[] {
@@ -239,7 +313,7 @@ export function buildProductFiltersFromParams(
   return filters;
 }
 
-export async function getProducts(params: {
+export async function getCatalogProducts(params: {
   query?: string;
   collection?: string;
   sortKey?: string;
@@ -249,9 +323,7 @@ export async function getProducts(params: {
   locale?: string;
 }): Promise<{
   products: ProductCard[];
-  total: number;
   pageInfo: PageInfo;
-  filters: ShopifyFilter[];
 }> {
   "use cache: remote";
   cacheLife("max");
@@ -267,28 +339,125 @@ export async function getProducts(params: {
     locale = defaultLocale,
   } = params;
 
-  const sortConfig = SEARCH_SORT_KEY_MAP[rawSortKey] ?? SEARCH_SORT_KEY_MAP["best-matches"];
+  const sortConfig = CATALOG_SORT_KEY_MAP[rawSortKey] ?? CATALOG_SORT_KEY_MAP["best-matches"];
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
-  const searchQuery = buildShopifySearchQuery(query, collection);
+  const catalogQuery = buildCatalogQuery({ query, collection, filters });
+
+  // RELEVANCE only orders results meaningfully when there's a query string;
+  // fall back to TITLE for plain catalog browse.
+  const sortKey =
+    sortConfig.sortKey === "RELEVANCE" && !catalogQuery ? "TITLE" : sortConfig.sortKey;
+
+  const data = await shopifyFetch<{
+    products: {
+      edges: Array<{ cursor: string; node: ShopifyProductCard | null }>;
+      pageInfo: PageInfo;
+    };
+  }>({
+    operation: "catalogProducts",
+    query: CATALOG_PRODUCTS_QUERY,
+    variables: {
+      first: limit,
+      after: cursor,
+      query: catalogQuery || undefined,
+      sortKey,
+      reverse: sortConfig.reverse,
+      country,
+      language,
+    },
+  });
+
+  const shopifyProducts = data.products.edges
+    .map((edge) => edge.node)
+    .filter((node): node is ShopifyProductCard => node !== null);
+
+  tagProducts(shopifyProducts);
+
+  return {
+    products: shopifyProducts.map(transformShopifyProductCard),
+    pageInfo: data.products.pageInfo,
+  };
+}
+
+export async function getSearchFacets(params: {
+  query?: string;
+  collection?: string;
+  filters?: ProductFilter[];
+  locale?: string;
+}): Promise<{ filters: ShopifyFilter[]; total: number }> {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("products");
+
+  const { query, collection, filters = [], locale = defaultLocale } = params;
+  const country = getCountryCode(locale);
+  const language = getLanguageCode(locale);
+
+  const queryParts: string[] = [];
+  if (query?.trim()) queryParts.push(query.trim());
+  if (collection) queryParts.push(`collection:'${escapeProductQuery(collection)}'`);
+  const searchQuery = queryParts.length > 0 ? queryParts.join(" AND ") : "*";
 
   const data = await shopifyFetch<{
     search: {
       totalCount: number;
       productFilters: ShopifyFilter[];
+    };
+  }>({
+    operation: "searchFacets",
+    query: SEARCH_FACETS_QUERY,
+    variables: {
+      query: searchQuery,
+      productFilters: filters.length > 0 ? filters : undefined,
+      country,
+      language,
+    },
+  });
+
+  return {
+    filters: data.search.productFilters,
+    total: data.search.totalCount,
+  };
+}
+
+// Index-based search; ranks by relevance over the search index. Reserved for
+// callers that genuinely want search semantics (the AI agent tool). Catalog
+// browse and the /search page should use getCatalogProducts instead.
+export async function searchIndexProducts(params: {
+  query: string;
+  sortKey?: string;
+  limit?: number;
+  locale?: string;
+}): Promise<{ products: ProductCard[]; total: number }> {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("products");
+
+  const {
+    query,
+    sortKey: rawSortKey = "best-matches",
+    limit = 50,
+    locale = defaultLocale,
+  } = params;
+
+  const sortConfig = SEARCH_SORT_KEY_MAP[rawSortKey] ?? SEARCH_SORT_KEY_MAP["best-matches"];
+  const country = getCountryCode(locale);
+  const language = getLanguageCode(locale);
+
+  const data = await shopifyFetch<{
+    search: {
+      totalCount: number;
       edges: Array<{ node: ShopifyProductCard | null }>;
-      pageInfo: PageInfo;
     };
   }>({
     operation: "searchProducts",
     query: PRODUCTS_SEARCH_QUERY,
     variables: {
-      query: searchQuery,
-      first: filters.length > 0 ? 250 : limit,
-      after: filters.length > 0 ? undefined : cursor,
+      query: query.trim() || "*",
+      first: limit,
       sortKey: sortConfig.sortKey,
       reverse: sortConfig.reverse,
-      productFilters: filters.length > 0 ? filters : undefined,
       country,
       language,
     },
@@ -300,20 +469,9 @@ export async function getProducts(params: {
 
   tagProducts(shopifyProducts);
 
-  let products = shopifyProducts.map(transformShopifyProductCard);
-
-  // Shopify's search query productFilters only affect facet counts, not actual
-  // results. Apply filters in memory to match the collection products behavior.
-  if (filters.length > 0) {
-    products = applyFiltersInMemory(products, filters);
-  }
-
   return {
-    products,
-    total: filters.length > 0 ? products.length : data.search.totalCount,
-    pageInfo:
-      filters.length > 0 ? { ...data.search.pageInfo, hasNextPage: false } : data.search.pageInfo,
-    filters: data.search.productFilters,
+    products: shopifyProducts.map(transformShopifyProductCard),
+    total: data.search.totalCount,
   };
 }
 

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -345,9 +345,10 @@ export async function getCatalogProducts(params: {
   const catalogQuery = buildCatalogQuery({ query, collection, filters });
 
   // RELEVANCE only orders results meaningfully when there's a query string;
-  // fall back to TITLE for plain catalog browse.
+  // fall back to BEST_SELLING for plain catalog browse so the landing order
+  // matches typical storefront expectations.
   const sortKey =
-    sortConfig.sortKey === "RELEVANCE" && !catalogQuery ? "TITLE" : sortConfig.sortKey;
+    sortConfig.sortKey === "RELEVANCE" && !catalogQuery ? "BEST_SELLING" : sortConfig.sortKey;
 
   const data = await shopifyFetch<{
     products: {


### PR DESCRIPTION
## Summary

Three scoped changes; toolbar/skeleton/strategy refinements were rolled out and will be picked up in follow-up prompts.

1. **Fix `/search` missing products** — switches the data path from Shopify's index-based `search` query (which returned a partial wildcard result set) to `QueryRoot.products`, encoding URL filters into product-query syntax (`vendor:`, `product_type:`, `tag:`, `available_for_sale:`, `variants.price:>=N`). Filter sidebar facets come from a parallel `getSearchFacets` call.
2. **Re-enable the search result count** — `total` from `getSearchFacets` is now reliable.
3. **Default catalog browse to `BEST_SELLING`** when there's no text query — so popular items lead instead of alphabetical.

## Test plan

- [ ] `/search` (no query, no filters) — scrolls past the previous ~250-item ceiling; previously-missing vendors are present.
- [ ] `/search?filter.p.vendor=Nordfolk` — filters server-side; same products appear in the unfiltered list.
- [ ] `/search?q=shirt` — text search ranks by relevance.
- [ ] `/search?filter.p.tag=<tag>` and `/search?filter.p.product_type=<type>` — filters that were silently ignored now work.
- [ ] `/search?filter.v.price.gte=10&filter.v.price.lte=50` — price range filters.
- [ ] Filter sidebar facet counts still render and reflect the selected filters.
- [ ] Result count badge reappears in the toolbar.
- [ ] First page on bare `/search` orders by best-selling.
- [ ] `curl /search/md?q=foo` — markdown export still returns valid output.
- [ ] `/collections/<handle>` — untouched data path; spot-check no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)