### PR TITLE
BannerSection: optional video background, drop required image dims

### DIFF
--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -42,6 +42,13 @@ export default async function HomePage() {
             id: "homepage-hero",
             headline: "Agentic Infrastructure for Commerce",
             subheadline: "A production-ready, agent-friendly Shopify storefront built on Next.js.",
+            backgroundImage: {
+              url: "https://cdn.shopify.com/s/files/1/0968/7236/6467/files/a60299db-53b9-433c-8ed8-1536b094bdee-1-eZIhPYkLEQmYZi0Wfy4znewVcLR3CP_4483df00-a8e6-409b-ad89-0765b64918d6.png?v=1776523442",
+              alt: "Hero",
+            },
+            backgroundVideo: {
+              url: "https://cdn.shopify.com/videos/c/o/v/db1572ad04ae4ecbad692430c6269fcf.mp4",
+            },
             ctaText: "Browse the Catalog",
             ctaLink: "/search",
           }}

--- a/apps/template/components/product-detail/lightbox.tsx
+++ b/apps/template/components/product-detail/lightbox.tsx
@@ -6,9 +6,8 @@ import { Dialog as DialogPrimitive } from "radix-ui";
 import { createContext, useCallback, useContext, useState } from "react";
 import type { ReactNode } from "react";
 
+import { AutoPlayVideo } from "@/components/ui/auto-play-video";
 import type { Image as ImageType, Video } from "@/lib/types";
-
-import { AutoPlayVideo } from "./auto-play-video";
 
 type MediaItem = { type: "video"; video: Video } | { type: "image"; image: ImageType };
 

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -4,10 +4,10 @@ import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 
+import { AutoPlayVideo } from "@/components/ui/auto-play-video";
 import type { Image as ImageType, Video } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-import { AutoPlayVideo } from "./auto-play-video";
 import { Lightbox, LightboxTrigger } from "./lightbox";
 
 type MediaItem = { type: "video"; video: Video } | { type: "image"; image: ImageType };

--- a/apps/template/components/sections/banner-section.tsx
+++ b/apps/template/components/sections/banner-section.tsx
@@ -2,8 +2,9 @@ import type { StaticImageData } from "next/image";
 import Image from "next/image";
 import Link from "next/link";
 
+import { AutoPlayVideo } from "@/components/ui/auto-play-video";
 import { Button } from "@/components/ui/button";
