### PR TITLE
[template] shopifyFetch: brotli, fail-fast on env, drop variable hash

### DIFF
--- a/apps/docs/content/docs/reference/storefront-api.mdx
+++ b/apps/docs/content/docs/reference/storefront-api.mdx
@@ -32,13 +32,12 @@ The return type is generic - pass the expected shape of `data` from the GraphQL 
 
 ## Request details
 
-Every request is a `POST` to `https://{SHOPIFY_STORE_DOMAIN}/api/2025-01/graphql.json` with headers:
+Every request is a `POST` to `https://{SHOPIFY_STORE_DOMAIN}/api/2026-04/graphql.json` with headers:
 
 | Header                              | Value                        |
 | ----------------------------------- | ---------------------------- |
 | `Content-Type`                      | `application/json`           |
 | `X-Shopify-Storefront-Access-Token` | Your public storefront token |
-| `Accept-Encoding`                   | `gzip, deflate`              |
 
 The URL includes query parameters for `operation` and a 12-character SHA-1 hash of the serialized variables. This ensures Next.js treats requests with different variables as distinct cache entries, even though they hit the same endpoint.
 

--- a/apps/docs/content/docs/reference/storefront-api.mdx
+++ b/apps/docs/content/docs/reference/storefront-api.mdx
@@ -6,7 +6,7 @@ prerequisites:
   - /docs/getting-started
 ---
 
-All Shopify data flows through a single `shopifyFetch` function in `lib/shopify/fetch.ts`. It wraps the native `fetch` API with Shopify authentication, variable hashing for cache keys, and error handling.
+All Shopify data flows through a single `shopifyFetch` function in `lib/shopify/fetch.ts`. It wraps the native `fetch` API with Shopify authentication and error handling.
 
 For Shopify admin setup and required token scopes, see [Storefront API Permissions](/docs/reference/storefront-api-permissions).
 
