### PR TITLE
Split PDP color gallery fallback

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -63,7 +63,7 @@ Both layouts receive pre-filtered images as props from the server.
 
 ### Color-based image filtering
 
-When a product has color variants, the gallery shows only images relevant to the selected color. The `getPartitionedImagesForSelectedColor()` function in `lib/product/index.ts`:
+When a product has color variants, the gallery shows only images relevant to the selected color. Shared images render immediately, the first selected-color image uses a small Suspense fallback while `?variant` resolves, and the rest of the selected-color media streams in without additional skeletons. The `getPartitionedImagesForSelectedColor()` function in `lib/product/index.ts`:
 
 1. Identifies the color option via swatch data or option name
 2. Collects variant images assigned to each color

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -75,61 +75,75 @@ export async function ProductDetailSection({
           aspectRatio={aspectRatio}
           className="lg:col-span-6"
           desktopSlot={
-            <Suspense
-              fallback={
-                <>
+            <>
+              <Suspense
+                fallback={
                   <Skeleton
                     data-aspect-ratio={aspectRatio}
                     className={cn("w-full rounded-none", aspectRatioClasses)}
                   />
-                  <Skeleton
-                    data-aspect-ratio={aspectRatio}
-                    className={cn("w-full rounded-none", aspectRatioClasses)}
-                  />
-                  <Skeleton
-                    data-aspect-ratio={aspectRatio}
-                    className={cn("w-full rounded-none", aspectRatioClasses)}
-                  />
-                  <Skeleton
-                    data-aspect-ratio={aspectRatio}
-                    className={cn("w-full rounded-none", aspectRatioClasses)}
-                  />
-                </>
-              }
-            >
-              <ResolvedColorImages
-                images={images}
-                options={options}
-                variants={variants}
-                title={title}
-                aspectRatio={aspectRatio}
-                variantIdPromise={variantIdPromise}
-              />
-            </Suspense>
+                }
+              >
+                <ResolvedColorImages
+                  images={images}
+                  options={options}
+                  variants={variants}
+                  title={title}
+                  aspectRatio={aspectRatio}
+                  variantIdPromise={variantIdPromise}
+                  mode="first"
+                />
+              </Suspense>
+              <Suspense>
+                <ResolvedColorImages
+                  images={images}
+                  options={options}
+                  variants={variants}
+                  title={title}
+                  aspectRatio={aspectRatio}
+                  variantIdPromise={variantIdPromise}
+                  mode="rest"
+                />
+              </Suspense>
+            </>
           }
           mobileSlot={
-            <Suspense
-              fallback={
-                <div
-                  data-aspect-ratio={aspectRatio}
-                  className={cn(
-                    "relative shrink-0 w-full snap-start snap-always overflow-hidden",
-                    aspectRatioClasses,
-                  )}
-                >
-                  <Skeleton className="size-full rounded-none" />
-                </div>
-              }
-            >
-              <ResolvedColorCarouselImages
-                images={images}
-                options={options}
-                variants={variants}
-                title={title}
-                aspectRatio={aspectRatio}
-                variantIdPromise={variantIdPromise}
-              />
-            </Suspense>
+            <>
+              <Suspense
+                fallback={
+                  <div
+                    data-aspect-ratio={aspectRatio}
+                    className={cn(
+                      "relative shrink-0 w-full snap-start snap-always overflow-hidden",
+                      aspectRatioClasses,
+                    )}
+                  >
+                    <Skeleton className="size-full rounded-none" />
+                  </div>
+                }
+              >
+                <ResolvedColorCarouselImages
+                  images={images}
+                  options={options}
+                  variants={variants}
+                  title={title}
+                  aspectRatio={aspectRatio}
+                  variantIdPromise={variantIdPromise}
+                  mode="first"
+                />
+              </Suspense>
+              <Suspense>
+                <ResolvedColorCarouselImages
+                  images={images}
+                  options={options}
+                  variants={variants}
+                  title={title}
+                  aspectRatio={aspectRatio}
+                  variantIdPromise={variantIdPromise}
+                  mode="rest"
+                />
+              </Suspense>
+            </>
           }
         />
       ) : (
@@ -327,6 +341,7 @@ async function ResolvedColorImages({
   title,
   aspectRatio,
   variantIdPromise,
+  mode,
 }: {
   images: ImageType[];
   options: ProductOption[];
@@ -334,6 +349,7 @@ async function ResolvedColorImages({
   title: string;
   aspectRatio: ProductCardAspectRatio;
   variantIdPromise: Promise<string | undefined>;
+  mode: "first" | "rest";
 }) {
   const variantId = await variantIdPromise;
   const selectedOptions = computeInitialSelectedOptions(variants, variantId);
@@ -343,10 +359,19 @@ async function ResolvedColorImages({
     variants,
     selectedOptions,
   );
+  const visibleImages = mode === "first" ? colorImages.slice(0, 1) : colorImages.slice(1);
+  const startIndex = mode === "first" ? 0 : 1;
 
-  if (colorImages.length === 0) return null;
+  if (visibleImages.length === 0) return null;
 
-  return <ColorImageGrid images={colorImages} title={title} aspectRatio={aspectRatio} />;
+  return (
+    <ColorImageGrid
+      images={visibleImages}
+      title={title}
+      aspectRatio={aspectRatio}
+      startIndex={startIndex}
+    />
+  );
 }
 
 async function ResolvedColorCarouselImages({
@@ -356,6 +381,7 @@ async function ResolvedColorCarouselImages({
   title,
   aspectRatio,
   variantIdPromise,
+  mode,
 }: {
   images: ImageType[];
   options: ProductOption[];
@@ -363,6 +389,7 @@ async function ResolvedColorCarouselImages({
   title: string;
   aspectRatio: ProductCardAspectRatio;
   variantIdPromise: Promise<string | undefined>;
+  mode: "first" | "rest";
 }) {
   const variantId = await variantIdPromise;
   const selectedOptions = computeInitialSelectedOptions(variants, variantId);
@@ -372,8 +399,17 @@ async function ResolvedColorCarouselImages({
     variants,
     selectedOptions,
   );
+  const visibleImages = mode === "first" ? colorImages.slice(0, 1) : colorImages.slice(1);
+  const startIndex = mode === "first" ? 0 : 1;
 
-  if (colorImages.length === 0) return null;
+  if (visibleImages.length === 0) return null;
 
-  return <ColorImageCarouselItems images={colorImages} title={title} aspectRatio={aspectRatio} />;
+  return (
+    <ColorImageCarouselItems
+      images={visibleImages}
+      title={title}
+      aspectRatio={aspectRatio}
+      startIndex={startIndex}
+    />
+  );
 }

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -293,22 +293,27 @@ export function ColorImageGrid({
   images,
   title,
   aspectRatio,
+  startIndex = 0,
 }: {
   images: ImageType[];
   title: string;
   aspectRatio: ProductCardAspectRatio;
+  startIndex?: number;
 }) {
-  return images.map((image, idx) => (
-    <GridItem
-      key={image.url}
-      item={{ type: "image", image }}
-      title={title}
-      idx={idx}
-      aspectRatio={aspectRatio}
-      priority={idx === 0}
-      eager={idx === 1}
-    />
-  ));
+  return images.map((image, idx) => {
+    const itemIndex = startIndex + idx;
+    return (
+      <GridItem
+        key={image.url}
+        item={{ type: "image", image }}
+        title={title}
+        idx={itemIndex}
+        aspectRatio={aspectRatio}
+        priority={itemIndex === 0}
+        eager={itemIndex === 1}
+      />
+    );
+  });
 }
 
 /**
@@ -319,14 +324,17 @@ export function ColorImageCarouselItems({
   images,
   title,
   aspectRatio,
+  startIndex = 0,
 }: {
   images: ImageType[];
   title: string;
   aspectRatio: ProductCardAspectRatio;
+  startIndex?: number;
 }) {
   return images.map((image, idx) => {
-    const priority = idx === 0;
-    const eager = idx === 1;
+    const itemIndex = startIndex + idx;
+    const priority = itemIndex === 0;
+    const eager = itemIndex === 1;
     return (
       <div
         key={image.url}
@@ -338,7 +346,7 @@ export function ColorImageCarouselItems({
       >
         <Image
           src={image.url}
-          alt={image.altText || `${title} image ${idx + 1}`}
+          alt={image.altText || `${title} image ${itemIndex + 1}`}
           fill
           className="object-cover"
           sizes="100vw"

--- a/packages/plugin/template-rollout-log/2026-05-07-pdp-split-color-gallery-fallback.md
+++ b/packages/plugin/template-rollout-log/2026-05-07-pdp-split-color-gallery-fallback.md
@@ -1,0 +1,46 @@
+---
+title: PDP color gallery fallback — split first image from remaining media
+changeKey: pdp-split-color-gallery-fallback
+introducedOn: 2026-05-07
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-detail/product-detail-section.tsx
+  - apps/template/components/product-detail/product-media.tsx
+  - apps/docs/content/docs/anatomy/pages/pdp.mdx
+---
+
+## Summary
+
+Color-partitioned PDP galleries now split the selected-color media into two Suspense slots: the first image slot renders a single skeleton while `searchParams.variant` resolves, and the remaining selected-color media streams with no visible fallback.
+
+Shared/unassigned media still renders immediately through `ProductMedia`.
+
+## Why it matters
+
+- Limits visible fallback UI to the dynamic first selected-variant image slot.
+- Avoids showing skeleton placeholders for later selected-color images that are not immediate LCP candidates.
+- Keeps the server-rendered `?variant=` navigation model without introducing variant-specific PDP routing.
+
+## Apply when
+
+- The storefront uses the template PDP gallery with color-based image partitioning.
+- Users see multiple desktop gallery skeletons when opening a product URL with `?variant=`.
+
+## Safe to skip when
+
+- The storefront replaced `ProductMedia` or the color-partitioned gallery with a custom implementation.
+- The custom gallery already separates the first variant-dependent media slot from the rest of the gallery.
+
+## Notes
+
+- `ColorImageGrid` and `ColorImageCarouselItems` now accept an optional `startIndex` so split rendering preserves image alt text, priority, and eager-loading semantics.
+
+## Validation
+
+1. Open a color-partitioned PDP with a `?variant=` query parameter on desktop and confirm only one gallery skeleton tile is visible before the first selected-color image streams in.
+2. Confirm the remaining selected-color images appear after resolution without their own skeleton placeholders.
+3. Open the same PDP on mobile and confirm the carousel fallback remains one slide.
+4. Open a PDP without color partitioning and confirm all gallery images render without this fallback path.


### PR DESCRIPTION
## Summary
- Split color-partitioned PDP gallery media into first-image and remaining-media Suspense slots
- Keep a visible fallback only for the first selected-color image while remaining selected-color media streams without skeletons
- Preserve image priority/eager semantics across the split with `startIndex`
- Update PDP docs and add a rollout log entry for downstream adoption

## Test plan
- [x] `pnpm --filter template lint` (passes with existing react-hooks warnings)
- [x] `pnpm --filter template build`
- [ ] Manually verify a color-partitioned PDP on desktop shows one gallery skeleton tile for the first selected-color image
- [ ] Manually verify remaining selected-color media appears without additional skeleton placeholders
- [ ] Manually verify mobile fallback remains one carousel slide

Alternate to #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)