### PR TITLE
Polish product variant selection spacing

### DIFF
--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -51,7 +51,7 @@ export function ColorPicker({
           const swatch = (
             <div
               className={cn(
-                "aspect-square w-full transition-all overflow-hidden",
+                "aspect-square w-full rounded-lg transition-all overflow-hidden",
                 isSelected ? "ring-1 ring-inset ring-foreground/50" : "ring-1 ring-transparent",
               )}
             >

--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -61,11 +61,11 @@ export function ColorPicker({
                   width={200}
                   height={200}
                   alt={`${value.name} swatch`}
-                  className="size-full border border-foreground/10 object-cover"
+                  className="size-full rounded-lg border border-foreground/10 object-cover"
                 />
               ) : (
                 <div
-                  className="size-full border border-foreground/10 bg-accent"
+                  className="size-full rounded-lg border border-foreground/10 bg-accent"
                   style={value.swatch?.color ? { backgroundColor: value.swatch.color } : undefined}
                 />
               )}

--- a/apps/template/components/product-detail/product-info.tsx
+++ b/apps/template/components/product-detail/product-info.tsx
@@ -67,8 +67,7 @@ function ProductInfoOptions({
 
   return (
     <div data-slot="product-info-options" className={className} {...props}>
-      <div className="grid gap-10">
-        {/* Color Pickers (with images or swatches) */}
+      <div className="grid gap-5">
         {colorOptions.map((colorOption) => (
           <ColorPicker
             key={colorOption.id}
@@ -81,7 +80,6 @@ function ProductInfoOptions({
           />
         ))}
 
-        {/* Other Options (text buttons) */}
         {otherOptions.map((option) => (
           <OptionPicker
             key={option.id}


### PR DESCRIPTION
## Summary
- Reduce vertical spacing between variant option groups from `gap-10` to `gap-5`.
- Apply the same `rounded-lg` corner radius to color variant thumbnails as text variant buttons.
- Remove stale inline comments around the option group render.

## Test plan
- [x] `pnpm --filter template lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)