### PR TITLE
Comma-join multi-value filter params on search/collections

### DIFF
--- a/apps/template/components/collections/filter-sidebar.tsx
+++ b/apps/template/components/collections/filter-sidebar.tsx
@@ -71,20 +71,19 @@ function buildHref(pathname: string, params: URLSearchParams): string {
   return query ? `${pathname}?${query}` : pathname;
 }
 
+function readFilterValues(params: URLSearchParams, key: string): string[] {
+  return params
+    .getAll(key)
+    .flatMap((v) => v.split(","))
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
 function toggleFilterParam(params: URLSearchParams, key: string, value: string): void {
-  const nextValues = getFilterValues(params.getAll(key));
-
-  if (nextValues.includes(value)) {
-    params.delete(key);
-    for (const nextValue of nextValues) {
-      if (nextValue !== value) {
-        params.append(key, nextValue);
-      }
-    }
-    return;
-  }
-
-  params.append(key, value);
+  const current = readFilterValues(params, key);
+  const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+  params.delete(key);
+  if (next.length > 0) params.set(key, next.join(","));
 }
 
 function parsePriceValue(value: string | null): number | null {

--- a/apps/template/lib/seo.ts
+++ b/apps/template/lib/seo.ts
@@ -24,8 +24,12 @@ function toSearchParams(input: SearchParamsInput): URLSearchParams {
   for (const [key, value] of Object.entries(input)) {
     if (value === undefined) continue;
     if (Array.isArray(value)) {
-      for (const item of value) {
-        params.append(key, item);
+      if (key.startsWith("filter.")) {
+        if (value.length > 0) params.set(key, value.join(","));
+      } else {
+        for (const item of value) {
+          params.append(key, item);
+        }
       }
       continue;
     }

--- a/apps/template/lib/utils.ts
+++ b/apps/template/lib/utils.ts
@@ -13,6 +13,10 @@ export function formatPrice(amount: number, currencyCode: string, locale: string
   }).format(amount);
 }
 
+// Price keys are scalar (gte/lte) — buildProductFiltersFromParams' parsePrice
+// bails on arrays, so don't comma-split them.
+const PRICE_FILTER_KEYS = new Set(["filter.v.price.gte", "filter.v.price.lte"]);
+
 export function parseFiltersFromSearchParams(
   searchParams: Record<string, string | string[] | undefined>,
 ): Record<string, string | string[] | undefined> {
@@ -22,7 +26,18 @@ export function parseFiltersFromSearchParams(
     if (!key.startsWith("filter.") || value === undefined) {
       continue;
     }
-    filters[key] = value;
+    if (PRICE_FILTER_KEYS.has(key)) {
+      filters[key] = value;
+      continue;
+    }
+    const raw = Array.isArray(value) ? value : [value];
+    const split = raw
+      .flatMap((v) => v.split(","))
+      .map((v) => v.trim())
+      .filter(Boolean);
+    const deduped = [...new Set(split)];
+    if (deduped.length === 0) continue;
+    filters[key] = deduped.length === 1 ? deduped[0] : deduped;
   }
 
   return filters;


### PR DESCRIPTION
## Summary

- Multi-value filter params on `/search` and `/collections/[handle]` now use comma-joined single-key form (`?filter.p.vendor=A,B`) instead of repeated keys (`?filter.p.vendor=A&filter.p.vendor=B`). Toggling becomes one atomic `set()` instead of delete-and-rebuild.
- Read path is permissive: `parseFiltersFromSearchParams` accepts both forms, so any existing inbound links continue to work. Canonical URLs emitted from `generateMetadata` are now comma-joined.
- Three files touched: `lib/utils.ts` (parser), `components/collections/filter-sidebar.tsx` (toggle), `lib/seo.ts` (canonical URL builder). No changes needed to downstream consumers — `buildProductFiltersFromParams`, `getActiveFilterBadges`, load-more actions, and the markdown routes already handle the polyglot `string | string[]` shape.

## Why

The delete-then-re-append toggle pattern interacted badly with Next.js navigation caching: clicking Brand A → +Brand B → -Brand A would update the URL to `?filter.p.vendor=B` but leave the rendered tree stuck on the previous request's data. Server logs confirmed the new request was made and returned correct results; the client just didn't apply them. Disabling `experimental.cachedNavigations` and `experimental.optimisticRouting` did not change the symptom, so the deeper Next.js cause is left for upstream. Comma-joined makes the toggle idempotent and sidesteps the failure mode.

## Trade-off

A filter value containing a literal `,` (e.g. vendor `"Smith, Jones & Co"`) would split incorrectly. `encodeURIComponent` per-value doesn't survive `URLSearchParams`' decode round-trip, so the simple form requires no commas in values. Acceptable for typical Shopify vendor / product_type / tag / metafield values. Escape hatch if a real catalog ever needs commas: switch the delimiter to `~` (RFC 3986 unreserved, not encoded by `encodeURIComponent`) — same code shape.

## Test plan

- [x] `/search` 3-click sequence (Brand A → +Brand B → -Brand A) produces correct URL, pills, item count, and grid at every step
- [x] Same sequence on `/collections/automated-collection`
- [x] Legacy URL `?filter.p.vendor=A&filter.p.vendor=B` parses correctly when pasted directly
- [x] Canonical `<link rel="canonical">` for a legacy URL emits the comma-joined form
- [x] Markdown route returns identical content for both URL forms
- [x] Price filter (`filter.v.price.gte`/`lte`) untouched — exempt from the comma-split path
- [x] `pnpm lint` and `pnpm format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)