### PR TITLE
Fix infinite scroll on /search and /collections (cipher error in inline action)

### DIFF
--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -14,23 +14,28 @@ import {
 } from "@/components/product-card/components";
 import type { PageInfo, ProductCard } from "@/lib/types";
 
-interface InfiniteProductGridProps {
+interface InfiniteProductGridProps<TParams> {
   initialProducts: ProductCard[];
   initialPageInfo: PageInfo;
   locale: string;
   outOfStockText: string;
-  loadMore: (cursor: string) => Promise<{ products: ProductCard[]; pageInfo: PageInfo }>;
+  // Top-level "use server" action; passed by reference, no closure encryption.
+  loadMore: (
+    params: TParams & { cursor: string },
+  ) => Promise<{ products: ProductCard[]; pageInfo: PageInfo }>;
+  loadMoreParams: TParams;
   children: React.ReactNode;
 }
 
-export function InfiniteProductGrid({
+export function InfiniteProductGrid<TParams>({
   initialProducts,
   initialPageInfo,
   locale,
   outOfStockText,
   loadMore,
+  loadMoreParams,
   children,
-}: InfiniteProductGridProps) {
+}: InfiniteProductGridProps<TParams>) {
   const [additionalProducts, setAdditionalProducts] = useState<ProductCard[]>([]);
   const [pageInfo, setPageInfo] = useState<PageInfo>(initialPageInfo);
   const [isLoading, setIsLoading] = useState(false);
@@ -51,14 +56,14 @@ export function InfiniteProductGrid({
     setIsLoading(true);
 
     try {
-      const result = await loadMore(pageInfo.endCursor);
+      const result = await loadMore({ ...loadMoreParams, cursor: pageInfo.endCursor });
       setAdditionalProducts((prev) => [...prev, ...result.products]);
       setPageInfo(result.pageInfo);
     } finally {
       setIsLoading(false);
       loadingRef.current = false;
     }
-  }, [pageInfo, loadMore]);
+  }, [pageInfo, loadMore, loadMoreParams]);
 
   useEffect(() => {
     const sentinel = sentinelRef.current;

--- a/apps/template/components/collections/results-grid.tsx
+++ b/apps/template/components/collections/results-grid.tsx
@@ -42,24 +42,14 @@ async function Render({
     );
   }
 
-  const boundLoadMore = async (cursor: string) => {
-    "use server";
-    return loadMoreCollectionProducts({
-      collection,
-      cursor,
-      sortKey: sort,
-      filters,
-      locale,
-    });
-  };
-
   return (
     <InfiniteProductGrid
       initialProducts={products}
       initialPageInfo={result.pageInfo}
       locale={locale}
       outOfStockText={tProduct("outOfStock")}
-      loadMore={boundLoadMore}
+      loadMore={loadMoreCollectionProducts}
+      loadMoreParams={{ collection, sortKey: sort, filters, locale }}
     >
       {products.map((product) => (
         <ProductCard

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -122,18 +122,6 @@ async function SearchResultsGridRender({
     );
   }
 
-  const boundLoadMore = async (cursor: string) => {
-    "use server";
-    return loadMoreSearchProducts({
-      query: data.query,
-      collection: data.collection,
-      cursor,
-      sortKey: data.sort,
-      filters: data.filters,
-      locale,
-    });
-  };
-
   return (
     <FilterPendingScope>
       <ProductGridPendingOverlay>
@@ -142,7 +130,14 @@ async function SearchResultsGridRender({
           initialPageInfo={data.pageInfo}
           locale={locale}
           outOfStockText={tProduct("outOfStock")}
-          loadMore={boundLoadMore}
+          loadMore={loadMoreSearchProducts}
+          loadMoreParams={{
+            query: data.query,
+            collection: data.collection,
+            sortKey: data.sort,
+            filters: data.filters,
+            locale,
+          }}
         >
           {products.map((product) => (
             <ProductCard

--- a/packages/plugin/template-rollout-log/2026-05-05-infinite-scroll-cipher-fix.md
+++ b/packages/plugin/template-rollout-log/2026-05-05-infinite-scroll-cipher-fix.md
@@ -1,0 +1,42 @@
+---
+title: Fix /search and /collections infinite scroll — drop inline server action closure
+changeKey: infinite-scroll-cipher-fix
+introducedOn: 2026-05-05
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/collections/infinite-product-grid.tsx
+  - apps/template/components/collections/results-grid.tsx
+  - apps/template/components/search/results.tsx
+---
+
+## Summary
+
+`InfiniteProductGrid` is now generic over its load-more params: it takes a top-level `"use server"` action by reference (`loadMore`) and a serializable `loadMoreParams` prop, and calls `loadMore({ ...loadMoreParams, cursor })` from the client. The two consumers (`SearchResultsGridRender`, collections `Render`) drop their inline `boundLoadMore = async (cursor) => { "use server"; ... }` closures and pass `loadMoreSearchProducts` / `loadMoreCollectionProducts` directly.
+
+## Why it matters
+
+Inline `"use server"` actions defined inside an async server component encrypt their closed-over values into a bound-args blob. On Next.js 16 canary the cipher is failing on /search and /collections — the action returns HTTP 500 with `OperationError: Cipher job failed` underneath. Symptom: infinite scroll silently does nothing (the `try/finally` inside `InfiniteProductGrid` swallows the error). Users only ever see the first page (24 products).
+
+A top-level server action passed as a prop is sent by reference and not subject to closure encryption, so the failure goes away.
+
+## Apply when
+
+- The storefront uses the bundled `InfiniteProductGrid` on `/search` or `/collections/<slug>`.
+
+## Safe to skip when
+
+- The storefront has replaced infinite scroll with cursor-URL pagination, or replaced `InfiniteProductGrid` with a custom client component that doesn't capture closures in a `"use server"` block.
+
+## Notes
+
+- `InfiniteProductGrid` is now `InfiniteProductGrid<TParams>`. Existing callers infer the type from `loadMoreParams`.
+- The action signatures for `loadMoreSearchProducts` / `loadMoreCollectionProducts` are unchanged — they still take a single params object that includes `cursor`. Only the call site moved from server to client.
+
+## Validation
+
+1. `pnpm --filter template lint` and `pnpm --filter template build` clean.
+2. `pnpm --filter template dev`. On `/search` and `/collections/<any>` scroll past the first 24 products — the next page loads in.
+3. `curl` the action endpoint with a cursor and confirm HTTP 200 (no `Cipher job failed`).


### PR DESCRIPTION
## Summary

Infinite scroll on \`/search\` and \`/collections/<slug>\` is silently broken — pages only ever show the first 24 products. The client-side IntersectionObserver fires, but the server action it calls returns HTTP 500. Local dev surfaces the underlying error: \`OperationError: Cipher job failed\` from WebCrypto. The \`try/finally\` inside \`InfiniteProductGrid\` swallows the error, so there's no console warning.

The action being called is an inline \`"use server"\` closure (\`boundLoadMore\` in \`components/search/results.tsx\` and \`components/collections/results-grid.tsx\`) that captures \`data.query\`, \`data.filters\`, etc. Next.js 16 canary encrypts those captured values into a bound-args blob; the cipher is failing at invocation.

This PR drops the inline closure pattern in both places. \`InfiniteProductGrid\` becomes generic over its load-more params: it takes a top-level \`"use server"\` action by reference (\`loadMore\`) and a serializable \`loadMoreParams\` prop, then calls \`loadMore({ ...loadMoreParams, cursor })\` from the client. The action is sent by action ID, not as an encrypted closure — no more cipher.

Verified by hitting the action endpoint with a cursor and confirming HTTP 200 with products + pageInfo where it previously returned 500. Adds a rollout log entry under \`packages/plugin/template-rollout-log/\`.

## Test plan

- [ ] \`pnpm --filter template lint\` and \`pnpm --filter template build\` clean
- [ ] On \`/search\` (no filters), scroll past the first page — second page loads
- [ ] On \`/search?filter.p.vendor=<X>\`, scroll past the first page — second page loads and stays filtered
- [ ] On \`/collections/<slug>\`, scroll past the first page — second page loads
- [ ] Network tab: the load-more request returns 200 (was 500)
- [ ] No console errors during scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)