### PR TITLE
Reorder Shopify section, flip hero CTAs, tidy commerce copy

### DIFF
--- a/apps/docs/app/(home)/components/cta.tsx
+++ b/apps/docs/app/(home)/components/cta.tsx
@@ -36,6 +36,11 @@ export const CTA = ({
       <p className="text-lg text-muted-foreground">{description}</p>
     </div>
     <div className="flex flex-wrap items-center gap-3">
+      <Button asChild className="h-12 w-full sm:w-fit rounded-full px-5">
+        <Link href={primary.href} target={primary.target}>
+          {primary.label}
+        </Link>
+      </Button>
       {secondary ? (
         <Button
           asChild
@@ -47,11 +52,6 @@ export const CTA = ({
           </Link>
         </Button>
       ) : null}
-      <Button asChild className="h-12 w-full sm:w-fit rounded-full px-5">
-        <Link href={primary.href} target={primary.target}>
-          {primary.label}
-        </Link>
-      </Button>
     </div>
   </section>
 );

--- a/apps/docs/app/(home)/components/shopify-commerce.tsx
+++ b/apps/docs/app/(home)/components/shopify-commerce.tsx
@@ -1,6 +1,3 @@
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-
 interface Column {
   title: string;
   items: string[];
@@ -11,7 +8,7 @@ const columns: Column[] = [
     title: "Checkout and Payments",
     items: [
       "Shopify Checkout",
-      "Shopify Pay for accelerated checkout",
+      "Shop Pay for accelerated checkout",
       "Shopify Payments",
     ],
   },
@@ -28,25 +25,13 @@ const columns: Column[] = [
 
 export const ShopifyCommerce = () => (
   <div className="grid gap-12 py-12 lg:grid-cols-3 lg:gap-16">
-    {/* Title + CTA */}
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-4">
-        <h2 className="font-sans font-semibold text-2xl tracking-tight text-foreground sm:text-3xl">
-          Shopify as the commerce engine
-        </h2>
-        <p className="text-lg text-muted-foreground">
-          Run checkout, payments, and your product catalog on Shopify.
-        </p>
-      </div>
-      <Button
-        asChild
-        className="h-12 w-fit rounded-full px-5"
-        variant="secondary"
-      >
-        <Link href="https://vercel.com/contact/sales" target="_blank">
-          Start Your Shop Today
-        </Link>
-      </Button>
+    <div className="flex flex-col gap-4">
+      <h2 className="font-sans font-semibold text-2xl tracking-tight text-foreground sm:text-3xl">
+        Shopify as the commerce engine
+      </h2>
+      <p className="text-lg text-muted-foreground">
+        Run checkout, payments, and your product catalog on Shopify.
+      </p>
     </div>
 
     {/* Feature columns */}

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -137,11 +137,15 @@ const HomePage = () => (
       <CTA
         description="Fully customizable with AI agents. Built on Next.js."
         primary={{
+          href: "https://vercel.com/contact/sales",
+          label: "Talk to an expert",
+          target: "_blank",
+        }}
+        secondary={{
           href: "https://template.vercel.shop/",
           label: "Go to Demo",
           target: "_blank",
         }}
-        secondary={{ href: "/docs", label: "View Documentation" }}
         title="Start your shop today."
         className="mt-12 sm:mt-32"
       />

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -61,17 +61,17 @@ const HomePage = () => (
       title={homeTitle}
     >
       <div className="flex flex-wrap items-center justify-center gap-3">
+        <Button asChild className="h-12 w-fit rounded-full px-5">
+          <Link href="https://template.vercel.shop/" target="_blank">
+            Go to Demo
+          </Link>
+        </Button>
         <Button
           asChild
           className="h-12 w-fit rounded-full px-5"
           variant="secondary"
         >
           <Link href="/docs">View Documentation</Link>
-        </Button>
-        <Button asChild className="h-12 w-fit rounded-full px-5">
-          <Link href="https://template.vercel.shop/" target="_blank">
-            Go to Demo
-          </Link>
         </Button>
       </div>
     </Hero>
@@ -107,6 +107,7 @@ const HomePage = () => (
       >
         <StorefrontHero />
       </CenteredSection>
+      <ShopifyCommerce />
       <OneTwoSection
         description="The vercel-shop plugin and template recipes let agents extend your store with a single command. Add markets, CMS, auth, and more."
         leftClassName="xl:pt-[52px]"
@@ -132,7 +133,6 @@ const HomePage = () => (
       >
         <ContentNegotiationDemo />
       </OneTwoSection>
-      <ShopifyCommerce />
       <LogosMarquee />
       <CTA
         description="Fully customizable with AI agents. Built on Next.js."


### PR DESCRIPTION
## Summary
- Move "Shopify as the commerce engine" up between "Dynamic at the speed of static" and "Agentic development" so it isn't buried at the bottom (Shopify flagged it).
- Flip hero CTAs so "Go to Demo" is primary and "View Documentation" is secondary.
- Drop the "Start Your Shop Today" CTA from the Shopify section — it routed to contact sales, not the right flow for that placement.
- Rename "Shopify Pay" → "Shop Pay" under Checkout and Payments.

