### PR TITLE
Narrow PDP gallery variant suspension

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -59,7 +59,7 @@ The gallery is handled by a single `ProductMedia` component that adapts to scree
 
 **Mobile** - A horizontal snap-scroll carousel with dot indicators below. Swiping or tapping a dot navigates between images.
 
-Both layouts receive pre-filtered images as props from the server.
+Both layouts receive pre-filtered images as props from the server. When a URL-selected variant can change the first color image, only that first image position waits on `searchParams`; the gallery streams immediately with the default color images as the Suspense fallback.
 
 ### Color-based image filtering
 

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -1,28 +1,26 @@
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
-import {
-  aspectRatioClasses,
-  type ProductCardAspectRatio,
-} from "@/components/product-card/components";
+import type { ProductCardAspectRatio } from "@/components/product-card/components";
 import { BuyButtons } from "@/components/product-detail/buy-buttons";
 import {
   ProductInfoDescription,
   ProductInfoOptions,
 } from "@/components/product-detail/product-info";
 import {
+  ColorImageCarouselItem,
   ColorImageCarouselItems,
   ColorImageGrid,
+  ColorImageGridItem,
   ProductMedia,
 } from "@/components/product-detail/product-media";
 import { ProductPrice } from "@/components/product-detail/product-price";
 import { ShopLogo } from "@/components/product-detail/shop-logo";
