### PR TITLE
AutoPlayVideo: promote to ui/ primitive, fix cold-load race

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -127,7 +127,7 @@ The page emits two JSON-LD schemas:
 | `components/product-detail/lightbox.tsx` | Full-screen image viewer with click-outside to close |
 | `components/product-detail/product-price.tsx` | Price display with discount badge, handles variant-specific pricing |
 | `components/product-detail/buy-buttons.tsx` | Buy with Shop + add to cart buttons |
-| `components/product-detail/auto-play-video.tsx` | Inline video player with preview image fallback |
+| `components/ui/auto-play-video.tsx` | Inline video player with preview image fallback |
 | `components/product-detail/about-item.tsx` | Product description rendered from HTML |
 | `components/product-detail/schema.tsx` | JSON-LD Product and Breadcrumb structured data |
 | `components/product-detail/shop-logo.tsx` | Shop wordmark SVG for the Buy with Shop button |

--- a/apps/template/components/product-detail/lightbox.tsx
+++ b/apps/template/components/product-detail/lightbox.tsx
@@ -6,9 +6,8 @@ import { Dialog as DialogPrimitive } from "radix-ui";
 import { createContext, useCallback, useContext, useState } from "react";
 import type { ReactNode } from "react";
 
+import { AutoPlayVideo } from "@/components/ui/auto-play-video";
 import type { Image as ImageType, Video } from "@/lib/types";
-
-import { AutoPlayVideo } from "./auto-play-video";
 
 type MediaItem = { type: "video"; video: Video } | { type: "image"; image: ImageType };
 

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -4,10 +4,10 @@ import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 
+import { AutoPlayVideo } from "@/components/ui/auto-play-video";
 import type { Image as ImageType, Video } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-import { AutoPlayVideo } from "./auto-play-video";
 import { Lightbox, LightboxTrigger } from "./lightbox";
 
 type MediaItem = { type: "video"; video: Video } | { type: "image"; image: ImageType };

--- a/apps/template/components/ui/auto-play-video.tsx
+++ b/apps/template/components/ui/auto-play-video.tsx
@@ -4,11 +4,17 @@ import Image from "next/image";
 import type * as React from "react";
 import { useEffect, useRef, useState } from "react";
 
-import type { Image as ImageType } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
+export interface AutoPlayVideoPreviewImage {
+  altText: string;
+  height: number;
+  url: string;
+  width: number;
+}
+
 interface AutoPlayVideoProps extends Omit<React.ComponentProps<"video">, "autoPlay" | "ref"> {
-  previewImage?: ImageType | null;
+  previewImage?: AutoPlayVideoPreviewImage | null;
   sizes?: string;
   priorityImage?: boolean;
 }
@@ -37,21 +43,32 @@ export function AutoPlayVideo({
     const el = videoRef.current;
     if (!el) return;
 
+    let isVisible = false;
+
+    // play() called at readyState=0 can race the metadata load and reject
+    // silently. The observer only re-fires on intersection transitions, so a
+    // failed initial play would never retry. Retrying on `canplay` (only when
+    // currently visible) covers the cold-load race without auto-playing
+    // off-screen videos.
+    const tryPlay = () => {
+      if (isVisible) el.play().catch(() => {});
+    };
+
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry?.isIntersecting) {
-          el.play().catch(() => {});
-        } else {
-          el.pause();
-        }
+        isVisible = !!entry?.isIntersecting;
+        if (isVisible) tryPlay();
+        else el.pause();
       },
       { threshold: 0.25 },
     );
 
     observer.observe(el);
+    el.addEventListener("canplay", tryPlay);
 
     return () => {
       observer.disconnect();
+      el.removeEventListener("canplay", tryPlay);
     };
   }, []);
 

