### PR TITLE
Relax banner mobile sizing

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/home.mdx
+++ b/apps/docs/content/docs/anatomy/pages/home.mdx
@@ -10,9 +10,9 @@ The home page is a server component that renders a hero banner and a featured pr
 
 ## Hero section
 
-A full-width banner with a background image, gradient overlay, headline, subheadline, and a CTA link. The hero scales responsively - 300px tall on mobile, 400px on small screens, and 500px on medium and up.
+A full-width banner with a background image, gradient overlay, headline, subheadline, and a CTA link. On mobile, the hero height comes from its vertical padding; on medium screens and up, it keeps a wide `3 / 1` aspect ratio.
 
-By default the hero uses a statically imported image from `public/hero.jpg`, which enables automatic blur placeholders and prevents layout shift. To use a custom image, pass a `backgroundImage` prop — either a static import (`import myHero from "@/public/my-hero.jpg"`) or a remote URL object (`{ url: "https://...", alt: "...", width: 1920, height: 1080 }`).
+By default the hero uses a statically imported image from `public/hero.jpg`, which enables automatic blur placeholders and prevents layout shift. To use a custom image, pass a `backgroundImage` prop — either a static import (`import myHero from "@/public/my-hero.jpg"`) or a remote URL object (`{ url: "https://...", alt: "..." }`).
 
 The headline and CTA are configurable through the `BannerSection` component's `hero` prop. By default the CTA links to `/search` to browse the catalog.
 

--- a/apps/docs/content/docs/anatomy/pages/home.mdx
+++ b/apps/docs/content/docs/anatomy/pages/home.mdx
@@ -10,9 +10,11 @@ The home page is a server component that renders a hero banner and a featured pr
 
 ## Hero section
 
-A full-width banner with a background image, gradient overlay, headline, subheadline, and a CTA link. On mobile, the hero height comes from its vertical padding; on medium screens and up, it keeps a wide `3 / 1` aspect ratio.
+A full-width banner with a background image or autoplaying background video, gradient overlay, headline, subheadline, and a CTA link. On mobile, the hero height comes from its vertical padding; on medium screens and up, it keeps a wide `3 / 1` aspect ratio.
 
 By default the hero uses a statically imported image from `public/hero.jpg`, which enables automatic blur placeholders and prevents layout shift. To use a custom image, pass a `backgroundImage` prop — either a static import (`import myHero from "@/public/my-hero.jpg"`) or a remote URL object (`{ url: "https://...", alt: "..." }`).
+
+To use a video hero, pass `backgroundVideo: { url: "https://...", previewImage: { url: "https://...", alt: "..." } }`. Videos use the shared `AutoPlayVideo` component, so they autoplay when visible and pause when off-screen. When both `backgroundVideo` and `backgroundImage` are present, the video is used.
 
 The headline and CTA are configurable through the `BannerSection` component's `hero` prop. By default the CTA links to `/search` to browse the catalog.
 

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -127,7 +127,7 @@ The page emits two JSON-LD schemas:
 | `components/product-detail/lightbox.tsx` | Full-screen image viewer with click-outside to close |
 | `components/product-detail/product-price.tsx` | Price display with discount badge, handles variant-specific pricing |
 | `components/product-detail/buy-buttons.tsx` | Buy with Shop + add to cart buttons |
-| `components/product-detail/auto-play-video.tsx` | Inline video player with preview image fallback |
+| `components/ui/auto-play-video.tsx` | Shared inline video player with preview image fallback |
 | `components/product-detail/about-item.tsx` | Product description rendered from HTML |
 | `components/product-detail/schema.tsx` | JSON-LD Product and Breadcrumb structured data |
 | `components/product-detail/shop-logo.tsx` | Shop wordmark SVG for the Buy with Shop button |

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -40,17 +40,6 @@ export default async function HomePage() {
             id: "homepage-hero",
             headline: "Agentic Infrastructure for Commerce",
             subheadline: "A production-ready, agent-friendly Shopify storefront built on Next.js.",
-            backgroundImage: {
-              url: "https://cdn.shopify.com/s/files/1/0968/7236/6467/files/boomerang-poster.jpg?v=1777564966",
-              alt: "The Outdoor Edit",
-            },
-            backgroundVideo: {
-              url: "https://cdn.shopify.com/videos/c/o/v/db1572ad04ae4ecbad692430c6269fcf.mp4",
-              previewImage: {
-                url: "https://cdn.shopify.com/s/files/1/0968/7236/6467/files/boomerang-poster.jpg?v=1777564966",
-                alt: "The Outdoor Edit",
-              },
-            },
             ctaText: "Browse the Catalog",
             ctaLink: "/search",
           }}

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -40,6 +40,17 @@ export default async function HomePage() {
             id: "homepage-hero",
             headline: "Agentic Infrastructure for Commerce",
             subheadline: "A production-ready, agent-friendly Shopify storefront built on Next.js.",
+            backgroundImage: {
+              url: "https://cdn.shopify.com/s/files/1/0968/7236/6467/files/boomerang-poster.jpg?v=1777564966",
+              alt: "The Outdoor Edit",
+            },
+            backgroundVideo: {
+              url: "https://cdn.shopify.com/videos/c/o/v/db1572ad04ae4ecbad692430c6269fcf.mp4",
+              previewImage: {
+                url: "https://cdn.shopify.com/s/files/1/0968/7236/6467/files/boomerang-poster.jpg?v=1777564966",
+                alt: "The Outdoor Edit",
+              },
+            },
             ctaText: "Browse the Catalog",
             ctaLink: "/search",
           }}

