### PR TITLE
chore: remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @blurrah @laugharn


### PR DESCRIPTION
## Summary

- Removes `.github/CODEOWNERS`. The current ownership rules are too strict for the team's review flow right now; revisit later if/when we want enforced review routing again.

## Test plan

- [ ] Open a follow-up PR touching any path previously owned and confirm GitHub no longer auto-requests review from the removed owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)