### PR TITLE
Limit /collections/[handle] generateStaticParams to one collection

### DIFF
--- a/apps/template/app/collections/[handle]/page.tsx
+++ b/apps/template/app/collections/[handle]/page.tsx
@@ -8,8 +8,9 @@ import { buildAlternates, buildOpenGraph } from "@/lib/seo";
 import { getCollection, getCollections } from "@/lib/shopify/operations/collections";
 
 export async function generateStaticParams() {
-  const collections = await getCollections();
-  return collections.map((collection) => ({ handle: collection.handle }));
+  const collections = await getCollections({ limit: 1 });
+  const first = collections[0];
+  return first ? [{ handle: first.handle }] : [];
 }
 
 export async function generateMetadata({

--- a/apps/template/lib/agent/tools/list-collections.ts
+++ b/apps/template/lib/agent/tools/list-collections.ts
@@ -13,7 +13,7 @@ Use this when the user asks "what categories do you have?", "show me your depart
     execute: async () => {
       try {
         const { user } = getAgentContext();
-        const collections = await getCollections(user.locale);
+        const collections = await getCollections({ locale: user.locale });
 
         return {
           success: true,

--- a/apps/template/lib/shopify/operations/collections.ts
+++ b/apps/template/lib/shopify/operations/collections.ts
@@ -18,7 +18,10 @@ type CollectionResponse = {
   collection: ShopifyCollection | null;
 };
 
-export async function getCollections(locale: string = defaultLocale): Promise<Collection[]> {
+export async function getCollections({
+  limit = 250,
+  locale = defaultLocale,
+}: { limit?: number; locale?: string } = {}): Promise<Collection[]> {
   "use cache: remote";
   cacheLife("max");
   cacheTag("collections");
@@ -52,7 +55,7 @@ export async function getCollections(locale: string = defaultLocale): Promise<Co
         }
       }
     `,
-    variables: { first: 250, country, language },
+    variables: { first: limit, country, language },
   });
 
   const rawCollections = data.collections.edges.map((edge) => edge.node);


### PR DESCRIPTION
## Summary
- Builds were prerendering every collection page at build time, ballooning duration and provider usage. Mirror the `/products/[handle]` pattern: fetch one collection in `generateStaticParams` and return a single placeholder so the rest are generated on-demand at runtime.
- `getCollections` now takes an options bag (\`{ limit, locale }\`) instead of a positional locale arg. The sitemap call still defaults to 250, the agent's \`listCollectionsTool\` passes \`{ locale }\`, and the build path passes \`{ limit: 1 }\`.

## Test plan
- [ ] \`pnpm build\` completes faster and shows a single \`/collections/[handle]\` placeholder in the static-params output
- [ ] \`/sitemap.xml\` still lists every collection (sitemap call uses default limit)
- [ ] Agent \`listCollections\` tool still returns the full list

🤖 Generated with [Claude Code](https://claude.com/claude-code)