### PR TITLE
Trim verbose comments + one-line-max rule

### DIFF
--- a/apps/docs/components/ai-elements/prompt-input.tsx
+++ b/apps/docs/components/ai-elements/prompt-input.tsx
@@ -65,10 +65,6 @@ import {
   useState,
 } from "react";
 
-// ============================================================================
-// Provider Context & Types
-// ============================================================================
-
 export interface AttachmentsContext {
   files: (FileUIPart & { id: string })[];
   add: (files: File[] | FileList) => void;
@@ -253,10 +249,6 @@ export function PromptInputProvider({
   );
 }
 
-// ============================================================================
-// Component Context & Hooks
-// ============================================================================
-
 const LocalAttachmentsContext = createContext<AttachmentsContext | null>(null);
 
 export const usePromptInputAttachments = () => {
@@ -271,10 +263,6 @@ export const usePromptInputAttachments = () => {
   }
   return context;
 };
-
-// ============================================================================
-// Referenced Sources (Local to PromptInput)
-// ============================================================================
 
 export interface ReferencedSourcesContext {
   sources: (SourceDocumentUIPart & { id: string })[];

--- a/apps/docs/components/geistdocs/mobile-docs-bar.tsx
+++ b/apps/docs/components/geistdocs/mobile-docs-bar.tsx
@@ -35,11 +35,6 @@ export const MobileDocsBar = ({ headings, navigation }: MobileDocsBarProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [tocOpen, setTocOpen] = useState(false);
 
-  // useEffect(() => {
-  //   setMenuOpen(false);
-  //   setTocOpen(false);
-  // }, [pathname]);
-
   const showToc = headings && headings.length > 0;
 
   return (

--- a/apps/docs/scripts/sync-skills.ts
+++ b/apps/docs/scripts/sync-skills.ts
@@ -1,12 +1,5 @@
-// Syncs skill content from packages/plugin/skills/SKILL.md
-// into the corresponding docs MDX pages at content/docs/skills/*.mdx.
-//
-// Usage:
-//   npx tsx apps/docs/scripts/sync-skills.ts
-//
-// For each MDX file that contains BEGIN/END SKILL CONTENT comment
-// delimiters, the script replaces everything between them with the
-// current SKILL.md content (frontmatter stripped).
+// Syncs SKILL.md content into content/docs/skills/*.mdx between BEGIN/END SKILL CONTENT markers.
+// Usage: npx tsx apps/docs/scripts/sync-skills.ts
 
 import { readFileSync, writeFileSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -116,6 +116,8 @@ A comment earns its place when it captures one of:
 - A non-obvious algorithmic choice or invariant.
 - A cross-system quirk (e.g. "Shopify's `productFilters` only affects facet counts, not results").
 
+**One line max.** If you can't say it in a single line, the code probably needs renaming, splitting, or extracting a constant — not more prose. Long-form context belongs in the PR description, not the source file.
+
 Don't write:
 
 - JSDoc that restates the function name (`/** Verify webhook signature */` over `verifyWebhook()`). Either drop it or replace it with the WHY.

--- a/apps/template/app/api/webhooks/shopify/route.ts
+++ b/apps/template/app/api/webhooks/shopify/route.ts
@@ -19,11 +19,7 @@ async function verifyWebhook(body: string, hmacHeader: string | null): Promise<b
   return crypto.timingSafeEqual(Buffer.from(hash, "base64"), Buffer.from(hmacHeader, "base64"));
 }
 
-/**
- * Cache invalidation handler. Configure topics in Shopify Admin →
- * Settings → Notifications → Webhooks. Supported: `products/*`,
- * `collections/*`, `inventory_levels/*`, `metaobjects/*`.
- */
+// Configure webhook topics in Shopify Admin → Settings → Notifications → Webhooks.
 export async function POST(request: Request) {
   const body = await request.text();
   const hmacHeader = request.headers.get("x-shopify-hmac-sha256");

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -28,9 +28,7 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-// Placeholder homepage. Replace this file's contents to swap in your own —
-// CMS-driven sections, hand-written marketing, etc. Copy is intentionally
-// inline (not in i18n catalogs) so you can rip the whole page out cleanly.
+// Placeholder homepage; copy is inline so the file can be replaced wholesale.
 export default async function HomePage() {
   const locale = await getLocale();
 

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -82,9 +82,7 @@ export const unstable_prefetch = "force-runtime";
 export default async function SearchPage({ searchParams }: PageProps<"/search">) {
   const [locale, t] = await Promise.all([getLocale(), getTranslations("search")]);
 
-  // searchParams is a Promise; awaiting it at the page level would force the
-  // route fully dynamic, so we kick off the data fetch as a derived promise
-  // and let child Suspense boundaries await it.
+  // Don't await searchParams here — it would force the route fully dynamic.
   const searchResultsDataPromise = (async () => {
     const resolved = await searchParams;
     return getSearchResultsData({

--- a/apps/template/components/ai-elements/prompt-input.tsx
+++ b/apps/template/components/ai-elements/prompt-input.tsx
@@ -123,10 +123,7 @@ export type PromptInputProviderProps = PropsWithChildren<{
   initialInput?: string;
 }>;
 
-/**
- * Optional global provider that lifts PromptInput state outside of PromptInput.
- * If you don't use it, PromptInput stays fully self-managed.
- */
+/** Optional provider that lifts PromptInput state out; if unused, PromptInput self-manages. */
 export function PromptInputProvider({
   initialInput: initialTextInput = "",
   children,

--- a/apps/template/components/ai-elements/speech-input.tsx
+++ b/apps/template/components/ai-elements/speech-input.tsx
@@ -13,12 +13,7 @@ type SpeechInputMode = "speech-recognition" | "media-recorder" | "none";
 
 export type SpeechInputProps = ComponentProps<typeof Button> & {
   onTranscriptionChange?: (text: string) => void;
-  /**
-   * Callback for when audio is recorded using MediaRecorder fallback.
-   * This is called in browsers that don't support the Web Speech API (Firefox, Safari).
-   * The callback receives an audio Blob that should be sent to a transcription service.
-   * Return the transcribed text, which will be passed to onTranscriptionChange.
-   */
+  /** MediaRecorder fallback for browsers without Web Speech API; resolved text feeds onTranscriptionChange. */
   onAudioRecorded?: (audioBlob: Blob) => Promise<string>;
   lang?: string;
 };

--- a/apps/template/components/cart/context.tsx
+++ b/apps/template/components/cart/context.tsx
@@ -402,10 +402,7 @@ export function CartProvider({
     });
   };
 
-  /**
-   * quantity > 0: update with leading-edge debounce (first instant, rest debounced).
-   * quantity === 0: remove immediately, no debounce.
-   */
+  // quantity > 0: leading-edge debounce. quantity === 0: remove immediately.
   const updateItemOptimistic = (lineId: string, quantity: number) => {
     if (quantity < 0 || quantity > 99 || !cart) return;
 

--- a/apps/template/components/collections/sort-select-fallback.tsx
+++ b/apps/template/components/collections/sort-select-fallback.tsx
@@ -1,8 +1,6 @@
 import { ChevronDownIcon } from "lucide-react";
 
-// Server-rendered lookalike of the live <CollectionsSortSelect> trigger.
-// Used as a Suspense fallback so the toolbar row height (h-9) and the
-// trigger's text + chevron are byte-identical pre/post hydration.
+// Byte-identical Suspense fallback for <CollectionsSortSelect> to avoid hydration shift.
 export function SortSelectFallback({ label }: { label: string }) {
   return (
     <div className="flex h-9 w-fit items-center justify-between gap-2 rounded-md bg-transparent px-0 py-2 text-sm whitespace-nowrap">

--- a/apps/template/components/collections/toolbar.tsx
+++ b/apps/template/components/collections/toolbar.tsx
@@ -3,9 +3,7 @@ import type * as React from "react";
 interface CollectionToolbarProps {
   filterSheet: React.ReactNode;
   sortSelect: React.ReactNode;
-  // Pass JSX (e.g. a Suspense'd count) on pages that surface a result count.
-  // Pages without a count (collections) should omit this prop entirely so the
-  // slot doesn't reserve space.
+  // Omit on pages without a count so the slot doesn't reserve space.
   resultCount?: React.ReactNode;
 }
 

--- a/apps/template/components/nav/quick-links.tsx
+++ b/apps/template/components/nav/quick-links.tsx
@@ -63,9 +63,7 @@ function NavItem({ item }: { item: MenuItem }) {
           "absolute inset-x-0 top-full z-40",
           "invisible opacity-0",
           "group-hover:visible group-hover:opacity-100",
-          // :focus-visible (instead of :focus-within) so a clicked link's
-          // lingering mouse focus doesn't pin the menu open after navigation —
-          // only keyboard focus keeps it visible.
+          // :focus-visible (not :focus-within) so post-click mouse focus doesn't pin the menu open.
           "group-has-[:focus-visible]:visible group-has-[:focus-visible]:opacity-100",
           "transition-opacity duration-150",
           "bg-background border-b shadow-md",

--- a/apps/template/components/product-detail/shop-logo.tsx
+++ b/apps/template/components/product-detail/shop-logo.tsx
@@ -1,10 +1,6 @@
 import type { SVGProps } from "react";
 
-/**
- * Shop wordmark logo for the "Buy with Shop" button.
- * Extracted from the official Shop Pay logo per Shopify brand guidelines.
- * @see https://help.shopify.com/en/manual/payments/shop-pay/assets
- */
+// https://help.shopify.com/en/manual/payments/shop-pay/assets
 export function ShopLogo(props: SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/apps/template/lib/auth/index.ts
+++ b/apps/template/lib/auth/index.ts
@@ -1,4 +1,2 @@
-// Universal auth flag: safe to import from server and client code.
-// `NEXT_PUBLIC_AUTH_ENABLED` is computed at build time in next.config.ts based on
-// whether the three required secrets are set. Don't set it manually.
+// Computed at build time in next.config.ts; don't set NEXT_PUBLIC_AUTH_ENABLED manually.
 export const isAuthEnabled = process.env.NEXT_PUBLIC_AUTH_ENABLED === "1";

--- a/apps/template/lib/auth/server.ts
+++ b/apps/template/lib/auth/server.ts
@@ -1,7 +1,3 @@
-// Core better-auth configuration with Shopify Customer Account API OIDC.
-// Auth turns on automatically when BETTER_AUTH_SECRET, SHOPIFY_CUSTOMER_CLIENT_ID,
-// and SHOPIFY_CUSTOMER_CLIENT_SECRET are all set. See .env.example for setup.
-// The universal `isAuthEnabled` flag lives in ./index so client code can import it too.
 import "server-only";
 import { betterAuth } from "better-auth/minimal";
 import { genericOAuth } from "better-auth/plugins";

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -180,10 +180,7 @@ function joinOr(field: string, values: string[]): string {
   return expressions.length > 1 ? `(${expressions.join(" OR ")})` : expressions[0];
 }
 
-// Translates ProductFilter[] (from URL params) into Shopify's product-query syntax.
-// `productFilters` on Search only affects facet counts; QueryRoot.products has no
-// equivalent arg, so structured filters are encoded into the `query` string instead.
-// variantOption / productMetafield filters have no product-query syntax and are dropped.
+// QueryRoot.products has no productFilters arg, so filters are encoded into the query string; variantOption/productMetafield are dropped.
 function buildCatalogQuery(args: {
   query?: string;
   collection?: string;
@@ -344,9 +341,7 @@ export async function getCatalogProducts(params: {
   const language = getLanguageCode(locale);
   const catalogQuery = buildCatalogQuery({ query, collection, filters });
 
-  // RELEVANCE only orders results meaningfully when there's a query string;
-  // fall back to BEST_SELLING for plain catalog browse so the landing order
-  // matches typical storefront expectations.
+  // RELEVANCE is meaningless without a query; fall back to BEST_SELLING for plain browse.
   const sortKey =
     sortConfig.sortKey === "RELEVANCE" && !catalogQuery ? "BEST_SELLING" : sortConfig.sortKey;
 
@@ -422,9 +417,7 @@ export async function getSearchFacets(params: {
   };
 }
 
-// Index-based search; ranks by relevance over the search index. Reserved for
-// callers that genuinely want search semantics (the AI agent tool). Catalog
-// browse and the /search page should use getCatalogProducts instead.
+// Use getCatalogProducts for catalog browse / the /search page; this is the relevance-ranked search index.
 export async function searchIndexProducts(params: {
   query: string;
   sortKey?: string;

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -23,10 +23,6 @@ const nextConfig: NextConfig = {
     turbopackFileSystemCacheForDev: true,
   },
   images: {
-    // Trimmed from the Next defaults (8 device + 8 image widths). Our largest
-    // realistic display is the lightbox at ~1920w; smallest is the 64px cart
-    // thumbnail (served at 128w for retina). Cuts ~half the optimized variants
-    // per Shopify asset without visible quality loss.
     deviceSizes: [640, 828, 1200, 1920],
     imageSizes: [64, 128, 384],
     minimumCacheTTL: 31536000,


### PR DESCRIPTION
## Summary

- Sweep 12 multi-line `//` blocks and 4 multi-line JSDoc across `apps/template/` and `apps/docs/` down to one line each (or delete entirely if they didn't earn their length).
- Delete 3 `// ===== Section =====` banners and one commented-out `useEffect` in apps/docs.
- AGENTS.md: add explicit **"One line max"** rule under the Comments section. The earlier guidance allowed multi-paragraph comments in practice; this closes that loophole.

Net: **−68 lines** of comment prose with no behavior change.

## Test plan

- [ ] `pnpm --filter template build` passes locally (verified during commit)
- [ ] CI passes
- [ ] Spot-check that the trimmed comments still convey the WHY they need to

🤖 Generated with [Claude Code](https://claude.com/claude-code)