### PR TITLE
[template] PLP page size 24 → 20

### DIFF
--- a/apps/template/lib/utils.ts
+++ b/apps/template/lib/utils.ts
@@ -61,4 +61,4 @@ export function searchParamsToRecord(
   return record;
 }
 
-export const RESULTS_PER_PAGE = 24;
+export const RESULTS_PER_PAGE = 20;

--- a/packages/plugin/template-rollout-log/2026-05-21-plp-page-size-20.md
+++ b/packages/plugin/template-rollout-log/2026-05-21-plp-page-size-20.md
@@ -1,0 +1,31 @@
+---
+title: PLP page size 24 → 20
+changeKey: plp-page-size-20
+introducedOn: 2026-05-21
+changeType: enhancement
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/utils.ts
+---
+
+## Summary
+
+`RESULTS_PER_PAGE` drops from 24 to 20 across all PLP grids (`/search`, `/collections/[handle]`, `/collections/all`, and the markdown route mirrors).
+
+## Why it matters
+
+The grid uses `grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5` breakpoints. At the widest (xl, 5 cols) 24 leaves a 4-item dangling row; 20 fills the grid evenly at base (2), lg (4), and xl (5) and is only short at sm (3, two-item dangling). For an xl-first layout 20 reads cleaner.
+
+## Apply when
+
+Storefront still uses the template's default column breakpoints.
+
+## Safe to skip when
+
+Fork has retuned the grid to different breakpoints (e.g. always 3-col, or 6-col at xl). Pick a `RESULTS_PER_PAGE` that's a multiple of the widest column count.
+
+## Validation
+
+`pnpm --filter template dev`. Visit `/search`, `/collections/frontpage`, `/collections/all` at viewport widths matching each breakpoint and confirm the initial page fills evenly at lg/xl.


### PR DESCRIPTION
## Summary

Drops \`RESULTS_PER_PAGE\` from 24 to 20 in \`lib/utils.ts\`. Affects every PLP grid (\`/search\`, \`/collections/[handle]\`, \`/collections/all\`, and the markdown route mirrors) through the single constant.

## Why

The grid uses \`grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5\`. Cleanliness at each breakpoint:

| cols | 24 | 20 |
|---|---|---|
| 2 (base) | 12 rows clean | 10 rows clean |
| 3 (sm) | 8 rows clean | 6+⅔ (2 dangling) |
| 4 (lg) | 6 rows clean | 5 rows clean |
| 5 (xl) | 4+⅘ (4 dangling) | 4 rows clean |

For an xl-first layout 20 reads cleaner. The sm breakpoint is the only one where 20 has a partial last row, but it's a 2-item dangle vs 24's 4-item dangle at xl.

## Test plan

- [x] \`pnpm --filter template build\` clean
- [x] \`pnpm --filter template lint\` clean
- [ ] Visual: \`/search\`, \`/collections/frontpage\`, \`/collections/all\` at lg + xl widths — initial page fills the grid evenly

🤖 Generated with [Claude Code](https://claude.com/claude-code)