### PR TITLE
Introduce auth/agent feature flags in lib/config

### DIFF
--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -8,6 +8,10 @@ prerequisites:
 
 The storefront includes an AI shopping assistant powered by Claude via the Vercel AI SDK. It can search products, browse collections, manage the cart, and render rich product cards - all through natural conversation. The assistant is context-aware, adapting its behavior based on what page the user is viewing.
 
+## Configuration
+
+The agent is opt-in via `NEXT_PUBLIC_ENABLE_AGENT="1"`. When unset, the agent button is hidden from the storefront and the `/api/chat` route returns 404.
+
 ## Architecture
 
 The agent runs as a `ToolLoopAgent` that streams responses back to a floating chat panel:
@@ -100,10 +104,6 @@ The agent panel is toggled from a button in the bottom bar. The panel includes:
 - **Token cap** — set `maxOutputTokens` on the `ToolLoopAgent` defaults to bound worst-case gateway spend per call.
 
 If `/api/chat` sits behind an existing WAF (Cloudflare, etc.), prefer that and keep the token cap.
-
-## Configuration
-
-The agent is opt-in via `NEXT_PUBLIC_ENABLE_AGENT="1"`. When unset, the agent button is hidden from the storefront and the `/api/chat` route returns 404.
 
 ## Key files
 

--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -103,7 +103,7 @@ If `/api/chat` sits behind an existing WAF (Cloudflare, etc.), prefer that and k
 
 ## Configuration
 
-The agent can be disabled entirely by setting the `AI_AGENT_DISABLED` environment variable, which hides the agent button from the storefront.
+The agent is opt-in via `NEXT_PUBLIC_ENABLE_AGENT="1"`. When unset, the agent button is hidden from the storefront and the `/api/chat` route returns 404.
 
 ## Key files
 

