### PR TITLE
Close mega menu after a mouse-triggered link click

### DIFF
--- a/apps/template/components/nav/quick-links.tsx
+++ b/apps/template/components/nav/quick-links.tsx
@@ -63,7 +63,10 @@ function NavItem({ item }: { item: MenuItem }) {
           "absolute inset-x-0 top-full z-40",
           "invisible opacity-0",
           "group-hover:visible group-hover:opacity-100",
-          "group-focus-within:visible group-focus-within:opacity-100",
+          // :focus-visible (instead of :focus-within) so a clicked link's
+          // lingering mouse focus doesn't pin the menu open after navigation —
+          // only keyboard focus keeps it visible.
+          "group-has-[:focus-visible]:visible group-has-[:focus-visible]:opacity-100",
           "transition-opacity duration-150",
           "bg-background border-b shadow-md",
         )}


### PR DESCRIPTION
## Summary
- The desktop mega menu uses \`:focus-within\` to stay visible while keyboard users tab through items. After Chrome processes a Next.js client navigation, the clicked link retains focus, so \`:focus-within\` keeps matching and the dropdown stays open until the user explicitly clicks somewhere else — surprising and fiddly.
- Swap the focus pin to a \`:focus-visible\`-inside check via \`group-has-[:focus-visible]\`. Only keyboard focus pins the menu open now; mouse clicks let it close naturally once the cursor moves away from the trigger area.

## Test plan
- [ ] Hover \"Shop\" → mega menu opens; click any leaf link → menu closes after navigation (Chrome)
- [ ] Tab through nav items → mega menu opens when focus enters a triggering item; tab past last item → menu closes
- [ ] Keyboard Enter on a leaf link → navigation occurs; menu may briefly remain visible while focus is still on the clicked link, but Tab dismisses it (acceptable)
- [ ] Hover-only behavior unchanged — moving the cursor away from the dropdown still closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)