### PR TITLE
[template] don't construct betterAuth when auth is disabled

### DIFF
--- a/apps/template/app/api/auth/[...all]/route.ts
+++ b/apps/template/app/api/auth/[...all]/route.ts
@@ -2,4 +2,8 @@ import { toNextJsHandler } from "better-auth/next-js";
 
 import { auth } from "@/lib/auth/server";
 
-export const { GET, POST } = toNextJsHandler(auth);
+const handlers = auth ? toNextJsHandler(auth) : null;
+const notFound = async () => new Response(null, { status: 404 });
+
+export const GET = handlers?.GET ?? notFound;
+export const POST = handlers?.POST ?? notFound;

--- a/apps/template/lib/auth/server.ts
+++ b/apps/template/lib/auth/server.ts
@@ -5,6 +5,8 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { cache } from "react";
 
+import { isAuthEnabled } from "@/lib/auth";
+
 const SHOPIFY_STORE_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN;
 
 const SHOPIFY_OIDC_SCOPES = ["openid", "email", "customer-account-api:full"];
@@ -73,76 +75,80 @@ function decodeIdTokenPayload(idToken: string): {
   return JSON.parse(decoded);
 }
 
-export const auth = betterAuth({
-  baseURL: authBaseUrl,
-  secret: process.env.BETTER_AUTH_SECRET,
+// Skip betterAuth construction when auth is disabled — calling it without a real
+// BETTER_AUTH_SECRET logs a default-secret warning at module load during build.
+export const auth = isAuthEnabled
+  ? betterAuth({
+      baseURL: authBaseUrl,
+      secret: process.env.BETTER_AUTH_SECRET,
 
-  session: {
-    expiresIn: 7 * 24 * 60 * 60,
-    updateAge: 24 * 60 * 60,
-    cookieCache: {
-      enabled: true,
-      maxAge: 7 * 24 * 60 * 60,
-    },
-  },
-
-  account: {
-    storeStateStrategy: "cookie",
-    storeAccountCookie: true,
-  },
-
-  plugins: [
-    genericOAuth({
-      config: [
-        {
-          providerId: "shopify",
-          clientId: process.env.SHOPIFY_CUSTOMER_CLIENT_ID ?? "",
-          clientSecret: process.env.SHOPIFY_CUSTOMER_CLIENT_SECRET ?? "",
-          discoveryUrl: SHOPIFY_STORE_DOMAIN
-            ? `https://${SHOPIFY_STORE_DOMAIN}/.well-known/openid-configuration`
-            : undefined,
-          scopes: SHOPIFY_OIDC_SCOPES,
-          pkce: true,
-          accessType: "offline",
-          getUserInfo: async (tokens) => {
-            const idToken = tokens.idToken;
-            if (!idToken) {
-              throw new Error("No ID token received from Shopify");
-            }
-
-            const decoded = decodeIdTokenPayload(idToken);
-
-            const nameParts = [decoded.given_name, decoded.family_name].filter(Boolean);
-            let name = nameParts.join(" ");
-            if (!name) {
-              name = decoded.email?.split("@")[0] || "Customer";
-            }
-
-            return {
-              id: decoded.sub,
-              email: decoded.email,
-              emailVerified: decoded.email_verified ?? false,
-              name,
-              image: undefined,
-            };
-          },
-          mapProfileToUser: (profile) => {
-            return {
-              id: profile.id,
-              email: profile.email,
-              name: profile.name,
-              image: profile.image,
-              emailVerified: profile.emailVerified,
-            };
-          },
+      session: {
+        expiresIn: 7 * 24 * 60 * 60,
+        updateAge: 24 * 60 * 60,
+        cookieCache: {
+          enabled: true,
+          maxAge: 7 * 24 * 60 * 60,
         },
-      ],
-    }),
-  ],
+      },
 
-  basePath: "/api/auth",
-  trustedOrigins: getTrustedOrigins(authBaseUrl),
-});
+      account: {
+        storeStateStrategy: "cookie",
+        storeAccountCookie: true,
+      },
+
+      plugins: [
+        genericOAuth({
+          config: [
+            {
+              providerId: "shopify",
+              clientId: process.env.SHOPIFY_CUSTOMER_CLIENT_ID ?? "",
+              clientSecret: process.env.SHOPIFY_CUSTOMER_CLIENT_SECRET ?? "",
+              discoveryUrl: SHOPIFY_STORE_DOMAIN
+                ? `https://${SHOPIFY_STORE_DOMAIN}/.well-known/openid-configuration`
+                : undefined,
+              scopes: SHOPIFY_OIDC_SCOPES,
+              pkce: true,
+              accessType: "offline",
+              getUserInfo: async (tokens) => {
+                const idToken = tokens.idToken;
+                if (!idToken) {
+                  throw new Error("No ID token received from Shopify");
+                }
+
+                const decoded = decodeIdTokenPayload(idToken);
+
+                const nameParts = [decoded.given_name, decoded.family_name].filter(Boolean);
+                let name = nameParts.join(" ");
+                if (!name) {
+                  name = decoded.email?.split("@")[0] || "Customer";
+                }
+
+                return {
+                  id: decoded.sub,
+                  email: decoded.email,
+                  emailVerified: decoded.email_verified ?? false,
+                  name,
+                  image: undefined,
+                };
+              },
+              mapProfileToUser: (profile) => {
+                return {
+                  id: profile.id,
+                  email: profile.email,
+                  name: profile.name,
+                  image: profile.image,
+                  emailVerified: profile.emailVerified,
+                };
+              },
+            },
+          ],
+        }),
+      ],
+
+      basePath: "/api/auth",
+      trustedOrigins: getTrustedOrigins(authBaseUrl),
+    })
+  : null;
 
 export type Auth = typeof auth;
 
@@ -158,6 +164,7 @@ export interface FullSession extends CustomerSession {
 }
 
 const getAuthSession = cache(async () => {
+  if (!auth) return null;
   const reqHeaders = await headers();
   return auth.api.getSession({ headers: reqHeaders });
 });
@@ -178,6 +185,7 @@ function mapCustomerSession(
 }
 
 const getAccessToken = cache(async (): Promise<string> => {
+  if (!auth) return "";
   const session = await getAuthSession();
   if (!session?.user) return "";
 

--- a/packages/plugin/template-rollout-log/2026-05-26-auth-disabled-no-better-auth-warning.md
+++ b/packages/plugin/template-rollout-log/2026-05-26-auth-disabled-no-better-auth-warning.md
@@ -1,0 +1,43 @@
+---
+title: Don't construct betterAuth when auth is disabled
+changeKey: auth-disabled-no-better-auth-warning
+introducedOn: 2026-05-26
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/auth/server.ts
+  - apps/template/app/api/auth/[...all]/route.ts
+---
+
+## Summary
+
+`lib/auth/server.ts` no longer constructs a betterAuth instance when `isAuthEnabled` is `false`. Calling `betterAuth({...})` without a real `BETTER_AUTH_SECRET` logs a default-secret warning at module-load — and the module gets compiled at build time because the auth route imports it, so the warning fired during every build of a storefront that doesn't opt into auth.
+
+The fix:
+
+- `lib/auth/server.ts`: `export const auth = isAuthEnabled ? betterAuth({...}) : null`. The internal `getAuthSession` and `getAccessToken` helpers short-circuit when `auth` is `null`. `getCustomerSession` / `getSession` naturally return `null` from there.
+- `app/api/auth/[...all]/route.ts`: the route handler returns a 404 when `auth` is `null` (the user-facing surface is already gated by `isAuthEnabled` elsewhere; this is a defensive backstop so the route never tries to call `toNextJsHandler(null)`).
+
+## Why it matters
+
+- A storefront that hasn't opted into auth now produces a clean build — no more "You are using the default secret" noise from better-auth.
+- Removes a footgun where the warning could be read as "auth is misconfigured" when in fact auth is simply turned off.
+- Aligns the runtime cost too: an auth-disabled deployment no longer pays for a betterAuth instance, an OIDC plugin, and a cookie session config it will never use.
+
+## Apply when
+
+- The storefront still uses the template's `lib/auth/*` modules and gates auth via `NEXT_PUBLIC_ENABLE_AUTH`.
+- The storefront wants clean build output when auth is disabled.
+
+## Safe to skip when
+
+- The storefront has rewired auth onto a different provider (Clerk, Auth0, custom) and `lib/auth/server.ts` no longer matches the template.
+- The storefront always runs with `NEXT_PUBLIC_ENABLE_AUTH=1`, so the unconfigured path never executes.
+
+## Validation
+
+1. Build with `NEXT_PUBLIC_ENABLE_AUTH` unset — the "default secret" warning should be gone from build output.
+2. Build with `NEXT_PUBLIC_ENABLE_AUTH=1` and the three required secrets — sign-in flow, `/account/*` pages, and `/api/auth/*` callbacks behave as before.
+3. With auth disabled, `curl http://localhost:3000/api/auth/anything` returns `404`.


### PR DESCRIPTION
## Summary

- `betterAuth({...})` runs at module load and logs `You are using the default secret. Please set BETTER_AUTH_SECRET...` when no secret is set. The auth module gets compiled at build time via `app/api/auth/[...all]/route.ts`, so the warning fired on every build of a storefront that hadn't opted into auth.
- `lib/auth/server.ts` now gates the `betterAuth({...})` call on `isAuthEnabled`: `auth` is `null` when auth is disabled. The internal `getAuthSession` / `getAccessToken` helpers short-circuit; `getCustomerSession` / `getSession` naturally return `null` from there.
- `app/api/auth/[...all]/route.ts` returns `404` when `auth` is `null` so we never try to call `toNextJsHandler(null)`.
- All user-facing surfaces (`NavAccount`, `(authenticated)` layout, `profile/page.tsx`) are already gated by `isAuthEnabled` and already handle a `null` session, so no consumer changes are needed.
- Rollout log entry added.

## Test plan

- [ ] `pnpm --filter template build` with `NEXT_PUBLIC_ENABLE_AUTH` unset — no more \"default secret\" warning in the build output.
- [ ] `pnpm --filter template build` with `NEXT_PUBLIC_ENABLE_AUTH=1` and the three required secrets — sign-in, `/account/*`, and `/api/auth/*` flows still work.
- [ ] With auth disabled, `curl http://localhost:3000/api/auth/anything` returns `404`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)