### PR TITLE
Use shadow border for docs secondary button, update demo CTA

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -69,8 +69,8 @@ const HomePage = () => (
           <Link href="/docs">View Documentation</Link>
         </Button>
         <Button asChild className="h-12 w-fit rounded-full px-5">
-          <Link href="https://vercel.com/contact/sales" target="_blank">
-            Talk to an expert
+          <Link href="https://template.vercel.shop/" target="_blank">
+            Go to Demo
           </Link>
         </Button>
       </div>
@@ -137,8 +137,8 @@ const HomePage = () => (
       <CTA
         description="Fully customizable with AI agents. Built on Next.js."
         primary={{
-          href: "https://vercel.com/contact/sales",
-          label: "Talk to an Expert",
+          href: "https://template.vercel.shop/",
+          label: "Go to Demo",
           target: "_blank",
         }}
         secondary={{ href: "/docs", label: "View Documentation" }}

--- a/apps/docs/components/geistdocs/ask-ai-button.tsx
+++ b/apps/docs/components/geistdocs/ask-ai-button.tsx
@@ -15,7 +15,7 @@ export const AskAIButton = ({ className, onClick }: AskAIButtonProps) => {
   return (
     <Button
       className={cn(
-        "shadow-none font-medium text-gray-1000 bg-background-100 hover:bg-gray-100 hover:text-gray-1000",
+        "font-medium text-gray-1000 bg-background-100 hover:bg-gray-100 hover:text-gray-1000",
         className,
       )}
       onClick={() => {

--- a/apps/docs/components/geistdocs/search-button.tsx
+++ b/apps/docs/components/geistdocs/search-button.tsx
@@ -19,7 +19,7 @@ export const SearchButton = ({ className, onClick }: SearchButtonProps) => {
   return (
     <Button
       className={cn(
-        "group justify-between gap-8 pr-1.5 font-normal text-gray-900 shadow-none hover:bg-gray-100 hover:text-gray-1000 lg:h-8 lg:w-[150px] lg:bg-background-200 lg:hover:bg-background-200",
+        "group justify-between gap-8 pr-1.5 font-normal text-gray-900 hover:bg-gray-100 hover:text-gray-1000 lg:h-8 lg:w-[150px] lg:bg-background-200 lg:hover:bg-background-200",
         "h-10",
         className,
       )}

--- a/apps/docs/components/ui/button.tsx
+++ b/apps/docs/components/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
         default: "bg-gray-1000 text-background-100 hover:bg-gray-1000/90",
         destructive: "bg-red-800 text-background-100 hover:bg-red-800/90",
         secondary:
-          "border border-gray-alpha-400 bg-background-100 text-gray-1000 shadow-none hover:bg-gray-100",
+          "bg-background-100 text-gray-1000 shadow-[0_0_0_1px_var(--ds-gray-400)] hover:bg-gray-100",
         tertiary: "text-gray-1000 hover:bg-gray-alpha-200",
         link: "text-gray-1000 underline-offset-4 hover:underline",
       },


### PR DESCRIPTION
## Summary
- Switch the docs `secondary` button variant to use a 1px `box-shadow` instead of a real `border` — matching the Geist secondary button approach in `front/packages/geist`. Removes layout shift from the border edge and keeps the visual the same.
- Rename the two "Talk to an expert" CTAs on the docs home page to **Go to Demo**, pointing at https://template.vercel.shop/.

## Test plan
- [ ] Verify the secondary button on `/` (hero + CTA section) still looks correct in light + dark
- [ ] Confirm hover background still applies (`hover:bg-gray-100`)
- [ ] Click "Go to Demo" in hero and bottom CTA → opens template.vercel.shop in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)