-import { Skeleton } from "@/components/ui/skeleton";
 import type { Locale } from "@/lib/i18n";
 import {
   computeInitialSelectedOptions,
-  getPartitionedImagesForSelectedColor,
-  getSharedImages,
+  getDefaultPartitionedImagesForColor,
+  getPartitionedImagesForVariant,
   hasColorImagePartitioning,
   hasUniformPricing,
   hasUniformStock,
@@ -50,6 +48,9 @@ export async function ProductDetailSection({
   const { handle, title, featuredImage, images, videos, variants, options } = product;
 
   const needsPartitioning = hasColorImagePartitioning(options, variants);
+  const defaultPartitionedImages = needsPartitioning
+    ? getDefaultPartitionedImagesForColor(images, options, variants)
+    : null;
   const uniformPrice = hasUniformPricing(variants);
   const singleVariant = variants.length === 1;
   const uniformStock = hasUniformStock(variants);
@@ -67,69 +68,34 @@ export async function ProductDetailSection({
 
   return (
     <div className="grid gap-10 lg:grid-cols-10 lg:items-start lg:gap-5">
-      {needsPartitioning ? (
+      {needsPartitioning && defaultPartitionedImages ? (
         <ProductMedia
-          otherImages={getSharedImages(images, options, variants)}
+          otherImages={defaultPartitionedImages.otherImages}
           videos={videos}
           title={title}
           aspectRatio={aspectRatio}
           className="lg:col-span-6"
           desktopSlot={
-            <Suspense
-              fallback={
-                <>
-                  <Skeleton
-                    data-aspect-ratio={aspectRatio}
-                    className={cn("w-full rounded-none", aspectRatioClasses)}
-                  />
-                  <Skeleton
-                    data-aspect-ratio={aspectRatio}
-                    className={cn("w-full rounded-none", aspectRatioClasses)}
-                  />
-                  <Skeleton
-                    data-aspect-ratio={aspectRatio}
-                    className={cn("w-full rounded-none", aspectRatioClasses)}
-                  />
-                  <Skeleton
-                    data-aspect-ratio={aspectRatio}
-                    className={cn("w-full rounded-none", aspectRatioClasses)}
-                  />
-                </>
-              }
-            >
-              <ResolvedColorImages
-                images={images}
-                options={options}
-                variants={variants}
-                title={title}
-                aspectRatio={aspectRatio}
-                variantIdPromise={variantIdPromise}
-              />
-            </Suspense>
+            <ColorImages
+              defaultImages={defaultPartitionedImages.colorImages}
+              images={images}
+              options={options}
+              variants={variants}
+              title={title}
+              aspectRatio={aspectRatio}
+              variantIdPromise={variantIdPromise}
+            />
           }
           mobileSlot={
-            <Suspense
-              fallback={
-                <div
-                  data-aspect-ratio={aspectRatio}
-                  className={cn(
-                    "relative shrink-0 w-full snap-start snap-always overflow-hidden",
-                    aspectRatioClasses,
-                  )}
-                >
-                  <Skeleton className="size-full rounded-none" />
-                </div>
-              }
-            >
-              <ResolvedColorCarouselImages
-                images={images}
-                options={options}
-                variants={variants}
-                title={title}
-                aspectRatio={aspectRatio}
-                variantIdPromise={variantIdPromise}
-              />
-            </Suspense>
+            <ColorCarouselImages
+              defaultImages={defaultPartitionedImages.colorImages}
+              images={images}
+              options={options}
+              variants={variants}
+              title={title}
+              aspectRatio={aspectRatio}
+              variantIdPromise={variantIdPromise}
+            />
           }
         />
       ) : (
@@ -320,7 +286,8 @@ async function ResolvedPrice({
   );
 }
 
-async function ResolvedColorImages({
+function ColorImages({
+  defaultImages,
   images,
   options,
   variants,
@@ -328,6 +295,7 @@ async function ResolvedColorImages({
   aspectRatio,
   variantIdPromise,
 }: {
+  defaultImages: ImageType[];
   images: ImageType[];
   options: ProductOption[];
   variants: ProductVariant[];
@@ -335,21 +303,198 @@ async function ResolvedColorImages({
   aspectRatio: ProductCardAspectRatio;
   variantIdPromise: Promise<string | undefined>;
 }) {
-  const variantId = await variantIdPromise;
-  const selectedOptions = computeInitialSelectedOptions(variants, variantId);
-  const { colorImages } = getPartitionedImagesForSelectedColor(
-    images,
-    options,
-    variants,
-    selectedOptions,
+  const [firstImage, ...remainingImages] = defaultImages;
+
+  if (!firstImage) return null;
+
+  return (
+    <>
+      <Suspense
+        fallback={
+          <ColorImageGridItem
+            image={firstImage}
+            title={title}
+            idx={0}
+            aspectRatio={aspectRatio}
+            priority
+            eager={false}
+          />
+        }
+      >
+        <ResolvedFirstColorImage
+          defaultImage={firstImage}
+          images={images}
+          options={options}
+          variants={variants}
+          title={title}
+          aspectRatio={aspectRatio}
+          variantIdPromise={variantIdPromise}
+        />
+      </Suspense>
+      <Suspense
+        fallback={
+          <ColorImageGridTail images={remainingImages} title={title} aspectRatio={aspectRatio} />
+        }
+      >
+        <ResolvedColorImageTail
+          images={images}
+          options={options}
+          variants={variants}
+          title={title}
+          aspectRatio={aspectRatio}
+          variantIdPromise={variantIdPromise}
+        />
+      </Suspense>
+    </>
   );
-
-  if (colorImages.length === 0) return null;
-
-  return <ColorImageGrid images={colorImages} title={title} aspectRatio={aspectRatio} />;
 }
 
-async function ResolvedColorCarouselImages({
+function ColorCarouselImages({
+  defaultImages,
+  images,
+  options,
+  variants,
+  title,
+  aspectRatio,
+  variantIdPromise,
+}: {
+  defaultImages: ImageType[];
+  images: ImageType[];
+  options: ProductOption[];
+  variants: ProductVariant[];
+  title: string;
+  aspectRatio: ProductCardAspectRatio;
+  variantIdPromise: Promise<string | undefined>;
+}) {
+  const [firstImage, ...remainingImages] = defaultImages;
+
+  if (!firstImage) return null;
+
+  return (
+    <>
+      <Suspense
+        fallback={
+          <ColorImageCarouselItem
+            image={firstImage}
+            title={title}
+            idx={0}
+            aspectRatio={aspectRatio}
+            priority
+            eager={false}
+          />
+        }
+      >
+        <ResolvedFirstColorCarouselImage
+          defaultImage={firstImage}
+          images={images}
+          options={options}
+          variants={variants}
+          title={title}
+          aspectRatio={aspectRatio}
+          variantIdPromise={variantIdPromise}
+        />
+      </Suspense>
+      <Suspense
+        fallback={
+          <ColorImageCarouselTail
+            images={remainingImages}
+            title={title}
+            aspectRatio={aspectRatio}
+          />
+        }
+      >
+        <ResolvedColorCarouselImageTail
+          images={images}
+          options={options}
+          variants={variants}
+          title={title}
+          aspectRatio={aspectRatio}
+          variantIdPromise={variantIdPromise}
+        />
+      </Suspense>
+    </>
+  );
+}
+
+function ColorImageGridTail({
+  images,
+  title,
+  aspectRatio,
+}: {
+  images: ImageType[];
+  title: string;
+  aspectRatio: ProductCardAspectRatio;
+}) {
+  return images.map((image, idx) => (
+    <ColorImageGridItem
+      key={image.url}
+      image={image}
+      title={title}
+      idx={idx + 1}
+      aspectRatio={aspectRatio}
+      priority={false}
+      eager={idx === 0}
+    />
+  ));
+}
+
+function ColorImageCarouselTail({
+  images,
+  title,
+  aspectRatio,
+}: {
+  images: ImageType[];
+  title: string;
+  aspectRatio: ProductCardAspectRatio;
+}) {
+  return images.map((image, idx) => (
+    <ColorImageCarouselItem
+      key={image.url}
+      image={image}
+      title={title}
+      idx={idx + 1}
+      aspectRatio={aspectRatio}
+      priority={false}
+      eager={idx === 0}
+    />
+  ));
+}
+
+async function ResolvedFirstColorImage({
+  defaultImage,
+  images,
+  options,
+  variants,
+  title,
+  aspectRatio,
+  variantIdPromise,
+}: {
+  defaultImage: ImageType;
+  images: ImageType[];
+  options: ProductOption[];
+  variants: ProductVariant[];
+  title: string;
+  aspectRatio: ProductCardAspectRatio;
+  variantIdPromise: Promise<string | undefined>;
+}) {
+  const variantId = await variantIdPromise;
+  const image =
+    getPartitionedImagesForVariant(images, options, variants, variantId).colorImages[0] ??
+    defaultImage;
+
+  return (
+    <ColorImageGridItem
+      image={image}
+      title={title}
+      idx={0}
+      aspectRatio={aspectRatio}
+      priority
+      eager={false}
+    />
+  );
+}
+
+async function ResolvedColorImageTail({
   images,
   options,
   variants,
@@ -365,15 +510,72 @@ async function ResolvedColorCarouselImages({
   variantIdPromise: Promise<string | undefined>;
 }) {
   const variantId = await variantIdPromise;
-  const selectedOptions = computeInitialSelectedOptions(variants, variantId);
-  const { colorImages } = getPartitionedImagesForSelectedColor(
+  const tailImages = getPartitionedImagesForVariant(
     images,
     options,
     variants,
-    selectedOptions,
+    variantId,
+  ).colorImages.slice(1);
+
+  return <ColorImageGridTail images={tailImages} title={title} aspectRatio={aspectRatio} />;
+}
+
+async function ResolvedFirstColorCarouselImage({
+  defaultImage,
+  images,
+  options,
+  variants,
+  title,
+  aspectRatio,
+  variantIdPromise,
+}: {
+  defaultImage: ImageType;
+  images: ImageType[];
+  options: ProductOption[];
+  variants: ProductVariant[];
+  title: string;
+  aspectRatio: ProductCardAspectRatio;
+  variantIdPromise: Promise<string | undefined>;
+}) {
+  const variantId = await variantIdPromise;
+  const image =
+    getPartitionedImagesForVariant(images, options, variants, variantId).colorImages[0] ??
+    defaultImage;
+
+  return (
+    <ColorImageCarouselItem
+      image={image}
+      title={title}
+      idx={0}
+      aspectRatio={aspectRatio}
+      priority
+      eager={false}
+    />
   );
+}
 
-  if (colorImages.length === 0) return null;
+async function ResolvedColorCarouselImageTail({
+  images,
+  options,
+  variants,
+  title,
+  aspectRatio,
+  variantIdPromise,
+}: {
+  images: ImageType[];
+  options: ProductOption[];
+  variants: ProductVariant[];
+  title: string;
+  aspectRatio: ProductCardAspectRatio;
+  variantIdPromise: Promise<string | undefined>;
+}) {
+  const variantId = await variantIdPromise;
+  const tailImages = getPartitionedImagesForVariant(
+    images,
+    options,
+    variants,
+    variantId,
+  ).colorImages.slice(1);
 
-  return <ColorImageCarouselItems images={colorImages} title={title} aspectRatio={aspectRatio} />;
+  return <ColorImageCarouselTail images={tailImages} title={title} aspectRatio={aspectRatio} />;
 }

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -289,6 +289,33 @@ function Grid({
  * Renders color-specific images as grid items (desktop).
  * Designed to be used inside a Suspense boundary as children of ProductMedia.
  */
+export function ColorImageGridItem({
+  image,
+  title,
+  idx,
+  aspectRatio,
+  priority,
+  eager,
+}: {
+  image: ImageType;
+  title: string;
+  idx: number;
+  aspectRatio: ProductCardAspectRatio;
+  priority: boolean;
+  eager: boolean;
+}) {
+  return (
+    <GridItem
+      item={{ type: "image", image }}
+      title={title}
+      idx={idx}
+      aspectRatio={aspectRatio}
+      priority={priority}
+      eager={eager}
+    />
+  );
+}
+
 export function ColorImageGrid({
   images,
   title,
@@ -299,9 +326,9 @@ export function ColorImageGrid({
   aspectRatio: ProductCardAspectRatio;
 }) {
   return images.map((image, idx) => (
-    <GridItem
+    <ColorImageGridItem
       key={image.url}
-      item={{ type: "image", image }}
+      image={image}
       title={title}
       idx={idx}
       aspectRatio={aspectRatio}
@@ -315,6 +342,43 @@ export function ColorImageGrid({
  * Renders color-specific images as carousel items (mobile).
  * Matches the Carousel item structure for consistent snap-scroll behavior.
  */
+export function ColorImageCarouselItem({
+  image,
+  title,
+  idx,
+  aspectRatio,
+  priority,
+  eager,
+}: {
+  image: ImageType;
+  title: string;
+  idx: number;
+  aspectRatio: ProductCardAspectRatio;
+  priority: boolean;
+  eager: boolean;
+}) {
+  return (
+    <div
+      data-aspect-ratio={aspectRatio}
+      className={cn(
+        "relative shrink-0 w-full snap-start snap-always overflow-hidden",
+        aspectRatioClasses,
+      )}
+    >
+      <Image
+        src={image.url}
+        alt={image.altText || `${title} image ${idx + 1}`}
+        fill
+        className="object-cover"
+        sizes="100vw"
+        priority={priority}
+        loading={priority || eager ? "eager" : "lazy"}
+        draggable={false}
+      />
+    </div>
+  );
+}
+
 export function ColorImageCarouselItems({
   images,
   title,
@@ -324,31 +388,17 @@ export function ColorImageCarouselItems({
   title: string;
   aspectRatio: ProductCardAspectRatio;
 }) {
-  return images.map((image, idx) => {
-    const priority = idx === 0;
-    const eager = idx === 1;
-    return (
-      <div
-        key={image.url}
-        data-aspect-ratio={aspectRatio}
-        className={cn(
-          "relative shrink-0 w-full snap-start snap-always overflow-hidden",
-          aspectRatioClasses,
-        )}
-      >
-        <Image
-          src={image.url}
-          alt={image.altText || `${title} image ${idx + 1}`}
-          fill
-          className="object-cover"
-          sizes="100vw"
-          priority={priority}
-          loading={priority || eager ? "eager" : "lazy"}
-          draggable={false}
-        />
-      </div>
-    );
-  });
+  return images.map((image, idx) => (
+    <ColorImageCarouselItem
+      key={image.url}
+      image={image}
+      title={title}
+      idx={idx}
+      aspectRatio={aspectRatio}
+      priority={idx === 0}
+      eager={idx === 1}
+    />
+  ));
 }
 
 export function ProductMedia({

--- a/apps/template/lib/product.ts
+++ b/apps/template/lib/product.ts
@@ -162,19 +162,21 @@ export function getImagesForSelectedColor(
   return [...colorImages, ...sharedImages];
 }
 
-export function getPartitionedImagesForSelectedColor(
+function getColorOption(options: ProductOption[]) {
+  return options.find(
+    (opt) =>
+      opt.values.some((v) => v.swatch?.color || v.swatch?.image) ||
+      opt.name.toLowerCase().includes("color"),
+  );
+}
+
+function partitionImagesForSelectedColor(
   images: Image[],
   options: ProductOption[],
   variants: ProductVariant[],
   selectedOptions: SelectedOptions,
 ): { colorImages: Image[]; otherImages: Image[] } {
-  // Find the color option using swatch data (locale-agnostic) first, then
-  // fall back to the English name for stores without swatches configured.
-  const colorOption = options.find(
-    (opt) =>
-      opt.values.some((v) => v.swatch?.color || v.swatch?.image) ||
-      opt.name.toLowerCase().includes("color"),
-  );
+  const colorOption = getColorOption(options);
 
   if (!colorOption) return { colorImages: [], otherImages: images };
 
@@ -208,7 +210,6 @@ export function getPartitionedImagesForSelectedColor(
     }
   }
 
-  // Images shared with the selected color must not be excluded.
   const selectedColorUrls = colorToImageUrls.get(selectedColor);
   if (selectedColorUrls) {
     for (const url of selectedColorUrls) {
@@ -231,18 +232,58 @@ export function getPartitionedImagesForSelectedColor(
     }
   }
 
+  return { colorImages, otherImages };
+}
+
+function promoteVariantImage(
+  colorImages: Image[],
+  variants: ProductVariant[],
+  selectedOptions: SelectedOptions,
+): Image[] {
   const selectedVariant = resolveSelectedVariant(variants, selectedOptions);
   const variantImageUrl = selectedVariant?.image?.url;
 
-  if (variantImageUrl) {
-    const variantIdx = colorImages.findIndex((img) => img.url === variantImageUrl);
-    if (variantIdx > 0) {
-      const [variantImage] = colorImages.splice(variantIdx, 1);
-      colorImages.unshift(variantImage);
-    }
-  }
+  if (!variantImageUrl) return colorImages;
 
-  return { colorImages, otherImages };
+  const variantIdx = colorImages.findIndex((img) => img.url === variantImageUrl);
+  if (variantIdx <= 0) return colorImages;
+
+  const nextImages = [...colorImages];
+  const [variantImage] = nextImages.splice(variantIdx, 1);
+  nextImages.unshift(variantImage);
+  return nextImages;
+}
+
+export function getDefaultPartitionedImagesForColor(
+  images: Image[],
+  options: ProductOption[],
+  variants: ProductVariant[],
+): { colorImages: Image[]; otherImages: Image[] } {
+  const selectedOptions = getInitialSelectedOptions(variants);
+  return partitionImagesForSelectedColor(images, options, variants, selectedOptions);
+}
+
+export function getPartitionedImagesForVariant(
+  images: Image[],
+  options: ProductOption[],
+  variants: ProductVariant[],
+  variantId: string | undefined,
+): { colorImages: Image[]; otherImages: Image[] } {
+  const selectedOptions = computeInitialSelectedOptions(variants, variantId);
+  return getPartitionedImagesForSelectedColor(images, options, variants, selectedOptions);
+}
+
+export function getPartitionedImagesForSelectedColor(
+  images: Image[],
+  options: ProductOption[],
+  variants: ProductVariant[],
+  selectedOptions: SelectedOptions,
+): { colorImages: Image[]; otherImages: Image[] } {
+  const partitioned = partitionImagesForSelectedColor(images, options, variants, selectedOptions);
+  return {
+    colorImages: promoteVariantImage(partitioned.colorImages, variants, selectedOptions),
+    otherImages: partitioned.otherImages,
+  };
 }
 
 /** When true, the price renders without waiting for searchParams to resolve the variant. */
@@ -269,11 +310,7 @@ export function hasColorImagePartitioning(
   options: ProductOption[],
   variants: ProductVariant[],
 ): boolean {
-  const colorOption = options.find(
-    (opt) =>
-      opt.values.some((v) => v.swatch?.color || v.swatch?.image) ||
-      opt.name.toLowerCase().includes("color"),
-  );
+  const colorOption = getColorOption(options);
 
   if (!colorOption || colorOption.values.length <= 1) return false;
 
@@ -288,11 +325,7 @@ export function getSharedImages(
   options: ProductOption[],
   variants: ProductVariant[],
 ): Image[] {
-  const colorOption = options.find(
-    (opt) =>
-      opt.values.some((v) => v.swatch?.color || v.swatch?.image) ||
-      opt.name.toLowerCase().includes("color"),
-  );
+  const colorOption = getColorOption(options);
 
   if (!colorOption || colorOption.values.length <= 1) return images;
 

--- a/packages/plugin/template-rollout-log/2026-05-06-pdp-first-image-suspense.md
+++ b/packages/plugin/template-rollout-log/2026-05-06-pdp-first-image-suspense.md
@@ -1,0 +1,37 @@
+---
+title: PDP gallery narrows variant suspension to the first image
+changeKey: pdp-first-image-suspense
+introducedOn: 2026-05-06
+changeType: refactor
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-detail/product-detail-section.tsx
+  - apps/template/components/product-detail/product-media.tsx
+  - apps/template/lib/product.ts
+---
+
+## Summary
+
+The PDP gallery now renders its default color-partitioned images immediately and narrows `variant` search-param resolution to the first image position that may need to change for a URL-selected variant.
+
+## Why it matters
+
+Color-partitioned PDP galleries no longer put the whole color image slot behind Suspense just to resolve the selected variant image. This keeps the gallery shell and default color images streaming earlier while preserving URL-selected variant image ordering once `searchParams` resolves.
+
+## Apply when
+
+- The storefront uses the template PDP gallery with Shopify variant images assigned by color.
+- PDP navigation or preview performance is sensitive to gallery Suspense boundaries.
+
+## Safe to skip when
+
+- The storefront has replaced the PDP gallery or does not use color-based variant image filtering.
+- The storefront prefers blocking the whole gallery until the URL-selected variant is fully resolved to avoid any first-image swap.
+
+## Validation
+
+1. Run template lint and build.
+2. Open a color-partitioned PDP with a `?variant=` query that changes the first gallery image and confirm the selected variant image still becomes first.
+3. Open a PDP whose variant does not change gallery images and confirm the gallery renders without an all-gallery skeleton wait.


### PR DESCRIPTION
## Summary
- render default color-partitioned PDP gallery images immediately instead of suspending the whole color slot
- resolve URL-selected variant image ordering inside first/tail image Suspense boundaries
- update PDP docs and add rollout guidance for downstream storefronts

## Test plan
- [x] `pnpm --dir apps/template lint` (passes with existing warnings)
- [x] `pnpm --dir apps/template build`
- [x] local smoke check for the Arceau and Kenso PDP URLs returned 200
- [ ] `pnpm --dir apps/docs typecheck` (blocked by existing generated OG route type issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)