### PR TITLE
Fix mobile gallery pagination with variant images/videos

### DIFF
--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -95,6 +95,7 @@ function Carousel({
   children?: React.ReactNode;
 }) {
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [itemCount, setItemCount] = useState(mediaItems.length);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const prevMediaRef = useRef<string>("");
   const t = useTranslations("product");
@@ -121,20 +122,30 @@ function Carousel({
     const container = scrollContainerRef.current;
     if (!container) return;
 
-    const syncIndex = () => {
-      const newIndex = Math.min(
-        Math.max(0, Math.round(container.scrollLeft / container.offsetWidth)),
-        mediaItems.length - 1,
-      );
+    // Variant/video items arrive via slot children, so count the rendered DOM, not just mediaItems.
+    const sync = () => {
+      const width = container.offsetWidth;
+      if (width === 0) return;
+      const total = Math.max(1, container.children.length);
+      const newIndex = Math.min(Math.max(0, Math.round(container.scrollLeft / width)), total - 1);
+      setItemCount(total);
       setSelectedIndex(newIndex);
     };
 
-    // Sync indicator from actual scroll position on mount / Activity re-activation
-    syncIndex();
+    sync();
 
-    container.addEventListener("scroll", syncIndex, { passive: true });
-    return () => container.removeEventListener("scroll", syncIndex);
-  }, [mediaItems.length]);
+    container.addEventListener("scroll", sync, { passive: true });
+    const resizeObserver = new ResizeObserver(sync);
+    resizeObserver.observe(container);
+    const mutationObserver = new MutationObserver(sync);
+    mutationObserver.observe(container, { childList: true });
+
+    return () => {
+      container.removeEventListener("scroll", sync);
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, []);
 
   return (
     <div className="grid gap-5">
@@ -174,11 +185,11 @@ function Carousel({
       </div>
 
       {/* Dot indicators – reserve space but hide when there's only one image */}
-      <div className={cn("flex justify-center gap-2", mediaItems.length <= 1 && "invisible")}>
-        {mediaItems.map((item, idx) => (
+      <div className={cn("flex justify-center gap-2", itemCount <= 1 && "invisible")}>
+        {Array.from({ length: itemCount }, (_, idx) => (
           <button
             type="button"
-            key={mediaKey(item)}
+            key={idx}
             onClick={() => scrollToImage(idx)}
             className={cn(
               "h-1.5 rounded-full transition-all",


### PR DESCRIPTION
## Summary
- Mobile product gallery dot indicators were derived from `mediaItems.length` only, ignoring variant/color images injected via the `mobileSlot` Suspense children. As a result, dot count was wrong, dot clicks scrolled to the wrong item, and the active dot was clamped incorrectly when scrolling past the shared-media range.
- Repro: https://template.vercel.shop/products/vellura-interiors-arceau-lounge-chair-srenit-collection-1f4z?variant=57465981960579 (mobile viewport)
- Fix: count the actual rendered items from the carousel DOM via `ResizeObserver` + `MutationObserver`, so dots, scroll targets, and the active index reflect every item including the slot-injected variant images.

## Test plan
- [ ] Open the linked PDP at a mobile width and confirm the dot count matches the visible items (variant image + shared images/videos).
- [ ] Tap each dot and confirm it scrolls to the corresponding item.
- [ ] Swipe through and confirm the active dot tracks the visible item all the way to the last one.
- [ ] Switch color variants and confirm the dot count updates if the variant image set changes.
- [ ] PDP with no variant images (no `mobileSlot`) still paginates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)