### PR TITLE
Scope Shopify caching by query cardinality

### DIFF
--- a/apps/docs/content/docs/reference/storefront-api.mdx
+++ b/apps/docs/content/docs/reference/storefront-api.mdx
@@ -92,7 +92,7 @@ import { PRODUCT_FRAGMENT } from "../fragments";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 
 export async function getProduct(handle: string, locale: string = defaultLocale) {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("products", `product-${handle}`);
 
@@ -112,14 +112,14 @@ export async function getProduct(handle: string, locale: string = defaultLocale)
 
 Key elements:
 
-1. **`"use cache: remote"`** - opts the function into Next.js request-level caching
+1. **`"use cache"`** - uses the local Next.js cache for stable, low-cardinality reads
 2. **`cacheLife("max")`** - caches indefinitely until manually revalidated
 3. **`cacheTag(...)`** - assigns tags for granular invalidation via `revalidateTag()`
 4. **Transform** - convert the Shopify response to a domain type before returning. Components never import Shopify types directly.
 
 ## Caching
 
-All read operations use `"use cache: remote"` with `cacheLife("max")` and one or more cache tags. Tags follow a hierarchy:
+Read operations use `"use cache"` with `cacheLife("max")` and one or more cache tags when their inputs are stable, such as product detail, collection, menu, sitemap, and recommendation queries. High-cardinality operations that depend on search, filters, sort, or cursors use `"use cache: remote"` instead. Tags follow a hierarchy:
 
 | Tag pattern | Scope |
 |-------------|-------|

--- a/apps/docs/content/docs/shopify/writing-shopify-queries.mdx
+++ b/apps/docs/content/docs/shopify/writing-shopify-queries.mdx
@@ -74,7 +74,7 @@ import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import { shopifyFetch } from "../client";
 
 export async function getPrivacyPolicy(locale: string = defaultLocale) {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("policies");
 
@@ -93,9 +93,10 @@ export async function getPrivacyPolicy(locale: string = defaultLocale) {
 
 Key points:
 
-- **`"use cache: remote"`** enables Next.js caching for the function
+- **`"use cache"`** uses the local Next.js cache for stable, low-cardinality reads
 - **`cacheLife("max")`** caches until you manually invalidate
 - **`cacheTag("policies")`** lets you invalidate with `revalidateTag("policies")` later
+- Use `"use cache: remote"` instead for high-cardinality reads that depend on search, filters, sort, or cursors
 - Always pass `locale` and extract `country`/`language` from it
 
 ## 5. Add a transform (if needed)
@@ -175,7 +176,7 @@ Expose mutations to the client through server actions in `components/cart/action
 - [ ] Operation name in the query string matches the `operation` parameter
 - [ ] Variables passed as an object, never interpolated into the query
 - [ ] `@inContext` directive included if data is locale-sensitive
-- [ ] `"use cache: remote"`, `cacheLife`, and `cacheTag` set for read operations
+- [ ] `"use cache"` or `"use cache: remote"`, `cacheLife`, and `cacheTag` set for read operations
 - [ ] Transform added if the Shopify response shape needs mapping
 - [ ] Components import domain types from `lib/types`, not Shopify response types
 - [ ] Cart mutations call `invalidateCartCache()`

--- a/apps/docs/content/docs/skills/enable-shopify-cms.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-cms.mdx
@@ -66,7 +66,7 @@ import { shopifyFetch } from "@/lib/shopify/client";
 import type { Homepage, MarketingPage } from "@/lib/types";
 
 export async function getHomepage(locale: string): Promise<Homepage | null> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cms-content");
   // Query cms_homepage metaobject, transform to Homepage type
@@ -76,7 +76,7 @@ export async function getMarketingPage(
   slug: string,
   locale: string,
 ): Promise<MarketingPage | null> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cms-content");
   // Query cms_page metaobject by slug, transform to MarketingPage type
@@ -85,7 +85,7 @@ export async function getMarketingPage(
 export async function getAllMarketingPageSlugs(): Promise<
   Array<{ slug: string; updatedAt: string }>
 > {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cms-content");
   // Query all cms_page metaobjects, return slugs

--- a/apps/docs/content/docs/skills/enable-shopify-menus.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-menus.mdx
@@ -76,13 +76,13 @@ const items = menu?.items ?? footerItems;
 
 Replace `"FOOTER_HANDLE"` with the handle the user provided. `FooterMenu` already accepts `MenuItem[]`. Keep the `footerItems` import as the fallback.
 
-The `Footer` callsite in `app/layout.tsx` (or wherever it is rendered) already passes `locale`; if it is not wrapped in `<Suspense>`, the menu fetch will block layout render — that is acceptable since `getMenu` is cached with `"use cache: remote"` and `cacheLife("max")`. Wrap in `<Suspense>` only if you specifically want the rest of the page to stream ahead of the footer.
+The `Footer` callsite in `app/layout.tsx` (or wherever it is rendered) already passes `locale`; if it is not wrapped in `<Suspense>`, the menu fetch will block layout render — that is acceptable since `getMenu` is cached with `"use cache"` and `cacheLife("max")`. Wrap in `<Suspense>` only if you specifically want the rest of the page to stream ahead of the footer.
 
 ---
 
 ## Guardrails
 
-- The `getMenu()` operation in `lib/shopify/operations/menu.ts` already handles caching (`"use cache: remote"`, `cacheTag("menus")`) and URL transformation. Do not duplicate that logic.
+- The `getMenu()` operation in `lib/shopify/operations/menu.ts` already handles caching (`"use cache"`, `cacheTag("menus")`) and URL transformation. Do not duplicate that logic.
 - Always preserve the `navItems` / `footerItems` fallback so a missing or empty Shopify menu doesn't leave the user with a blank nav or footer.
 - External links (URLs starting with `http`) are handled by the existing `MenuLink` helpers in each component — no change needed.
 

--- a/apps/template/lib/shopify/operations/collections.ts
+++ b/apps/template/lib/shopify/operations/collections.ts
@@ -22,7 +22,7 @@ export async function getCollections({
   limit = 250,
   locale = defaultLocale,
 }: { limit?: number; locale?: string } = {}): Promise<Collection[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("collections");
 
@@ -66,7 +66,7 @@ export async function getCollection(
   handle: string,
   locale: string = defaultLocale,
 ): Promise<Collection | undefined> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("collections", `collection-${handle}`);
 

--- a/apps/template/lib/shopify/operations/menu.ts
+++ b/apps/template/lib/shopify/operations/menu.ts
@@ -87,7 +87,7 @@ export async function getMenu(
   handle: string,
   _locale: string = defaultLocale,
 ): Promise<Menu | null> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("menus");
 

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -38,7 +38,7 @@ const GET_PRODUCT_BY_HANDLE_QUERY = `
 `;
 
 export async function getProduct(handle: string, locale: string = defaultLocale) {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("products", `product-${handle}`);
   const country = getCountryCode(locale);
@@ -311,32 +311,33 @@ export function buildProductFiltersFromParams(
   return filters;
 }
 
-export async function getCatalogProducts(params: {
+type CatalogProductsResult = {
+  products: ProductCard[];
+  pageInfo: PageInfo;
+};
+
+type CatalogProductsParams = {
+  limit?: number;
+  locale?: string;
+};
+
+type FilteredCatalogProductsParams = CatalogProductsParams & {
   query?: string;
   collection?: string;
   sortKey?: string;
-  limit?: number;
   cursor?: string;
   filters?: ProductFilter[];
-  locale?: string;
-}): Promise<{
-  products: ProductCard[];
-  pageInfo: PageInfo;
-}> {
-  "use cache: remote";
-  cacheLife("max");
-  cacheTag("products");
+};
 
-  const {
-    query,
-    collection,
-    sortKey: rawSortKey = "best-matches",
-    limit = 50,
-    cursor,
-    filters = [],
-    locale = defaultLocale,
-  } = params;
-
+async function fetchCatalogProducts({
+  query,
+  collection,
+  sortKey: rawSortKey = "best-matches",
+  limit = 50,
+  cursor,
+  filters = [],
+  locale = defaultLocale,
+}: FilteredCatalogProductsParams): Promise<CatalogProductsResult> {
   const sortConfig = CATALOG_SORT_KEY_MAP[rawSortKey] ?? CATALOG_SORT_KEY_MAP["best-matches"];
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
@@ -375,6 +376,26 @@ export async function getCatalogProducts(params: {
     products: shopifyProducts.map(transformShopifyProductCard),
     pageInfo: data.products.pageInfo,
   };
+}
+
+export async function getCatalogProducts(
+  params: CatalogProductsParams,
+): Promise<CatalogProductsResult> {
+  "use cache";
+  cacheLife("max");
+  cacheTag("products");
+
+  return fetchCatalogProducts(params);
+}
+
+export async function getFilteredCatalogProducts(
+  params: FilteredCatalogProductsParams,
+): Promise<CatalogProductsResult> {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("products");
+
+  return fetchCatalogProducts(params);
 }
 
 export async function getSearchFacets(params: {
@@ -630,7 +651,7 @@ export async function getProductRecommendations(
   handle: string,
   locale: string = defaultLocale,
 ): Promise<ProductCard[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("products", `recommendations-${handle}`);
 
@@ -703,7 +724,7 @@ export async function getProductById(
   id: string,
   locale: string = defaultLocale,
 ): Promise<ProductDetails> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("products", `product-id-${id}`);
 
@@ -732,7 +753,7 @@ export async function getProductsByIds(
   ids: string[],
   locale: string = defaultLocale,
 ): Promise<ProductCard[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("products");
 
@@ -762,7 +783,7 @@ export async function getProductsByHandles(
   handles: string[],
   locale: string = defaultLocale,
 ): Promise<ProductCard[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("products");
 

--- a/apps/template/lib/shopify/operations/sitemap.ts
+++ b/apps/template/lib/shopify/operations/sitemap.ts
@@ -35,7 +35,7 @@ const GET_PRODUCT_HANDLES_QUERY = `
 const PAGE_SIZE = 250;
 
 export async function getAllProductHandles(): Promise<ProductHandleNode[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("products");
 

--- a/packages/plugin/skills/enable-shopify-cms/SKILL.md
+++ b/packages/plugin/skills/enable-shopify-cms/SKILL.md
@@ -55,7 +55,7 @@ import { shopifyFetch } from "@/lib/shopify/client";
 import type { Homepage, MarketingPage } from "@/lib/types";
 
 export async function getHomepage(locale: string): Promise<Homepage | null> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cms-content");
   // Query cms_homepage metaobject, transform to Homepage type
@@ -65,7 +65,7 @@ export async function getMarketingPage(
   slug: string,
   locale: string,
 ): Promise<MarketingPage | null> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cms-content");
   // Query cms_page metaobject by slug, transform to MarketingPage type
@@ -74,7 +74,7 @@ export async function getMarketingPage(
 export async function getAllMarketingPageSlugs(): Promise<
   Array<{ slug: string; updatedAt: string }>
 > {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cms-content");
   // Query all cms_page metaobjects, return slugs

--- a/packages/plugin/skills/enable-shopify-menus/SKILL.md
+++ b/packages/plugin/skills/enable-shopify-menus/SKILL.md
@@ -65,12 +65,12 @@ const items = menu?.items ?? footerItems;
 
 Replace `"FOOTER_HANDLE"` with the handle the user provided. `FooterMenu` already accepts `MenuItem[]`. Keep the `footerItems` import as the fallback.
 
-The `Footer` callsite in `app/layout.tsx` (or wherever it is rendered) already passes `locale`; if it is not wrapped in `<Suspense>`, the menu fetch will block layout render — that is acceptable since `getMenu` is cached with `"use cache: remote"` and `cacheLife("max")`. Wrap in `<Suspense>` only if you specifically want the rest of the page to stream ahead of the footer.
+The `Footer` callsite in `app/layout.tsx` (or wherever it is rendered) already passes `locale`; if it is not wrapped in `<Suspense>`, the menu fetch will block layout render — that is acceptable since `getMenu` is cached with `"use cache"` and `cacheLife("max")`. Wrap in `<Suspense>` only if you specifically want the rest of the page to stream ahead of the footer.
 
 ---
 
 ## Guardrails
 
-- The `getMenu()` operation in `lib/shopify/operations/menu.ts` already handles caching (`"use cache: remote"`, `cacheTag("menus")`) and URL transformation. Do not duplicate that logic.
+- The `getMenu()` operation in `lib/shopify/operations/menu.ts` already handles caching (`"use cache"`, `cacheTag("menus")`) and URL transformation. Do not duplicate that logic.
 - Always preserve the `navItems` / `footerItems` fallback so a missing or empty Shopify menu doesn't leave the user with a blank nav or footer.
 - External links (URLs starting with `http`) are handled by the existing `MenuLink` helpers in each component — no change needed.

--- a/packages/plugin/skills/shopify-graphql-reference/SKILL.md
+++ b/packages/plugin/skills/shopify-graphql-reference/SKILL.md
@@ -51,7 +51,8 @@ Use this skill as the reference source for Shopify GraphQL work in the template.
 
 ### 5. Apply cache rules to reads
 
-- Read operations should include `"use cache: remote"`, `cacheLife(...)`, and `cacheTag(...)`.
+- Stable, low-cardinality reads should include `"use cache"`, `cacheLife(...)`, and `cacheTag(...)`.
+- High-cardinality reads that depend on search, filters, sort, or cursors should use `"use cache: remote"` instead.
 - Pick existing cache tags when the data belongs to an established surface.
 - Mutations should not use read-cache directives.
 - Every cart mutation must call `invalidateCartCache()` after the write succeeds.
@@ -88,7 +89,7 @@ Use this skill as the reference source for Shopify GraphQL work in the template.
 ### Add a new read operation
 
 1. Define the GraphQL query using existing fragments where possible.
-2. Add `"use cache: remote"`, `cacheLife(...)`, and `cacheTag(...)`.
+2. Add `"use cache"`, `cacheLife(...)`, and `cacheTag(...)`; use `"use cache: remote"` for search/filter/sort/cursor reads.
 3. Call `shopifyFetch` with the query and variables object.
 4. Transform the response before returning it.
 

--- a/packages/plugin/skills/shopify-graphql-reference/references/REFERENCE.md
+++ b/packages/plugin/skills/shopify-graphql-reference/references/REFERENCE.md
@@ -28,7 +28,7 @@ import { PRODUCT_FRAGMENT } from "@/lib/shopify/fragments";
 import { transformShopifyProductDetails } from "@/lib/shopify/transforms/product";
 
 export async function getProduct(handle: string, locale: string) {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("products");
 
@@ -99,7 +99,7 @@ const products = flattenEdges(data.collection.products);
 ## Guardrails
 
 - Always verify fields against the live schema with `shopify-ai-toolkit`.
-- Read operations need `"use cache: remote"`, `cacheLife(...)`, and `cacheTag(...)`.
+- Stable, low-cardinality reads need `"use cache"`, `cacheLife(...)`, and `cacheTag(...)`; use `"use cache: remote"` for search/filter/sort/cursor reads.
 - Use `PRODUCT_CARD_FRAGMENT` for listings and `PRODUCT_FRAGMENT` for PDP work unless you have a clear reason not to.
 - Transform Shopify responses to domain types before returning them from operations.
 - Cart mutations must call `invalidateCartCache()`.
@@ -116,7 +116,7 @@ const products = flattenEdges(data.collection.products);
 ### Write a new read operation
 
 1. Define the GraphQL query using existing fragments where possible.
-2. Add `"use cache: remote"`, `cacheLife(...)`, and `cacheTag(...)`.
+2. Add `"use cache"`, `cacheLife(...)`, and `cacheTag(...)`; use `"use cache: remote"` for search/filter/sort/cursor reads.
 3. Call `shopifyFetch` with the query and variables object.
 4. Transform the response before returning it.
 

--- a/packages/plugin/template-rollout-log/2026-05-06-shopify-static-cache-scope.md
+++ b/packages/plugin/template-rollout-log/2026-05-06-shopify-static-cache-scope.md
@@ -1,0 +1,39 @@
+---
+title: Shopify static reads — use local cache unless query shape is high-cardinality
+changeKey: shopify-static-cache-scope
+introducedOn: 2026-05-06
+changeType: refactor
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/shopify/operations/products.ts
+  - apps/template/lib/shopify/operations/collections.ts
+  - apps/template/lib/shopify/operations/menu.ts
+  - apps/template/lib/shopify/operations/sitemap.ts
+---
+
+## Summary
+
+Stable Shopify read operations now use vanilla `"use cache"` with `cacheLife("max")` and existing cache tags instead of `"use cache: remote"`. Search/filter/sort/cursor product flows remain on `"use cache: remote"`, and catalog products are split into `getCatalogProducts()` for static browse calls and `getFilteredCatalogProducts()` for high-cardinality filtered calls.
+
+## Why it matters
+
+- Static PDP, PLP, menu, sitemap, collection, recommendation, and batch product reads behave like ISR-style cache entries without relying on the remote runtime cache.
+- Filtered catalog requests keep using the remote cache path because their query, filter, sort, and cursor combinations can create many distinct cache entries.
+
+## Apply when
+
+- The storefront has Shopify operations with stable inputs such as product handle, collection handle, locale, or a small fixed limit.
+- Catalog browse calls do not pass query, collection, sort, cursor, or filter params.
+
+## Safe to skip when
+
+- An operation depends on request-time search params, arbitrary filters, sort options, or pagination cursors.
+- The storefront intentionally wants a high-cardinality operation stored in the Vercel Runtime Cache.
+
+## Validation
+
+1. Run `pnpm --filter template lint`.
+2. Run `pnpm --filter template build`.
+3. Check filtered/search surfaces still call the remote-cache operation path when they pass high-cardinality params.


### PR DESCRIPTION
## Summary
- Move stable Shopify reads to vanilla `use cache` while keeping cache tags and `cacheLife("max")` intact
- Split catalog products into a static browse path and a remote-cache filtered path for search/filter/sort/cursor inputs
- Update docs, skills, and rollout guidance to explain when to use local vs remote cache

## Test plan
- [x] `pnpm --filter template lint` (passes with existing hook warnings)
- [x] `pnpm --filter template build`
- [x] `pnpm --filter docs build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)