### PR TITLE
PDP: split image priority from loading=eager; account for color slot

### DIFF
--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -26,6 +26,7 @@ function MediaImage({
   idx,
   sizes,
   priority,
+  eager,
   className,
 }: {
   item: Extract<MediaItem, { type: "image" }>;
@@ -33,6 +34,7 @@ function MediaImage({
   idx: number;
   sizes: string;
   priority: boolean;
+  eager: boolean;
   className?: string;
 }) {
   return (
@@ -43,7 +45,7 @@ function MediaImage({
       className={cn("object-cover", className)}
       sizes={sizes}
       priority={priority}
-      loading={priority ? "eager" : "lazy"}
+      loading={priority || eager ? "eager" : "lazy"}
       draggable={false}
     />
   );
@@ -83,11 +85,13 @@ function Carousel({
   mediaItems,
   title,
   aspectRatio,
+  hasColorSlot,
   children,
 }: {
   mediaItems: MediaItem[];
   title: string;
   aspectRatio: ProductCardAspectRatio;
+  hasColorSlot: boolean;
   children?: React.ReactNode;
 }) {
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -140,28 +144,33 @@ function Carousel({
         style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
       >
         {children}
-        {mediaItems.map((item, idx) => (
-          <div
-            key={mediaKey(item)}
-            data-aspect-ratio={aspectRatio}
-            className={cn(
-              "relative shrink-0 w-full snap-start snap-always overflow-hidden",
-              aspectRatioClasses,
-            )}
-          >
-            {item.type === "video" ? (
-              <MediaVideo item={item} sizes="100vw" priority={!children && idx === 0} />
-            ) : (
-              <MediaImage
-                item={item}
-                title={title}
-                idx={idx}
-                sizes="100vw"
-                priority={!children && idx === 0}
-              />
-            )}
-          </div>
-        ))}
+        {mediaItems.map((item, idx) => {
+          const priority = !hasColorSlot && idx === 0;
+          const eager = hasColorSlot ? idx === 0 : idx === 1;
+          return (
+            <div
+              key={mediaKey(item)}
+              data-aspect-ratio={aspectRatio}
+              className={cn(
+                "relative shrink-0 w-full snap-start snap-always overflow-hidden",
+                aspectRatioClasses,
+              )}
+            >
+              {item.type === "video" ? (
+                <MediaVideo item={item} sizes="100vw" priority={priority || eager} />
+              ) : (
+                <MediaImage
+                  item={item}
+                  title={title}
+                  idx={idx}
+                  sizes="100vw"
+                  priority={priority}
+                  eager={eager}
+                />
+              )}
+            </div>
+          );
+        })}
       </div>
 
       {/* Dot indicators – reserve space but hide when there's only one image */}
@@ -190,11 +199,15 @@ function GridItem({
   title,
   idx,
   aspectRatio,
+  priority,
+  eager,
 }: {
   item: MediaItem;
   title: string;
   idx: number;
   aspectRatio: ProductCardAspectRatio;
+  priority: boolean;
+  eager: boolean;
 }) {
   return (
     <div
@@ -202,7 +215,11 @@ function GridItem({
       className={cn("relative w-full overflow-hidden bg-accent", aspectRatioClasses)}
     >
       {item.type === "video" ? (
-        <MediaVideo item={item} sizes="(min-width: 1024px) 25vw, 50vw" priority={idx < 2} />
+        <MediaVideo
+          item={item}
+          sizes="(min-width: 1024px) 25vw, 50vw"
+          priority={priority || eager}
+        />
       ) : (
         <LightboxTrigger item={item}>
           <MediaImage
@@ -210,7 +227,8 @@ function GridItem({
             title={title}
             idx={idx}
             sizes="(min-width: 1024px) 25vw, 50vw"
-            priority={idx < 2}
+            priority={priority}
+            eager={eager}
           />
         </LightboxTrigger>
       )}
@@ -223,26 +241,34 @@ function Grid({
   mediaItems,
   title,
   aspectRatio,
+  hasColorSlot,
   children,
 }: {
   mediaItems: MediaItem[];
   title: string;
   aspectRatio: ProductCardAspectRatio;
+  hasColorSlot: boolean;
   children?: React.ReactNode;
 }) {
   return (
     <Lightbox label={title}>
       <div className="grid grid-cols-2 gap-2.5">
         {children}
-        {mediaItems.map((item, idx) => (
-          <GridItem
-            key={mediaKey(item)}
-            item={item}
-            title={title}
-            idx={idx}
-            aspectRatio={aspectRatio}
-          />
-        ))}
+        {mediaItems.map((item, idx) => {
+          const priority = !hasColorSlot && idx === 0;
+          const eager = hasColorSlot ? idx === 0 : idx === 1;
+          return (
+            <GridItem
+              key={mediaKey(item)}
+              item={item}
+              title={title}
+              idx={idx}
+              aspectRatio={aspectRatio}
+              priority={priority}
+              eager={eager}
+            />
+          );
+        })}
       </div>
     </Lightbox>
   );
@@ -268,6 +294,8 @@ export function ColorImageGrid({
       title={title}
       idx={idx}
       aspectRatio={aspectRatio}
+      priority={idx === 0}
+      eager={idx === 1}
     />
   ));
 }
@@ -285,26 +313,31 @@ export function ColorImageCarouselItems({
   title: string;
   aspectRatio: ProductCardAspectRatio;
 }) {
-  return images.map((image, idx) => (
-    <div
-      key={image.url}
-      data-aspect-ratio={aspectRatio}
-      className={cn(
-        "relative shrink-0 w-full snap-start snap-always overflow-hidden",
-        aspectRatioClasses,
-      )}
-    >
-      <Image
-        src={image.url}
-        alt={image.altText || `${title} image ${idx + 1}`}
-        fill
-        className="object-cover"
-        sizes="100vw"
-        priority={idx === 0}
-        draggable={false}
-      />
-    </div>
-  ));
+  return images.map((image, idx) => {
+    const priority = idx === 0;
+    const eager = idx === 1;
+    return (
+      <div
+        key={image.url}
+        data-aspect-ratio={aspectRatio}
+        className={cn(
+          "relative shrink-0 w-full snap-start snap-always overflow-hidden",
+          aspectRatioClasses,
+        )}
+      >
+        <Image
+          src={image.url}
+          alt={image.altText || `${title} image ${idx + 1}`}
+          fill
+          className="object-cover"
+          sizes="100vw"
+          priority={priority}
+          loading={priority || eager ? "eager" : "lazy"}
+          draggable={false}
+        />
+      </div>
+    );
+  });
 }
 
 export function ProductMedia({
@@ -333,15 +366,27 @@ export function ProductMedia({
 
   if (sharedMediaItems.length === 0 && !desktopSlot && !mobileSlot) return null;
 
+  const hasColorSlot = !!mobileSlot || !!desktopSlot;
+
   return (
     <div className={className}>
       <div className="lg:hidden">
-        <Carousel mediaItems={sharedMediaItems} title={title} aspectRatio={aspectRatio}>
+        <Carousel
+          mediaItems={sharedMediaItems}
+          title={title}
+          aspectRatio={aspectRatio}
+          hasColorSlot={hasColorSlot}
+        >
           {mobileSlot}
         </Carousel>
       </div>
       <div className="hidden lg:block">
-        <Grid mediaItems={sharedMediaItems} title={title} aspectRatio={aspectRatio}>
+        <Grid
+          mediaItems={sharedMediaItems}
+          title={title}
+          aspectRatio={aspectRatio}
+          hasColorSlot={hasColorSlot}
+        >
           {desktopSlot}
         </Grid>
       </div>

--- a/packages/plugin/template-rollout-log/2026-05-04-pdp-image-priority.md
+++ b/packages/plugin/template-rollout-log/2026-05-04-pdp-image-priority.md
@@ -1,0 +1,52 @@
+---
+title: PDP image loading — split priority from eager and account for the color slot
+changeKey: pdp-image-priority
+introducedOn: 2026-05-04
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-detail/product-media.tsx
+---
+
+## Summary
+
+The PDP gallery's `priority` handling had two problems that hurt LCP and over-reserved preload bandwidth:
+
+1. **Mobile carousel under-prioritized in color-partitioned mode.** The shared-items map used `priority={!children && idx === 0}`. Whenever a `mobileSlot` was passed (the resolved-color-images Suspense node), `children` was always truthy, so *no* shared item was marked priority — even if the resolved color images turned out to be empty. The mobile LCP candidate was lazy-loaded.
+2. **Desktop grid double-prioritized.** `GridItem` used `priority={idx < 2}` independently for color images and shared items. With color partitioning on, the first two color images were priority *and* the first two shared items at visual positions 3/4 also got priority — four `<link rel=preload>` competing for a single PDP.
+
+This change separates `priority` (the single LCP candidate — `fetchPriority="high"` plus a preload link) from `loading="eager"` (above-the-fold but not LCP — loads immediately without fighting the LCP for bandwidth), and computes both centrally in `ProductMedia` based on a `hasColorSlot` flag.
+
+The rules are:
+
+- **Color slot present** → `colorImage[0]` is `priority`, `colorImage[1]` is `eager`. The first shared item is `eager` to cover the case where color partitioning resolves to zero or one images and the shared item is therefore the second (or first) visible.
+- **No color slot** → `shared[0]` is `priority`, `shared[1]` is `eager`.
+
+`MediaImage` now accepts a separate `eager` prop so loading semantics aren't conflated with priority. `MediaVideo`'s preview image continues to use the combined `priority || eager` signal since the cost is small and the preview is what affects perceived load.
+
+## Why it matters
+
+- LCP: in color-partitioned mode with zero color images, the first shared image was lazy. Now it's eager (or priority where applicable).
+- Bandwidth: only one image per PDP is now `priority`; the second visible is `eager` without a preload link. Browsers can prioritize correctly instead of seeing four equal-priority preloads.
+
+## Apply when
+
+- The storefront uses `ProductMedia`, `ColorImageGrid`, or `ColorImageCarouselItems` directly.
+
+## Safe to skip when
+
+- The storefront has replaced `ProductMedia` with a custom gallery that already routes priority through a single LCP candidate.
+
+## Notes
+
+- `MediaImage` now requires a `priority: boolean` and an `eager: boolean`. If you have callers outside `ProductMedia`, pass both explicitly.
+- Videos still use the combined `priority || eager` signal for their preview image — the fix is image-focused.
+
+## Validation
+
+1. `pnpm --filter template lint` and `tsc --noEmit` clean.
+2. `pnpm --filter template dev`. Open a PDP without color partitioning. In DevTools → Network, the first image is `fetchpriority=high` with a preload link in `<head>`, the second is `loading=eager` (no preload), the rest are lazy.
+3. Open a PDP with color partitioning (a product with multiple colors that have their own images). Confirm the first color image is the only `priority` request, the second color image is `eager`, and the first shared image is `eager`. No second `<link rel=preload>` for product images.
+4. Edge case: a color-partitioned product where the selected color resolves to no color images. Confirm the first shared image still loads quickly (`eager`).


### PR DESCRIPTION
Stacks on #248. Targets `pdp-aspect-ratio-and-oos-slideshow` so the diff stays scoped to image-loading changes; GitHub will auto-retarget to `main` once #248 merges.

## Summary

Two priority bugs in `ProductMedia`:

1. **Mobile carousel under-prioritized in color-partitioned mode.** The shared-items map used `priority={!children && idx === 0}`. Whenever a `mobileSlot` was passed, `children` was always truthy, so no shared item was marked priority — even if the resolved color images turned out to be empty. The mobile LCP candidate was lazy-loaded.
2. **Desktop grid double-prioritized.** `GridItem` used `priority={idx < 2}` independently for color images and shared items, so in color-partitioned mode four `<link rel=preload>` ended up competing for a single PDP.

Fix separates `priority` (the single LCP candidate; `fetchPriority="high"` + preload) from `loading="eager"` (above-the-fold but not LCP; loads now without fighting the LCP for bandwidth), and computes both centrally in `ProductMedia` based on a `hasColorSlot` flag.

Rules:
- **Color slot present** → `colorImage[0]` priority, `colorImage[1]` eager, `shared[0]` eager (covers 0- or 1-color-image cases).
- **No color slot** → `shared[0]` priority, `shared[1]` eager.

`MediaImage` now takes an explicit `eager` prop so loading semantics aren't conflated with priority. `MediaVideo`'s preview image keeps the combined `priority||eager` signal — small cost, and the preview is what drives perceived load.

Includes a template-rollout-log entry.

## Test plan

- [ ] `pnpm --filter template lint` and `tsc --noEmit` clean
- [ ] PDP without color partitioning: first image is the only `fetchpriority=high` request with a `<link rel=preload>` in `<head>`, second is `loading=eager` (no preload), rest lazy
- [ ] PDP with color partitioning: first color image is the only priority/preloaded request; second color image and first shared image are `eager`; rest lazy
- [ ] Color-partitioned product where the selected color resolves to no color images: first shared image still loads quickly (`eager`)
- [ ] No regression in initial paint speed on PDPs with videos as the first media item

🤖 Generated with [Claude Code](https://claude.com/claude-code)