### PR TITLE
pnpm: set minimumReleaseAge to 2880 (48h)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
+minimumReleaseAge: 2880
+
 packages:
   - "apps/*"
-
-minimumReleaseAge: 2880

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - "apps/*"
+
+minimumReleaseAge: 2880


### PR DESCRIPTION
## Summary

Adds `minimumReleaseAge: 2880` to `pnpm-workspace.yaml`.

pnpm will refuse to resolve any package version published within the last 48 hours. This narrows the window in which a freshly-published compromised package can land in this repo via a transitive update.

## Test plan

- [ ] `pnpm config get minimumReleaseAge` prints `2880`
- [ ] `pnpm install` still resolves the existing lockfile cleanly (no version older than 48h gets demoted)
- [ ] CI install steps still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)