### PR TITLE
Upgrade Next.js to 16.3.0-canary.25, exclude next from minimumReleaseAge

### DIFF
--- a/apps/docs/content/docs/skills/enable-i18n.mdx
+++ b/apps/docs/content/docs/skills/enable-i18n.mdx
@@ -49,41 +49,73 @@ export const enabledLocales: readonly Locale[] = locales;
 
 The template runs with `cacheComponents: true` (Next.js 16). That changes a few things this skill needs to handle correctly. Skipping any of these will produce build errors that look unrelated:
 
-### A. `experimental.rootParams: true` must stay on
-
-`next/root-params` (used by `getLocale()` below) is gated behind a flag. The template ships with it enabled in `next.config.ts`:
-
-```ts
-const nextConfig: NextConfig = {
-  cacheComponents: true,
-  experimental: {
-    rootParams: true,
-    // ...existing experimental flags
-  },
-};
-```
-
-If it's been removed, add it back. Without it, `import { locale } from "next/root-params"` resolves but returns `undefined`, and you'll see `notFound()` on every request.
-
-### B. There must be no `app/layout.tsx` above `app/[locale]/`
+### A. There must be no `app/layout.tsx` above `app/[locale]/`
 
 For `[locale]` to be recognized as a root param, the dynamic segment must be the root layout. After Step 2, the file at `app/layout.tsx` should be gone (moved into `app/[locale]/layout.tsx`). If both exist, `rootParams.locale()` returns `undefined`.
 
-### C. `setRequestLocale` is not used
+### B. `setRequestLocale` is not used
 
 next-intl docs sometimes show `setRequestLocale(locale)` calls in layouts/pages. **Don't add them under cacheComponents.** That helper writes to a request-scoped store and forces dynamic rendering — it defeats the cache. The rootParams + request-config pattern below makes it unnecessary because the resolved locale is already a cache key.
 
-### D. Don't swap `next/link` to next-intl's `<Link>`
+### C. Don't swap `next/link` to next-intl's `<Link>`
 
-The straightforward instinct is to replace every `import Link from "next/link"` with `import { Link } from "@/lib/i18n/navigation"`. **Don't.** next-intl's Link reads request context (locale) on render; in a server-component tree under cacheComponents, that can turn otherwise static shells into blocking dynamic work and trigger instant-navigation warnings.
+The straightforward instinct is to replace every `import Link from "next/link"` with `import { Link } from "@/lib/i18n/navigation"`. **Don't.** next-intl's Link reads request context (locale) on render; in a server-component tree under cacheComponents, that triggers:
+
+```
+Error: Route "/[locale]/..." accessed [...] which is not defined in the `samples` of `unstable_instant`.
+```
+
+or a generic "blocking route" prerender failure.
 
 **Do this instead:** keep `next/link` and let `proxy.ts` middleware redirect unprefixed paths (`/products/foo` → `/en-US/products/foo`). Internal links work; there's a one-time middleware redirect on click for unprefixed hrefs. Trade a few redirects for a clean prerender.
 
 If you must locale-prefix a programmatic URL (server actions, `redirect()`, `permanentRedirect()`), build the path yourself: `` `/${await getLocale()}/account/login` ``.
 
-### E. Keep `unstable_instant` simple
+### D. `unstable_instant` samples need `locale` in `params`
 
-Leave existing `unstable_instant = true` exports as-is. The template uses Next's default instant navigation behavior, which keeps development warnings without requiring route samples during this i18n rollout.
+Any route that exports `unstable_instant` (currently: products `[handle]`, collections `[handle]`, search) needs `locale` added to every sample, or the build fails:
+
+```
+Error: Route "/[locale]/products/[handle]" accessed root param "locale"
+       which is not defined in the `samples` of `unstable_instant`.
+```
+
+Fix:
+
+```ts
+export const unstable_instant = {
+  samples: [
+    {
+      params: { locale: "en-US", handle: "__placeholder__" }, // ← add locale
+      searchParams: { variant: "1" },
+      cookies: [{ name: "shopify_cartId", value: null }],
+    },
+  ],
+};
+```
+
+### E. `unstable_instant` samples need `headers` declarations if any layout-level server component reads `headers()`
+
+This is easy to forget. If you (or a downstream skill) adds a server component to the layout that calls `headers()` — e.g. a "Shipping to {postal}" bar reading `x-vercel-ip-postal-code` — every `unstable_instant` sample in the app must declare the headers it might access:
+
+```ts
+samples: [
+  {
+    params: { locale: "en-US", handle: "__placeholder__" },
+    searchParams: { variant: "1" },
+    cookies: [{ name: "shopify_cartId", value: null }],
+    headers: [["x-vercel-ip-postal-code", null]], // ← add this
+  },
+],
+```
+
+`null` means "header may be absent." If you forget, the build error is explicit:
+
+```
+Error: Route "..." accessed header "x-vercel-ip-postal-code" which is not
+       defined in the `samples` of `unstable_instant`. Add it to the
+       sample's `headers` array, or `["...", null]` if it should be absent.
+```
 
 ### F. `redirect()` from next-intl doesn't return `never`
 