@@ -24,7 +24,7 @@ const data = await shopifyFetch<{ productByHandle: ShopifyProduct }>({
 
 The function accepts three fields:
 
-- **operation** - the GraphQL operation name. Must match the name in the query string. Appended to the request URL as a query parameter for cache key differentiation.
+- **operation** - the GraphQL operation name. Must match the name in the query string. Appended to the request URL as a query parameter so network logs identify which call was made.
 - **query** - the full GraphQL query or mutation as a template string, including any fragment interpolations.
 - **variables** - an optional object passed as JSON in the request body. Never interpolate values into the query string directly.
 
@@ -39,7 +39,7 @@ Every request is a `POST` to `https://{SHOPIFY_STORE_DOMAIN}/api/2026-04/graphql
 | `Content-Type`                      | `application/json`           |
 | `X-Shopify-Storefront-Access-Token` | Your public storefront token |
 
-The URL includes query parameters for `operation` and a 12-character SHA-1 hash of the serialized variables. This ensures Next.js treats requests with different variables as distinct cache entries, even though they hit the same endpoint.
+The operation name is appended as a query parameter (`?operation=getProductByHandle`) so calls are easy to identify in network logs. Cache isolation between different variables comes from the `"use cache"` wrappers in `lib/shopify/operations/`, which key on function arguments.
 
 ## Writing a query
 

--- a/apps/template/lib/shopify/fetch.ts
+++ b/apps/template/lib/shopify/fetch.ts
@@ -54,7 +54,7 @@ export async function shopifyFetch<T>({
     headers: {
       "Content-Type": "application/json",
       "X-Shopify-Storefront-Access-Token": SHOPIFY_ACCESS_TOKEN || "",
-      "Accept-Encoding": "gzip, deflate",
+      "Accept-Encoding": "gzip, br",
     },
     body: JSON.stringify({ query, variables, operationName: operation }),
   });

--- a/apps/template/lib/shopify/fetch.ts
+++ b/apps/template/lib/shopify/fetch.ts
@@ -1,15 +1,9 @@
 import { createHash } from "node:crypto";
 
-const SHOPIFY_STORE_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN;
-const SHOPIFY_ACCESS_TOKEN = process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN;
+const SHOPIFY_STORE_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN as string;
+const SHOPIFY_ACCESS_TOKEN = process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN as string;
 const SHOPIFY_API_VERSION = process.env.SHOPIFY_API_VERSION ?? "2026-04";
 const DEBUG = process.env.DEBUG_SHOPIFY === "true";
-
-if (!SHOPIFY_STORE_DOMAIN || !SHOPIFY_ACCESS_TOKEN) {
-  console.warn(
-    "Shopify environment variables not configured. Set SHOPIFY_STORE_DOMAIN and SHOPIFY_STOREFRONT_ACCESS_TOKEN.",
-  );
-}
 
 const baseEndpoint = `https://${SHOPIFY_STORE_DOMAIN}/api/${SHOPIFY_API_VERSION}/graphql.json`;
 
@@ -53,7 +47,7 @@ export async function shopifyFetch<T>({
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-Shopify-Storefront-Access-Token": SHOPIFY_ACCESS_TOKEN || "",
+      "X-Shopify-Storefront-Access-Token": SHOPIFY_ACCESS_TOKEN,
       "Accept-Encoding": "gzip, br",
     },
     body: JSON.stringify({ query, variables, operationName: operation }),

--- a/apps/template/lib/shopify/fetch.ts
+++ b/apps/template/lib/shopify/fetch.ts
@@ -1,32 +1,9 @@
-import { createHash } from "node:crypto";
-
 const SHOPIFY_STORE_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN as string;
 const SHOPIFY_ACCESS_TOKEN = process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN as string;
 const SHOPIFY_API_VERSION = process.env.SHOPIFY_API_VERSION ?? "2026-04";
 const DEBUG = process.env.DEBUG_SHOPIFY === "true";
 
 const baseEndpoint = `https://${SHOPIFY_STORE_DOMAIN}/api/${SHOPIFY_API_VERSION}/graphql.json`;
-
-function stableSerialize(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map(stableSerialize).join(",")}]`;
-  }
-
-  if (value && typeof value === "object") {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableSerialize(entryValue)}`)
-      .join(",")}}`;
-  }
-
-  return JSON.stringify(value);
-}
-
-function buildVariableCacheKey(variables?: Record<string, unknown>): string {
-  if (!variables) return "";
-
-  return createHash("sha1").update(stableSerialize(variables)).digest("hex").slice(0, 12);
-}
 
 export async function shopifyFetch<T>({
   operation,
@@ -37,10 +14,7 @@ export async function shopifyFetch<T>({
   query: string;
   variables?: Record<string, unknown>;
 }): Promise<T> {
-  const variableCacheKey = buildVariableCacheKey(variables);
-  const endpoint = variableCacheKey
-    ? `${baseEndpoint}?operation=${operation}&variables=${variableCacheKey}`
-    : `${baseEndpoint}?operation=${operation}`;
+  const endpoint = `${baseEndpoint}?operation=${operation}`;
   const start = DEBUG ? performance.now() : 0;
 
   const response = await fetch(endpoint, {

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -1,6 +1,16 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
+const missingShopify = ["SHOPIFY_STORE_DOMAIN", "SHOPIFY_STOREFRONT_ACCESS_TOKEN"].filter(
+  (key) => !process.env[key],
+);
+
+if (missingShopify.length > 0) {
+  throw new Error(
+    `Missing required Shopify environment variables: ${missingShopify.join(", ")}. See .env.example.`,
+  );
+}
+
 if (process.env.NEXT_PUBLIC_ENABLE_AUTH === "1") {
   const missing = [
     "BETTER_AUTH_SECRET",


### PR DESCRIPTION
## Summary

Four small cleanups to `apps/template/lib/shopify/fetch.ts` and the related docs reference.

- **Brotli on Shopify responses.** Swap `Accept-Encoding` from `gzip, deflate` to `gzip, br`. Brotli is ~15–20% smaller than gzip on JSON; deflate-as-a-distinct-option sees almost no real-world use. undici decompresses transparently, no other code changes needed.
- **Fail the build when Shopify env vars are missing.** The runtime `console.warn` for missing `SHOPIFY_STORE_DOMAIN` / `SHOPIFY_STOREFRONT_ACCESS_TOKEN` scrolled past in build logs and left the first request to fail with an opaque 401. Validation now lives in `next.config.ts`, matching the pattern already used for `NEXT_PUBLIC_ENABLE_AUTH`. The defensive `|| ""` fallback in the request headers is now unreachable; dropped.
- **Drop the variable-hash-in-URL trick.** `stableSerialize` + `buildVariableCacheKey` predate Next.js 16 cache components. They were there to give Next's URL-keyed fetch cache distinct entries per variables tuple. The wrappers in `lib/shopify/operations/` now use `"use cache"`, which keys on function arguments — the URL hash no longer participates in cache isolation. `?operation=` stays on the URL for network-log readability.
- **Docs reference updated.** Drop the `Accept-Encoding` row from the request-headers table (not part of the Shopify contract, just a perf hint that drifts). Bump the documented API version `2025-01` → `2026-04` to match `lib/shopify/fetch.ts`. Update the cache-key paragraph to point to `"use cache"` wrappers.

## Test plan

- [ ] `pnpm install && pnpm build` in `apps/template` succeeds
- [ ] `pnpm build` fails with a clear error when `SHOPIFY_STORE_DOMAIN` is unset
- [ ] Hit a product / collection / search page in dev and confirm rendering is unchanged
- [ ] (Optional) `DEBUG_SHOPIFY=true` and confirm no regression in `shopifyFetch` timings

🤖 Generated with [Claude Code](https://claude.com/claude-code)