### PR TITLE
[template] route storefront brand through siteConfig.name

### DIFF
--- a/apps/docs/content/docs/anatomy/footer.mdx
+++ b/apps/docs/content/docs/anatomy/footer.mdx
@@ -8,7 +8,7 @@ The footer renders at the bottom of every page. By default it displays a copyrig
 
 ## Default behavior
 
-The footer always renders. By default it shows a static copyright line ("Vercel Shop. All rights reserved.") and social media icons when configured. The [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) skill adds link columns sourced from a Shopify `"footer"` menu above the copyright.
+The footer always renders. By default it shows a copyright line ("© {year} {siteConfig.name}. All rights reserved.") and social media icons when configured. The [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) skill adds link columns sourced from a Shopify `"footer"` menu above the copyright.
 
 ## Social links
 
@@ -26,7 +26,7 @@ The default is an empty array, which hides the social links section entirely.
 
 ## Copyright
 
-The copyright line is a static string. To customize it, edit the `<p>` tag in `components/footer/index.tsx`.
+The copyright line uses the `footer.copyright` i18n key with the current year and `siteConfig.name` interpolated in. `siteConfig.name` reads from `NEXT_PUBLIC_SITE_NAME` and falls back to `"Vercel Shop"` — set that env var to brand your storefront. To change the wording (not just the name), edit the `footer.copyright` entry in `lib/i18n/messages/en.json`.
 
 ## Key files
 

--- a/apps/docs/content/docs/anatomy/footer.mdx
+++ b/apps/docs/content/docs/anatomy/footer.mdx
@@ -8,7 +8,7 @@ The footer renders at the bottom of every page. By default it displays a copyrig
 
 ## Default behavior
 
-The footer always renders. By default it shows a copyright line ("© {year} {siteConfig.name}. All rights reserved.") and social media icons when configured. The [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) skill adds link columns sourced from a Shopify `"footer"` menu above the copyright.
+The footer always renders. By default it shows a copyright line ("© {siteConfig.name}. All rights reserved.") and social media icons when configured. The [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) skill adds link columns sourced from a Shopify `"footer"` menu above the copyright.
 
 ## Social links
 
@@ -26,7 +26,7 @@ The default is an empty array, which hides the social links section entirely.
 
 ## Copyright
 
-The copyright line uses the `footer.copyright` i18n key with the current year and `siteConfig.name` interpolated in. `siteConfig.name` reads from `NEXT_PUBLIC_SITE_NAME` and falls back to `"Vercel Shop"` — set that env var to brand your storefront. To change the wording (not just the name), edit the `footer.copyright` entry in `lib/i18n/messages/en.json`.
+The copyright line uses the `footer.copyright` i18n key with `siteConfig.name` interpolated in. `siteConfig.name` reads from `NEXT_PUBLIC_SITE_NAME` and falls back to `"Vercel Shop"` — set that env var to brand your storefront. To change the wording (not just the name), edit the `footer.copyright` entry in `lib/i18n/messages/en.json`. The footer intentionally has no year — reading `new Date()` would force every page dynamic under Next.js 16 Cache Components; add a year only if you wrap it in a Suspense boundary.
 
 ## Key files
 

--- a/apps/docs/content/docs/reference/env-vars.mdx
+++ b/apps/docs/content/docs/reference/env-vars.mdx
@@ -10,7 +10,7 @@ type: reference
 |----------|-------------|
 | `SHOPIFY_STORE_DOMAIN` | Your Shopify store domain, e.g. `your-store.myshopify.com`. Found in **Settings → Domains** in your Shopify admin. |
 | `SHOPIFY_STOREFRONT_ACCESS_TOKEN` | Public Storefront API access token. Found in **Settings → Apps and sales channels → Headless**. |
-| `NEXT_PUBLIC_SITE_NAME` | The name displayed in your storefront's header and metadata. |
+| `NEXT_PUBLIC_SITE_NAME` | The storefront's display name. Used in the nav logo, footer copyright, About page, page titles, SEO metadata, and the AI agent's system prompt. Falls back to `"Vercel Shop"` if unset. |
 
 ## Customer Authentication
 