--- a/apps/template/components/product-detail/lightbox.tsx
+++ b/apps/template/components/product-detail/lightbox.tsx
@@ -6,9 +6,8 @@ import { Dialog as DialogPrimitive } from "radix-ui";
 import { createContext, useCallback, useContext, useState } from "react";
 import type { ReactNode } from "react";
 
+import { AutoPlayVideo } from "@/components/ui/auto-play-video";
 import type { Image as ImageType, Video } from "@/lib/types";
-
-import { AutoPlayVideo } from "./auto-play-video";
 
 type MediaItem = { type: "video"; video: Video } | { type: "image"; image: ImageType };
 
@@ -56,7 +55,14 @@ export function Lightbox({ label, children }: { label: string; children: ReactNo
               <div className="pointer-events-none flex h-full w-full items-center justify-center">
                 <AutoPlayVideo
                   src={activeItem.video.url}
-                  previewImage={activeItem.video.previewImage}
+                  previewImage={
+                    activeItem.video.previewImage
+                      ? {
+                          src: activeItem.video.previewImage.url,
+                          alt: activeItem.video.previewImage.altText || "",
+                        }
+                      : null
+                  }
                   sizes="90vw"
                   priorityImage
                   className="pointer-events-auto max-h-full max-w-full object-contain"

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -4,10 +4,10 @@ import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 
+import { AutoPlayVideo } from "@/components/ui/auto-play-video";
 import type { Image as ImageType, Video } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-import { AutoPlayVideo } from "./auto-play-video";
 import { Lightbox, LightboxTrigger } from "./lightbox";
 
 type MediaItem = { type: "video"; video: Video } | { type: "image"; image: ImageType };
@@ -59,7 +59,14 @@ function MediaVideo({
   return (
     <AutoPlayVideo
       src={item.video.url}
-      previewImage={item.video.previewImage}
+      previewImage={
+        item.video.previewImage
+          ? {
+              src: item.video.previewImage.url,
+              alt: item.video.previewImage.altText || "",
+            }
+          : null
+      }
       sizes={sizes}
       priorityImage={priority}
       className={cn("h-full w-full scale-[1.04] object-cover", className)}

--- a/apps/template/components/sections/banner-section.tsx
+++ b/apps/template/components/sections/banner-section.tsx
@@ -19,8 +19,7 @@ export function BannerSection({ hero, headingLevel = "h1" }: BannerSectionProps)
   return (
     <section className="relative w-full overflow-hidden">
       <div className="relative grid bg-linear-to-b from-black via-neutral-950 to-neutral-900">
-        {/* Aspect-ratio spacer: sets the minimum height */}
-        <div className="col-start-1 row-start-1 aspect-[16/9] md:aspect-[3/1]" />
+        <div className="col-start-1 row-start-1 hidden md:block md:aspect-[3/1]" />
 
         {isStatic ? (
           <>
@@ -51,7 +50,7 @@ export function BannerSection({ hero, headingLevel = "h1" }: BannerSectionProps)
           )
         )}
 
-        <div className="relative col-start-1 row-start-1 flex items-center justify-center px-5 py-5 lg:px-10 lg:py-10">
+        <div className="relative col-start-1 row-start-1 flex items-center justify-center px-5 py-10 lg:px-10">
           <div className="flex flex-col items-center text-center gap-2.5">
             <Heading className="text-3xl md:text-5xl font-semibold text-white tracking-tight max-w-3xl">
               {hero.headline}

--- a/apps/template/components/sections/banner-section.tsx
+++ b/apps/template/components/sections/banner-section.tsx
@@ -2,6 +2,7 @@ import type { StaticImageData } from "next/image";
 import Image from "next/image";
 import Link from "next/link";
 
+import { AutoPlayVideo } from "@/components/ui/auto-play-video";
 import { Button } from "@/components/ui/button";
 import type { BannerSection as BannerSectionType } from "@/lib/types";
 import heroDefault from "@/public/hero.jpg";
@@ -13,6 +14,7 @@ interface BannerSectionProps {
 
 export function BannerSection({ hero, headingLevel = "h1" }: BannerSectionProps) {
   const Heading = headingLevel;
+  const video = hero.backgroundVideo;
   const image = hero.backgroundImage ?? heroDefault;
   const isStatic = typeof image === "object" && "src" in image;
 
@@ -21,7 +23,25 @@ export function BannerSection({ hero, headingLevel = "h1" }: BannerSectionProps)
       <div className="relative grid bg-linear-to-b from-black via-neutral-950 to-neutral-900">
         <div className="col-start-1 row-start-1 hidden md:block md:aspect-[3/1]" />
 
-        {isStatic ? (
+        {video ? (
+          <>
+            <AutoPlayVideo
+              src={video.url}
+              previewImage={
+                video.previewImage
+                  ? {
+                      src: video.previewImage.url,
+                      alt: video.previewImage.alt,
+                    }
+                  : null
+              }
+              className="absolute inset-0 h-full w-full object-cover"
+              priorityImage
+              sizes="100vw"
+            />
+            <div className="absolute inset-0 bg-linear-to-t from-black/60 via-transparent to-transparent" />
+          </>
+        ) : isStatic ? (
           <>
             <Image
               src={image as StaticImageData}

--- a/apps/template/components/ui/auto-play-video.tsx
+++ b/apps/template/components/ui/auto-play-video.tsx
@@ -4,25 +4,21 @@ import Image from "next/image";
 import type * as React from "react";
 import { useEffect, useRef, useState } from "react";
 
-import type { Image as ImageType } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-interface AutoPlayVideoProps extends Omit<React.ComponentProps<"video">, "autoPlay" | "ref"> {
-  previewImage?: ImageType | null;
+interface AutoPlayVideoPreviewImage {
+  src: string;
+  alt: string;
+}
+
+interface AutoPlayVideoProps extends Omit<
+  React.ComponentProps<"video">,
+  "autoPlay" | "loop" | "muted" | "onCanPlay" | "playsInline" | "ref"
+> {
+  previewImage?: AutoPlayVideoPreviewImage | null;
   sizes?: string;
   priorityImage?: boolean;
 }
-
-/**
- * A video element that autoplays when visible and pauses when off-screen.
- * Uses IntersectionObserver instead of a one-shot `play()` call so the video
- * reliably restarts after scrolling back into view (desktop grid) or swiping
- * back in a carousel (mobile), and retries on mobile browsers that may block
- * the initial autoplay attempt.
- *
- * When a `previewImage` is provided, a next/image is rendered underneath the
- * video and stays visible until the video fires `canplay`.
- */
 export function AutoPlayVideo({
   previewImage,
   sizes,
@@ -59,8 +55,8 @@ export function AutoPlayVideo({
     <>
       {previewImage && !videoReady && (
         <Image
-          src={previewImage.url}
-          alt={previewImage.altText || ""}
+          src={previewImage.src}
+          alt={previewImage.alt}
           fill
           className={cn("object-cover", className)}
           sizes={sizes}

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -247,8 +247,8 @@ export interface PredictiveSearchResult {
 export interface MarketingImage {
   url: string;
   alt: string;
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
 }
 
 export interface BannerSection {

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -251,11 +251,17 @@ export interface MarketingImage {
   height?: number;
 }
 
+export interface MarketingVideo {
+  url: string;
+  previewImage?: MarketingImage | null;
+}
+
 export interface BannerSection {
   id: string;
   headline: string;
   subheadline: string | null;
   backgroundImage?: MarketingImage | StaticImageData | null;
+  backgroundVideo?: MarketingVideo | null;
   ctaText: string | null;
   ctaLink: string | null;
 }

--- a/packages/plugin/template-rollout-log/2026-05-02-banner-mobile-padding.md
+++ b/packages/plugin/template-rollout-log/2026-05-02-banner-mobile-padding.md
@@ -1,0 +1,41 @@
+---
+title: Banner mobile padding and optional image dimensions
+changeKey: banner-mobile-padding
+introducedOn: 2026-05-02
+changeType: feature
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/sections/banner-section.tsx
+  - apps/template/lib/types.ts
+  - apps/docs/content/docs/anatomy/pages/home.mdx
+---
+
+## Summary
+
+The home banner no longer uses a strict mobile aspect ratio. Mobile height now comes from the banner content area using `py-10`, while medium screens and up keep the wide `3 / 1` aspect ratio.
+
+Remote banner background images also no longer require `width` and `height` on the `MarketingImage` object. A remote hero can now pass only `url` and `alt`.
+
+## Why it matters
+
+Mobile banners need more breathing room for real merchant copy than a fixed image ratio provides, and background images rendered with `fill` do not need caller-provided dimensions.
+
+## Apply when
+
+- The storefront uses `BannerSection` or a copied version of the home hero.
+- The storefront passes remote `backgroundImage` objects and wants to stop plumbing unused dimensions.
+
+## Safe to skip when
+
+- The storefront already replaced the banner with a custom layout.
+- The storefront intentionally depends on a fixed mobile image aspect ratio.
+
+## Validation
+
+1. `pnpm --filter template dev`.
+2. Open the home page at mobile width and confirm the hero height is driven by content padding instead of a forced image ratio.
+3. Open the home page at medium and desktop widths and confirm the banner keeps the wide hero presentation.
+4. Pass a remote `backgroundImage` with only `url` and `alt` and confirm type checking passes.
+5. `pnpm --filter template lint` and `tsc --noEmit` clean.

--- a/packages/plugin/template-rollout-log/2026-05-02-banner-video-media.md
+++ b/packages/plugin/template-rollout-log/2026-05-02-banner-video-media.md
@@ -1,0 +1,50 @@
+---
+title: Banner video media and shared autoplay video
+changeKey: banner-video-media
+introducedOn: 2026-05-02
+changeType: feature
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/ui/auto-play-video.tsx
+  - apps/template/components/product-detail/product-media.tsx
+  - apps/template/components/product-detail/lightbox.tsx
+  - apps/template/components/sections/banner-section.tsx
+  - apps/template/lib/types.ts
+  - apps/docs/content/docs/anatomy/pages/home.mdx
+  - apps/docs/content/docs/anatomy/pages/pdp.mdx
+---
+
+## Summary
+
+`AutoPlayVideo` moves from the product-detail folder into `components/ui` so product media, lightbox media, and future shared surfaces can use the same autoplay behavior.
+
+`BannerSection` now accepts `backgroundVideo` in addition to `backgroundImage`. When present, the video renders behind the existing gradient and text overlay; otherwise the banner falls back to the existing image behavior.
+
+## Why it matters
+
+Hero videos are a common storefront request, and the autoplay behavior was already implemented for PDP media. Sharing it from `components/ui` avoids duplicating visibility-based play/pause logic.
+
+## Apply when
+
+- The storefront uses `components/product-detail/auto-play-video.tsx` directly or copied the product media implementation.
+- The storefront uses `BannerSection` or wants a video-backed home hero.
+
+## Safe to skip when
+
+- The storefront already has a custom video component with equivalent visibility-based autoplay behavior.
+- The storefront has replaced the home banner with a custom media implementation.
+
+## Notes
+
+- `components/ui/auto-play-video.tsx` accepts primitive preview image props and does not import domain types.
+- `backgroundVideo` wins over `backgroundImage` when both are present.
+
+## Validation
+
+1. `pnpm --filter template dev`.
+2. Open a PDP with video media and confirm videos autoplay in the gallery and lightbox.
+3. Pass `backgroundVideo` to the home banner and confirm it renders object-cover behind the existing gradient/text overlay.
+4. Remove `backgroundVideo` and confirm the default image banner still renders.
+5. `pnpm --filter template lint` and `pnpm --filter template exec tsc --noEmit` clean.


### PR DESCRIPTION
## Summary
- Replace the banner's strict mobile aspect ratio with content-driven `py-10` spacing
- Make remote `MarketingImage` dimensions optional because banner backgrounds render with `fill`
- Update home-page docs and add a template rollout log entry

## Test plan
- [x] `pnpm --filter template lint` (passes with pre-existing warnings)
- [x] `pnpm --filter template exec tsc --noEmit`
- [x] `git diff --check`
- [ ] `pnpm --filter docs exec tsc --noEmit` (blocked by existing TS `baseUrl` deprecation in docs tsconfig)
- [ ] Browser-check the home page at mobile and desktop widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)