@@ -130,13 +162,13 @@ import { routing } from "./routing";
 export const { Link, redirect, usePathname, useRouter } = createNavigation(routing);
 ```
 
-> Per "Cache Components compatibility D" above, `Link` here is mostly used by the locale switcher / programmatic routing in client components — not as a wholesale replacement for `next/link`.
+> Per "Cache Components compatibility C" above, `Link` here is mostly used by the locale switcher / programmatic routing in client components — not as a wholesale replacement for `next/link`.
 
 ### Step 2: Move routes under `app/[locale]/`
 
 Move every route file from `app/` into `app/[locale]/`:
 
-- `app/layout.tsx` → `app/[locale]/layout.tsx` (becomes the root layout for the locale segment). **Delete the original `app/layout.tsx` after the move** — see compatibility B above; both files cannot coexist.
+- `app/layout.tsx` → `app/[locale]/layout.tsx` (becomes the root layout for the locale segment). **Delete the original `app/layout.tsx` after the move** — see compatibility A above; both files cannot coexist.
 - `app/page.tsx`, `app/error.tsx`, `app/not-found.tsx` → `app/[locale]/...`
 - `app/about/`, `app/account/`, `app/cart/`, `app/collections/`, `app/products/`, `app/search/` → `app/[locale]/...`
 
@@ -298,9 +330,21 @@ export const generateStaticParams = async () => {
 };
 ```
 
-### Step 12: Keep `unstable_instant` simple
+### Step 12: Patch `unstable_instant` samples
 
-Leave existing `unstable_instant = true` exports as-is. Do not add route samples during the i18n rollout.
+Walk every route file that exports `unstable_instant` and add `locale` to each sample's `params`:
+
+```ts
+params: { locale: "en-US", handle: "__placeholder__" }
+```
+
+If any layout-level server component (e.g. a shipping/postal banner, geo-aware nav) reads `headers()`, also add a `headers` array to every sample:
+
+```ts
+headers: [["x-vercel-ip-postal-code", null]]
+```
+
+(See "Cache Components compatibility D/E" at the top.)
 
 ### Step 13: (Conditional) Re-enable `LocaleCurrencySelector` in the megamenu
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -25,7 +25,7 @@
 		"lucide-react": "1.16.0",
 		"motion": "12.38.0",
 		"nanoid": "5.1.11",
-		"next": "16.3.0-canary.24",
+		"next": "16.3.0-canary.25",
 		"next-mdx-remote": "6.0.0",
 		"next-themes": "0.4.6",
 		"postcss": "8.5.14",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -25,7 +25,7 @@
 		"lucide-react": "1.16.0",
 		"motion": "12.38.0",
 		"nanoid": "5.1.11",
