### PR TITLE
[template] fix /collections/all pagination + facets; PLP page size 24 → 20

### DIFF
--- a/apps/template/app/collections/all/page.tsx
+++ b/apps/template/app/collections/all/page.tsx
@@ -41,6 +41,15 @@ export const unstable_instant = true;
 
 export const unstable_prefetch = "force-runtime";
 
+// Storefront `search()` only supports RELEVANCE and PRICE sort keys.
+const ALL_PRODUCTS_SORT_EXCLUDE = [
+  "best-selling",
+  "date-new-to-old",
+  "date-old-to-new",
+  "product-name-ascending",
+  "product-name-descending",
+];
+
 export default async function AllProductsPage({ searchParams }: PageProps<"/collections/all">) {
   const locale = await getLocale();
   const handlePromise = Promise.resolve(ALL_PRODUCTS_HANDLE);
@@ -58,6 +67,7 @@ export default async function AllProductsPage({ searchParams }: PageProps<"/coll
       collectionResultsDataPromise={collectionResultsDataPromise}
       locale={locale}
       searchStatePromise={searchStatePromise}
+      sortExclude={ALL_PRODUCTS_SORT_EXCLUDE}
     />
   );
 }

--- a/apps/template/components/collections/collection-page.tsx
+++ b/apps/template/components/collections/collection-page.tsx
@@ -28,12 +28,14 @@ export async function CollectionDetailPage({
   collectionResultsDataPromise,
   locale,
   searchStatePromise,
+  sortExclude,
 }: {
   handlePromise: Promise<string>;
   collectionPromise: Promise<Collection | undefined>;
   collectionResultsDataPromise: Promise<CollectionResultsData>;
   locale: Locale;
   searchStatePromise: Promise<CollectionSearchState>;
+  sortExclude?: string[];
 }) {
   const tSearch = await getTranslations("search");
   const filtersLabel = tSearch("filters");
@@ -74,7 +76,7 @@ export async function CollectionDetailPage({
               }
               sortSelect={
                 <Suspense fallback={<SortSelectFallback label={sortByLabel} />}>
-                  <CollectionsSortSelect />
+                  <CollectionsSortSelect exclude={sortExclude} />
                 </Suspense>
               }
             />

--- a/apps/template/components/collections/results-grid.tsx
+++ b/apps/template/components/collections/results-grid.tsx
@@ -4,8 +4,9 @@ import { Suspense } from "react";
 import { ProductCard } from "@/components/product-card/product-card";
 import { ProductsGridSkeleton } from "@/components/product/products-grid";
 import { loadMoreCollectionProducts } from "@/lib/collections/action";
-import type { CollectionResultsData } from "@/lib/collections/server";
+import { ALL_PRODUCTS_HANDLE, type CollectionResultsData } from "@/lib/collections/server";
 import type { Locale } from "@/lib/i18n";
+import { loadMoreSearchProducts } from "@/lib/search/action";
 import { RESULTS_PER_PAGE } from "@/lib/utils";
 
 import { InfiniteProductGrid } from "./infinite-product-grid";
@@ -42,6 +43,32 @@ async function Render({
     );
   }
 
+  const cards = products.map((product) => (
+    <ProductCard
+      key={product.id}
+      product={product}
+      locale={locale}
+      outOfStockText={tProduct("outOfStock")}
+    />
+  ));
+
+  // /collections/all is backed by the catalog-browse search() field, not the collection
+  // field — load-more has to call the same backend the initial page used.
+  if (collection === ALL_PRODUCTS_HANDLE) {
+    return (
+      <InfiniteProductGrid
+        initialProducts={products}
+        initialPageInfo={result.pageInfo}
+        locale={locale}
+        outOfStockText={tProduct("outOfStock")}
+        loadMore={loadMoreSearchProducts}
+        loadMoreParams={{ sortKey: sort, filters, locale }}
+      >
+        {cards}
+      </InfiniteProductGrid>
+    );
+  }
+
   return (
     <InfiniteProductGrid
       initialProducts={products}
@@ -51,14 +78,7 @@ async function Render({
       loadMore={loadMoreCollectionProducts}
       loadMoreParams={{ collection, sortKey: sort, filters, locale }}
     >
-      {products.map((product) => (
-        <ProductCard
-          key={product.id}
-          product={product}
-          locale={locale}
-          outOfStockText={tProduct("outOfStock")}
-        />
-      ))}
+      {cards}
     </InfiniteProductGrid>
   );
 }

--- a/apps/template/lib/collections/server.ts
+++ b/apps/template/lib/collections/server.ts
@@ -4,7 +4,8 @@ import type { Locale } from "@/lib/i18n";
 import {
   buildProductFiltersFromParams,
   getCollectionProducts,
-  getFilteredCatalogProducts,
+  getSearchFacets,
+  searchIndexProducts,
 } from "@/lib/shopify/operations/products";
 import { type TransformedFilters, transformShopifyFilters } from "@/lib/shopify/transforms/filters";
 import type { ProductFilter } from "@/lib/shopify/types/filters";
@@ -113,19 +114,26 @@ export async function getAllProductsResultsData({
 }): Promise<CollectionResultsData> {
   const { activeFilters, sort } = await searchStatePromise;
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
-  const products = await getFilteredCatalogProducts({
-    sortKey: sort,
-    limit: RESULTS_PER_PAGE,
-    filters: shopifyFilters,
-    locale,
-  });
+  const [products, facets] = await Promise.all([
+    searchIndexProducts({
+      sortKey: sort,
+      limit: RESULTS_PER_PAGE,
+      filters: shopifyFilters,
+      locale,
+    }),
+    getSearchFacets({ filters: shopifyFilters, locale }),
+  ]);
 
   return {
     activeFilters,
     collection: ALL_PRODUCTS_HANDLE,
     sort,
     filters: shopifyFilters,
-    result: { ...products, filters: [] },
-    transformedFilters: transformShopifyFilters([], { activeFilters }),
+    result: {
+      products: products.products,
+      pageInfo: products.pageInfo,
+      filters: facets.filters,
+    },
+    transformedFilters: transformShopifyFilters(facets.filters, { activeFilters }),
   };
 }

--- a/apps/template/lib/utils.ts
+++ b/apps/template/lib/utils.ts
@@ -61,4 +61,4 @@ export function searchParamsToRecord(
   return record;
 }
 
-export const RESULTS_PER_PAGE = 24;
+export const RESULTS_PER_PAGE = 20;

--- a/packages/plugin/template-rollout-log/2026-05-21-collections-all-pagination-and-facets.md
+++ b/packages/plugin/template-rollout-log/2026-05-21-collections-all-pagination-and-facets.md
@@ -1,0 +1,53 @@
+---
+title: Fix /collections/all pagination and populate filter facets
+changeKey: collections-all-pagination-and-facets
+introducedOn: 2026-05-21
+changeType: bugfix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/app/collections/all/page.tsx
+  - apps/template/components/collections/collection-page.tsx
+  - apps/template/components/collections/results-grid.tsx
+  - apps/template/lib/collections/server.ts
+---
+
+## Summary
+
+`/collections/all` was returning 24 products and never loading more. The route's initial data came from `getFilteredCatalogProducts` (Storefront `products()` field), but `InfiniteProductGrid` was wired to `loadMoreCollectionProducts`, which calls `getCollectionProducts({ collection: "all" })` — a real-collection lookup. Shopify has no collection with handle `"all"`, so the load-more call short-circuited to `{ products: [], pageInfo: { hasNextPage: false } }` and pagination stopped after the first page.
+
+The same route also returned `filters: []` and an empty `transformedFilters`, so the filter sidebar showed nothing.
+
+Both are now fixed by aligning `/collections/all` with how `/search` already works:
+
+- `getAllProductsResultsData` now calls `searchIndexProducts` + `getSearchFacets` in parallel (the same backend pair `/search` uses). Real facet counts populate `transformedFilters`.
+- `results-grid.tsx` switches to `loadMoreSearchProducts` for the `ALL_PRODUCTS_HANDLE` case so load-more uses the cursor produced by the initial fetch.
+- `/collections/[handle]` is unchanged — it still uses `getCollectionProducts` + `loadMoreCollectionProducts` because real Shopify collections have their own paginated products edge.
+
+## Why it matters
+
+`/collections/all` is the destination for "Shop all" navigation. A 24-product cap with no filters is a visible regression once the catalog grows past one page.
+
+## Trade-off
+
+Storefront's `search()` field only supports `RELEVANCE` and `PRICE` sort keys. `/collections/all` now hides `best-selling`, `date-new-to-old`, `date-old-to-new`, `product-name-ascending`, and `product-name-descending` from the sort dropdown — matching `/search`'s existing exclusion list. `/collections/[handle]` keeps the full set because it uses the collection-level `ProductCollectionSortKeys`.
+
+If the storefront needs those sort options on the all-products page, the alternative is to back `/collections/all` with `products()` (which supports the full sort set) and call `getSearchFacets` separately for facet counts. The caveat is that `products()` silently drops `variantOption` and `productMetafield` filters at the backend, so applying those filter types on the all-products page would show counts but not actually filter products. Pick whichever trade-off matches the storefront's filter set.
+
+## Apply when
+
+Storefront has a `/collections/all` page (added 2026-05-20) and wants pagination + filters to work there.
+
+## Safe to skip when
+
+Storefront has replaced `/collections/all` with a custom virtual-collection implementation.
+
+## Validation
+
+1. `pnpm --filter template build` and `pnpm --filter template lint` clean.
+2. `pnpm --filter template dev`. Visit `/collections/all`:
+   - Scroll to the bottom of the initial 24-product grid; the next page loads.
+   - The filter sidebar shows real facets (availability, product type, price, etc.).
+   - The sort dropdown shows only the search()-compatible options (best-matches, price-low-to-high, price-high-to-low).
+3. Visit `/collections/frontpage` and confirm its sort dropdown still shows the full set (collection-level sort keys are unaffected) and pagination still works.

--- a/packages/plugin/template-rollout-log/2026-05-21-plp-page-size-20.md
+++ b/packages/plugin/template-rollout-log/2026-05-21-plp-page-size-20.md
@@ -1,0 +1,31 @@
+---
+title: PLP page size 24 → 20
+changeKey: plp-page-size-20
+introducedOn: 2026-05-21
+changeType: enhancement
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/utils.ts
+---
+
+## Summary
+
+`RESULTS_PER_PAGE` drops from 24 to 20 across all PLP grids (`/search`, `/collections/[handle]`, `/collections/all`, and the markdown route mirrors).
+
+## Why it matters
+
+The grid uses `grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5` breakpoints. At the widest (xl, 5 cols) 24 leaves a 4-item dangling row; 20 fills the grid evenly at base (2), lg (4), and xl (5) and is only short at sm (3, two-item dangling). For an xl-first layout 20 reads cleaner.
+
+## Apply when
+
+Storefront still uses the template's default column breakpoints.
+
+## Safe to skip when
+
+Fork has retuned the grid to different breakpoints (e.g. always 3-col, or 6-col at xl). Pick a `RESULTS_PER_PAGE` that's a multiple of the widest column count.
+
+## Validation
+
+`pnpm --filter template dev`. Visit `/search`, `/collections/frontpage`, `/collections/all` at viewport widths matching each breakpoint and confirm the initial page fills evenly at lg/xl.


### PR DESCRIPTION
Two PLP-side changes bundled together so they ship in one merge.

## 1. Fix /collections/all pagination + facets

\`/collections/all\` was capped at 24 products with no filters. Two stacked causes:

1. **Pagination didn't fire.** Initial render used \`getFilteredCatalogProducts\` (Storefront \`products()\` field), but \`InfiniteProductGrid\` was wired to \`loadMoreCollectionProducts\`, which calls \`getCollectionProducts({ collection: \"all\" })\`. Shopify has no collection with that handle, so the load-more call short-circuited to \`{ products: [], pageInfo: { hasNextPage: false } }\` and pagination stopped after the first page.
2. **Filter sidebar was empty.** \`getAllProductsResultsData\` returned \`filters: []\` and \`transformShopifyFilters([], ...)\`, so no facets ever populated.

Aligned \`/collections/all\` with the path \`/search\` already uses:

- \`getAllProductsResultsData\` now fetches via \`searchIndexProducts\` + \`getSearchFacets\` in parallel.
- \`results-grid.tsx\` switches to \`loadMoreSearchProducts\` when \`collection === ALL_PRODUCTS_HANDLE\`.
- \`CollectionDetailPage\` accepts \`sortExclude\`. \`/collections/all\` passes the search()-incompatible sort keys so the dropdown only shows what the backend can deliver.
- \`/collections/[handle]\` unchanged — real Shopify collections still use \`getCollectionProducts\` + \`loadMoreCollectionProducts\` and the full \`ProductCollectionSortKeys\` sort set.

### Trade-off

Storefront's \`search()\` field only supports \`RELEVANCE\` + \`PRICE\` sort keys. \`/collections/all\` now hides \`best-selling\`, \`date-new-to-old\`, \`date-old-to-new\`, \`product-name-ascending\`, \`product-name-descending\` from the sort dropdown — matching what \`/search\` already does.

If a downstream storefront needs those sort options on the all-products page, the alternative is to keep \`getFilteredCatalogProducts\` for products and call \`getSearchFacets\` separately for facet counts. The caveat: \`products()\` silently drops \`variantOption\` / \`productMetafield\` filters at the backend, so applying those filter types would show counts but not actually filter. Rollout-log entry documents this.

## 2. PLP page size 24 → 20

\`RESULTS_PER_PAGE\` drops from 24 to 20 in \`lib/utils.ts\`. Applies across \`/search\`, \`/collections/[handle]\`, \`/collections/all\`, and the markdown route mirrors.

The grid is \`grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5\`. At xl (5 cols), 24 leaves a 4-item dangling last row; 20 is clean at base/lg/xl and short only at sm (3 cols, 2-item dangle). xl-first reading.

## Test plan

- [x] \`pnpm --filter template build\` clean
- [x] \`pnpm --filter template lint\` clean (5 pre-existing warnings unrelated)
- [x] \`/collections/all\` — scroll past 20; next page loads
- [x] \`/collections/all\` — filter sidebar shows real facets (availability, product type, price)
- [x] \`/collections/all\` — sort dropdown only shows best-matches / price-low / price-high
- [x] \`/collections/frontpage\` — sort dropdown still has the full set; pagination still works
- [x] At xl width, every PLP grid fills evenly (no 4-item dangling last row on the initial page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)