### PR TITLE
Use native Shopify filters for search

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/plp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/plp.mdx
@@ -68,7 +68,7 @@ Products within a collection are fetched via `getCollectionProducts()`, which ac
 
 ## Search page
 
-The `/search` route accepts a `q` query parameter and combines it with the same filter, sort, and infinite scroll controls. The search page displays a heading with the query and shows a "no results" message with i18n support when the query returns empty. Predictive search is available from the navbar search modal, which shows suggestion chips and product results as the user types.
+The `/search` route accepts a `q` query parameter and combines it with the same filter, sort, and infinite scroll controls. Search results are fetched with Shopify's `search(productFilters: ...)` API, so the product grid, total count, and facet counts come from the same filtered response and match Hydrogen-style search behavior. The search page displays a heading with the query and shows a "no results" message with i18n support when the query returns empty. Predictive search is available from the navbar search modal, which shows suggestion chips and product results as the user types.
 
 ## Key files
 

--- a/apps/template/app/md/search/route.ts
+++ b/apps/template/app/md/search/route.ts
@@ -2,8 +2,7 @@ import { defaultLocale, resolveLocale } from "@/lib/i18n";
 import { searchResultsToMarkdown } from "@/lib/markdown/search";
 import {
   buildProductFiltersFromParams,
-  getCatalogProducts,
-  getSearchFacets,
+  getSearchProducts,
 } from "@/lib/shopify/operations/products";
 import { transformShopifyFilters } from "@/lib/shopify/transforms/filters";
 import { RESULTS_PER_PAGE, parseFiltersFromSearchParams, searchParamsToRecord } from "@/lib/utils";