-		"next": "16.3.0-canary.21",
+		"next": "16.3.0-canary.24",
 		"next-mdx-remote": "6.0.0",
 		"next-themes": "0.4.6",
 		"postcss": "8.5.14",

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -19,6 +19,7 @@ const nextConfig: NextConfig = {
     inlineCss: true,
     optimisticRouting: true,
     turbopackFileSystemCacheForDev: true,
+    varyParams: true,
   },
   images: {
     deviceSizes: [640, 828, 1200, 1920],

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -18,7 +18,6 @@ const nextConfig: NextConfig = {
     cachedNavigations: true,
     inlineCss: true,
     optimisticRouting: true,
-    rootParams: true,
     turbopackFileSystemCacheForDev: true,
   },
   images: {

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -29,7 +29,7 @@
     "cmdk": "1.1.1",
     "lucide-react": "1.16.0",
     "nanoid": "5.1.11",
-    "next": "16.3.0-canary.21",
+    "next": "16.3.0-canary.24",
     "next-intl": "4.12.0",
     "oxfmt": "0.50.0",
     "oxlint": "1.65.0",

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -29,7 +29,7 @@
     "cmdk": "1.1.1",
     "lucide-react": "1.16.0",
     "nanoid": "5.1.11",
-    "next": "16.3.0-canary.24",
+    "next": "16.3.0-canary.25",
     "next-intl": "4.12.0",
     "oxfmt": "0.50.0",
     "oxlint": "1.65.0",

--- a/packages/plugin/skills/enable-i18n/SKILL.md
+++ b/packages/plugin/skills/enable-i18n/SKILL.md
@@ -44,31 +44,15 @@ export const enabledLocales: readonly Locale[] = locales;
 
 The template runs with `cacheComponents: true` (Next.js 16). That changes a few things this skill needs to handle correctly. Skipping any of these will produce build errors that look unrelated:
 
-### A. `experimental.rootParams: true` must stay on
-
-`next/root-params` (used by `getLocale()` below) is gated behind a flag. The template ships with it enabled in `next.config.ts`:
-
-```ts
-const nextConfig: NextConfig = {
-  cacheComponents: true,
-  experimental: {
-    rootParams: true,
-    // ...existing experimental flags
-  },
-};
-```
-
-If it's been removed, add it back. Without it, `import { locale } from "next/root-params"` resolves but returns `undefined`, and you'll see `notFound()` on every request.
-
-### B. There must be no `app/layout.tsx` above `app/[locale]/`
+### A. There must be no `app/layout.tsx` above `app/[locale]/`
 
 For `[locale]` to be recognized as a root param, the dynamic segment must be the root layout. After Step 2, the file at `app/layout.tsx` should be gone (moved into `app/[locale]/layout.tsx`). If both exist, `rootParams.locale()` returns `undefined`.
 
-### C. `setRequestLocale` is not used
+### B. `setRequestLocale` is not used
 
 next-intl docs sometimes show `setRequestLocale(locale)` calls in layouts/pages. **Don't add them under cacheComponents.** That helper writes to a request-scoped store and forces dynamic rendering — it defeats the cache. The rootParams + request-config pattern below makes it unnecessary because the resolved locale is already a cache key.
 
-### D. Don't swap `next/link` to next-intl's `<Link>`
+### C. Don't swap `next/link` to next-intl's `<Link>`
 
 The straightforward instinct is to replace every `import Link from "next/link"` with `import { Link } from "@/lib/i18n/navigation"`. **Don't.** next-intl's Link reads request context (locale) on render; in a server-component tree under cacheComponents, that triggers:
 
@@ -82,7 +66,7 @@ or a generic "blocking route" prerender failure.
 
 If you must locale-prefix a programmatic URL (server actions, `redirect()`, `permanentRedirect()`), build the path yourself: `` `/${await getLocale()}/account/login` ``.
 
-### E. `unstable_instant` samples need `locale` in `params`
+### D. `unstable_instant` samples need `locale` in `params`
 
 Any route that exports `unstable_instant` (currently: products `[handle]`, collections `[handle]`, search) needs `locale` added to every sample, or the build fails:
 
@@ -105,7 +89,7 @@ export const unstable_instant = {
 };
 ```
 
-### F. `unstable_instant` samples need `headers` declarations if any layout-level server component reads `headers()`
+### E. `unstable_instant` samples need `headers` declarations if any layout-level server component reads `headers()`
 
 This is easy to forget. If you (or a downstream skill) adds a server component to the layout that calls `headers()` — e.g. a "Shipping to {postal}" bar reading `x-vercel-ip-postal-code` — every `unstable_instant` sample in the app must declare the headers it might access:
 
@@ -128,7 +112,7 @@ Error: Route "..." accessed header "x-vercel-ip-postal-code" which is not
        sample's `headers` array, or `["...", null]` if it should be absent.
 ```
 
-### G. `redirect()` from next-intl doesn't return `never`
+### F. `redirect()` from next-intl doesn't return `never`
 
 ```ts
 // BREAKS: TS doesn't narrow `session` after redirect
@@ -173,13 +157,13 @@ import { routing } from "./routing";
 export const { Link, redirect, usePathname, useRouter } = createNavigation(routing);
 ```
 
-> Per "Cache Components compatibility D" above, `Link` here is mostly used by the locale switcher / programmatic routing in client components — not as a wholesale replacement for `next/link`.
+> Per "Cache Components compatibility C" above, `Link` here is mostly used by the locale switcher / programmatic routing in client components — not as a wholesale replacement for `next/link`.
 
 ### Step 2: Move routes under `app/[locale]/`
 
 Move every route file from `app/` into `app/[locale]/`:
 
-- `app/layout.tsx` → `app/[locale]/layout.tsx` (becomes the root layout for the locale segment). **Delete the original `app/layout.tsx` after the move** — see compatibility B above; both files cannot coexist.
+- `app/layout.tsx` → `app/[locale]/layout.tsx` (becomes the root layout for the locale segment). **Delete the original `app/layout.tsx` after the move** — see compatibility A above; both files cannot coexist.
 - `app/page.tsx`, `app/error.tsx`, `app/not-found.tsx` → `app/[locale]/...`
 - `app/about/`, `app/account/`, `app/cart/`, `app/collections/`, `app/products/`, `app/search/` → `app/[locale]/...`
 
@@ -355,7 +339,7 @@ If any layout-level server component (e.g. a shipping/postal banner, geo-aware n
 headers: [["x-vercel-ip-postal-code", null]]
 ```
 
-(See "Cache Components compatibility E/F" at the top.)
+(See "Cache Components compatibility D/E" at the top.)
 
 ### Step 13: (Conditional) Re-enable `LocaleCurrencySelector` in the megamenu
 

--- a/packages/plugin/template-rollout-log/2026-05-20-next-canary-24-rootparams-default.md
+++ b/packages/plugin/template-rollout-log/2026-05-20-next-canary-24-rootparams-default.md
@@ -1,0 +1,37 @@
+---
+title: Next canary 24 — rootParams enabled by default
+changeKey: next-canary-24-rootparams-default
+introducedOn: 2026-05-20
+changeType: dependency
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/package.json
+  - apps/docs/package.json
+  - apps/template/next.config.ts
+  - packages/plugin/skills/enable-i18n/SKILL.md
+  - pnpm-lock.yaml
+---
+
+## Summary
+
+Bumps Next.js to `16.3.0-canary.24` in both apps. `next/root-params` is now available without a flag, so `experimental.rootParams: true` was removed from `apps/template/next.config.ts`. The `enable-i18n` skill no longer instructs storefronts to add the flag.
+
+## Why it matters
+
+Keeps the template on the latest Next.js canary so the cache-components / Turbopack / instant-navigation paths under active development are exercised. Removing the obsolete flag prevents a noisy build warning and a future hard error when Next removes the experimental key.
+
+## Apply when
+
+Storefront is upgrading to Next.js 16.3.0-canary.24 or newer.
+
+## Safe to skip when
+
+Storefront is pinned to an older Next.js canary that still gates `next/root-params` behind the flag.
+
+## Validation
+
+1. `pnpm install` resolves cleanly with the existing `minimumReleaseAgeExclude` entries for `next` and `@next/*`.
+2. `pnpm --filter template build` and `pnpm --filter docs build` succeed with no `experimental.rootParams is no longer needed` warning.
+3. `import { locale } from "next/root-params"` continues to work in `lib/params.ts` and any locale-aware code paths added by `enable-i18n`.

--- a/packages/plugin/template-rollout-log/2026-05-20-next-canary-24-rootparams-default.md
+++ b/packages/plugin/template-rollout-log/2026-05-20-next-canary-24-rootparams-default.md
@@ -16,7 +16,7 @@ paths:
 
 ## Summary
 
-Bumps Next.js to `16.3.0-canary.24` in both apps. `next/root-params` is now available without a flag, so `experimental.rootParams: true` was removed from `apps/template/next.config.ts`. The `enable-i18n` skill no longer instructs storefronts to add the flag.
+Bumps Next.js to `16.3.0-canary.25` in both apps. Starting at canary.24, `next/root-params` is available without a flag, so `experimental.rootParams: true` was removed from `apps/template/next.config.ts`. The `enable-i18n` skill no longer instructs storefronts to add the flag.
 
 ## Why it matters
 

--- a/packages/plugin/template-rollout-log/2026-05-21-next-vary-params.md
+++ b/packages/plugin/template-rollout-log/2026-05-21-next-vary-params.md
@@ -1,0 +1,32 @@
+---
+title: Re-enable Next vary params
+changeKey: next-vary-params
+introducedOn: 2026-05-21
+changeType: dependency
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/next.config.ts
+---
+
+## Summary
+
+Re-enables Next.js canary's `experimental.varyParams: true` flag in `apps/template/next.config.ts`. Previously enabled in #265, reverted on 2026-05-08, now restored on top of `next@16.3.0-canary.25`.
+
+## Why it matters
+
+`varyParams` lets the template exercise the request-variant behavior the current Next canary is built around, and it's one of the five flags `experimental.appShells` requires (cacheComponents, prefetchInlining, varyParams, optimisticRouting, cachedNavigations). Keeping varyParams on closes the gap to App Shells.
+
+## Apply when
+
+Storefront is on a Next.js canary that supports `experimental.varyParams` (canary.21+).
+
+## Safe to skip when
+
+Storefront has hit a varyParams-specific bug and is intentionally pinning to the flag off.
+
+## Validation
+
+1. `pnpm --filter template build` succeeds.
+2. `pnpm --filter template lint` passes.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,10 +55,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.1(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.0(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.184
         version: 6.0.184(zod@4.4.3)
@@ -82,10 +82,10 @@ importers:
         version: 5.2.1
       fromsrc:
         specifier: 0.0.31
-        version: 0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       geist:
         specifier: 1.7.0
-        version: 1.7.0(next@16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 1.7.0(next@16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       jotai:
         specifier: 2.20.0
         version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.6)
@@ -99,8 +99,8 @@ importers:
         specifier: 5.1.11
         version: 5.1.11
       next:
-        specifier: 16.3.0-canary.24
-        version: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 16.3.0-canary.25
+        version: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-mdx-remote:
         specifier: 6.0.0
         version: 6.0.0(@types/react@19.2.14)(react@19.2.6)
@@ -181,10 +181,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.1(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.0(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.184
         version: 6.0.184(zod@4.4.3)
@@ -193,7 +193,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -210,11 +210,11 @@ importers:
         specifier: 5.1.11
         version: 5.1.11
       next:
-        specifier: 16.3.0-canary.24
-        version: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 16.3.0-canary.25
+        version: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl:
         specifier: 4.12.0
-        version: 4.12.0(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+        version: 4.12.0(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       oxfmt:
         specifier: 0.50.0
         version: 0.50.0
@@ -769,57 +769,57 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@next/env@16.3.0-canary.24':
-    resolution: {integrity: sha512-ZD3XHYX5IYGpFJyETUiQ8XMaqo5ALmuTDxbK0bYGGCIQGCSFt7IdvzFRjxzYTwnLV3pkY8Tud+0EyBAg4BV0jw==}
+  '@next/env@16.3.0-canary.25':
+    resolution: {integrity: sha512-y/L3F/urOwBe/CKNLIOlfUvj2YNLFg0ktt5uwHIUxX2zf5lCkL2bYzKbzoMpFaJrtjkNk9RBvatQOswcA9MvtQ==}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.24':
-    resolution: {integrity: sha512-3oYgMOqS/T28EOY6t5O3hI4TlEgThWqhkk+XXMbywkF8FcERmOvt3OpCOxeRrcHaVGSPbQJdkzqK+VFyA/6q2g==}
+  '@next/swc-darwin-arm64@16.3.0-canary.25':
+    resolution: {integrity: sha512-3wwwtNdwp3++Pip2vnTZ5PDRk1nPe1I3WEGtfdLTC+OFmj/lPA7R7JiaMfX1VyT1WqE6Tf2N4bSfiAtDJqoqcg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.3.0-canary.24':
-    resolution: {integrity: sha512-H4z89+AIkFrJPKOsaEjsYWANuJ2L/riqe9IAMvybwo7DTLkhoK14+Yf6/VvUcrRdRreqYmGb9dF2eb1bgSil0g==}
+  '@next/swc-darwin-x64@16.3.0-canary.25':
+    resolution: {integrity: sha512-eXMfpfVnvHjoczvmTzM3kbR4Cv2JQhXWYXSkhPJqTotlIMOFncuS+paSaQjdpFFgg0vS3UbIsb8d8ymv2LNCKQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.24':
-    resolution: {integrity: sha512-J0e2ptF+NrDLNHMCGFE9ZckHQ1aQN+OZF6flv4T6Jt14eAylWe3K68aYNaQJvuHyT61fYNPQPzwl9FSlPCJc4Q==}
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.25':
+    resolution: {integrity: sha512-uPSyGPRSIsfHXl2tO1nRk/Gg0xpXyjx2tw+hp73jjhe5l9B8mR9VRTmZgnlMRTlr85X2AYCAH7vLEblBiHi15A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.24':
-    resolution: {integrity: sha512-ITEL3jWykiPAOnU6OVVk5F43K3R71LH0515wsH0NT3f5nxeY7NWydLdxXIYS7Jh+U6cBF7V4yMUonD0sJRihdg==}
+  '@next/swc-linux-arm64-musl@16.3.0-canary.25':
+    resolution: {integrity: sha512-TWUjoROv6ZC6rGBtLXgzrtkmRiviMrFhFi2bPIZDdbU87e4g+HOkBaLqR+aEUtphRnEikWToN7Xy1euF4OvV8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.24':
-    resolution: {integrity: sha512-oAyAVSb+kZ6fF7E9BHFlrYtsfDMoYCmeuVQdLC17UvEoJ2c1ROZzJBGk4yqmFBXe9IZy5dZ+90dmLYMN0WubGQ==}
+  '@next/swc-linux-x64-gnu@16.3.0-canary.25':
+    resolution: {integrity: sha512-/xcz6T7BKqJqm/x5eWsKDKWo+HfCuvbLbkvCkCnnpSs13Rtt8A/JeTrCld17zzCid6U5fyzzWW9mWjBaRmGteQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.24':
-    resolution: {integrity: sha512-duhsd9jhyYP+C14KkgfU+C/mxpz0gUuWQbVIf6BeUTW3vLKZOT6VNFys41u9eih3Y/xvctbsl3xNuTrxWhC/Cg==}
+  '@next/swc-linux-x64-musl@16.3.0-canary.25':
+    resolution: {integrity: sha512-B6F6dOPCY0ttaQPSGVoKb0u1Xiu8vDldLkruL0jsM1PgKKZPkJSjSi3bg4VuWc0wTq1moqevhoinK21L86RSmA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.24':
-    resolution: {integrity: sha512-jOD0yLH99LTPobe/ZZhJwo0pDMRYUzpNEou9cCinZmJZ/gjcq3F6N0KcsPom4DdGnAfePU2Zlg46pAp0TEqiMQ==}
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.25':
+    resolution: {integrity: sha512-GWhn3dcawZkg+MHwtR9xaMnanBrSuBODQC7eplbnLo++zmhexBmRR07VWzSQ4s5I8KnyNOtYgkEppgo27TywUQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.24':
-    resolution: {integrity: sha512-WGnjpnyQfZhGod/vXf8Qd5HUoORmGEL1yWVl1tD8MgZKnT5nSb4nOGQTiVq+2QeyNpyAvQOMhPGv6kfBgt5tnA==}
+  '@next/swc-win32-x64-msvc@16.3.0-canary.25':
+    resolution: {integrity: sha512-c0JyUJCpnHLSdtnAEKmPf5Nr5QE2i35DjqoyRkrLJiTVU82JZHSvB0MjTLVvohsSXJcLlhXUKOEfG4RKQW/Odw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3574,8 +3574,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.3.0-canary.24:
-    resolution: {integrity: sha512-OOa8vI+FwzOI+Yuf3XEqtm2MVAjK33HuVeIjzJLX6K0PTK9tL9+3IVXcWggsCaxY19RG5b84b8FQMlZUvaPftg==}
+  next@16.3.0-canary.25:
+    resolution: {integrity: sha512-3bL9/wGkejnI1JCCQT17JXzPkiWM0bxU3kbGuElk8p45n2vQ13xPmDvJzlh7dwdiZVFQlfDGMlqtaTQ1R0dTxg==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4873,30 +4873,30 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@next/env@16.3.0-canary.24': {}
+  '@next/env@16.3.0-canary.25': {}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.24':
+  '@next/swc-darwin-arm64@16.3.0-canary.25':
     optional: true
 
-  '@next/swc-darwin-x64@16.3.0-canary.24':
+  '@next/swc-darwin-x64@16.3.0-canary.25':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.24':
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.25':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.24':
+  '@next/swc-linux-arm64-musl@16.3.0-canary.25':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.24':
+  '@next/swc-linux-x64-gnu@16.3.0-canary.25':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.24':
+  '@next/swc-linux-x64-musl@16.3.0-canary.25':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.24':
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.25':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.24':
+  '@next/swc-win32-x64-msvc@16.3.0-canary.25':
     optional: true
 
   '@noble/ciphers@2.2.0': {}
@@ -6241,17 +6241,17 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       vue: 3.5.30(typescript@6.0.3)
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       vue: 3.5.30(typescript@6.0.3)
 
@@ -6358,7 +6358,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.7: {}
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3)):
+  better-auth@1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3)):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -6378,7 +6378,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       vue: 3.5.30(typescript@6.0.3)
@@ -6843,13 +6843,13 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  fromsrc@0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  fromsrc@0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@shikijs/rehype': 3.23.0
       '@shikijs/transformers': 3.23.0
       gray-matter: 4.0.3
-      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-mdx-remote: 6.0.0(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       remark-gfm: 4.0.1
@@ -6875,9 +6875,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
-  geist@1.7.0(next@16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  geist@1.7.0(next@16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
-      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   gensync@1.0.0-beta.2:
     optional: true
@@ -7759,14 +7759,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.12.0: {}
 
-  next-intl@4.12.0(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
+  next-intl@4.12.0(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.18
       icu-minify: 4.12.0
       negotiator: 1.0.0
-      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl-swc-plugin-extractor: 4.12.0
       po-parser: 2.1.1
       react: 19.2.6
@@ -7795,9 +7795,9 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@next/env': 16.3.0-canary.24
+      '@next/env': 16.3.0-canary.25
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.7
       caniuse-lite: 1.0.30001778
@@ -7806,14 +7806,14 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.6)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.3.0-canary.24
-      '@next/swc-darwin-x64': 16.3.0-canary.24
-      '@next/swc-linux-arm64-gnu': 16.3.0-canary.24
-      '@next/swc-linux-arm64-musl': 16.3.0-canary.24
-      '@next/swc-linux-x64-gnu': 16.3.0-canary.24
-      '@next/swc-linux-x64-musl': 16.3.0-canary.24
-      '@next/swc-win32-arm64-msvc': 16.3.0-canary.24
-      '@next/swc-win32-x64-msvc': 16.3.0-canary.24
+      '@next/swc-darwin-arm64': 16.3.0-canary.25
+      '@next/swc-darwin-x64': 16.3.0-canary.25
+      '@next/swc-linux-arm64-gnu': 16.3.0-canary.25
+      '@next/swc-linux-arm64-musl': 16.3.0-canary.25
+      '@next/swc-linux-x64-gnu': 16.3.0-canary.25
+      '@next/swc-linux-x64-musl': 16.3.0-canary.25
+      '@next/swc-win32-arm64-msvc': 16.3.0-canary.25
+      '@next/swc-win32-x64-msvc': 16.3.0-canary.25
       '@opentelemetry/api': 1.9.0
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,10 +55,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0-canary.21(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.1(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.0-canary.21(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.0(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.184
         version: 6.0.184(zod@4.4.3)
@@ -82,10 +82,10 @@ importers:
         version: 5.2.1
       fromsrc:
         specifier: 0.0.31
-        version: 0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       geist:
         specifier: 1.7.0
-        version: 1.7.0(next@16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 1.7.0(next@16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       jotai:
         specifier: 2.20.0
         version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.6)
@@ -99,8 +99,8 @@ importers:
         specifier: 5.1.11
         version: 5.1.11
       next:
-        specifier: 16.3.0-canary.21
-        version: 16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 16.3.0-canary.24
+        version: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-mdx-remote:
         specifier: 6.0.0
         version: 6.0.0(@types/react@19.2.14)(react@19.2.6)
@@ -181,10 +181,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0-canary.21(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.1(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.0-canary.21(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.0(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.184
         version: 6.0.184(zod@4.4.3)
@@ -193,7 +193,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.21(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -210,11 +210,11 @@ importers:
         specifier: 5.1.11
         version: 5.1.11
       next:
-        specifier: 16.3.0-canary.21
-        version: 16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 16.3.0-canary.24
+        version: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl:
         specifier: 4.12.0
-        version: 4.12.0(next@16.3.0-canary.21(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+        version: 4.12.0(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       oxfmt:
         specifier: 0.50.0
         version: 0.50.0
@@ -769,57 +769,57 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@next/env@16.3.0-canary.21':
-    resolution: {integrity: sha512-56TI+OSL3uohFlHeKdP5qftiXyM4mX52XjngNKXlGDAiqeipJd178DUgzxhBjiVUws58P6G6ADyHqc08kdRELg==}
+  '@next/env@16.3.0-canary.24':
+    resolution: {integrity: sha512-ZD3XHYX5IYGpFJyETUiQ8XMaqo5ALmuTDxbK0bYGGCIQGCSFt7IdvzFRjxzYTwnLV3pkY8Tud+0EyBAg4BV0jw==}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.21':
-    resolution: {integrity: sha512-tfuycDgiPoyuGWbtCfiZHYpUZWEavJbd197U20/fYMcTuS3FeMR3C15/tLrul26wFzOT4Buriq/qVidEg2Y/7w==}
+  '@next/swc-darwin-arm64@16.3.0-canary.24':
+    resolution: {integrity: sha512-3oYgMOqS/T28EOY6t5O3hI4TlEgThWqhkk+XXMbywkF8FcERmOvt3OpCOxeRrcHaVGSPbQJdkzqK+VFyA/6q2g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.3.0-canary.21':
-    resolution: {integrity: sha512-2SRX2kdVWJohBb8WhFsiEL62VJtN5mxf5sW1pOp4XXV/gi2tn5NMjXI/axDbwKnGGaNEFYbN9xz5RzNuB6Ckqg==}
+  '@next/swc-darwin-x64@16.3.0-canary.24':
+    resolution: {integrity: sha512-H4z89+AIkFrJPKOsaEjsYWANuJ2L/riqe9IAMvybwo7DTLkhoK14+Yf6/VvUcrRdRreqYmGb9dF2eb1bgSil0g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.21':
-    resolution: {integrity: sha512-iY/YWb2hp05I8HjLzHTziRwHhLNA0MwEVhdAdpAfma6QEe8lsFszzgg4Si8COJgCSrW8oAVd7WKAaW0KMVo1QA==}
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.24':
+    resolution: {integrity: sha512-J0e2ptF+NrDLNHMCGFE9ZckHQ1aQN+OZF6flv4T6Jt14eAylWe3K68aYNaQJvuHyT61fYNPQPzwl9FSlPCJc4Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.21':
-    resolution: {integrity: sha512-GNtUMY3+ymkuvmRu+4vdhRpvysEbVeJaJOCSyGnS6gHs97T7dxggad34od3N0ryLEP7peHHqLnUR4pFge/dEpg==}
+  '@next/swc-linux-arm64-musl@16.3.0-canary.24':
+    resolution: {integrity: sha512-ITEL3jWykiPAOnU6OVVk5F43K3R71LH0515wsH0NT3f5nxeY7NWydLdxXIYS7Jh+U6cBF7V4yMUonD0sJRihdg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.21':
-    resolution: {integrity: sha512-g0GtFKw9smDRCBZbUCmiCiSdJA64O/LUEEaEhSwTkDjEB3EG+frT0GieqwFQbT+/Lw22aJfPpkFmukWmTItYbA==}
+  '@next/swc-linux-x64-gnu@16.3.0-canary.24':
+    resolution: {integrity: sha512-oAyAVSb+kZ6fF7E9BHFlrYtsfDMoYCmeuVQdLC17UvEoJ2c1ROZzJBGk4yqmFBXe9IZy5dZ+90dmLYMN0WubGQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.21':
-    resolution: {integrity: sha512-n+7OVteqiQhpAr2ED/0OuZrh0AF6tBphPboNApDMooEPV1bcdbDpd0FR2Jg9R9/5ipb1h9JHR+xlMmhwVmt0TQ==}
+  '@next/swc-linux-x64-musl@16.3.0-canary.24':
+    resolution: {integrity: sha512-duhsd9jhyYP+C14KkgfU+C/mxpz0gUuWQbVIf6BeUTW3vLKZOT6VNFys41u9eih3Y/xvctbsl3xNuTrxWhC/Cg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.21':
-    resolution: {integrity: sha512-RfJwlQBGDeE5twHCmVNeq2fmiFTPva87H6Gs4ZCbbTPZHAvIeDVgYpZqucZdWNislgPhAbvQBunjA8Vtf+869Q==}
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.24':
+    resolution: {integrity: sha512-jOD0yLH99LTPobe/ZZhJwo0pDMRYUzpNEou9cCinZmJZ/gjcq3F6N0KcsPom4DdGnAfePU2Zlg46pAp0TEqiMQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.21':
-    resolution: {integrity: sha512-YZkWPnBenjwAYcA3MDGyYv0B1nb94/DAQvEKqP6XDhTEBQR9B0CLKZZgEs1bx1LQ7lwDArP+I2N5wBPkKxUbGA==}
+  '@next/swc-win32-x64-msvc@16.3.0-canary.24':
+    resolution: {integrity: sha512-WGnjpnyQfZhGod/vXf8Qd5HUoORmGEL1yWVl1tD8MgZKnT5nSb4nOGQTiVq+2QeyNpyAvQOMhPGv6kfBgt5tnA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3574,8 +3574,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.3.0-canary.21:
-    resolution: {integrity: sha512-ZSACNdtm25Chpz+P56l4VeNxstlp80XOdSKkrkNgs1xRf9YAVlqSz0E55eYKXgRjThf92oGqokVLa6kZKsGM/g==}
+  next@16.3.0-canary.24:
+    resolution: {integrity: sha512-OOa8vI+FwzOI+Yuf3XEqtm2MVAjK33HuVeIjzJLX6K0PTK9tL9+3IVXcWggsCaxY19RG5b84b8FQMlZUvaPftg==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4873,30 +4873,30 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@next/env@16.3.0-canary.21': {}
+  '@next/env@16.3.0-canary.24': {}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.21':
+  '@next/swc-darwin-arm64@16.3.0-canary.24':
     optional: true
 
-  '@next/swc-darwin-x64@16.3.0-canary.21':
+  '@next/swc-darwin-x64@16.3.0-canary.24':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.21':
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.24':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.21':
+  '@next/swc-linux-arm64-musl@16.3.0-canary.24':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.21':
+  '@next/swc-linux-x64-gnu@16.3.0-canary.24':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.21':
+  '@next/swc-linux-x64-musl@16.3.0-canary.24':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.21':
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.24':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.21':
+  '@next/swc-win32-x64-msvc@16.3.0-canary.24':
     optional: true
 
   '@noble/ciphers@2.2.0': {}
@@ -6241,17 +6241,17 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(next@16.3.0-canary.21(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       vue: 3.5.30(typescript@6.0.3)
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.21(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       vue: 3.5.30(typescript@6.0.3)
 
@@ -6358,7 +6358,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.7: {}
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.21(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3)):
+  better-auth@1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3)):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -6378,7 +6378,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      next: 16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       vue: 3.5.30(typescript@6.0.3)
@@ -6843,13 +6843,13 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  fromsrc@0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  fromsrc@0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@shikijs/rehype': 3.23.0
       '@shikijs/transformers': 3.23.0
       gray-matter: 4.0.3
-      next: 16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-mdx-remote: 6.0.0(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       remark-gfm: 4.0.1
@@ -6875,9 +6875,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
-  geist@1.7.0(next@16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  geist@1.7.0(next@16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
-      next: 16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   gensync@1.0.0-beta.2:
     optional: true
@@ -7759,14 +7759,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.12.0: {}
 
-  next-intl@4.12.0(next@16.3.0-canary.21(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
+  next-intl@4.12.0(next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.18
       icu-minify: 4.12.0
       negotiator: 1.0.0
-      next: 16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl-swc-plugin-extractor: 4.12.0
       po-parser: 2.1.1
       react: 19.2.6
@@ -7795,9 +7795,9 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@16.3.0-canary.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.3.0-canary.24(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@next/env': 16.3.0-canary.21
+      '@next/env': 16.3.0-canary.24
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.7
       caniuse-lite: 1.0.30001778
@@ -7806,14 +7806,14 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.6)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.3.0-canary.21
-      '@next/swc-darwin-x64': 16.3.0-canary.21
-      '@next/swc-linux-arm64-gnu': 16.3.0-canary.21
-      '@next/swc-linux-arm64-musl': 16.3.0-canary.21
-      '@next/swc-linux-x64-gnu': 16.3.0-canary.21
-      '@next/swc-linux-x64-musl': 16.3.0-canary.21
-      '@next/swc-win32-arm64-msvc': 16.3.0-canary.21
-      '@next/swc-win32-x64-msvc': 16.3.0-canary.21
+      '@next/swc-darwin-arm64': 16.3.0-canary.24
+      '@next/swc-darwin-x64': 16.3.0-canary.24
+      '@next/swc-linux-arm64-gnu': 16.3.0-canary.24
+      '@next/swc-linux-arm64-musl': 16.3.0-canary.24
+      '@next/swc-linux-x64-gnu': 16.3.0-canary.24
+      '@next/swc-linux-x64-musl': 16.3.0-canary.24
+      '@next/swc-win32-arm64-msvc': 16.3.0-canary.24
+      '@next/swc-win32-x64-msvc': 16.3.0-canary.24
       '@opentelemetry/api': 1.9.0
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 minimumReleaseAge: 2880
 
+minimumReleaseAgeExclude:
+  - "@next/*"
+  - next
+
 packages:
   - "apps/*"


### PR DESCRIPTION
## Summary

- `pnpm-workspace.yaml`: adds `minimumReleaseAgeExclude` covering `next` and `@next/*` so canary upgrades aren't blocked by the 48h release-age delay. (The Next.js package and its platform-specific SWC binaries / `@next/env` are published together as a set.)
- Bumps `apps/template` and `apps/docs` to `next@16.3.0-canary.24`.
- canary.24 makes `next/root-params` available without a flag. Removes `experimental.rootParams: true` from `apps/template/next.config.ts` (canary.24 errors on the now-unknown key in its `ExperimentalConfig` type) and updates the `enable-i18n` skill to drop the flag from its setup steps.

## Test plan

- [ ] `pnpm install` resolves cleanly with the new exclude entries
- [ ] `pnpm --filter template build` succeeds, no `experimental.rootParams is no longer needed` warning
- [ ] `pnpm --filter docs build` succeeds
- [ ] `pnpm --filter template lint` passes
- [ ] `apps/docs/scripts/sync-skills.ts` reports no drift between `SKILL.md` and `*.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)