### PR TITLE
Home Featured Products: use Shopify "frontpage" collection

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/home.mdx
+++ b/apps/docs/content/docs/anatomy/pages/home.mdx
@@ -32,7 +32,7 @@ The grid is responsive: 2 columns on mobile, 3 on tablet, 4 on desktop. The `Pro
 
 ## Data fetching
 
-Products are fetched server-side with `getProducts({ limit: 8, locale })`, which queries the Shopify Storefront API and caches the result with `cacheLife("max")` and product-level cache tags for granular revalidation.
+Products are fetched server-side with `getCollectionProducts({ collection: "frontpage", limit: 8, locale })`, which pulls from Shopify's default `frontpage` collection so merchants can curate the home page from the Shopify admin. The result is cached with `cacheLife("max")` and product- and collection-level cache tags for granular revalidation. To feature a different collection, change `collectionHandle` (and `collectionUrl`) on the `FeaturedProducts` call in `app/page.tsx`.
 
 ## Key files
 

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -50,7 +50,8 @@ export default async function HomePage() {
             title="Featured Products"
             limit={8}
             locale={locale}
-            collectionUrl="/search"
+            collectionHandle="frontpage"
+            collectionUrl="/collections/frontpage"
           />
         </Container>
       </Sections>

--- a/apps/template/components/product/products-grid.tsx
+++ b/apps/template/components/product/products-grid.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 
 import { ProductCard, ProductCardSkeleton } from "@/components/product-card/product-card";
 import type { Locale } from "@/lib/i18n";
-import { getCatalogProducts } from "@/lib/shopify/operations/products";
+import { getCollectionProducts } from "@/lib/shopify/operations/products";
 import { cn } from "@/lib/utils";
 
 interface ProductsGridSkeletonProps {
@@ -26,6 +26,7 @@ interface FeaturedProductsProps {
   title: string;
   limit: number;
   locale: Locale;
+  collectionHandle: string;
   collectionUrl?: string;
 }
 
@@ -33,6 +34,7 @@ export async function FeaturedProducts({
   title,
   limit,
   locale,
+  collectionHandle,
   collectionUrl,
 }: FeaturedProductsProps) {
   const t = await getTranslations("product");
@@ -51,22 +53,33 @@ export async function FeaturedProducts({
         )}
       </div>
       <Suspense fallback={<ProductsGridSkeleton count={limit} />}>
-        <FeaturedProductsGrid limit={limit} locale={locale} outOfStockText={t("outOfStock")} />
+        <FeaturedProductsGrid
+          collectionHandle={collectionHandle}
+          limit={limit}
+          locale={locale}
+          outOfStockText={t("outOfStock")}
+        />
       </Suspense>
     </div>
   );
 }
 
 async function FeaturedProductsGrid({
+  collectionHandle,
   limit,
   locale,
   outOfStockText,
 }: {
+  collectionHandle: string;
   limit: number;
   locale: Locale;
   outOfStockText: string;
 }) {
-  const { products } = await getCatalogProducts({ limit, locale });
+  const { products } = await getCollectionProducts({
+    collection: collectionHandle,
+    limit,
+    locale,
+  });
 
   if (products.length === 0) return null;
 

--- a/packages/plugin/template-rollout-log/2026-05-17-home-featured-frontpage-collection.md
+++ b/packages/plugin/template-rollout-log/2026-05-17-home-featured-frontpage-collection.md
@@ -1,0 +1,48 @@
+---
+title: Source home Featured Products from the Shopify "frontpage" collection
+changeKey: home-featured-frontpage-collection
+introducedOn: 2026-05-17
+changeType: refactor
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/app/page.tsx
+  - apps/template/components/product/products-grid.tsx
+---
+
+## Summary
+
+The home page's Featured Products grid previously called `getCatalogProducts({ limit, locale })`, which falls back to a `BEST_SELLING` browse of the entire catalog. There was no way for a merchant to curate which products appeared without code changes.
+
+It now reads from Shopify's default `frontpage` collection via `getCollectionProducts({ collection: "frontpage", limit, locale })`. Every Shopify store ships with this collection, and merchants can curate it from the admin like any other collection.
+
+- `FeaturedProducts` gained a required `collectionHandle` prop.
+- `app/page.tsx` passes `collectionHandle="frontpage"` and points the "View all" link at `/collections/frontpage` instead of `/search`.
+- `getCollectionProducts` already returns `{ products: [] }` when the collection is missing, so `FeaturedProductsGrid` continues to render nothing in that case (existing `products.length === 0` guard).
+
+## Why it matters
+
+- Merchants control the home page lineup from the Shopify admin without touching code.
+- `BEST_SELLING` was a poor proxy for "what the store owner wants to feature" — new stores have no sales history, and even mature stores often want to surface seasonal or promotional picks that aren't top sellers.
+- The "View all" link now lands on a real curated collection page instead of an unrelated full-catalog search.
+
+## Apply when
+
+- The storefront still calls `FeaturedProducts` with `collectionUrl="/search"` and no `collectionHandle`.
+
+## Safe to skip when
+
+- The storefront has already replaced the home grid with custom curation logic (manual handle list, metaobject-driven picks, a different collection handle, etc.).
+
+## Validation
+
+1. Confirm the `frontpage` collection exists in the connected Shopify store and contains at least one published product. (It ships by default but can be deleted.)
+2. `pnpm dev` in `apps/template`. Visit `/`.
+   - Featured Products grid renders the products in the `frontpage` collection, in the collection's configured order.
+   - "View all" link goes to `/collections/frontpage` and renders the same collection page.
+3. Empty the `frontpage` collection in the Shopify admin (or rename its handle). Trigger a fresh fetch. The Featured Products section should disappear gracefully (no error, no empty grid skeleton).
+
+## Follow-ups
+
+- If a storefront wants a different curated collection, they only need to change `collectionHandle` (and `collectionUrl`) in `app/page.tsx` — the component is otherwise collection-agnostic.


### PR DESCRIPTION
## Summary

- Home page Featured Products grid now reads from Shopify's default `frontpage` collection (via `getCollectionProducts`) instead of doing a generic catalog browse with a `BEST_SELLING` fallback.
- `FeaturedProducts` gains a `collectionHandle` prop; `app/page.tsx` passes `"frontpage"` and points "View all" at `/collections/frontpage`.
- Docs and a template-rollout-log entry updated so downstream storefronts can adopt or skip the change.

Merchants can now curate the home page lineup from the Shopify admin without touching code. Empty/missing collection still renders nothing thanks to the existing `products.length === 0` guard.

## Test plan

- [ ] `pnpm dev` in `apps/template`, visit `/`, confirm Featured Products renders the `frontpage` collection in its configured order.
- [ ] "View all" link goes to `/collections/frontpage` and renders the same products on the collection page.
- [ ] Empty the `frontpage` collection (or temporarily rename its handle), reload — the Featured Products section disappears gracefully (no error, no empty skeleton).
- [ ] `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)