### PR TITLE
Reduce PDP color gallery fallback

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -63,7 +63,7 @@ Both layouts receive pre-filtered images as props from the server.
 
 ### Color-based image filtering
 
-When a product has color variants, the gallery shows only images relevant to the selected color. The `getPartitionedImagesForSelectedColor()` function in `lib/product/index.ts`:
+When a product has color variants, the gallery shows only images relevant to the selected color. Shared images render immediately, while the color-specific slot streams behind a small Suspense fallback so changing `?variant` does not skeletonize the whole gallery. The `getPartitionedImagesForSelectedColor()` function in `lib/product/index.ts`:
 
 1. Identifies the color option via swatch data or option name
 2. Collects variant images assigned to each color

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -77,24 +77,10 @@ export async function ProductDetailSection({
           desktopSlot={
             <Suspense
               fallback={
-                <>
-                  <Skeleton
-                    data-aspect-ratio={aspectRatio}
-                    className={cn("w-full rounded-none", aspectRatioClasses)}
-                  />
-                  <Skeleton
-                    data-aspect-ratio={aspectRatio}
-                    className={cn("w-full rounded-none", aspectRatioClasses)}
-                  />
-                  <Skeleton
-                    data-aspect-ratio={aspectRatio}
-                    className={cn("w-full rounded-none", aspectRatioClasses)}
-                  />
-                  <Skeleton
-                    data-aspect-ratio={aspectRatio}
-                    className={cn("w-full rounded-none", aspectRatioClasses)}
-                  />
-                </>
+                <Skeleton
+                  data-aspect-ratio={aspectRatio}
+                  className={cn("w-full rounded-none", aspectRatioClasses)}
+                />
               }
             >
               <ResolvedColorImages

--- a/packages/plugin/template-rollout-log/2026-05-06-pdp-color-gallery-fallback.md
+++ b/packages/plugin/template-rollout-log/2026-05-06-pdp-color-gallery-fallback.md
@@ -1,0 +1,39 @@
+---
+title: PDP color gallery fallback — reduce skeleton to one tile
+changeKey: pdp-color-gallery-fallback
+introducedOn: 2026-05-06
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-detail/product-detail-section.tsx
+  - apps/docs/content/docs/anatomy/pages/pdp.mdx
+---
+
+## Summary
+
+Color-partitioned PDP galleries now render a single desktop skeleton tile while the selected color image slot waits on `searchParams.variant`, matching the existing mobile behavior.
+
+Shared/unassigned gallery media still renders immediately through `ProductMedia`; only the color-specific Suspense slot shows fallback UI.
+
+## Why it matters
+
+- Reduces the visible fallback on variant-image PDPs from a block of desktop gallery skeletons to the first dynamic image slot.
+- Keeps the existing server-rendered `?variant=` navigation model without introducing variant-specific PDP routing.
+
+## Apply when
+
+- The storefront uses the template PDP gallery with color-based image partitioning.
+- Users see multiple desktop gallery skeletons when opening a product URL with `?variant=`.
+
+## Safe to skip when
+
+- The storefront replaced `ProductMedia` or the color-partitioned gallery with a custom implementation.
+- The custom gallery already limits search-param fallback UI to the dynamic image slot.
+
+## Validation
+
+1. Open a color-partitioned PDP with a `?variant=` query parameter on desktop and confirm only one gallery skeleton tile is visible before the color-specific media streams in.
+2. Open the same PDP on mobile and confirm the carousel fallback remains one slide.
+3. Open a PDP without color partitioning and confirm all gallery images render without this fallback path.


### PR DESCRIPTION
## Summary
- Limit the desktop color-partitioned PDP gallery fallback to one skeleton tile while `searchParams.variant` resolves
- Document that shared media renders immediately and only the color-specific slot streams behind fallback
- Add a template rollout log entry for downstream storefront adoption

## Test plan
- [x] `pnpm --filter template lint` (passes with existing react-hooks warnings)
- [ ] Manually verify a color-partitioned PDP on desktop shows one gallery skeleton tile before color media streams in
- [ ] Manually verify mobile fallback remains one carousel slide

🤖 Generated with [Claude Code](https://claude.com/claude-code)