--- a/apps/docs/content/docs/anatomy/authentication.mdx
+++ b/apps/docs/content/docs/anatomy/authentication.mdx
@@ -7,7 +7,7 @@ The template includes built-in customer authentication using [better-auth](https
 
 Authentication is **opt-in via environment variables**. Without them, the storefront works as a guest-only experience and no auth UI is rendered.
 
-## Enabling authentication
+## Configuration
 
 Set the feature flag and three server-only secrets:
 

--- a/apps/docs/content/docs/anatomy/authentication.mdx
+++ b/apps/docs/content/docs/anatomy/authentication.mdx
@@ -9,15 +9,16 @@ Authentication is **opt-in via environment variables**. Without them, the storef
 
 ## Enabling authentication
 
-Add these three server-only secrets to enable the auth UI:
+Set the feature flag and three server-only secrets:
 
 ```bash
+NEXT_PUBLIC_ENABLE_AUTH="1"
 BETTER_AUTH_SECRET="generate-with-openssl-rand-base64-32"
 SHOPIFY_CUSTOMER_CLIENT_ID="your-customer-client-id"
 SHOPIFY_CUSTOMER_CLIENT_SECRET="your-customer-client-secret"
 ```
 
-That's the only knob. `next.config.ts` derives `NEXT_PUBLIC_AUTH_ENABLED` at build time from the presence of all three secrets and exposes it via the `env` config so client and server agree at hydration. Don't set `NEXT_PUBLIC_AUTH_ENABLED` yourself — probing the server-only secrets directly inside a component (instead of going through the build-time flag) causes hydration mismatches under cache components.
+`next.config.ts` throws at build time if `NEXT_PUBLIC_ENABLE_AUTH="1"` is set without the three secrets. The flag must be `NEXT_PUBLIC_` so its value is available identically on server and client — probing the server-only secrets directly inside a component causes hydration mismatches under cache components.
 
 Generate the auth secret with `openssl rand -base64 32`. The client ID and secret come from Shopify's Customer Account API.
 
@@ -46,7 +47,7 @@ The API route at `/api/auth/[...all]` handles all OAuth callbacks, session manag
 
 ### Feature gating
 
-The `isAuthEnabled` flag (from `lib/auth`) reads `NEXT_PUBLIC_AUTH_ENABLED`, which `next.config.ts` derives from secret presence at build time. When `false`:
+The `isAuthEnabled` flag (from `lib/auth`) reads `auth.enabled` from `lib/config`, which is `process.env.NEXT_PUBLIC_ENABLE_AUTH === "1"`. When `false`:
 
 - The account icon does not appear in the nav
 - `/account/login` and `/account/*` return 404
@@ -117,7 +118,7 @@ function AccountMenu() {
 - The Customer Account API uses a separate GraphQL endpoint from the Storefront API — validate fields with the Shopify schema
 - Session cookies use `httpOnly` and `secure` flags automatically via better-auth
 - PKCE is enabled for the OAuth flow — never disable it
-- `isAuthEnabled` must read a `NEXT_PUBLIC_` variable — server-only env vars cause hydration mismatches with cache components. The flag is derived at build time in `next.config.ts`; don't replace it with an inline `process.env.BETTER_AUTH_SECRET` check
+- `isAuthEnabled` must read a `NEXT_PUBLIC_` variable — server-only env vars cause hydration mismatches with cache components. Don't replace it with an inline `process.env.BETTER_AUTH_SECRET` check
 
 ## Next steps
 

--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -64,15 +64,16 @@ You can find the storefront token in **Settings → Apps and sales channels → 
 
 ### Optional: Enable customer authentication
 
-The template includes built-in customer authentication using [better-auth](https://www.better-auth.com/) with Shopify Customer Account API. To enable it, add these three server-only secrets to your `.env.local`:
+The template includes built-in customer authentication using [better-auth](https://www.better-auth.com/) with Shopify Customer Account API. To enable it, set the feature flag and three server-only secrets in your `.env.local`:
 
 ```bash
+NEXT_PUBLIC_ENABLE_AUTH="1"
 BETTER_AUTH_SECRET="generate-with-openssl-rand-base64-32"
 SHOPIFY_CUSTOMER_CLIENT_ID="your-customer-client-id"
 SHOPIFY_CUSTOMER_CLIENT_SECRET="your-customer-client-secret"
 ```
 
-The auth UI (account icon, login page, account pages) turns on automatically when all three are set — `next.config.ts` derives `NEXT_PUBLIC_AUTH_ENABLED` at build time from their presence. Don't set `NEXT_PUBLIC_AUTH_ENABLED` yourself. Without these variables, the storefront works as a guest-only experience. See [Environment Variables](/docs/reference/env-vars) for details.
+`next.config.ts` throws at build time if `NEXT_PUBLIC_ENABLE_AUTH="1"` is set without the three secrets. Without the flag, the storefront works as a guest-only experience. See [Environment Variables](/docs/reference/env-vars) for details.
 
 ## Step 4: Run locally
 

--- a/apps/docs/content/docs/reference/env-vars.mdx
+++ b/apps/docs/content/docs/reference/env-vars.mdx
@@ -12,9 +12,18 @@ type: reference
 | `SHOPIFY_STOREFRONT_ACCESS_TOKEN` | Public Storefront API access token. Found in **Settings → Apps and sales channels → Headless**. |
 | `NEXT_PUBLIC_SITE_NAME` | The name displayed in your storefront's header and metadata. |
 
+## Feature flags
+
+Both optional features are opt-in via explicit `NEXT_PUBLIC_ENABLE_*` flags. The `NEXT_PUBLIC_` prefix is required so the conditional rendering matches between server and client under cache components.
+
+| Variable | Description |
+|----------|-------------|
+| `NEXT_PUBLIC_ENABLE_AUTH` | Set to `"1"` to enable the auth UI and the `/account/*` routes. Requires the three Customer Authentication secrets below — `next.config.ts` throws at build time if any are missing. |
+| `NEXT_PUBLIC_ENABLE_AGENT` | Set to `"1"` to enable the AI shopping assistant button and the `/api/chat` route. |
+
 ## Customer Authentication
 
-These variables enable built-in customer authentication with [better-auth](https://www.better-auth.com/) and Shopify Customer Account API OIDC. Provide all three server-side secrets to turn on the auth UI; `next.config.ts` derives `NEXT_PUBLIC_AUTH_ENABLED` from their presence at build time so client and server agree at hydration.
+Required when `NEXT_PUBLIC_ENABLE_AUTH="1"`. Powers built-in customer authentication via [better-auth](https://www.better-auth.com/) and Shopify Customer Account API OIDC.
 
 | Variable | Description |
 |----------|-------------|
@@ -22,13 +31,10 @@ These variables enable built-in customer authentication with [better-auth](https
 | `SHOPIFY_CUSTOMER_CLIENT_ID` | Customer Account API client ID. Found in **Shopify Admin → Settings → Customer accounts → API clients**. |
 | `SHOPIFY_CUSTOMER_CLIENT_SECRET` | Customer Account API client secret. Found in the same location as the client ID. |
 
-`NEXT_PUBLIC_AUTH_ENABLED` is computed automatically — don't set it manually. It must be a public variable so the auth UI's conditional rendering matches between server and client under cache components.
-
 ## Optional
 
 | Variable | Description |
 |----------|-------------|
-| `AI_AGENT_DISABLED` | Set to any non-empty value to hide the AI shopping assistant button. |
 | `BETTER_AUTH_BASE_URL` | Override the base URL for auth callbacks. Defaults to `NEXT_PUBLIC_BASE_URL` or the Vercel production URL. |
 | `BETTER_AUTH_TRUSTED_ORIGINS` | Comma-separated list of trusted origins for auth callbacks. |
 | `CMS_DRAFT_MODE_SECRET` | Secret token guarding the `/api/draft` route for CMS preview links. Generate with `openssl rand -base64 32`. |

--- a/apps/template/.env.example
+++ b/apps/template/.env.example
@@ -6,9 +6,10 @@ SHOPIFY_STOREFRONT_ACCESS_TOKEN="your-storefront-access-token"
 NEXT_PUBLIC_SITE_NAME="Your Store Name"
 
 # Optional — Customer Authentication (better-auth + Shopify OIDC)
-# Set all three secrets below to enable the account icon and login flow.
-# next.config.ts derives NEXT_PUBLIC_AUTH_ENABLED from their presence at build time;
-# don't set NEXT_PUBLIC_AUTH_ENABLED yourself.
+# Set NEXT_PUBLIC_FEATURE_AUTH="1" to enable the account icon, login flow, and
+# auth-gated /account routes. The three secrets below must also be set for auth
+# to work end-to-end.
+# NEXT_PUBLIC_FEATURE_AUTH="1"
 # BETTER_AUTH_SECRET="generate-with-openssl-rand-base64-32"
 # SHOPIFY_CUSTOMER_CLIENT_ID="your-customer-client-id"
 # SHOPIFY_CUSTOMER_CLIENT_SECRET="your-customer-client-secret"
@@ -30,8 +31,10 @@ NEXT_PUBLIC_SITE_NAME="Your Store Name"
 # Required if you use /api/draft for CMS preview links.
 # CMS_DRAFT_MODE_SECRET="generate-with-openssl-rand-base64-32"
 
-# Optional — Hide the AI shopping assistant button. Set to any non-empty value.
-# AI_AGENT_DISABLED="1"
+# Optional — AI shopping assistant.
+# Set NEXT_PUBLIC_FEATURE_AGENT="1" to enable the assistant button and the
+# /api/chat route.
+# NEXT_PUBLIC_FEATURE_AGENT="1"
 
 # Optional — Verbose Shopify Storefront API request logging in the server console.
 # DEBUG_SHOPIFY="true"

--- a/apps/template/.env.example
+++ b/apps/template/.env.example
@@ -5,14 +5,14 @@ SHOPIFY_STOREFRONT_ACCESS_TOKEN="your-storefront-access-token"
 # Store display name (shown in header, metadata, etc.)
 NEXT_PUBLIC_SITE_NAME="Your Store Name"
 
+# Optional — AI shopping assistant.
+# NEXT_PUBLIC_ENABLE_AGENT="1"
+
 # Optional — Customer Authentication (better-auth + Shopify OIDC).
 # NEXT_PUBLIC_ENABLE_AUTH="1"
 # BETTER_AUTH_SECRET="generate-with-openssl-rand-base64-32"
 # SHOPIFY_CUSTOMER_CLIENT_ID="your-customer-client-id"
 # SHOPIFY_CUSTOMER_CLIENT_SECRET="your-customer-client-secret"
-# Optional — Override callback host or comma-separated trusted origins.
-# By default, auth derives production from VERCEL_PROJECT_PRODUCTION_URL,
-# previews from VERCEL_BRANCH_URL or VERCEL_URL, and local dev from localhost.
 # BETTER_AUTH_BASE_URL="https://your-domain.com"
 # BETTER_AUTH_TRUSTED_ORIGINS="https://your-domain.com,https://staging.your-domain.com"
 
@@ -27,9 +27,6 @@ NEXT_PUBLIC_SITE_NAME="Your Store Name"
 # Optional — CMS draft mode (preview unpublished metaobject content).
 # Required if you use /api/draft for CMS preview links.
 # CMS_DRAFT_MODE_SECRET="generate-with-openssl-rand-base64-32"
-
-# Optional — AI shopping assistant.
-# NEXT_PUBLIC_ENABLE_AGENT="1"
 
 # Optional — Verbose Shopify Storefront API request logging in the server console.
 # DEBUG_SHOPIFY="true"

--- a/apps/template/.env.example
+++ b/apps/template/.env.example
@@ -5,11 +5,8 @@ SHOPIFY_STOREFRONT_ACCESS_TOKEN="your-storefront-access-token"
 # Store display name (shown in header, metadata, etc.)
 NEXT_PUBLIC_SITE_NAME="Your Store Name"
 
-# Optional — Customer Authentication (better-auth + Shopify OIDC)
-# Set NEXT_PUBLIC_FEATURE_AUTH="1" to enable the account icon, login flow, and
-# auth-gated /account routes. The three secrets below must also be set for auth
-# to work end-to-end.
-# NEXT_PUBLIC_FEATURE_AUTH="1"
+# Optional — Customer Authentication (better-auth + Shopify OIDC).
+# NEXT_PUBLIC_ENABLE_AUTH="1"
 # BETTER_AUTH_SECRET="generate-with-openssl-rand-base64-32"
 # SHOPIFY_CUSTOMER_CLIENT_ID="your-customer-client-id"
 # SHOPIFY_CUSTOMER_CLIENT_SECRET="your-customer-client-secret"
@@ -32,9 +29,7 @@ NEXT_PUBLIC_SITE_NAME="Your Store Name"
 # CMS_DRAFT_MODE_SECRET="generate-with-openssl-rand-base64-32"
 
 # Optional — AI shopping assistant.
-# Set NEXT_PUBLIC_FEATURE_AGENT="1" to enable the assistant button and the
-# /api/chat route.
-# NEXT_PUBLIC_FEATURE_AGENT="1"
+# NEXT_PUBLIC_ENABLE_AGENT="1"
 
 # Optional — Verbose Shopify Storefront API request logging in the server console.
 # DEBUG_SHOPIFY="true"

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -177,7 +177,7 @@ These are agent-side conveniences. The template runs and deploys without them.
 
 ## Authentication
 
-Customer authentication is built in using better-auth with Shopify Customer Account API OIDC. It turns on automatically when all three server-only secrets — `BETTER_AUTH_SECRET`, `SHOPIFY_CUSTOMER_CLIENT_ID`, `SHOPIFY_CUSTOMER_CLIENT_SECRET` — are set. `next.config.ts` derives `NEXT_PUBLIC_AUTH_ENABLED` from their presence at build time and exposes it to the browser via `env`, so server and client agree at hydration (probing the server-only secrets directly inside a component causes mismatches under cache components). Don't set `NEXT_PUBLIC_AUTH_ENABLED` manually.
+Customer authentication is built in using better-auth with Shopify Customer Account API OIDC. It is **opt-in**: set `NEXT_PUBLIC_ENABLE_AUTH="1"` to enable it. When the flag is set, `next.config.ts` validates that the three required server-only secrets — `BETTER_AUTH_SECRET`, `SHOPIFY_CUSTOMER_CLIENT_ID`, `SHOPIFY_CUSTOMER_CLIENT_SECRET` — are present and throws a build error if any are missing. The flag is read in `lib/config.ts` and re-exported as `isAuthEnabled` from `lib/auth/index.ts`, keeping server and client in agreement at hydration (safe for cache components).
 
 Key files:
 

--- a/apps/template/app/account/(authenticated)/layout.tsx
+++ b/apps/template/app/account/(authenticated)/layout.tsx
@@ -22,8 +22,6 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default function AccountLayout({ children }: { children: React.ReactNode }) {
-  if (!isAuthEnabled) notFound();
-
   return (
     <Page className="flex flex-1 flex-col">
       <Container className="flex flex-1 flex-col gap-6 md:flex-row md:gap-10">
@@ -61,11 +59,13 @@ export default function AccountLayout({ children }: { children: React.ReactNode 
 }
 
 async function AccountGate({ children }: { children: React.ReactNode }) {
+  if (!isAuthEnabled) notFound();
   await requireCustomerSession();
   return <>{children}</>;
 }
 
 async function UserInfo() {
+  if (!isAuthEnabled) notFound();
   const session = await requireCustomerSession();
 
   return (

--- a/apps/template/app/account/login/layout.tsx
+++ b/apps/template/app/account/login/layout.tsx
@@ -1,19 +1,5 @@
-import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
-import { notFound } from "next/navigation";
-
-import { isAuthEnabled } from "@/lib/auth";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("seo");
-  return {
-    title: t("loginTitle"),
-    robots: { index: false, follow: false },
-  };
-}
+import { Suspense } from "react";
 
 export default function LoginLayout({ children }: { children: React.ReactNode }) {
-  if (!isAuthEnabled) notFound();
-
-  return children;
+  return <Suspense>{children}</Suspense>;
 }

--- a/apps/template/app/account/login/login-redirect.tsx
+++ b/apps/template/app/account/login/login-redirect.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect } from "react";
+
+import { signIn } from "@/lib/auth/client";
+
+export function LoginRedirect() {
+  const t = useTranslations("common");
+
+  useEffect(() => {
+    signIn("/account");
+  }, []);
+
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <div className="text-center">
+        <p className="text-muted-foreground">{t("loginRedirecting")}</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {t("loginNotRedirected")}{" "}
+          <button type="button" onClick={() => signIn("/account")} className="underline">
+            {t("loginClickHere")}
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/template/app/account/login/page.tsx
+++ b/apps/template/app/account/login/page.tsx
@@ -1,28 +1,20 @@
-"use client";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
 
-import { useTranslations } from "next-intl";
-import { useEffect } from "react";
+import { isAuthEnabled } from "@/lib/auth";
 
-import { signIn } from "@/lib/auth/client";
+import { LoginRedirect } from "./login-redirect";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("seo");
+  return {
+    title: t("loginTitle"),
+    robots: { index: false, follow: false },
+  };
+}
 
 export default function LoginPage() {
-  const t = useTranslations("common");
-
-  useEffect(() => {
-    signIn("/account");
-  }, []);
-
-  return (
-    <div className="flex flex-1 items-center justify-center">
-      <div className="text-center">
-        <p className="text-muted-foreground">{t("loginRedirecting")}</p>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {t("loginNotRedirected")}{" "}
-          <button type="button" onClick={() => signIn("/account")} className="underline">
-            {t("loginClickHere")}
-          </button>
-        </p>
-      </div>
-    </div>
-  );
+  if (!isAuthEnabled) notFound();
+  return <LoginRedirect />;
 }

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -8,6 +8,7 @@ import {
 import { cookies } from "next/headers";
 
 import { createAgent, type PageContext, type User, withAgentContext } from "@/lib/agent/server";
+import { agent as agentConfig } from "@/lib/config";
 import { defaultLocale, type Locale } from "@/lib/i18n";
 import { createCartWithoutCookie } from "@/lib/shopify/operations/cart";
 import { getCollection } from "@/lib/shopify/operations/collections";
@@ -84,6 +85,10 @@ async function resolvePageContext(
 }
 
 export async function POST(request: Request) {
+  if (!agentConfig.enabled) {
+    return new Response(null, { status: 404 });
+  }
+
   const body = await request.json();
   const store = await cookies();
   const { messages, chatId } = body;

--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -13,7 +13,7 @@ import { CartOverlay } from "@/components/cart/overlay";
 import { Footer } from "@/components/footer";
 import { Nav } from "@/components/nav";
 import { SiteSchema } from "@/components/schema/site-schema";
-import { siteConfig } from "@/lib/config";
+import { agent, siteConfig } from "@/lib/config";
 import { getLocale } from "@/lib/params";
 import { buildAlternates } from "@/lib/seo";
 
@@ -58,7 +58,7 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
               <CartOverlay locale={locale} />
             </Suspense>
             <Suspense>
-              <ActionBar>{process.env.AI_AGENT_DISABLED ? null : <AgentButton />}</ActionBar>
+              <ActionBar>{agent.enabled && <AgentButton />}</ActionBar>
             </Suspense>
           </CartProvider>
         </NextIntlClientProvider>

--- a/apps/template/lib/auth/index.ts
+++ b/apps/template/lib/auth/index.ts
@@ -1,2 +1,3 @@
-// Computed at build time in next.config.ts; don't set NEXT_PUBLIC_AUTH_ENABLED manually.
-export const isAuthEnabled = process.env.NEXT_PUBLIC_AUTH_ENABLED === "1";
+import { auth } from "@/lib/config";
+
+export const isAuthEnabled = auth.enabled;

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -29,6 +29,14 @@ export const siteConfig = {
   url: trimTrailingSlash(process.env.NEXT_PUBLIC_BASE_URL || defaultUrl),
 } as const;
 
+export const auth = {
+  enabled: process.env.NEXT_PUBLIC_FEATURE_AUTH === "1",
+} as const;
+
+export const agent = {
+  enabled: process.env.NEXT_PUBLIC_FEATURE_AGENT === "1",
+} as const;
+
 export const navItems: MenuItem[] = [
   {
     id: "default-nav-shop",

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -30,11 +30,11 @@ export const siteConfig = {
 } as const;
 
 export const auth = {
-  enabled: process.env.NEXT_PUBLIC_FEATURE_AUTH === "1",
+  enabled: process.env.NEXT_PUBLIC_ENABLE_AUTH === "1",
 } as const;
 
 export const agent = {
-  enabled: process.env.NEXT_PUBLIC_FEATURE_AGENT === "1",
+  enabled: process.env.NEXT_PUBLIC_ENABLE_AGENT === "1",
 } as const;
 
 export const navItems: MenuItem[] = [

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -1,6 +1,21 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
+if (process.env.NEXT_PUBLIC_FEATURE_AUTH === "1") {
+  const missing = [
+    "BETTER_AUTH_SECRET",
+    "SHOPIFY_CUSTOMER_CLIENT_ID",
+    "SHOPIFY_CUSTOMER_CLIENT_SECRET",
+  ].filter((key) => !process.env[key]);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `NEXT_PUBLIC_FEATURE_AUTH=1 requires: ${missing.join(", ")}. ` +
+        `Set the missing variables or unset NEXT_PUBLIC_FEATURE_AUTH.`,
+    );
+  }
+}
+
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -1,19 +1,8 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
-// Auth turns on at build time when all three secrets are present. Exposed to the
-// browser as NEXT_PUBLIC_AUTH_ENABLED so client and server agree at hydration.
-const isAuthEnabled = !!(
-  process.env.BETTER_AUTH_SECRET &&
-  process.env.SHOPIFY_CUSTOMER_CLIENT_ID &&
-  process.env.SHOPIFY_CUSTOMER_CLIENT_SECRET
-);
-
 const nextConfig: NextConfig = {
   cacheComponents: true,
-  env: {
-    NEXT_PUBLIC_AUTH_ENABLED: isAuthEnabled ? "1" : "",
-  },
   experimental: {
     inlineCss: true,
     turbopackFileSystemCacheForDev: true,

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
-if (process.env.NEXT_PUBLIC_FEATURE_AUTH === "1") {
+if (process.env.NEXT_PUBLIC_ENABLE_AUTH === "1") {
   const missing = [
     "BETTER_AUTH_SECRET",
     "SHOPIFY_CUSTOMER_CLIENT_ID",
@@ -10,8 +10,8 @@ if (process.env.NEXT_PUBLIC_FEATURE_AUTH === "1") {
 
   if (missing.length > 0) {
     throw new Error(
-      `NEXT_PUBLIC_FEATURE_AUTH=1 requires: ${missing.join(", ")}. ` +
-        `Set the missing variables or unset NEXT_PUBLIC_FEATURE_AUTH.`,
+      `NEXT_PUBLIC_ENABLE_AUTH=1 requires: ${missing.join(", ")}. ` +
+        `Set the missing variables or unset NEXT_PUBLIC_ENABLE_AUTH.`,
     );
   }
 }


### PR DESCRIPTION
## Summary
Treats auth and agent as first-class optional **features** gated by explicit env flags. Both share the same convention: `NEXT_PUBLIC_ENABLE_<NAME>="1"` to enable.

### `lib/config.ts` — feature flag exports
Two new exports — `auth = { enabled }` and `agent = { enabled }` — as top-level per-feature objects so each can grow keys later (`auth.providers`, `agent.model`, etc.) without restructuring.

### `next.config.ts` — drop auto-derive, add build-time validation
- Removes the old `isAuthEnabled` derivation and the `env: { NEXT_PUBLIC_AUTH_ENABLED }` mapping. Both flags are now set directly by the user.
- Throws at build time if `NEXT_PUBLIC_ENABLE_AUTH="1"` is set without `BETTER_AUTH_SECRET`, `SHOPIFY_CUSTOMER_CLIENT_ID`, or `SHOPIFY_CUSTOMER_CLIENT_SECRET`.

### Wiring
- `lib/auth/index.ts` sources `isAuthEnabled` from `auth.enabled`.
- `app/layout.tsx` replaces inline `process.env.AI_AGENT_DISABLED` with `agent.enabled`.
- `app/api/chat/route.ts` returns 404 when `agent.enabled` is false.

### Account routes — fix PPR bailouts
Moving the auth gate from layout-level to inside Suspense'd server components to dodge a Next 16 canary bug where layout-level `notFound()` triggers internal `useSearchParams()` bailouts under PPR, silently dropping prerendered HTML for `/account/*`:
- `(authenticated)/layout.tsx` — gate moved into `AccountGate` and `UserInfo` (already inside Suspense).
- `login/layout.tsx` — slimmed to `<Suspense>{children}</Suspense>`; gate moved to `login/page.tsx` (server).
- `login/page.tsx` — server component that gates and renders new `<LoginRedirect />` client subcomponent.
- `login/login-redirect.tsx` — extracted client redirect logic.

All six account routes now prerender to HTML with 0 bailouts.

### Docs + env example
- `apps/docs`: `anatomy/authentication.mdx`, `anatomy/agent.mdx`, `getting-started/index.mdx`, `reference/env-vars.mdx` updated. Auth and agent anatomy pages now lead with `## Configuration`.
- `.env.example`: documents both new vars, removes `AI_AGENT_DISABLED`, slimmer comments matching the existing terse style.

### Migration
- Storefronts relying on auth auto-enabling from secret presence must now also set `NEXT_PUBLIC_ENABLE_AUTH="1"`.
- Storefronts using `AI_AGENT_DISABLED="1"` should remove it; agent is now off by default — set `NEXT_PUBLIC_ENABLE_AGENT="1"` to turn on.

Rollout log entry deferred — will follow once shape settles.

## Test plan
- [x] `pnpm --filter template build` succeeds (0 bailouts, all `/account/*` routes emit HTML)
- [x] `pnpm --filter template lint` passes
- [x] `pnpm --filter docs build` succeeds
- [x] Verified throw fires when `NEXT_PUBLIC_ENABLE_AUTH=1` is set with a missing secret
- [ ] Manual: with `NEXT_PUBLIC_ENABLE_AUTH=1` + secrets: account icon visible, /account/login reachable
- [ ] Manual: without `NEXT_PUBLIC_ENABLE_AUTH`: account icon hidden, /account/* returns 404
- [ ] Manual: with `NEXT_PUBLIC_ENABLE_AGENT=1`: AgentButton visible, /api/chat responds
- [ ] Manual: without `NEXT_PUBLIC_ENABLE_AGENT`: AgentButton hidden, /api/chat returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)