### PR TITLE
Upgrade Next.js to 16.3.0-canary.26

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -25,7 +25,7 @@
 		"lucide-react": "1.16.0",
 		"motion": "12.38.0",
 		"nanoid": "5.1.11",
-		"next": "16.3.0-canary.25",
+		"next": "16.3.0-canary.26",
 		"next-mdx-remote": "6.0.0",
 		"next-themes": "0.4.6",
 		"postcss": "8.5.14",

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -15,11 +15,8 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_AUTH_ENABLED: isAuthEnabled ? "1" : "",
   },
   experimental: {
-    cachedNavigations: true,
     inlineCss: true,
-    optimisticRouting: true,
     turbopackFileSystemCacheForDev: true,
-    varyParams: true,
   },
   images: {
     deviceSizes: [640, 828, 1200, 1920],

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -29,7 +29,7 @@
     "cmdk": "1.1.1",
     "lucide-react": "1.16.0",
     "nanoid": "5.1.11",
-    "next": "16.3.0-canary.25",
+    "next": "16.3.0-canary.26",
     "next-intl": "4.12.0",
     "oxfmt": "0.50.0",
     "oxlint": "1.65.0",

--- a/packages/plugin/template-rollout-log/2026-05-21-next-canary-26-routing-flags-default.md
+++ b/packages/plugin/template-rollout-log/2026-05-21-next-canary-26-routing-flags-default.md
@@ -1,0 +1,36 @@
+---
+title: Next canary 26 — varyParams, optimisticRouting, cachedNavigations enabled by default
+changeKey: next-canary-26-routing-flags-default
+introducedOn: 2026-05-21
+changeType: dependency
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/package.json
+  - apps/docs/package.json
+  - apps/template/next.config.ts
+  - pnpm-lock.yaml
+---
+
+## Summary
+
+Bumps Next.js to `16.3.0-canary.26` in both apps. canary.26 flips three experimental flags on by default — `experimental.varyParams`, `experimental.optimisticRouting`, and `experimental.cachedNavigations` (the last automatically when `cacheComponents` is on) — so all three keys are removed from `apps/template/next.config.ts`. Supersedes [[2026-05-21-next-vary-params]].
+
+## Why it matters
+
+Keeps the template on the latest Next.js canary so the cache-components / Turbopack / instant-navigation paths under active development are exercised. Removing the now-default keys prevents a noisy build warning and a future hard error when Next removes the experimental key.
+
+## Apply when
+
+Storefront is upgrading to Next.js 16.3.0-canary.26 or newer.
+
+## Safe to skip when
+
+Storefront is pinned to an older Next.js canary that still gates these flags behind explicit opt-in, or has hit a regression with one of the three behaviors and is intentionally turning it off via the experimental key.
+
+## Validation
+
+1. `pnpm install` resolves cleanly with the existing `minimumReleaseAgeExclude` entries for `next` and `@next/*`.
+2. `pnpm --filter template build` and `pnpm --filter docs build` succeed with no warnings about removed experimental flags.
+3. `pnpm --filter template lint` passes.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,10 +55,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.1(next@16.3.0-canary.26(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.0(next@16.3.0-canary.26(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.184
         version: 6.0.184(zod@4.4.3)
@@ -82,10 +82,10 @@ importers:
         version: 5.2.1
       fromsrc:
         specifier: 0.0.31
-        version: 0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       geist:
         specifier: 1.7.0
-        version: 1.7.0(next@16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 1.7.0(next@16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       jotai:
         specifier: 2.20.0
         version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.6)
@@ -99,8 +99,8 @@ importers:
         specifier: 5.1.11
         version: 5.1.11
       next:
-        specifier: 16.3.0-canary.25
-        version: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 16.3.0-canary.26
+        version: 16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-mdx-remote:
         specifier: 6.0.0
         version: 6.0.0(@types/react@19.2.14)(react@19.2.6)
@@ -181,10 +181,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.1(next@16.3.0-canary.26(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.0(next@16.3.0-canary.26(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.184
         version: 6.0.184(zod@4.4.3)
@@ -193,7 +193,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
+        version: 1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.26(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -210,11 +210,11 @@ importers:
         specifier: 5.1.11
         version: 5.1.11
       next:
-        specifier: 16.3.0-canary.25
-        version: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 16.3.0-canary.26
+        version: 16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl:
         specifier: 4.12.0
-        version: 4.12.0(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+        version: 4.12.0(next@16.3.0-canary.26(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       oxfmt:
         specifier: 0.50.0
         version: 0.50.0
@@ -769,57 +769,57 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@next/env@16.3.0-canary.25':
-    resolution: {integrity: sha512-y/L3F/urOwBe/CKNLIOlfUvj2YNLFg0ktt5uwHIUxX2zf5lCkL2bYzKbzoMpFaJrtjkNk9RBvatQOswcA9MvtQ==}
+  '@next/env@16.3.0-canary.26':
+    resolution: {integrity: sha512-QQigNHYlBvtATYoqtYxkvizJYXTwOiA4/fkfcjN8Jkydm0MvTEK8NSMScDNu7NDbPbVyLp3848dW+e4W13Hp+g==}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.25':
-    resolution: {integrity: sha512-3wwwtNdwp3++Pip2vnTZ5PDRk1nPe1I3WEGtfdLTC+OFmj/lPA7R7JiaMfX1VyT1WqE6Tf2N4bSfiAtDJqoqcg==}
+  '@next/swc-darwin-arm64@16.3.0-canary.26':
+    resolution: {integrity: sha512-XHI6rARAsGJiDyyDVsT8oYUB8SC1UxHVIQRLw1y0S9Yw4d2zMhIfemMd0QX30nydmyq/Fu0IrGIb7viBG84AvA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.3.0-canary.25':
-    resolution: {integrity: sha512-eXMfpfVnvHjoczvmTzM3kbR4Cv2JQhXWYXSkhPJqTotlIMOFncuS+paSaQjdpFFgg0vS3UbIsb8d8ymv2LNCKQ==}
+  '@next/swc-darwin-x64@16.3.0-canary.26':
+    resolution: {integrity: sha512-orTc877oz1mSkiv7VRE2kS1ZpY0DUtDv3zVdvtKfRYvRTXmWQQjbuziPJdECkq0vjCKl8MD0v+jlZHDlNSH9pA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.25':
-    resolution: {integrity: sha512-uPSyGPRSIsfHXl2tO1nRk/Gg0xpXyjx2tw+hp73jjhe5l9B8mR9VRTmZgnlMRTlr85X2AYCAH7vLEblBiHi15A==}
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.26':
+    resolution: {integrity: sha512-eqJuG46YwWNWvNmhjGA1nBMcuUoyZKNHzj9oiBD+XpigZ2hkz8zaFOzVC+8eSTGdjPbhKgn8M4PDBc1AMjIOGQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.25':
-    resolution: {integrity: sha512-TWUjoROv6ZC6rGBtLXgzrtkmRiviMrFhFi2bPIZDdbU87e4g+HOkBaLqR+aEUtphRnEikWToN7Xy1euF4OvV8A==}
+  '@next/swc-linux-arm64-musl@16.3.0-canary.26':
+    resolution: {integrity: sha512-mZPbgSalHnJSChyZLDmm0j4oKXLd/MsueX58zSQG+rJz/kQSnPNiRmbinxDuuTGf6b9iFsqSmV+qL79OTqjYQA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.25':
-    resolution: {integrity: sha512-/xcz6T7BKqJqm/x5eWsKDKWo+HfCuvbLbkvCkCnnpSs13Rtt8A/JeTrCld17zzCid6U5fyzzWW9mWjBaRmGteQ==}
+  '@next/swc-linux-x64-gnu@16.3.0-canary.26':
+    resolution: {integrity: sha512-cc6X0+lmMDJKHeVWyYzLCzB86xNi5g0BdpFD2VzHbrnMDD1hk7FH7Io8Aj0b0q+tvKWlNmACshR78CyEEXRxvw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.25':
-    resolution: {integrity: sha512-B6F6dOPCY0ttaQPSGVoKb0u1Xiu8vDldLkruL0jsM1PgKKZPkJSjSi3bg4VuWc0wTq1moqevhoinK21L86RSmA==}
+  '@next/swc-linux-x64-musl@16.3.0-canary.26':
+    resolution: {integrity: sha512-7SElcBLZj+6yCTbvh2i8/f/N+wH8dXoJk+tqKQehfSF2Ov60FM8WsbKG32LCCMV23ovwHGwiU2GKShl4N3sC6g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.25':
-    resolution: {integrity: sha512-GWhn3dcawZkg+MHwtR9xaMnanBrSuBODQC7eplbnLo++zmhexBmRR07VWzSQ4s5I8KnyNOtYgkEppgo27TywUQ==}
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.26':
+    resolution: {integrity: sha512-9iaJhDEjiLTt0EHxKX9bW/gyqJrZHfdMo5cxBoHjdcjVtIPvlQosicKkLMrgNvd6J0bX897DtvwIZdH2mW6MRQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.25':
-    resolution: {integrity: sha512-c0JyUJCpnHLSdtnAEKmPf5Nr5QE2i35DjqoyRkrLJiTVU82JZHSvB0MjTLVvohsSXJcLlhXUKOEfG4RKQW/Odw==}
+  '@next/swc-win32-x64-msvc@16.3.0-canary.26':
+    resolution: {integrity: sha512-MR0D9LuhELmlKyuZV13L1p+Zcjvz0QZnYgYrDSRuucYS98JM99pl++jXXwEX2TqwetcuGbqnPjbczJB4feZrZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3574,8 +3574,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.3.0-canary.25:
-    resolution: {integrity: sha512-3bL9/wGkejnI1JCCQT17JXzPkiWM0bxU3kbGuElk8p45n2vQ13xPmDvJzlh7dwdiZVFQlfDGMlqtaTQ1R0dTxg==}
+  next@16.3.0-canary.26:
+    resolution: {integrity: sha512-ZZVffjC8Z2Yh4U5ZqLUQDT2FCzNPOrsKKsYpsYzF4dSh55ygY8wBnpn1qoTu3S5v54F6hW2q+L+Y++mBjSKyKg==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4873,30 +4873,30 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@next/env@16.3.0-canary.25': {}
+  '@next/env@16.3.0-canary.26': {}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.25':
+  '@next/swc-darwin-arm64@16.3.0-canary.26':
     optional: true
 
-  '@next/swc-darwin-x64@16.3.0-canary.25':
+  '@next/swc-darwin-x64@16.3.0-canary.26':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.25':
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.26':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.25':
+  '@next/swc-linux-arm64-musl@16.3.0-canary.26':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.25':
+  '@next/swc-linux-x64-gnu@16.3.0-canary.26':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.25':
+  '@next/swc-linux-x64-musl@16.3.0-canary.26':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.25':
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.26':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.25':
+  '@next/swc-win32-x64-msvc@16.3.0-canary.26':
     optional: true
 
   '@noble/ciphers@2.2.0': {}
@@ -6241,17 +6241,17 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(next@16.3.0-canary.26(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       vue: 3.5.30(typescript@6.0.3)
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.26(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       vue: 3.5.30(typescript@6.0.3)
 
@@ -6358,7 +6358,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.7: {}
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3)):
+  better-auth@1.6.11(@opentelemetry/api@1.9.0)(next@16.3.0-canary.26(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vue@3.5.30(typescript@6.0.3)):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -6378,7 +6378,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       vue: 3.5.30(typescript@6.0.3)
@@ -6843,13 +6843,13 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  fromsrc@0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  fromsrc@0.0.31(@types/react@19.2.14)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@shikijs/rehype': 3.23.0
       '@shikijs/transformers': 3.23.0
       gray-matter: 4.0.3
-      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-mdx-remote: 6.0.0(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       remark-gfm: 4.0.1
@@ -6875,9 +6875,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
-  geist@1.7.0(next@16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  geist@1.7.0(next@16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
-      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   gensync@1.0.0-beta.2:
     optional: true
@@ -7759,14 +7759,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.12.0: {}
 
-  next-intl@4.12.0(next@16.3.0-canary.25(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
+  next-intl@4.12.0(next@16.3.0-canary.26(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.18
       icu-minify: 4.12.0
       negotiator: 1.0.0
-      next: 16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl-swc-plugin-extractor: 4.12.0
       po-parser: 2.1.1
       react: 19.2.6
@@ -7795,9 +7795,9 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@16.3.0-canary.25(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.3.0-canary.26(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@next/env': 16.3.0-canary.25
+      '@next/env': 16.3.0-canary.26
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.7
       caniuse-lite: 1.0.30001778
@@ -7806,14 +7806,14 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.6)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.3.0-canary.25
-      '@next/swc-darwin-x64': 16.3.0-canary.25
-      '@next/swc-linux-arm64-gnu': 16.3.0-canary.25
-      '@next/swc-linux-arm64-musl': 16.3.0-canary.25
-      '@next/swc-linux-x64-gnu': 16.3.0-canary.25
-      '@next/swc-linux-x64-musl': 16.3.0-canary.25
-      '@next/swc-win32-arm64-msvc': 16.3.0-canary.25
-      '@next/swc-win32-x64-msvc': 16.3.0-canary.25
+      '@next/swc-darwin-arm64': 16.3.0-canary.26
+      '@next/swc-darwin-x64': 16.3.0-canary.26
+      '@next/swc-linux-arm64-gnu': 16.3.0-canary.26
+      '@next/swc-linux-arm64-musl': 16.3.0-canary.26
+      '@next/swc-linux-x64-gnu': 16.3.0-canary.26
+      '@next/swc-linux-x64-musl': 16.3.0-canary.26
+      '@next/swc-win32-arm64-msvc': 16.3.0-canary.26
+      '@next/swc-win32-x64-msvc': 16.3.0-canary.26
       '@opentelemetry/api': 1.9.0
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5


### PR DESCRIPTION
## Summary
- Bump `next` to `16.3.0-canary.26` in `apps/template` and `apps/docs`.
- canary.26 enables `experimental.varyParams`, `experimental.optimisticRouting`, and `experimental.cachedNavigations` (the last with `cacheComponents`) by default — remove all three keys from `apps/template/next.config.ts`.
- Add rollout log entry `2026-05-21-next-canary-26-routing-flags-default.md` (supersedes the `next-vary-params` entry).

[Next.js canary.25 → canary.26 diff](https://github.com/vercel/next.js/compare/v16.3.0-canary.25...v16.3.0-canary.26)

## Test plan
- [x] `pnpm install` resolves cleanly
- [x] `pnpm --filter template build` succeeds, no warnings about removed experimental flags
- [x] `pnpm --filter docs build` succeeds
- [x] `pnpm --filter template lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)