### PR TITLE
[template] consolidate next/image variants to two widths

### DIFF
--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -23,8 +23,8 @@ const nextConfig: NextConfig = {
     turbopackFileSystemCacheForDev: true,
   },
   images: {
-    deviceSizes: [640, 828, 1200, 1920],
-    imageSizes: [64, 128, 384],
+    deviceSizes: [1080, 1920],
+    imageSizes: [],
     minimumCacheTTL: 31536000,
     remotePatterns: [
       {

--- a/packages/plugin/template-rollout-log/2026-05-30-image-variants-consolidate.md
+++ b/packages/plugin/template-rollout-log/2026-05-30-image-variants-consolidate.md
@@ -1,0 +1,48 @@
+---
+title: Consolidate next/image variant matrix to two widths
+changeKey: image-variants-consolidate
+introducedOn: 2026-05-30
+changeType: config
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/next.config.ts
+---
+
+## Summary
+
+`apps/template/next.config.ts` drops from seven candidate widths (`deviceSizes: [640, 828, 1200, 1920]` + `imageSizes: [64, 128, 384]`) to two (`deviceSizes: [1080, 1920]`, `imageSizes: []`). Every Shopify image now resolves to one of two optimizer URLs per source — `?w=1080` or `?w=1920` — across PDPs, PLPs, the home banner, recommendations, cart thumbnails, search thumbnails, and lightbox.
+
+## Why it matters
+
+The previous matrix produced up to 14 cached objects per source image (7 widths × 2 formats), and the small `imageSizes` entries only had a handful of consumers (`cart/overlay-item.tsx`, `predictive-search-results.tsx`, `search-modal.tsx`, `color-picker.tsx`, `agent/registry.tsx`). Most surfaces use viewport-relative `sizes`, so cache hits across pages were rare — the PDP, PLP, recommendations row, and cart for the same product each hit a different URL.
+
+Consolidating to two widths trades per-image bytes (small thumbnails now decode a 1080-wide source) for:
+
+- Near-100% cross-surface cache hit rate after first product view
+- ~4× smaller optimizer cache footprint
+- Fewer cold-miss transforms (each new variant on first request runs the optimizer; the small entries were the most likely to be cold)
+- Simpler mental model: one Shopify source → at most two cached assets
+
+The tradeoff is real and concentrated on mobile PLP loads: a 20-card grid where each card used to fetch a `640` now fetches a `1080`, ~10KB extra per card, ~200KB extra per PLP visit on cellular. Downstream storefronts with heavy mobile-cellular traffic should evaluate against their own session economics before adopting.
+
+## Apply when
+
+- The storefront still uses the template's image configuration and has not customized `deviceSizes`/`imageSizes`.
+- The storefront's traffic is predominantly broadband/fast-4G, or first-paint cache warmth matters more than per-thumbnail bandwidth.
+- The storefront wants to reduce optimizer compute spend or LRU cache pressure on the Vercel image cache.
+
+## Safe to skip when
+
+- Mobile-cellular sessions dominate traffic and the ~200KB PLP bump is a measurable LCP/CLS regression.
+- The storefront has already tuned its own variant matrix against analytics.
+- The storefront serves a large, retina-dominant desktop audience and relies on the lightbox at near-pixel-perfect resolution (the cap at 1920 is unchanged from the previous config, so this is only a concern if you were already considering raising the ceiling).
+
+## Validation
+
+1. `pnpm --filter template dev`. Visit `/`, a PDP, a PLP, the cart overlay, and the lightbox. Confirm images render visibly the same.
+2. DevTools → Network → filter `_next/image`. Confirm every optimized request is `&w=1080` or `&w=1920`. No `&w=640`, `&w=384`, `&w=128`, etc.
+3. On a PLP, scroll and verify no images are visibly blurry on a retina mobile device (393×3 = ~1180 effective pixels, well within the 1080 → 1920 step).
+4. Open the cart overlay with several items. Confirm thumbnails render; check decode time in Performance panel — should be ≤ ~20ms per thumbnail on a mid-tier mobile.
+5. `pnpm --filter template lint` and `pnpm --filter template build` clean.


### PR DESCRIPTION
## Summary
- `next.config.ts`: `deviceSizes` `[640, 828, 1200, 1920]` → `[1080, 1920]`, `imageSizes` `[64, 128, 384]` → `[]`.
- Every optimized image (PDP hero, PLP grid, banner, recommendations, cart thumbnails, search thumbnails, lightbox, color swatches) now resolves to one of two URLs per source: `?w=1080` or `?w=1920`.
- Adds a template-rollout-log entry (`2026-05-30-image-variants-consolidate.md`) so downstream storefronts can decide whether to adopt.

## Why
The previous matrix produced up to 14 cached objects per source image (7 widths × 2 formats). Cache locality across surfaces was poor — PDP / PLP / recs / cart for the same product all used different URLs and never reinforced each other. The small `imageSizes` entries served a handful of consumers but the bytes saved on each cart/search thumbnail (~20KB) is dwarfed by the cache-warmth value of consolidating to a small number of canonical assets, especially for non-cellular users.

## Tradeoff
- Mobile cellular PLP loads: each card moves from a 640 fetch to a 1080 fetch (~10KB × 20 cards ≈ 200KB extra per PLP visit).
- Cart/search thumbnails decode a 1080 source instead of a 64/128 source. Extra decode work is on the order of ~10–20ms per thumbnail on mid-tier mobile.
- High-DPR ceiling unchanged at 1920 — softness on full-bleed hero / lightbox at retina is no worse than today.

## Test plan
- [ ] `pnpm --filter template dev`, visit home / PDP / PLP / cart overlay / lightbox. Visual diff against `main`: nothing visibly degraded.
- [ ] DevTools → Network → filter `_next/image`. Every optimized request URL ends in `&w=1080` or `&w=1920`. No `&w=640` / `&w=384` / `&w=128`.
- [ ] On a PLP, scroll on a retina mobile preset and verify no visible blur on card images.
- [ ] Open the cart overlay with several items, check decode time in Performance panel (≤ ~20ms per thumbnail).
- [ ] `pnpm --filter template lint` and `pnpm --filter template build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)