--- a/packages/plugin/template-rollout-log/2026-05-01-auto-play-video-ui-primitive.md
+++ b/packages/plugin/template-rollout-log/2026-05-01-auto-play-video-ui-primitive.md
@@ -1,0 +1,53 @@
+---
+title: AutoPlayVideo — promote to ui/ primitive, fix cold-load race
+changeKey: auto-play-video-ui-primitive
+introducedOn: 2026-05-01
+changeType: refactor
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/ui/auto-play-video.tsx
+  - apps/template/components/product-detail/lightbox.tsx
+  - apps/template/components/product-detail/product-media.tsx
+  - apps/docs/content/docs/anatomy/pages/pdp.mdx
+---
+
+## Summary
+
+Two changes to the autoplay video helper:
+
+1. **Move from `components/product-detail/` to `components/ui/`.** The component is a generic primitive (a `<video>` that auto-plays when in view, with an image poster underneath until `canplay`). Keeping it under `product-detail/` was incidental — it was first added there. Moving it to `ui/` matches the convention that `components/ui/` is for components that don't import domain types and don't translate. The previous `import type { Image as ImageType } from "@/lib/types"` is replaced with a locally exported `AutoPlayVideoPreviewImage` interface (structurally compatible with the lib `Image` shape, so existing call sites pass through unchanged).
+
+2. **Fix cold-load race in autoplay.** The IntersectionObserver was the only autoplay trigger. On a cold cache the observer's initial callback can fire before the video's metadata loads — `play()` at `readyState=0` races the load and silently rejects on Safari and slow Chrome. Since the observer only re-fires on intersection transitions, a failed initial play would never retry, leaving the poster stuck. A `canplay` listener inside the same effect now retries `play()` when the element is currently visible, pairing with the observer rather than replacing it.
+
+Imports in `components/product-detail/lightbox.tsx` and `components/product-detail/product-media.tsx` are updated to the new path. The PDP anatomy doc's key-files table is updated to point at the new path.
+
+## Why it matters
+
+- The cold-load race shows up as "the hero/PDP video sometimes never starts on first load." It's not deterministic, so it's been easy to miss in dev where the video is usually warm. The fix is a single small effect addition.
+- Promoting AutoPlayVideo to `ui/` makes it reusable from non-product surfaces (banners, marketing sections, custom media tiles) without forcing those surfaces to import from `components/product-detail/`. Sets up the `BannerSection` video pattern cleanly for downstream forks.
+- The rule "components in `ui/` must not import domain types" is documented in `apps/template/AGENTS.md`. AutoPlayVideo previously violated it; the move + the locally exported preview-image interface bring it into compliance.
+
+## Apply when
+
+- The storefront uses `AutoPlayVideo` directly, or imports from `components/product-detail/auto-play-video`.
+- Or the storefront has noticed videos occasionally not autoplaying on first load.
+
+## Safe to skip when
+
+- The storefront has already replaced `AutoPlayVideo` with its own video primitive.
+- The storefront only ever serves warm-cached videos on first paint and has not seen the autoplay regression.
+
+## Notes
+
+- The new path is `@/components/ui/auto-play-video`. The old path `@/components/product-detail/auto-play-video` is deleted.
+- `AutoPlayVideoPreviewImage` is exported from the new module. The lib `Image` shape (from `lib/types`) is structurally assignable, so existing call sites do not need to change their data shape.
+- The cold-load fix is independent of the move — a downstream fork that wants only the bug fix can patch the existing file in place.
+
+## Validation
+
+1. `pnpm --filter template dev`.
+2. PDP with a video media item: confirm the gallery video autoplays after a hard refresh (no cache). Repeat in Safari if available.
+3. Hover the desktop gallery thumbnails or swipe the mobile carousel — the video should pause when out of view and resume when it returns.
+4. `tsc --noEmit` and `pnpm --filter template lint` both clean.


### PR DESCRIPTION
## Summary

Two changes to the autoplay video helper, bundled because the move is the cleanest moment to also pick up the bug fix.

1. **Move `components/product-detail/auto-play-video.tsx` to `components/ui/auto-play-video.tsx`.** The component is a generic primitive (a \`<video>\` that autoplays when in view, pauses off-screen, with an image poster underneath until \`canplay\`). Keeping it under \`product-detail/\` was incidental — it was first added there. Moving it to \`ui/\` matches the convention documented in \`apps/template/AGENTS.md\`: \`components/ui/\` may not import domain types and may not translate. The previous \`import type { Image as ImageType } from \"@/lib/types\"\` is replaced with a locally exported \`AutoPlayVideoPreviewImage\` interface (structurally compatible with the lib \`Image\` shape, so existing callers pass through unchanged).

2. **Fix cold-load autoplay race.** The IntersectionObserver was the only autoplay trigger. On a cold cache the observer's initial callback can fire before the video's metadata loads — \`play()\` at \`readyState=0\` races the load and silently rejects on Safari and slow Chrome. Since the observer only re-fires on intersection transitions, a failed initial play would never retry, leaving the poster stuck. A \`canplay\` listener inside the same effect now retries \`play()\` when the element is currently visible. Pairs with the observer rather than replacing it, so off-screen gallery videos still don't autoplay.

Imports in \`components/product-detail/lightbox.tsx\` and \`components/product-detail/product-media.tsx\` are updated. The PDP anatomy doc's key-files table is updated to point at the new path. Includes a \`packages/plugin/template-rollout-log/\` entry.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`pnpm lint\` clean (preexisting warnings only)
- [ ] Open a PDP with a video media item on a cold cache, confirm the gallery video autoplays. Repeat in Safari.
- [ ] Hover the desktop gallery thumbnails / swipe the mobile carousel — video pauses when out of view, resumes on return.
- [ ] Lightbox: open a product video in the lightbox, confirm playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)