@@ -29,30 +28,27 @@ export async function GET(request: Request) {
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
 
   try {
-    const [catalog, facets] = await Promise.all([
-      getCatalogProducts({
-        query,
-        collection,
-        sortKey: sort,
-        limit: RESULTS_PER_PAGE,
-        cursor,
-        filters: shopifyFilters,
-        locale,
-      }),
-      getSearchFacets({ query, collection, filters: shopifyFilters, locale }),
-    ]);
+    const result = await getSearchProducts({
+      query,
+      collection,
+      sortKey: sort,
+      limit: RESULTS_PER_PAGE,
+      cursor,
+      filters: shopifyFilters,
+      locale,
+    });
 
-    const transformedFilters = transformShopifyFilters(facets.filters, { activeFilters });
-    const hasPriceRange = facets.filters.some((filter) => filter.type === "PRICE_RANGE");
+    const transformedFilters = transformShopifyFilters(result.filters, { activeFilters });
+    const hasPriceRange = result.filters.some((filter) => filter.type === "PRICE_RANGE");
     const markdown = searchResultsToMarkdown({
       query,
       collection,
-      products: catalog.products,
-      total: facets.total,
+      products: result.products,
+      total: result.total,
       filters: transformedFilters.filters,
       priceRange: hasPriceRange ? transformedFilters.priceRange : undefined,
       activeFilters,
-      pageInfo: catalog.pageInfo,
+      pageInfo: result.pageInfo,
       locale,
       sort,
     });

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -12,8 +12,7 @@ import type { Locale } from "@/lib/i18n";
 import { loadMoreSearchProducts } from "@/lib/search/action";
 import {
   buildProductFiltersFromParams,
-  getCatalogProducts,
-  getSearchFacets,
+  getSearchProducts,
 } from "@/lib/shopify/operations/products";
 import { transformShopifyFilters } from "@/lib/shopify/transforms/filters";
 import type { TransformedFilters } from "@/lib/shopify/transforms/filters";
@@ -47,23 +46,20 @@ export async function getSearchResultsData({
   activeFilters: Record<string, string | string[] | undefined>;
 }): Promise<SearchResultsData> {
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
-  const [catalog, facets] = await Promise.all([
-    getCatalogProducts({
-      query,
-      collection,
-      sortKey: sort,
-      limit: RESULTS_PER_PAGE,
-      filters: shopifyFilters,
-      locale,
-    }),
-    getSearchFacets({ query, collection, filters: shopifyFilters, locale }),
-  ]);
+  const result = await getSearchProducts({
+    query,
+    collection,
+    sortKey: sort,
+    limit: RESULTS_PER_PAGE,
+    filters: shopifyFilters,
+    locale,
+  });
 
   return {
-    products: catalog.products,
-    total: facets.total,
-    pageInfo: catalog.pageInfo,
-    transformedFilters: transformShopifyFilters(facets.filters, { activeFilters }),
+    products: result.products,
+    total: result.total,
+    pageInfo: result.pageInfo,
+    transformedFilters: transformShopifyFilters(result.filters, { activeFilters }),
     activeFilters,
     filters: shopifyFilters,
     query,

--- a/apps/template/lib/search/action.ts
+++ b/apps/template/lib/search/action.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getCatalogProducts } from "@/lib/shopify/operations/products";
+import { getSearchProducts } from "@/lib/shopify/operations/products";
 import { predictiveSearch } from "@/lib/shopify/operations/search";
 import type { ProductFilter } from "@/lib/shopify/types/filters";
 import type { PageInfo, PredictiveSearchResult, ProductCard } from "@/lib/types";
@@ -24,7 +24,7 @@ export async function loadMoreSearchProducts(params: {
   filters?: ProductFilter[];
   locale: string;
 }): Promise<{ products: ProductCard[]; pageInfo: PageInfo }> {
-  const result = await getCatalogProducts({
+  const result = await getSearchProducts({
     query: params.query,
     collection: params.collection,
     cursor: params.cursor,

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -87,13 +87,17 @@ const CATALOG_PRODUCTS_QUERY = `
   }
 `;
 
-const SEARCH_FACETS_QUERY = `
-  query searchFacets($query: String!, $productFilters: [ProductFilter!], $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+const SEARCH_PRODUCTS_QUERY = `
+  ${PRODUCT_CARD_FRAGMENT}
+  query searchProducts($query: String!, $first: Int!, $after: String, $sortKey: SearchSortKeys, $reverse: Boolean, $productFilters: [ProductFilter!], $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     search(
       query: $query
+      first: $first
+      after: $after
+      sortKey: $sortKey
+      reverse: $reverse
       productFilters: $productFilters
       types: PRODUCT
-      first: 1
     ) {
       totalCount
       productFilters {
@@ -107,22 +111,6 @@ const SEARCH_FACETS_QUERY = `
           input
         }
       }
-    }
-  }
-`;
-
-const PRODUCTS_SEARCH_QUERY = `
-  ${PRODUCT_CARD_FRAGMENT}
-  query searchProducts($query: String!, $first: Int!, $after: String, $sortKey: SearchSortKeys, $reverse: Boolean, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
-    search(
-      query: $query
-      first: $first
-      after: $after
-      sortKey: $sortKey
-      reverse: $reverse
-      types: PRODUCT
-    ) {
-      totalCount
       edges {
         cursor
         node {
@@ -136,6 +124,28 @@ const PRODUCTS_SEARCH_QUERY = `
         hasPreviousPage
         startCursor
         endCursor
+      }
+    }
+  }
+`;
+
+const SEARCH_INDEX_PRODUCTS_QUERY = `
+  ${PRODUCT_CARD_FRAGMENT}
+  query searchIndexProducts($query: String!, $first: Int!, $sortKey: SearchSortKeys, $reverse: Boolean, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    search(
+      query: $query
+      first: $first
+      sortKey: $sortKey
+      reverse: $reverse
+      types: PRODUCT
+    ) {
+      totalCount
+      edges {
+        node {
+          ... on Product {
+            ...ProductCardFields
+          }
+        }
       }
     }
   }
@@ -376,17 +386,34 @@ export async function getCatalogProducts(params: {
   };
 }
 
-export async function getSearchFacets(params: {
+export async function getSearchProducts(params: {
   query?: string;
   collection?: string;
+  sortKey?: string;
+  limit?: number;
+  cursor?: string;
   filters?: ProductFilter[];
   locale?: string;
-}): Promise<{ filters: ShopifyFilter[]; total: number }> {
+}): Promise<{
+  products: ProductCard[];
+  pageInfo: PageInfo;
+  filters: ShopifyFilter[];
+  total: number;
+}> {
   "use cache: remote";
   cacheLife("max");
   cacheTag("products");
 
-  const { query, collection, filters = [], locale = defaultLocale } = params;
+  const {
+    query,
+    collection,
+    sortKey: rawSortKey = "best-matches",
+    limit = 50,
+    cursor,
+    filters = [],
+    locale = defaultLocale,
+  } = params;
+  const sortConfig = SEARCH_SORT_KEY_MAP[rawSortKey] ?? SEARCH_SORT_KEY_MAP["best-matches"];
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 
@@ -399,25 +426,39 @@ export async function getSearchFacets(params: {
     search: {
       totalCount: number;
       productFilters: ShopifyFilter[];
+      edges: Array<{ cursor: string; node: ShopifyProductCard | null }>;
+      pageInfo: PageInfo;
     };
   }>({
-    operation: "searchFacets",
-    query: SEARCH_FACETS_QUERY,
+    operation: "searchProducts",
+    query: SEARCH_PRODUCTS_QUERY,
     variables: {
       query: searchQuery,
+      first: limit,
+      after: cursor,
+      sortKey: sortConfig.sortKey,
+      reverse: sortConfig.reverse,
       productFilters: filters.length > 0 ? filters : undefined,
       country,
       language,
     },
   });
 
+  const shopifyProducts = data.search.edges
+    .map((edge) => edge.node)
+    .filter((node): node is ShopifyProductCard => node !== null);
+
+  tagProducts(shopifyProducts);
+
   return {
+    products: shopifyProducts.map(transformShopifyProductCard),
+    pageInfo: data.search.pageInfo,
     filters: data.search.productFilters,
     total: data.search.totalCount,
   };
 }
 
-// Use getCatalogProducts for catalog browse / the /search page; this is the relevance-ranked search index.
+// This powers AI-agent text search; PLP search uses getSearchProducts for faceted filtering.
 export async function searchIndexProducts(params: {
   query: string;
   sortKey?: string;
@@ -446,7 +487,7 @@ export async function searchIndexProducts(params: {
     };
   }>({
     operation: "searchProducts",
-    query: PRODUCTS_SEARCH_QUERY,
+    query: SEARCH_INDEX_PRODUCTS_QUERY,
     variables: {
       query: query.trim() || "*",
       first: limit,

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -89,7 +89,7 @@ const CATALOG_PRODUCTS_QUERY = `
 
 const SEARCH_PRODUCTS_QUERY = `
   ${PRODUCT_CARD_FRAGMENT}
-  query searchProducts($query: String!, $first: Int!, $after: String, $sortKey: SearchSortKeys, $reverse: Boolean, $productFilters: [ProductFilter!], $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+  query searchProducts($query: String!, $first: Int!, $after: String, $sortKey: SearchSortKeys, $reverse: Boolean, $productFilters: [ProductFilter!]) {
     search(
       query: $query
       first: $first
@@ -414,9 +414,6 @@ export async function getSearchProducts(params: {
     locale = defaultLocale,
   } = params;
   const sortConfig = SEARCH_SORT_KEY_MAP[rawSortKey] ?? SEARCH_SORT_KEY_MAP["best-matches"];
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-
   const queryParts: string[] = [];
   if (query?.trim()) queryParts.push(query.trim());
   if (collection) queryParts.push(`collection:'${escapeProductQuery(collection)}'`);
@@ -439,8 +436,6 @@ export async function getSearchProducts(params: {
       sortKey: sortConfig.sortKey,
       reverse: sortConfig.reverse,
       productFilters: filters.length > 0 ? filters : undefined,
-      country,
-      language,
     },
   });
 

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -486,7 +486,7 @@ export async function searchIndexProducts(params: {
       edges: Array<{ node: ShopifyProductCard | null }>;
     };
   }>({
-    operation: "searchProducts",
+    operation: "searchIndexProducts",
     query: SEARCH_INDEX_PRODUCTS_QUERY,
     variables: {
       query: query.trim() || "*",

--- a/packages/plugin/template-rollout-log/2026-05-02-search-native-product-filters.md
+++ b/packages/plugin/template-rollout-log/2026-05-02-search-native-product-filters.md
@@ -1,0 +1,43 @@
+---
+title: Use native Shopify product filters on search
+changeKey: search-native-product-filters
+introducedOn: 2026-05-02
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/shopify/operations/products.ts
+  - apps/template/components/search/results.tsx
+  - apps/template/lib/search/action.ts
+  - apps/template/app/md/search/route.ts
+relatedSkills:
+  - /vercel-shop:shopify-graphql-reference
+---
+
+## Summary
+
+The search page now fetches products, facets, total count, and pagination through Shopify's native `search(productFilters: ...)` API.
+
+## Why it matters
+
+This aligns search with Hydrogen-style filtering, keeps counts consistent with the rendered products, and supports filters such as variant options and product metafields that query-string catalog search could not apply.
+
+## Apply when
+
+- `/search` uses faceted filters or displays a result count.
+- Search pages need variant option filters such as color or size to affect the product grid.
+- Search pages need product metafield filters to behave like collection filters.
+
+## Safe to skip when
+
+- The storefront does not expose faceted filters on `/search`.
+- The storefront intentionally uses a custom search provider instead of Shopify Storefront API search.
+
+## Validation
+
+1. `/search?filter.v.price.gte=2000` should show a filtered count consistent with the rendered products.
+2. `/search?q=shirt&filter.v.option.color=red` should only show products matching the selected variant option.
+3. Infinite scroll on a filtered search should keep applying the same active filters.
+4. `/app/md/search` with equivalent filters should return filtered products and total count.
+5. `pnpm --filter template lint` and `pnpm --filter template build` should pass.


### PR DESCRIPTION
## Summary
- Route `/search` product results, facets, total count, and pagination through Shopify `search(productFilters: ...)`.
- Keep infinite scroll and `/md/search` using the same native filtered search path.
- Document the Hydrogen-style search behavior and add a rollout-log entry for downstream storefronts.

## Test plan
- [x] Shopify Storefront GraphQL validation passed for `search(productFilters: ...)`.
- [x] `pnpm --filter template lint` passed with existing warnings only.
- [x] `pnpm --filter template build` passed with existing Better Auth base URL warning only.
- [x] `/md/search?filter.v.price.gte=2000` returned 200 with applied filter.
- [x] `/search?filter.v.price.gte=2000` returned 200 HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)