### PR TITLE
re-enable experimental.varyParams in template

### DIFF
--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -19,6 +19,7 @@ const nextConfig: NextConfig = {
     inlineCss: true,
     optimisticRouting: true,
     turbopackFileSystemCacheForDev: true,
+    varyParams: true,
   },
   images: {
     deviceSizes: [640, 828, 1200, 1920],

--- a/packages/plugin/template-rollout-log/2026-05-21-next-vary-params.md
+++ b/packages/plugin/template-rollout-log/2026-05-21-next-vary-params.md
@@ -1,0 +1,32 @@
+---
+title: Re-enable Next vary params
+changeKey: next-vary-params
+introducedOn: 2026-05-21
+changeType: dependency
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/next.config.ts
+---
+
+## Summary
+
+Re-enables Next.js canary's `experimental.varyParams: true` flag in `apps/template/next.config.ts`. Previously enabled in #265, reverted on 2026-05-08, now restored on top of `next@16.3.0-canary.25`.
+
+## Why it matters
+
+`varyParams` lets the template exercise the request-variant behavior the current Next canary is built around, and it's one of the five flags `experimental.appShells` requires (cacheComponents, prefetchInlining, varyParams, optimisticRouting, cachedNavigations). Keeping varyParams on closes the gap to App Shells.
+
+## Apply when
+
+Storefront is on a Next.js canary that supports `experimental.varyParams` (canary.21+).
+
+## Safe to skip when
+
+Storefront has hit a varyParams-specific bug and is intentionally pinning to the flag off.
+
+## Validation
+
+1. `pnpm --filter template build` succeeds.
+2. `pnpm --filter template lint` passes.


### PR DESCRIPTION
## Summary

Re-enables `experimental.varyParams: true` in `apps/template/next.config.ts`.

Previously turned on in #265, reverted on 2026-05-08. Restoring on top of the `next@16.3.0-canary.25` upgrade (PR #280 — this PR is stacked on top of `dan/next-canary-24`).

Closes the gap toward `experimental.appShells`, which requires cacheComponents + prefetchInlining + varyParams + optimisticRouting + cachedNavigations.

## Test plan

- [ ] `pnpm --filter template build` succeeds
- [ ] `pnpm --filter template lint` passes
- [ ] Dev server starts without varyParams-related errors
- [ ] Wait for #280 to merge first, then this can rebase onto main

🤖 Generated with [Claude Code](https://claude.com/claude-code)