-import type { BannerSection as BannerSectionType } from "@/lib/types";
+import type { BannerSection as BannerSectionType, MarketingImage } from "@/lib/types";
 import heroDefault from "@/public/hero.jpg";
 
 interface BannerSectionProps {
@@ -13,8 +14,15 @@ interface BannerSectionProps {
 
 export function BannerSection({ hero, headingLevel = "h1" }: BannerSectionProps) {
   const Heading = headingLevel;
-  const image = hero.backgroundImage ?? heroDefault;
-  const isStatic = typeof image === "object" && "src" in image;
+  const video = hero.backgroundVideo;
+  const image = hero.backgroundImage ?? (video ? null : heroDefault);
+  const isStatic = image !== null && typeof image === "object" && "src" in image;
+
+  // AutoPlayVideo's preview shape uses `altText`; MarketingImage uses `alt`. Map locally.
+  const videoPreview =
+    video && image && !isStatic
+      ? { url: (image as MarketingImage).url, altText: (image as MarketingImage).alt }
+      : null;
 
   return (
     <section className="relative w-full overflow-hidden">
@@ -22,7 +30,21 @@ export function BannerSection({ hero, headingLevel = "h1" }: BannerSectionProps)
         {/* Aspect-ratio spacer: sets the minimum height */}
         <div className="col-start-1 row-start-1 aspect-[16/9] md:aspect-[3/1]" />
 
-        {isStatic ? (
+        {video ? (
+          <>
+            <AutoPlayVideo
+              src={video.url}
+              previewImage={videoPreview}
+              priorityImage
+              sizes="100vw"
+              poster={video.poster}
+              preload="auto"
+              aria-hidden
+              className="absolute inset-0 h-full w-full object-cover"
+            />
+            <div className="absolute inset-0 bg-linear-to-t from-black/60 via-transparent to-transparent" />
+          </>
+        ) : isStatic ? (
           <>
             <Image
               src={image as StaticImageData}
@@ -39,8 +61,8 @@ export function BannerSection({ hero, headingLevel = "h1" }: BannerSectionProps)
           image && (
             <>
               <Image
-                src={(image as { url: string }).url}
-                alt={(image as { alt: string }).alt}
+                src={(image as MarketingImage).url}
+                alt={(image as MarketingImage).alt}
                 fill
                 className="object-cover"
                 priority

--- a/apps/template/components/ui/auto-play-video.tsx
+++ b/apps/template/components/ui/auto-play-video.tsx
@@ -4,11 +4,10 @@ import Image from "next/image";
 import type * as React from "react";
 import { useEffect, useRef, useState } from "react";
 
-import type { Image as ImageType } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 interface AutoPlayVideoProps extends Omit<React.ComponentProps<"video">, "autoPlay" | "ref"> {
-  previewImage?: ImageType | null;
+  previewImage?: { url: string; altText?: string } | null;
   sizes?: string;
   priorityImage?: boolean;
 }

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -247,8 +247,15 @@ export interface PredictiveSearchResult {
 export interface MarketingImage {
   url: string;
   alt: string;
-  width: number;
-  height: number;
+  /** Optional — BannerSection renders with `fill`, so dimensions are metadata-only. */
+  width?: number;
+  height?: number;
+}
+
+export interface MarketingVideo {
+  url: string;
+  /** Optional explicit poster URL. Defaults to `backgroundImage` when present. */
+  poster?: string;
 }
 
 export interface BannerSection {
@@ -256,6 +263,12 @@ export interface BannerSection {
   headline: string;
   subheadline: string | null;
   backgroundImage?: MarketingImage | StaticImageData | null;
+  /**
+   * When set, an autoplaying muted loop renders in place of the background
+   * image. `backgroundImage` (if also passed) acts as a poster while the
+   * video buffers, mirroring the PDP gallery's video pattern.
+   */
+  backgroundVideo?: MarketingVideo | null;
   ctaText: string | null;
   ctaLink: string | null;
 }


### PR DESCRIPTION
## Summary
Two BannerSection ergonomics fixes from real-world template use:

- **Optional video background.** \`BannerSection.backgroundVideo\` (\`MarketingVideo: { url, poster? }\`) renders via the existing \`AutoPlayVideo\` component, with \`backgroundImage\` (when also passed) acting as the poster underneath until \`canplay\` fires. Mirrors the image-then-video pattern the PDP product gallery already uses, so the hero matches the rest of the storefront.
- **Drop the required \`width\`/\`height\` on \`MarketingImage\`.** The banner renders the image with \`fill\`, so dimensions were metadata-only — every caller with a remote URL had to invent plausible numbers that the runtime didn't use. Now optional.

\`AutoPlayVideo\` moved from \`components/product-detail/\` → \`components/ui/\` since it's no longer PDP-specific (PDP gallery + lightbox + banner now all use it). Its \`previewImage\` prop loosened to a structural \`{ url; altText? }\` so callers don't have to manufacture the full \`Image\` type for a poster.

## Test plan
- [ ] PDP gallery and lightbox still render product videos correctly (PDP imports updated to the new path)
- [ ] BannerSection with only \`backgroundImage\` renders an image-only hero (existing behavior)
- [ ] BannerSection with both \`backgroundImage\` and \`backgroundVideo\` renders the image first, then the video fades in once buffered
- [ ] BannerSection with only \`backgroundVideo\` renders the video on top of the dark gradient (browser native first-frame poster)
- [ ] Existing callers passing \`MarketingImage\` without \`width\`/\`height\` continue to type-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)