### PR TITLE
Fix PDP recommendations fallback skeleton

### DIFF
--- a/apps/template/components/product-detail/product-detail-page.tsx
+++ b/apps/template/components/product-detail/product-detail-page.tsx
@@ -5,7 +5,10 @@ import {
   type ProductCardAspectRatio,
 } from "@/components/product-card/components";
 import { ProductSchema } from "@/components/product-detail/schema";
-import { RelatedProductsSection } from "@/components/product/related-products-section";
+import {
+  RelatedProductsSection,
+  RelatedProductsSectionSkeleton,
+} from "@/components/product/related-products-section";
 import { BreadcrumbSchema } from "@/components/schema/breadcrumb-schema";
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
@@ -51,6 +54,7 @@ function ProductPageFallback({ aspectRatio }: { aspectRatio: ProductCardAspectRa
           <Skeleton className="h-32 w-full" />
         </div>
       </div>
+      <RelatedProductsSectionSkeleton />
     </Sections>
   );
 }

--- a/apps/template/components/product/related-products-section.tsx
+++ b/apps/template/components/product/related-products-section.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import type { ProductCardAspectRatio } from "@/components/product-card/components";
 import { ProductCardSkeleton } from "@/components/product-card/product-card";
 import { ProductsSlider } from "@/components/product/products-slider";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { Locale } from "@/lib/i18n";
 import { getProductRecommendations } from "@/lib/shopify/operations/products";
 
@@ -11,13 +12,17 @@ export function RelatedProductsSectionSkeleton({
   title,
   aspectRatio = "square",
 }: {
-  title: string;
+  title?: string;
   aspectRatio?: ProductCardAspectRatio;
 }) {
   return (
     <div className="overflow-x-clip">
       <div className="mx-auto min-w-0 grid gap-4">
-        <h2 className="text-2xl sm:text-3xl font-semibold tracking-tighter">{title}</h2>
+        {title ? (
+          <h2 className="text-2xl sm:text-3xl font-semibold tracking-tighter">{title}</h2>
+        ) : (
+          <Skeleton className="h-9 w-48" />
+        )}
         <div className="grid grid-flow-col gap-5 relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen max-w-none auto-cols-[58.33vw] px-5 sm:left-auto sm:right-auto sm:mx-0 sm:w-full sm:max-w-full sm:auto-cols-[calc((100%-1rem)/2)] sm:px-0 lg:auto-cols-[calc((100%-2rem)/3)] xl:auto-cols-[calc((100%-3rem)/4)]">
           {["a", "b", "c", "d"].map((key) => (
             <ProductCardSkeleton key={key} aspectRatio={aspectRatio} />

--- a/packages/plugin/template-rollout-log/2026-05-09-pdp-recommendations-fallback.md
+++ b/packages/plugin/template-rollout-log/2026-05-09-pdp-recommendations-fallback.md
@@ -1,0 +1,39 @@
+---
+title: Add recommended products skeleton to PDP fallback
+changeKey: pdp-recommendations-fallback
+introducedOn: 2026-05-09
+changeType: fix
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-detail/product-detail-page.tsx
+  - apps/template/components/product/related-products-section.tsx
+---
+
+## Summary
+
+The product detail page fallback now reserves space for the recommended products section while the PDP content is suspended.
+
+## Why it matters
+
+The real PDP renders product details followed by recommended products. The previous top-level fallback only covered the product media/details area, so the page could shift when recommendations streamed in.
+
+## Migration in this PR
+
+- `ProductPageFallback` renders `RelatedProductsSectionSkeleton` after the product detail skeleton.
+- `RelatedProductsSectionSkeleton` can render a title skeleton when no translated title is available.
+
+## Apply when
+
+- The storefront uses the template PDP fallback and renders related/recommended products below PDP content.
+
+## Safe to skip when
+
+- The storefront removed the recommended products section or has a custom PDP loading state that already reserves this space.
+
+## Validation
+
+1. Load a PDP cold or under throttled network conditions.
+2. Confirm the fallback includes both the product detail area and recommended-product card row.
+3. Confirm the page does not jump when recommendations stream in.


### PR DESCRIPTION
## Summary
- Add the related products skeleton to the top-level PDP fallback so the recommended products row has reserved space during suspension
- Allow the related products skeleton to render a title placeholder when translations are not available
- Add a rollout log entry for downstream storefront review

## Test plan
- [x] pnpm --filter template format
- [x] pnpm --filter template lint (passes with existing unrelated warnings)
- [x] pnpm --filter template build

🤖 Generated with [Claude Code](https://claude.com/claude-code)