### PR TITLE
[docs] remove coming-soon skill placeholders

### DIFF
--- a/apps/docs/components/geistdocs/docs-sidebar.tsx
+++ b/apps/docs/components/geistdocs/docs-sidebar.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 interface NavItem {
@@ -15,11 +14,6 @@ interface NavSection {
   title: string;
   items: NavItem[];
 }
-
-const COMING_SOON_HREFS = new Set([
-  "/docs/skills/enable-content-summarization",
-  "/docs/skills/enable-virtual-try-on",
-]);
 
 export function DocsSidebar({ navigation }: { navigation: NavSection[] }) {
   const pathname = usePathname();
@@ -35,7 +29,6 @@ export function DocsSidebar({ navigation }: { navigation: NavSection[] }) {
               )}
               {section.items.map((item) => {
                 const active = pathname === item.href;
-                const comingSoon = COMING_SOON_HREFS.has(item.href);
                 return (
                   <Link
                     aria-current={active ? "page" : undefined}
@@ -47,11 +40,6 @@ export function DocsSidebar({ navigation }: { navigation: NavSection[] }) {
                     key={item.href}
                   >
                     <span className="min-w-0 truncate">{item.title}</span>
-                    {comingSoon && (
-                      <Badge className="ml-auto rounded-full" variant="secondary">
-                        Coming soon
-                      </Badge>
-                    )}
                   </Link>
                 );
               })}

--- a/apps/docs/content/docs/skills/_meta.json
+++ b/apps/docs/content/docs/skills/_meta.json
@@ -6,8 +6,6 @@
     "enable-i18n",
     "enable-shopify-markets",
     "enable-shopify-cms",
-    "enable-shopify-menus",
-    "enable-content-summarization",
-    "enable-virtual-try-on"
+    "enable-shopify-menus"
   ]
 }

--- a/apps/docs/content/docs/skills/enable-content-summarization.mdx
+++ b/apps/docs/content/docs/skills/enable-content-summarization.mdx
@@ -1,7 +1,0 @@
----
-title: Content Summarization
-description: Use AI to generate concise product and collection summaries for search, social, and agentic surfaces.
-type: guide
----
-
-_This skill is coming soon. When it ships, you'll be able to run it as `/vercel-shop:enable-content-summarization`._

--- a/apps/docs/content/docs/skills/enable-virtual-try-on.mdx
+++ b/apps/docs/content/docs/skills/enable-virtual-try-on.mdx
@@ -1,7 +1,0 @@
----
-title: Virtual Try-On
-description: Let shoppers visualize products on themselves with AI-powered virtual try-on.
-type: guide
----
-
-_This skill is coming soon. When it ships, you'll be able to run it as `/vercel-shop:enable-virtual-try-on`._

--- a/apps/docs/content/docs/skills/index.mdx
+++ b/apps/docs/content/docs/skills/index.mdx
@@ -18,11 +18,4 @@ Skills are agent-ready guides that transform your storefront. Run them with Clau
   <Card title="Shopify Menus" href="/docs/skills/enable-shopify-menus">
     Replace hardcoded nav and footer with Shopify-powered menus, plus optional megamenu.
   </Card>
-  <Card title="Content Summarization" href="/docs/skills/enable-content-summarization">
-    Use AI to generate concise product and collection summaries for search, social, and agentic
-    surfaces.
-  </Card>
-  <Card title="Virtual Try-On" href="/docs/skills/enable-virtual-try-on">
-    Let shoppers visualize products on themselves with AI-powered virtual try-on.
-  </Card>
 </Cards>


### PR DESCRIPTION
## Summary
- Deleted the `enable-content-summarization` and `enable-virtual-try-on` placeholder pages, plus their entries in `_meta.json` and the skills index cards.
- With no coming-soon items left, dropped the now-unused `COMING_SOON_HREFS` set and `Badge` import from `apps/docs/components/geistdocs/docs-sidebar.tsx`.

## Test plan
- [ ] `pnpm --filter docs dev` and confirm `/docs/skills` no longer lists the two removed cards and that the sidebar renders without "Coming soon" badges.
- [ ] Visiting `/docs/skills/enable-content-summarization` and `/docs/skills/enable-virtual-try-on` 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)