### PR TITLE
Use Shopify variant query parameter

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -23,7 +23,7 @@ export const unstable_instant = {
   samples: [
     {
       params: { handle: "__placeholder__" },
-      searchParams: { variantId: "1" },
+      searchParams: { variant: "1" },
       cookies: [{ name: "shopify_cartId", value: null }],
     },
   ],
@@ -36,17 +36,17 @@ export const unstable_prefetch = "force-runtime";
 
 ## Variant selection
 
-Variants are selected via `searchParams`. Each option (color, size, etc.) renders as a `<Link>` pointing to the same product with a `?variantId` query parameter:
+Variants are selected via `searchParams`. Each option (color, size, etc.) renders as a `<Link>` pointing to the same product with Shopify's `?variant` query parameter:
 
 ```
-/products/classic-tee?variantId=123456
+/products/classic-tee?variant=123456
 ```
 
-The page component receives `searchParams` as a promise and extracts the `variantId`:
+The page component receives `searchParams` as a promise and extracts the selected variant ID:
 
 ```tsx
 const variantIdPromise = searchParams.then(
-  (sp) => (sp?.variantId as string | undefined),
+  (sp) => (sp?.variant as string | undefined),
 );
 ```
 
@@ -57,7 +57,7 @@ On the server, `computeInitialSelectedOptions()` matches the numeric variant ID 
 - The page is fully server-rendered with zero layout shift
 - Variant links use `scroll={false}` to prevent the page from jumping to the top on selection
 
-The `getVariantUrl()` helper in `lib/product/index.ts` computes the target URL for each option. When a user selects a new option value, it finds the matching variant (or falls back to the first variant with that option) and returns the URL with the correct `variantId`.
+The `getVariantUrl()` helper in `lib/product/index.ts` computes the target URL for each option. When a user selects a new option value, it finds the matching variant (or falls back to the first variant with that option) and returns the URL with the correct `variant` query parameter.
 
 Unavailable options render as inert `<span>` elements instead of links.
 

--- a/apps/docs/content/docs/reference/routes.mdx
+++ b/apps/docs/content/docs/reference/routes.mdx
@@ -9,8 +9,7 @@ type: reference
 | Route | File | Description |
 |---|---|---|
 | `/` | `app/page.tsx` | Home page with hero, featured products, info section |
-| `/products/[handle]` | `app/products/[handle]/page.tsx` | Product detail page (default variant) |
-| `/products/[handle]/[variantId]` | `app/products/[handle]/[variantId]/page.tsx` | Product detail page (specific variant) |
+| `/products/[handle]` | `app/products/[handle]/page.tsx` | Product detail page; `?variant=` selects a specific variant |
 | `/collections/[handle]` | `app/collections/[handle]/page.tsx` | Collection listing with filters, sort, pagination |
 | `/search` | `app/search/page.tsx` | Search results (same grid as collections) |
 | `/cart` | `app/cart/page.tsx` | Full cart page with upsells |
@@ -25,10 +24,10 @@ type: reference
 | `POST /api/chat` | `app/api/chat/route.ts` | AI shopping assistant endpoint |
 | `GET /api/draft` | `app/api/draft/route.ts` | Draft mode toggle for content preview |
 
-## URL rewrites
+## Variant URLs
 
-The following rewrite in `next.config.ts` enables variant selection via query parameters:
+Product variant selection uses Shopify's standard `variant` query parameter directly on the product route:
 
-| Source | Destination | Purpose |
-|---|---|---|
-| `/products/:handle?variantId=:variantId` | `/products/:handle/:variantId` | Maps variant query param to route segment |
+| URL | Purpose |
+|---|---|
+| `/products/:handle?variant=:variantId` | Opens the product page with the matching variant selected |

--- a/apps/docs/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/content/docs/reference/troubleshooting.mdx
@@ -19,19 +19,9 @@ The cart ID is stored in a `shopify_cartId` HTTP-only cookie with a 7-day expiry
 
 ## Variant selection not working
 
-Variant selection relies on a rewrite rule in `next.config.ts` that maps `?variantId=123` to a route segment:
+Variant selection uses Shopify's standard `?variant=123` query parameter. If option links change the URL but the page does not update, check that `app/products/[handle]/page.tsx` reads `searchParams.variant` and passes it to the product detail components.
 
-```ts
-rewrites: async () => [
-  {
-    source: "/products/:handle",
-    has: [{ type: "query", key: "variantId", value: "(?<variantId>.+)" }],
-    destination: "/products/:handle/:variantId",
-  },
-],
-```
-
-If this rule is missing or modified, clicking a variant option will append a query parameter but the page won't re-render with the new variant.
+Also confirm variant links are generated with `getVariantUrl()` from `lib/product.ts`, which should return `/products/:handle?variant=:variantId` for variant-specific links.
 
 ## Images not loading
 

--- a/apps/docs/content/docs/skills/enable-i18n.mdx
+++ b/apps/docs/content/docs/skills/enable-i18n.mdx
@@ -103,7 +103,7 @@ export const unstable_instant = {
   samples: [
     {
       params: { locale: "en-US", handle: "__placeholder__" }, // ← add locale
-      searchParams: { variantId: "1" },
+      searchParams: { variant: "1" },
       cookies: [{ name: "shopify_cartId", value: null }],
     },
   ],
@@ -118,7 +118,7 @@ This is easy to forget. If you (or a downstream skill) adds a server component t
 samples: [
   {
     params: { locale: "en-US", handle: "__placeholder__" },
-    searchParams: { variantId: "1" },
+    searchParams: { variant: "1" },
     cookies: [{ name: "shopify_cartId", value: null }],
     headers: [["x-vercel-ip-postal-code", null]], // ← add this
   },

--- a/apps/docs/content/docs/skills/enable-shopify-markets.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-markets.mdx
@@ -254,7 +254,6 @@ Update all `PageProps` and `LayoutProps` type parameters to include `[locale]`:
 
 - `LayoutProps<"/">` → `LayoutProps<"/[locale]">`
 - `PageProps<"/products/[handle]">` → `PageProps<"/[locale]/products/[handle]">`
-- `PageProps<"/products/[handle]/[variantId]">` → `PageProps<"/[locale]/products/[handle]/[variantId]">`
 - `PageProps<"/collections/[handle]">` → `PageProps<"/[locale]/collections/[handle]">`
 - `PageProps<"/search">` → `PageProps<"/[locale]/search">`
 - `PageProps<"/pages/[slug]">` → `PageProps<"/[locale]/pages/[slug]">`
@@ -339,7 +338,7 @@ The base template keeps [`lib/shopify/operations/menu.ts`](../../lib/shopify/ope
 
 **File:** `proxy.ts`
 
-Add a `proxy.ts` with next-intl middleware for locale routing and variant ID rewrites:
+Add a `proxy.ts` with next-intl middleware for locale routing:
 
 ```ts
 export const config = {
@@ -348,37 +347,18 @@ export const config = {
   ],
 };
 
-import { type NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 import createMiddleware from "next-intl/middleware";
 import { routing } from "@/lib/i18n/routing";
 
 const handlei18n = createMiddleware(routing);
 
-export default async function middleware(request: NextRequest) {
-  // 1. Normal flow: locale routing via next-intl
-  let response = handlei18n(request);
-
-  // 2. Variant ID rewrite (after locale resolution)
-  const url = new URL(request.url);
-  const variantId = url.searchParams.get("variantId");
-  if (variantId) {
-    const segments = url.pathname.split("/").filter(Boolean);
-    const productIndex = segments.findIndex((s) => s === "products");
-    if (productIndex !== -1 && segments[productIndex + 1] && !segments[productIndex + 2]) {
-      const rewriteUrl = new URL(request.url);
-      rewriteUrl.pathname = `${url.pathname}/${variantId}`;
-      const params = new URLSearchParams(url.searchParams);
-      params.delete("variantId");
-      rewriteUrl.search = params.toString();
-      return NextResponse.rewrite(rewriteUrl);
-    }
-  }
-
-  return response;
+export function proxy(request: NextRequest) {
+  return handlei18n(request);
 }
 ```
 
-> **Note:** The built-in content negotiation rewrite in `next.config.ts` handles markdown negotiation automatically — no proxy.ts changes needed.
+> **Note:** Product variant selection stays on Shopify's standard `?variant=` query parameter. The built-in content negotiation rewrite in `next.config.ts` handles markdown negotiation automatically — no proxy.ts changes needed.
 
 ---
 
@@ -596,7 +576,7 @@ After completing all steps, verify the implementation:
    - Locale-prefixed URL works (e.g., `http://localhost:3000/de-DE/products/technest-smart-speaker-pro-jk0c`)
    - Product prices render in the correct currency for each locale
 3. **Locale selector**: Confirm the selector appears in the megamenu and switching locales changes the URL + cart currency
-4. **Middleware**: Confirm `?variantId=` rewrites still work
+4. **Variants**: Confirm product variant links preserve `?variant=` across locale-prefixed URLs
 5. **SEO**: Check that page metadata includes `hreflang` alternates for all enabled locales
 6. **Sitemap**: Visit `/sitemap.xml` and confirm per-locale entries
 

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -67,7 +67,7 @@ export const unstable_instant = {
   samples: [
     {
       params: { handle: "__placeholder__" },
-      searchParams: { variantId: "1" },
+      searchParams: { variant: "1" },
       cookies: [{ name: "shopify_cartId", value: null }],
     },
   ],
@@ -89,7 +89,7 @@ export default async function ProductPage({
     getProduct(handle, locale).catch(() => notFound()),
   );
 
-  const variantIdPromise = searchParams.then((sp) => sp?.variantId as string | undefined);
+  const variantIdPromise = searchParams.then((sp) => sp?.variant as string | undefined);
 
   return (
     <ProductDetailPage

--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -110,7 +110,7 @@ function ClientProductCard({
   outOfStockText: string;
 }) {
   const href = product.defaultVariantNumericId
-    ? `/products/${product.handle}?variantId=${product.defaultVariantNumericId}`
+    ? `/products/${product.handle}?variant=${product.defaultVariantNumericId}`
     : `/products/${product.handle}`;
 
   return (

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -42,7 +42,7 @@ export async function ProductCard({
     <Link
       href={
         product.defaultVariantNumericId
-          ? `/products/${product.handle}?variantId=${product.defaultVariantNumericId}`
+          ? `/products/${product.handle}?variant=${product.defaultVariantNumericId}`
           : `/products/${product.handle}`
       }
       className={className}

--- a/apps/template/lib/product.ts
+++ b/apps/template/lib/product.ts
@@ -68,7 +68,7 @@ export function getVariantUrl(
 
   const numericId = variant ? getNumericShopifyId(variant.id) : null;
   if (numericId) {
-    return `/products/${handle}?variantId=${numericId}`;
+    return `/products/${handle}?variant=${numericId}`;
   }
 
   return `/products/${handle}`;

--- a/packages/plugin/skills/enable-i18n/SKILL.md
+++ b/packages/plugin/skills/enable-i18n/SKILL.md
@@ -98,7 +98,7 @@ export const unstable_instant = {
   samples: [
     {
       params: { locale: "en-US", handle: "__placeholder__" }, // ← add locale
-      searchParams: { variantId: "1" },
+      searchParams: { variant: "1" },
       cookies: [{ name: "shopify_cartId", value: null }],
     },
   ],
@@ -113,7 +113,7 @@ This is easy to forget. If you (or a downstream skill) adds a server component t
 samples: [
   {
     params: { locale: "en-US", handle: "__placeholder__" },
-    searchParams: { variantId: "1" },
+    searchParams: { variant: "1" },
     cookies: [{ name: "shopify_cartId", value: null }],
     headers: [["x-vercel-ip-postal-code", null]], // ← add this
   },

--- a/packages/plugin/skills/enable-shopify-markets/SKILL.md
+++ b/packages/plugin/skills/enable-shopify-markets/SKILL.md
@@ -247,7 +247,6 @@ Update all `PageProps` and `LayoutProps` type parameters to include `[locale]`:
 
 - `LayoutProps<"/">` → `LayoutProps<"/[locale]">`
 - `PageProps<"/products/[handle]">` → `PageProps<"/[locale]/products/[handle]">`
-- `PageProps<"/products/[handle]/[variantId]">` → `PageProps<"/[locale]/products/[handle]/[variantId]">`
 - `PageProps<"/collections/[handle]">` → `PageProps<"/[locale]/collections/[handle]">`
 - `PageProps<"/search">` → `PageProps<"/[locale]/search">`
 - `PageProps<"/pages/[slug]">` → `PageProps<"/[locale]/pages/[slug]">`
@@ -332,7 +331,7 @@ The base template keeps [`lib/shopify/operations/menu.ts`](../../lib/shopify/ope
 
 **File:** `proxy.ts`
 
-Add a `proxy.ts` with next-intl middleware for locale routing and variant ID rewrites:
+Add a `proxy.ts` with next-intl middleware for locale routing:
 
 ```ts
 export const config = {
@@ -341,37 +340,18 @@ export const config = {
   ],
 };
 
-import { type NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 import createMiddleware from "next-intl/middleware";
 import { routing } from "@/lib/i18n/routing";
 
 const handlei18n = createMiddleware(routing);
 
-export default async function middleware(request: NextRequest) {
-  // 1. Normal flow: locale routing via next-intl
-  let response = handlei18n(request);
-
-  // 2. Variant ID rewrite (after locale resolution)
-  const url = new URL(request.url);
-  const variantId = url.searchParams.get("variantId");
-  if (variantId) {
-    const segments = url.pathname.split("/").filter(Boolean);
-    const productIndex = segments.findIndex((s) => s === "products");
-    if (productIndex !== -1 && segments[productIndex + 1] && !segments[productIndex + 2]) {
-      const rewriteUrl = new URL(request.url);
-      rewriteUrl.pathname = `${url.pathname}/${variantId}`;
-      const params = new URLSearchParams(url.searchParams);
-      params.delete("variantId");
-      rewriteUrl.search = params.toString();
-      return NextResponse.rewrite(rewriteUrl);
-    }
-  }
-
-  return response;
+export function proxy(request: NextRequest) {
+  return handlei18n(request);
 }
 ```
 
-> **Note:** The built-in content negotiation rewrite in `next.config.ts` handles markdown negotiation automatically — no proxy.ts changes needed.
+> **Note:** Product variant selection stays on Shopify's standard `?variant=` query parameter. The built-in content negotiation rewrite in `next.config.ts` handles markdown negotiation automatically — no proxy.ts changes needed.
 
 ---
 
@@ -589,6 +569,6 @@ After completing all steps, verify the implementation:
    - Locale-prefixed URL works (e.g., `http://localhost:3000/de-DE/products/technest-smart-speaker-pro-jk0c`)
    - Product prices render in the correct currency for each locale
 3. **Locale selector**: Confirm the selector appears in the megamenu and switching locales changes the URL + cart currency
-4. **Middleware**: Confirm `?variantId=` rewrites still work
+4. **Variants**: Confirm product variant links preserve `?variant=` across locale-prefixed URLs
 5. **SEO**: Check that page metadata includes `hreflang` alternates for all enabled locales
 6. **Sitemap**: Visit `/sitemap.xml` and confirm per-locale entries

--- a/packages/plugin/template-rollout-log/2026-05-01-shopify-variant-query-param.md
+++ b/packages/plugin/template-rollout-log/2026-05-01-shopify-variant-query-param.md
@@ -1,0 +1,42 @@
+---
+title: Use Shopify's variant query parameter for product variant URLs
+changeKey: shopify-variant-query-param
+introducedOn: 2026-05-01
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/app/products/[handle]/page.tsx
+  - apps/template/components/collections/infinite-product-grid.tsx
+  - apps/template/components/product-card/product-card.tsx
+  - apps/template/lib/product.ts
+relatedSkills:
+  - /vercel-shop:enable-i18n
+  - /vercel-shop:enable-shopify-markets
+---
+
+## Summary
+
+Product variant URLs now use Shopify's standard `?variant=` query parameter instead of the template-specific `?variantId=` parameter.
+
+## Why it matters
+
+This matches Shopify theme conventions, including Horizon, and makes storefront links easier to compare with native Shopify product URLs.
+
+## Apply when
+
+- The storefront still generates product variant links with `?variantId=`.
+- The PDP reads `searchParams.variantId` instead of `searchParams.variant`.
+
+## Safe to skip when
+
+- The storefront intentionally keeps a custom variant URL scheme and has redirects or analytics depending on it.
+- The storefront already uses `?variant=` for variant-specific product links.
+
+## Validation
+
+1. Product cards with a default variant should link to `/products/:handle?variant=:id`.
+2. PDP option links should update the URL with `?variant=:id`.
+3. Loading a product URL with `?variant=:id` should select the matching options and variant media.
+4. `pnpm --filter template lint` and `pnpm --filter template build` should pass.


### PR DESCRIPTION
## Summary
- Switch product variant URLs from `?variantId=` to Shopify's standard `?variant=` query parameter.
- Update PDP query handling, product card links, docs, and storefront skills to match the Shopify URL convention.
- Add a rollout log entry so downstream storefronts can adopt the change intentionally.

## Test plan
- [x] `pnpm --filter template lint`
- [x] `pnpm --filter template build`
- [x] Checked for obsolete `variantId` query references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)