--- a/apps/template/app/about/page.tsx
+++ b/apps/template/app/about/page.tsx
@@ -2,10 +2,11 @@ import type { Metadata } from "next";
 
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
+import { siteConfig } from "@/lib/config";
 
 export const metadata: Metadata = {
   title: "About",
-  description: "Learn about Vercel Shop, a Next.js storefront template for Shopify.",
+  description: `Learn about ${siteConfig.name}.`,
 };
 
 export default function AboutPage() {
@@ -13,26 +14,14 @@ export default function AboutPage() {
     <Page>
       <Container className="max-w-2xl">
         <article className="prose prose-neutral prose-headings:font-semibold prose-headings:tracking-tight">
-          <h1>About Vercel Shop</h1>
+          <h1>About {siteConfig.name}</h1>
           <p>
-            Vercel Shop is a Next.js storefront that connects to Shopify. You get product pages,
-            collections, a cart, and search out of the box. Point it at your store and you're
-            selling.
+            Welcome to {siteConfig.name}. Browse our products, explore our collections, and check
+            out when you're ready. If you have questions about an order or a product, get in touch.
           </p>
           <p>
-            The template is built for agents. It ships with context files and recipes, and the
-            scaffold installs project-scoped plugins that provide storefront skills and Shopify
-            tooling. Enable Shopify Markets, swap your CMS, add customer accounts: each one is a
-            single command.
-          </p>
-          <p>
-            Pages render on the server and stream by default. The cart is optimistic. Collection
-            filters update instantly, without a round-trip. Static shells are cached and dynamic
-            content streams in behind them.
-          </p>
-          <p>
-            The code is yours. Change the layout, pull out components, restyle things, wire in a
-            different CMS. It's written to be read and modified, not worked around.
+            This is placeholder copy — replace it with your own story, mission, and the details your
+            customers care about.
           </p>
         </article>
       </Container>

--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -73,8 +73,8 @@ export const generateMetadata = async (): Promise<Metadata> => {
 
   return {
     alternates: buildAlternates({ pathname: "/" }),
-    description: t("defaultDescription"),
-    generator: "Vercel Shop",
+    description: t("defaultDescription", { name: siteConfig.name }),
+    generator: siteConfig.name,
     metadataBase: new URL(siteConfig.url),
     openGraph: {
       images: [{ url: "/og-default.png", width: 1200, height: 630 }],

--- a/apps/template/components/footer/index.tsx
+++ b/apps/template/components/footer/index.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 
 import { Sections } from "@/components/ui/sections";
@@ -6,9 +7,10 @@ import type { MenuItem } from "@/lib/shopify/types/menu";
 
 import { SocialLinks } from "./social-links";
 
-export function Footer({ locale }: { locale: string }) {
+export async function Footer({ locale }: { locale: string }) {
   const { socialLinks } = siteConfig;
   const items = footerItems;
+  const t = await getTranslations("footer");
 
   return (
     <footer>
@@ -17,7 +19,7 @@ export function Footer({ locale }: { locale: string }) {
           {items.length > 0 && <FooterMenu items={items} />}
           <div className="flex flex-col sm:flex-row items-center justify-between gap-5">
             <p className="text-sm text-muted-foreground leading-5">
-              &copy; Vercel Shop. All rights reserved.
+              {t("copyright", { name: siteConfig.name, year: String(new Date().getFullYear()) })}
             </p>
             {socialLinks.length > 0 && <SocialLinks links={socialLinks} />}
           </div>

--- a/apps/template/components/footer/index.tsx
+++ b/apps/template/components/footer/index.tsx
@@ -19,7 +19,7 @@ export async function Footer({ locale }: { locale: string }) {
           {items.length > 0 && <FooterMenu items={items} />}
           <div className="flex flex-col sm:flex-row items-center justify-between gap-5">
             <p className="text-sm text-muted-foreground leading-5">
-              {t("copyright", { name: siteConfig.name, year: String(new Date().getFullYear()) })}
+              {t("copyright", { name: siteConfig.name })}
             </p>
             {socialLinks.length > 0 && <SocialLinks links={socialLinks} />}
           </div>

--- a/apps/template/components/nav/index.tsx
+++ b/apps/template/components/nav/index.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { Suspense } from "react";
 
 import { isAuthEnabled } from "@/lib/auth";
-import { navItems } from "@/lib/config";
+import { navItems, siteConfig } from "@/lib/config";
 
 import { NavAccount, NavAccountFallback } from "./account";
 import { CartIcon, CartIconFallback } from "./cart";
@@ -22,7 +22,7 @@ export async function Nav({ locale }: { locale: string }) {
         <MobileMenu items={items} />
 
         <Link className="flex items-center shrink-0" href="/">
-          <span className="text-xl font-semibold leading-4 tracking-tight">Vercel Shop</span>
+          <span className="text-xl font-semibold leading-4 tracking-tight">{siteConfig.name}</span>
         </Link>
 
         <QuickLinks items={items} />

--- a/apps/template/lib/agent/server.ts
+++ b/apps/template/lib/agent/server.ts
@@ -1,6 +1,7 @@
 import { stepCountIs, ToolLoopAgent, type ToolLoopAgentSettings } from "ai";
 
 import { catalog } from ".";
+import { siteConfig } from "../config";
 import type { Locale } from "../i18n";
 import type { ProductDetails } from "../types";
 import { addCartNoteTool } from "./tools/add-cart-note";
@@ -72,7 +73,7 @@ function dedent(strings: TemplateStringsArray, ...values: unknown[]): string {
 }
 
 const BASE_SYSTEM_PROMPT = dedent`
-You're a helpful shopping assistant for Vercel Shop. Never use emojis in your responses.
+You're a helpful shopping assistant for ${siteConfig.name}. Never use emojis in your responses.
 `;
 
 function createSystemPrompt(ctx: AgentContext) {

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -136,7 +136,7 @@
     "tryAgain": "Try again"
   },
   "footer": {
-    "copyright": "© {year} {name}. All rights reserved."
+    "copyright": "© {name}. All rights reserved."
   },
   "home": {
     "title": "Enterprise Commerce Template",

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -136,7 +136,7 @@
     "tryAgain": "Try again"
   },
   "footer": {
-    "copyright": "© {year} Vercel Shop. All rights reserved."
+    "copyright": "© {year} {name}. All rights reserved."
   },
   "home": {
     "title": "Enterprise Commerce Template",
@@ -314,7 +314,7 @@
     "collectionFallbackTitle": "Collection",
     "collectionsDescription": "Browse all product collections.",
     "collectionsTitle": "Collections",
-    "defaultDescription": "Shop premium products, curated collections, and latest offers from Vercel Shop.",
+    "defaultDescription": "Shop premium products, curated collections, and latest offers from {name}.",
     "homeDescription": "Explore featured products, curated collections, and seasonal campaigns.",
     "homeTitle": "Home",
     "loginTitle": "Sign In",

--- a/packages/plugin/template-rollout-log/2026-05-23-site-name-everywhere.md
+++ b/packages/plugin/template-rollout-log/2026-05-23-site-name-everywhere.md
@@ -1,0 +1,38 @@
+---
+title: Route every storefront brand reference through siteConfig.name
+changeKey: site-name-everywhere
+introducedOn: 2026-05-23
+changeType: refactor
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/nav/index.tsx
+  - apps/template/components/footer/index.tsx
+  - apps/template/app/layout.tsx
+  - apps/template/app/about/page.tsx
+  - apps/template/lib/agent/server.ts
+  - apps/template/lib/i18n/messages/en.json
+---
+
+## Summary
+
+Every user-facing "Vercel Shop" string in the template now reads from `siteConfig.name`, which already resolves `process.env.NEXT_PUBLIC_SITE_NAME ?? "Vercel Shop"`. Touched: nav logo, footer copyright (now wired to the existing `footer.copyright` i18n key it had been ignoring), `generator` metadata, About page metadata + body, agent system prompt, and the `footer.copyright` / `seo.defaultDescription` i18n entries (both now take a `{name}` arg).
+
+The About page copy was also rewritten to be brand-neutral so an interpolated `siteConfig.name` reads naturally.
+
+## Why it matters
+
+Setting `NEXT_PUBLIC_SITE_NAME` now actually brands the whole storefront — previously several spots hardcoded "Vercel Shop" and silently desynced from the env var. Storefronts that ship with the literal "Vercel Shop" string in the nav and footer copyright look unfinished.
+
+## Apply when
+
+Your fork still has hardcoded "Vercel Shop" strings in nav, footer, About, layout metadata, or the agent prompt, or your `footer.copyright` i18n key isn't actually consumed by `components/footer/index.tsx`.
+
+## Safe to skip when
+
+You've already replaced the About page with custom copy and removed the brand string from the other spots — in that case adopt only the footer i18n wiring and skip the About rewrite.
+
+## Validation
+
+`pnpm --filter template dev` with `NEXT_PUBLIC_SITE_NAME` set to something distinctive (e.g. `Acme`). Verify it appears in: the nav logo, footer copyright line, About page title + body, `<title>` template, OpenGraph metadata, and the agent's first message context. Unset the var and confirm everything falls back to "Vercel Shop".


### PR DESCRIPTION
## Summary

- Every user-facing "Vercel Shop" string in the template now reads from `siteConfig.name`, which already resolves `NEXT_PUBLIC_SITE_NAME ?? "Vercel Shop"`. Touched: nav logo, footer copyright, `generator` metadata, About page, agent system prompt.
- The footer now wires up the previously-unused `footer.copyright` i18n key (`© {year} {name}. All rights reserved.`) instead of hardcoding the string. `seo.defaultDescription` also takes `{name}`.
- About page copy rewritten brand-neutral so the interpolated name reads naturally for any storefront — the prior copy described "Vercel Shop the template" specifically.
- Docs updated: `anatomy/footer.mdx` describes the new copyright wiring; `reference/env-vars.mdx` lists every place `NEXT_PUBLIC_SITE_NAME` shows up and notes the fallback.
- Rollout-log entry added so existing forks can selectively adopt (e.g. skip the About rewrite if they've already replaced that page).

## Test plan

- [ ] `pnpm --filter template dev` with `NEXT_PUBLIC_SITE_NAME=Acme`; verify "Acme" appears in nav logo, footer copyright, About title/body, `<title>` template, OG metadata, and the agent's first response context
- [ ] Unset `NEXT_PUBLIC_SITE_NAME` and confirm everything falls back to "Vercel Shop"
- [ ] `pnpm --filter template lint` and `pnpm --filter template exec tsc --noEmit` clean
- [ ] Docs build still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)