### PR TITLE
[template] make generateStaticParams resilient to empty/unreachable stores

### DIFF
--- a/apps/template/app/collections/[handle]/page.tsx
+++ b/apps/template/app/collections/[handle]/page.tsx
@@ -8,10 +8,16 @@ import { getLocale } from "@/lib/params";
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
 import { getCollection, getCollections } from "@/lib/shopify/operations/collections";
 
+const PLACEHOLDER_HANDLE = "__placeholder__";
+
 export async function generateStaticParams() {
-  const collections = await getCollections({ limit: 1 });
-  const first = collections[0];
-  return first ? [{ handle: first.handle }] : [];
+  try {
+    const collections = await getCollections({ limit: 1 });
+    const first = collections[0];
+    return [{ handle: first ? first.handle : PLACEHOLDER_HANDLE }];
+  } catch {
+    return [{ handle: PLACEHOLDER_HANDLE }];
+  }
 }
 
 export async function generateMetadata({
@@ -19,7 +25,7 @@ export async function generateMetadata({
 }: PageProps<"/collections/[handle]">): Promise<Metadata> {
   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
 
-  if (handle === "__placeholder__") {
+  if (handle === PLACEHOLDER_HANDLE) {
     notFound();
   }
 
@@ -86,7 +92,10 @@ export default async function CollectionPage({
   searchParams,
 }: PageProps<"/collections/[handle]">) {
   const locale = await getLocale();
-  const handlePromise = params.then(({ handle }) => handle);
+  const handlePromise = params.then(({ handle }) => {
+    if (handle === PLACEHOLDER_HANDLE) notFound();
+    return handle;
+  });
   const collectionPromise = handlePromise.then((handle) => getCollection(handle, locale));
   const searchStatePromise = getCollectionSearchState(searchParams);
   const collectionResultsDataPromise = getCollectionResultsData({

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -53,9 +53,13 @@ async function buildProductMetadata(
 }
 
 export async function generateStaticParams() {
-  const { products } = await getCatalogProducts({ limit: 1 });
-  const first = products[0];
-  return first ? [{ handle: first.handle }] : [];
+  try {
+    const { products } = await getCatalogProducts({ limit: 1 });
+    const first = products[0];
+    return [{ handle: first ? first.handle : PLACEHOLDER_HANDLE }];
+  } catch {
+    return [{ handle: PLACEHOLDER_HANDLE }];
+  }
 }
 
 export async function generateMetadata({

--- a/packages/plugin/template-rollout-log/2026-05-26-generate-static-params-empty-store-resilience.md
+++ b/packages/plugin/template-rollout-log/2026-05-26-generate-static-params-empty-store-resilience.md
@@ -1,0 +1,50 @@
+---
+title: Make generateStaticParams resilient to empty / unreachable Shopify stores
+changeKey: generate-static-params-empty-store-resilience
+introducedOn: 2026-05-26
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/app/products/[handle]/page.tsx
+  - apps/template/app/collections/[handle]/page.tsx
+---
+
+## Summary
+
+`generateStaticParams` for `/products/[handle]` and `/collections/[handle]` no longer breaks the build when the Shopify store has zero products or zero collections, or when the Storefront API is briefly unreachable during build.
+
+Both routes now:
+
+1. Wrap the seed fetch (`getCatalogProducts({ limit: 1 })` / `getCollections({ limit: 1 })`) in `try/catch`.
+2. Always return at least one entry — falling back to a `__placeholder__` handle when the fetch returns nothing or throws.
+3. Short-circuit the placeholder in `generateMetadata` (empty metadata or `notFound()`) and in the page itself (`notFound()`), so the placeholder route never tries to fetch `productByHandle("__placeholder__")` or render a real page.
+
+The collections route previously had a `"__placeholder__"` literal in `generateMetadata` but no scaffolding in `generateStaticParams` or the default export. The PDP had a `PLACEHOLDER_HANDLE` constant referenced in metadata and the page but not in `generateStaticParams`. This change makes both routes use the same shape.
+
+## Why it matters
+
+- A freshly bootstrapped storefront with an empty Shopify catalog could fail `next build` because the prerender step had no params to work with. Returning a placeholder gives Next.js a stable shell to prerender; the page renders as a 404 at request time.
+- Transient Storefront API errors during build (network blip, throttling, missing build-time env) no longer cascade into a failed deploy. The build always produces at least the placeholder shell.
+- Aligns PDP and PLP on the same pattern so the next agent that touches either route doesn't have to rediscover the convention.
+
+## Apply when
+
+- The storefront still ships the default `/products/[handle]` and `/collections/[handle]` routes.
+- The storefront may be deployed before its Shopify catalog is populated, or has intermittent build-time connectivity to the Storefront API.
+
+## Safe to skip when
+
+- The storefront has replaced these routes with its own data layer that already handles empty / errored seed fetches.
+- The storefront asserts a non-empty catalog as a deploy precondition and prefers the build to fail loudly when the assumption breaks.
+
+## Tradeoff
+
+The placeholder route prerenders as a 404 shell. On an empty-store build, no real product or collection pages are statically prerendered — the first request to a real handle hits the dynamic path. This is the intended tradeoff: a slower first-request for the empty-store case in exchange for builds that never block on catalog state.
+
+## Validation
+
+1. With a populated store: `pnpm --filter template build` succeeds and prerenders one real product handle and one real collection handle.
+2. With Shopify credentials pointed at an empty store (or with the Storefront API blocked): the same build still succeeds and only prerenders the `__placeholder__` shells.
+3. Hitting `/products/__placeholder__` or `/collections/__placeholder__` at runtime returns a 404.


### PR DESCRIPTION
## Summary

- `app/products/[handle]/page.tsx` and `app/collections/[handle]/page.tsx`: `generateStaticParams` no longer breaks the build when the Shopify store has zero products/collections or when the Storefront API is briefly unreachable at build time.
- Both routes now wrap the seed fetch in `try/catch` and always return at least one entry, falling back to a `__placeholder__` handle when there's nothing to seed with. `generateMetadata` and the default export short-circuit the placeholder to 404 at request time.
- The PDP already had the placeholder constant + page/metadata scaffolding wired up but never returned it from `generateStaticParams`. The collections route had only a literal `"__placeholder__"` check in `generateMetadata` — it now gets the same full scaffolding (`PLACEHOLDER_HANDLE` constant + page `notFound()` short-circuit) so PDP and PLP follow the same shape.
- Adds a rollout log entry (`2026-05-26-generate-static-params-empty-store-resilience.md`) so downstream storefronts can opt in.

### Tradeoff

On an empty-store build only the placeholder shell is prerendered; the first request to a real handle hits the dynamic path. The alternative (failing the build) was worse for fresh bootstraps.

## Test plan

- [ ] `pnpm --filter template build` with a populated store still prerenders one real product handle and one real collection handle.
- [ ] `pnpm --filter template build` against an empty store (or with Storefront API blocked) succeeds and only prerenders the `__placeholder__` shells.
- [ ] `/products/__placeholder__` and `/collections/__placeholder__` return 404 at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)