### PR TITLE
Enable analytics by default in template

### DIFF
--- a/apps/docs/content/docs/skills/enable-analytics.mdx
+++ b/apps/docs/content/docs/skills/enable-analytics.mdx
@@ -16,18 +16,18 @@ type: guide
 
 # Enable Analytics
 
-By default, the storefront has no analytics or performance monitoring. This skill adds Vercel Analytics, Vercel Speed Insights, and/or Google Tag Manager using their recommended integrations.
+The current storefront includes Vercel Analytics and Vercel Speed Insights by default. This skill adds the same default wiring to older storefronts and can also add Google Tag Manager using the recommended integration.
 
 ## Before you start
 
 Ask the user two questions in order:
 
-### 1. Do you want Vercel Analytics and/or Vercel Speed Insights?
+### 1. Do you need to add or change Vercel Analytics and/or Vercel Speed Insights?
 
-- **Vercel Analytics** — page view and custom event tracking via `@vercel/analytics`
-- **Vercel Speed Insights** — Core Web Vitals monitoring via `@vercel/speed-insights`
-- **Both** (recommended)
-- **Neither**
+- **Keep both** — current template default: page views, custom events, and Core Web Vitals
+- **Analytics only** — page view and custom event tracking via `@vercel/analytics`
+- **Speed Insights only** — Core Web Vitals monitoring via `@vercel/speed-insights`
+- **Neither** — remove or skip both Vercel packages
 
 ### 2. Do you want Google Tag Manager?
 
@@ -46,7 +46,7 @@ Skip this section if the user selected neither.
 Install only the packages the user selected:
 
 ```bash
-# Both (recommended)
+# Both (current template default)
 pnpm add @vercel/analytics @vercel/speed-insights
 
 # Analytics only

--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -7,6 +7,7 @@ import { Suspense } from "react";
 
 import { ActionBar } from "@/components/action-bar";
 import { AgentButton } from "@/components/agent/agent-button";
+import { AnalyticsComponents } from "@/components/analytics";
 import { CartProvider } from "@/components/cart/context";
 import { CartOverlayWithAddress } from "@/components/cart/overlay-with-address";
 import { Footer } from "@/components/footer";
@@ -61,6 +62,7 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
             </Suspense>
           </CartProvider>
         </NextIntlClientProvider>
+        <AnalyticsComponents />
       </body>
     </html>
   );

--- a/apps/template/components/analytics.tsx
+++ b/apps/template/components/analytics.tsx
@@ -1,0 +1,11 @@
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
+
+export function AnalyticsComponents() {
+  return (
+    <>
+      <Analytics />
+      <SpeedInsights />
+    </>
+  );
+}

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -19,6 +19,8 @@
     "@types/node": "25.6.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "@vercel/analytics": "2.0.1",
+    "@vercel/speed-insights": "2.0.0",
     "ai": "6.0.168",
     "babel-plugin-react-compiler": "1.0.0",
     "better-auth": "1.6.9",

--- a/packages/plugin/skills/enable-analytics/SKILL.md
+++ b/packages/plugin/skills/enable-analytics/SKILL.md
@@ -5,18 +5,18 @@ description: Add Vercel Analytics, Vercel Speed Insights, and Google Tag Manager
 
 # Enable Analytics
 
-By default, the storefront has no analytics or performance monitoring. This skill adds Vercel Analytics, Vercel Speed Insights, and/or Google Tag Manager using their recommended integrations.
+The current storefront includes Vercel Analytics and Vercel Speed Insights by default. This skill adds the same default wiring to older storefronts and can also add Google Tag Manager using the recommended integration.
 
 ## Before you start
 
 Ask the user two questions in order:
 
-### 1. Do you want Vercel Analytics and/or Vercel Speed Insights?
+### 1. Do you need to add or change Vercel Analytics and/or Vercel Speed Insights?
 
-- **Vercel Analytics** — page view and custom event tracking via `@vercel/analytics`
-- **Vercel Speed Insights** — Core Web Vitals monitoring via `@vercel/speed-insights`
-- **Both** (recommended)
-- **Neither**
+- **Keep both** — current template default: page views, custom events, and Core Web Vitals
+- **Analytics only** — page view and custom event tracking via `@vercel/analytics`
+- **Speed Insights only** — Core Web Vitals monitoring via `@vercel/speed-insights`
+- **Neither** — remove or skip both Vercel packages
 
 ### 2. Do you want Google Tag Manager?
 
@@ -35,7 +35,7 @@ Skip this section if the user selected neither.
 Install only the packages the user selected:
 
 ```bash
-# Both (recommended)
+# Both (current template default)
 pnpm add @vercel/analytics @vercel/speed-insights
 
 # Analytics only

--- a/packages/plugin/template-rollout-log/2026-05-01-default-vercel-analytics.md
+++ b/packages/plugin/template-rollout-log/2026-05-01-default-vercel-analytics.md
@@ -1,0 +1,40 @@
+---
+title: Enable Vercel Analytics and Speed Insights by default
+changeKey: default-vercel-analytics
+introducedOn: 2026-05-01
+changeType: feature
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/app/layout.tsx
+  - apps/template/components/analytics.tsx
+  - apps/template/package.json
+  - pnpm-lock.yaml
+relatedSkills:
+  - /vercel-shop:enable-analytics
+---
+
+## Summary
+
+The template now installs `@vercel/analytics` and `@vercel/speed-insights`, renders both from `components/analytics.tsx`, and mounts the component from the root layout after the app provider.
+
+## Why it matters
+
+Downstream storefronts get first-party page analytics and Core Web Vitals monitoring without additional setup.
+
+## Apply when
+
+- The storefront deploys to Vercel and wants built-in traffic and performance monitoring.
+- The storefront has not already added a custom analytics wrapper.
+
+## Safe to skip when
+
+- The storefront intentionally avoids client-side analytics scripts.
+- The storefront already has an equivalent analytics/performance integration and does not want duplicate reporting.
+
+## Validation
+
+1. `pnpm --filter template lint` should pass.
+2. `pnpm --filter template build` should include no import errors for `@vercel/analytics/next` or `@vercel/speed-insights/next`.
+3. Confirm `<AnalyticsComponents />` renders as a sibling after `NextIntlClientProvider` in `apps/template/app/layout.tsx`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,12 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@vercel/analytics':
+        specifier: 2.0.1
+        version: 2.0.1(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vue@3.5.30(typescript@6.0.3))
+      '@vercel/speed-insights':
+        specifier: 2.0.0
+        version: 2.0.0(next@16.3.0-canary.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.168
         version: 6.0.168(zod@4.3.6)


### PR DESCRIPTION
## Summary
- Add Vercel Analytics and Speed Insights to the storefront template by default
- Mount analytics from a single template component in the root layout
- Update the analytics skill/docs and add a rollout-log entry for downstream storefronts

## Test plan
- [x] `pnpm --filter template lint`
- [x] `pnpm --filter template build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)