### PR TITLE
[template] align Shopify data layer

### DIFF
--- a/apps/docs/content/docs/reference/storefront-api.mdx
+++ b/apps/docs/content/docs/reference/storefront-api.mdx
@@ -160,7 +160,7 @@ The client handles errors at two levels:
 
 **GraphQL errors** - if the response contains `errors` and no `data`, the client throws. If there are errors but `data` is also present (partial success), it logs a warning and returns the partial data.
 
-Individual operations add their own handling on top. For example, `getCart()` wraps the call in try-catch and returns `undefined` on failure, while `getProduct()` throws if the product isn't found.
+Individual operations follow a consistent contract on top of this: they **throw** on transport or GraphQL failure, and **return** `undefined`/`null`/`[]` when a resource is simply missing. For example, `getProduct()` returns `undefined` when the product isn't found (rather than throwing), and `getCart()` returns `undefined` when there's no cart. For render paths that should degrade gracefully instead of crashing on a transport error, wrap the call in the `withFallback(promise, fallback)` helper — e.g. `withFallback(getCart(), undefined)` in the nav and cart page.
 
 ## Debug logging
 

--- a/apps/docs/content/docs/reference/storefront-api.mdx
+++ b/apps/docs/content/docs/reference/storefront-api.mdx
@@ -89,8 +89,15 @@ import { cacheLife, cacheTag } from "next/cache";
 import { shopifyFetch } from "../fetch";
 import { PRODUCT_FRAGMENT } from "../fragments";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
+import type { ProductDetails } from "@/lib/types";
 
-export async function getProduct(handle: string, locale: string = defaultLocale) {
+export async function getProduct({
+  handle,
+  locale = defaultLocale,
+}: {
+  handle: string;
+  locale?: string;
+}): Promise<ProductDetails | undefined> {
   "use cache";
   cacheLife("max");
   cacheTag("products", `product-${handle}`);
@@ -104,6 +111,8 @@ export async function getProduct(handle: string, locale: string = defaultLocale)
       language: getLanguageCode(locale),
     },
   });
+
+  if (!data.productByHandle) return undefined;
 
   return transformShopifyProductDetails(data.productByHandle);
 }

--- a/apps/docs/content/docs/skills/enable-shopify-cms.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-cms.mdx
@@ -62,20 +62,28 @@ Add Shopify metaobject-based CMS support to the shop template. This replaces the
 Implement three operations that return domain types from `lib/types.ts`:
 
 ```ts
-import { shopifyFetch } from "@/lib/shopify/client";
+import { defaultLocale } from "@/lib/i18n";
+import { shopifyFetch } from "@/lib/shopify/fetch";
 import type { Homepage, MarketingPage } from "@/lib/types";
 
-export async function getHomepage(locale: string): Promise<Homepage | null> {
+export async function getHomepage({
+  locale = defaultLocale,
+}: {
+  locale?: string;
+} = {}): Promise<Homepage | null> {
   "use cache";
   cacheLife("max");
   cacheTag("cms-content");
   // Query cms_homepage metaobject, transform to Homepage type
 }
 
-export async function getMarketingPage(
-  slug: string,
-  locale: string,
-): Promise<MarketingPage | null> {
+export async function getMarketingPage({
+  slug,
+  locale = defaultLocale,
+}: {
+  slug: string;
+  locale?: string;
+}): Promise<MarketingPage | null> {
   "use cache";
   cacheLife("max");
   cacheTag("cms-content");

--- a/apps/docs/content/docs/skills/enable-shopify-markets.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-markets.mdx
@@ -330,7 +330,7 @@ export default getRequestConfig(async () => {
 
 ### Scope menu queries for markets
 
-The base template keeps [`lib/shopify/operations/menu.ts`](../../lib/shopify/operations/menu.ts) unscoped so menus load before Shopify Markets is configured. When enabling markets, update `getMenu` to derive `country` and `language` from the active locale and query `menu` with `@inContext(country: $country, language: $language)`. Without that change, quick links and footer menu stay pinned to the default market. If the `enable-shopify-menus` skill has been run, the megamenu will also need this scoping.
+The base template keeps [`lib/shopify/operations/menu.ts`](../../lib/shopify/operations/menu.ts) unscoped (it takes only `{ handle }`) so menus load before Shopify Markets is configured. When enabling markets, extend `getMenu` to accept the active locale (e.g. `getMenu({ handle, locale })`), derive `country` and `language` from that locale, and query `menu` with `@inContext(country: $country, language: $language)`. Without that change, quick links and footer menu stay pinned to the default market. If the `enable-shopify-menus` skill has been run, the megamenu will also need this scoping.
 
 ---
 

--- a/apps/docs/content/docs/skills/enable-shopify-menus.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-menus.mdx
@@ -49,7 +49,7 @@ import { getMenu } from "@/lib/shopify/operations/menu";
 Inside `Nav`, replace `const items = navItems;` with:
 
 ```tsx
-const menu = await getMenu("NAV_HANDLE", locale);
+const menu = await getMenu({ handle: "NAV_HANDLE" });
 const items = menu?.items ?? navItems;
 ```
 
@@ -70,7 +70,7 @@ import { getMenu } from "@/lib/shopify/operations/menu";
 Change the signature to `async` and replace `const items = footerItems;` with:
 
 ```tsx
-const menu = await getMenu("FOOTER_HANDLE", locale);
+const menu = await getMenu({ handle: "FOOTER_HANDLE" });
 const items = menu?.items ?? footerItems;
 ```
 

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -48,13 +48,13 @@ async function resolvePageContext(
 
   if (pageType === "products" && segments.length >= 2) {
     const handle = segments[1];
-    const product = await withFallback(getProduct(handle, locale), undefined);
+    const product = await withFallback(getProduct({ handle, locale }), undefined);
     if (product) return { type: "product", product };
   }
 
   if (pageType === "collections" && segments.length >= 2) {
     const handle = segments[1];
-    const collection = await withFallback(getCollection(handle, locale), undefined);
+    const collection = await withFallback(getCollection({ handle, locale }), undefined);
     if (collection) return { type: "collection", handle, title: collection.title };
   }
 

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -10,6 +10,7 @@ import { cookies } from "next/headers";
 import { createAgent, type PageContext, type User, withAgentContext } from "@/lib/agent/server";
 import { agent as agentConfig } from "@/lib/config";
 import { defaultLocale, type Locale } from "@/lib/i18n";
+import { withFallback } from "@/lib/shopify/errors";
 import { createCartWithoutCookie } from "@/lib/shopify/operations/cart";
 import { getCollection } from "@/lib/shopify/operations/collections";
 import { getProduct } from "@/lib/shopify/operations/products";
@@ -46,25 +47,15 @@ async function resolvePageContext(
   const pageType = segments[0];
 
   if (pageType === "products" && segments.length >= 2) {
-    try {
-      const handle = segments[1];
-      const product = await getProduct(handle, locale);
-      return { type: "product", product };
-    } catch {
-      // Product not found — fall through to other branches.
-    }
+    const handle = segments[1];
+    const product = await withFallback(getProduct(handle, locale), undefined);
+    if (product) return { type: "product", product };
   }
 
   if (pageType === "collections" && segments.length >= 2) {
-    try {
-      const handle = segments[1];
-      const collection = await getCollection(handle, locale);
-      if (collection) {
-        return { type: "collection", handle, title: collection.title };
-      }
-    } catch {
-      // Collection not found — fall through to other branches.
-    }
+    const handle = segments[1];
+    const collection = await withFallback(getCollection(handle, locale), undefined);
+    if (collection) return { type: "collection", handle, title: collection.title };
   }
 
   if (pageType === "search") {

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -5,9 +5,8 @@ import {
   createUIMessageStreamResponse,
   safeValidateUIMessages,
 } from "ai";
-import { cookies } from "next/headers";
-
 import { createAgent, type PageContext, type User, withAgentContext } from "@/lib/agent/server";
+import { buildCartIdSetCookieHeader, getCartIdFromCookie } from "@/lib/cart/server";
 import { agent as agentConfig } from "@/lib/config";
 import { defaultLocale, type Locale } from "@/lib/i18n";
 import { withFallback } from "@/lib/shopify/errors";
@@ -81,7 +80,6 @@ export async function POST(request: Request) {
   }
 
   const body = await request.json();
-  const store = await cookies();
   const { messages, chatId } = body;
 
   if (!chatId) {
@@ -102,15 +100,15 @@ export async function POST(request: Request) {
   const page = await resolvePageContext(segments, locale, referer);
 
   // Get or create cart before streaming (cookies can't be set during stream)
-  let cartId = store.get("shopify_cartId")?.value;
+  let cartId = await getCartIdFromCookie();
   let newCartCookie: string | undefined;
 
   if (!cartId) {
     const newCart = await createCartWithoutCookie(locale);
-    cartId = newCart.id;
-    const secure = process.env.NODE_ENV === "production";
-    const maxAge = 60 * 60 * 24 * 7; // 7 days
-    newCartCookie = `shopify_cartId=${cartId}; Path=/; HttpOnly; SameSite=Strict; Max-Age=${maxAge}${secure ? "; Secure" : ""}`;
+    if (newCart.id) {
+      cartId = newCart.id;
+      newCartCookie = buildCartIdSetCookieHeader(newCart.id);
+    }
   }
 
   return withAgentContext(

--- a/apps/template/app/cart/page.tsx
+++ b/apps/template/app/cart/page.tsx
@@ -15,6 +15,7 @@ import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
 import type { Locale } from "@/lib/i18n";
 import { getLocale } from "@/lib/params";
+import { withFallback } from "@/lib/shopify/errors";
 import { getCart } from "@/lib/shopify/operations/cart";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -41,7 +42,10 @@ export default async function CartPage() {
 }
 
 async function CartContent({ locale }: { locale: Locale }) {
-  const [cart, messages] = await Promise.all([getCart(), getMessages()]);
+  const [cart, messages] = await Promise.all([
+    withFallback(getCart(), undefined),
+    getMessages(),
+  ]);
 
   return (
     <NextIntlClientProvider messages={{ cart: messages.cart }}>

--- a/apps/template/app/collections/[handle]/page.tsx
+++ b/apps/template/app/collections/[handle]/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata({
   }
 
   const [collection, t] = await Promise.all([
-    getCollection(handle, locale),
+    getCollection({ handle, locale }),
     getTranslations("seo"),
   ]);
 
@@ -96,7 +96,7 @@ export default async function CollectionPage({
     if (handle === PLACEHOLDER_HANDLE) notFound();
     return handle;
   });
-  const collectionPromise = handlePromise.then((handle) => getCollection(handle, locale));
+  const collectionPromise = handlePromise.then((handle) => getCollection({ handle, locale }));
   const searchStatePromise = getCollectionSearchState(searchParams);
   const collectionResultsDataPromise = getCollectionResultsData({
     handlePromise,

--- a/apps/template/app/md/collections/[handle]/route.ts
+++ b/apps/template/app/md/collections/[handle]/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ hand
 
   try {
     const [collection, result] = await Promise.all([
-      getCollection(handle, locale),
+      getCollection({ handle, locale }),
       getCollectionProducts({
         collection: handle,
         sortKey: sort,

--- a/apps/template/app/md/collections/[handle]/route.ts
+++ b/apps/template/app/md/collections/[handle]/route.ts
@@ -5,7 +5,6 @@ import {
   buildProductFiltersFromParams,
   getCollectionProducts,
 } from "@/lib/shopify/operations/products";
-import { transformShopifyFilters } from "@/lib/shopify/transforms/filters";
 import { RESULTS_PER_PAGE, parseFiltersFromSearchParams, searchParamsToRecord } from "@/lib/utils";
 
 function markdownHeaders(cacheControl: string): HeadersInit {
@@ -31,6 +30,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ hand
     const [collection, result] = await Promise.all([
       getCollection({ handle, locale }),
       getCollectionProducts({
+        activeFilters,
         collection: handle,
         sortKey: sort,
         limit: RESULTS_PER_PAGE,
@@ -50,13 +50,11 @@ export async function GET(request: Request, { params }: { params: Promise<{ hand
       );
     }
 
-    const transformedFilters = transformShopifyFilters(result.filters, { activeFilters });
-    const hasPriceRange = result.filters.some((filter) => filter.type === "PRICE_RANGE");
     const markdown = collectionToMarkdown({
       collection,
       products: result.products,
-      filters: transformedFilters.filters,
-      priceRange: hasPriceRange ? transformedFilters.priceRange : undefined,
+      filters: result.filters,
+      priceRange: result.priceRange,
       activeFilters,
       pageInfo: result.pageInfo,
       locale,

--- a/apps/template/app/md/products/[handle]/route.ts
+++ b/apps/template/app/md/products/[handle]/route.ts
@@ -9,6 +9,22 @@ export async function GET(request: Request, { params }: { params: Promise<{ hand
 
   try {
     const product = await getProduct(handle, locale);
+
+    if (!product) {
+      return new Response(
+        `# Product Not Found\n\nThe product with handle \`${handle}\` could not be found.`,
+        {
+          status: 404,
+          headers: {
+            "Content-Type": "text/markdown; charset=utf-8",
+            "Cache-Control": "public, max-age=3600, stale-while-revalidate=604800",
+            Vary: "Accept",
+            "X-Robots-Tag": "noindex",
+          },
+        },
+      );
+    }
+
     const markdown = productToMarkdown(product, locale);
 
     return new Response(markdown, {
@@ -19,21 +35,14 @@ export async function GET(request: Request, { params }: { params: Promise<{ hand
         "X-Robots-Tag": "noindex",
       },
     });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    const isNotFound = message.includes("Product not found");
-
+  } catch {
     return new Response(
-      isNotFound
-        ? `# Product Not Found\n\nThe product with handle \`${handle}\` could not be found.`
-        : `# Server Error\n\nAn error occurred while retrieving the product. Please try again later.`,
+      `# Server Error\n\nAn error occurred while retrieving the product. Please try again later.`,
       {
-        status: isNotFound ? 404 : 500,
+        status: 500,
         headers: {
           "Content-Type": "text/markdown; charset=utf-8",
-          "Cache-Control": isNotFound
-            ? "public, max-age=3600, stale-while-revalidate=604800"
-            : "no-cache, no-store, must-revalidate",
+          "Cache-Control": "no-cache, no-store, must-revalidate",
           Vary: "Accept",
           "X-Robots-Tag": "noindex",
         },

--- a/apps/template/app/md/products/[handle]/route.ts
+++ b/apps/template/app/md/products/[handle]/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ hand
   const locale = resolveLocale(url.searchParams.get("locale") || defaultLocale);
 
   try {
-    const product = await getProduct(handle, locale);
+    const product = await getProduct({ handle, locale });
 
     if (!product) {
       return new Response(

--- a/apps/template/app/md/search/route.ts
+++ b/apps/template/app/md/search/route.ts
@@ -5,7 +5,6 @@ import {
   getSearchFacets,
   searchIndexProducts,
 } from "@/lib/shopify/operations/products";
-import { transformShopifyFilters } from "@/lib/shopify/transforms/filters";
 import { RESULTS_PER_PAGE, parseFiltersFromSearchParams, searchParamsToRecord } from "@/lib/utils";
 
 function markdownHeaders(cacheControl: string): HeadersInit {
@@ -39,18 +38,16 @@ export async function GET(request: Request) {
         filters: shopifyFilters,
         locale,
       }),
-      getSearchFacets({ query, collection, filters: shopifyFilters, locale }),
+      getSearchFacets({ activeFilters, query, collection, filters: shopifyFilters, locale }),
     ]);
 
-    const transformedFilters = transformShopifyFilters(facets.filters, { activeFilters });
-    const hasPriceRange = facets.filters.some((filter) => filter.type === "PRICE_RANGE");
     const markdown = searchResultsToMarkdown({
       query,
       collection,
       products: results.products,
       total: facets.total,
-      filters: transformedFilters.filters,
-      priceRange: hasPriceRange ? transformedFilters.priceRange : undefined,
+      filters: facets.filters,
+      priceRange: facets.priceRange,
       activeFilters,
       pageInfo: results.pageInfo,
       locale,

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -18,7 +18,7 @@ async function buildProductMetadata(
   locale: string,
   canonicalPath: string,
 ): Promise<Metadata> {
-  const product = await getProduct(handle, locale);
+  const product = await getProduct({ handle, locale });
   if (!product) notFound();
   const images = product.featuredImage
     ? [
@@ -86,7 +86,7 @@ export default async function ProductPage({
   });
 
   const productPromise = handlePromise.then(async (handle) => {
-    const product = await getProduct(handle, locale);
+    const product = await getProduct({ handle, locale });
     if (!product) notFound();
     return product;
   });

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -18,7 +18,8 @@ async function buildProductMetadata(
   locale: string,
   canonicalPath: string,
 ): Promise<Metadata> {
-  const product = await getProduct(handle, locale).catch(() => notFound());
+  const product = await getProduct(handle, locale);
+  if (!product) notFound();
   const images = product.featuredImage
     ? [
         {
@@ -84,9 +85,11 @@ export default async function ProductPage({
     return handle;
   });
 
-  const productPromise = handlePromise.then((handle) =>
-    getProduct(handle, locale).catch(() => notFound()),
-  );
+  const productPromise = handlePromise.then(async (handle) => {
+    const product = await getProduct(handle, locale);
+    if (!product) notFound();
+    return product;
+  });
 
   const variantIdPromise = searchParams.then((sp) => sp?.variant as string | undefined);
 

--- a/apps/template/components/nav/cart.tsx
+++ b/apps/template/components/nav/cart.tsx
@@ -1,13 +1,14 @@
 import { HandbagIcon } from "lucide-react";
 import { cookies } from "next/headers";
 
+import { withFallback } from "@/lib/shopify/errors";
 import { getCart } from "@/lib/shopify/operations/cart";
 
 import { CartIconClient } from "./cart-client";
 
 export async function CartIcon() {
   const cartId = (await cookies()).get("shopify_cartId")?.value;
-  const cart = cartId ? await getCart(cartId) : undefined;
+  const cart = cartId ? await withFallback(getCart(cartId), undefined) : undefined;
 
   return <CartIconClient initialCart={cart ?? null} />;
 }

--- a/apps/template/components/product/related-products-section.tsx
+++ b/apps/template/components/product/related-products-section.tsx
@@ -37,7 +37,7 @@ async function Render({ handle, locale }: { handle: string | Promise<string>; lo
   const resolvedHandle = await handle;
   const [t, recommendations] = await Promise.all([
     getTranslations("product"),
-    getProductRecommendations(resolvedHandle, locale),
+    getProductRecommendations({ handle: resolvedHandle, locale }),
   ]);
 
   if (recommendations.length === 0) return null;

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -15,17 +15,20 @@ import {
   getSearchFacets,
   searchIndexProducts,
 } from "@/lib/shopify/operations/products";
-import { transformShopifyFilters } from "@/lib/shopify/transforms/filters";
-import type { TransformedFilters } from "@/lib/shopify/transforms/filters";
 import type { ProductFilter } from "@/lib/shopify/types/filters";
-import type { PageInfo, ProductCard as ProductCardType } from "@/lib/types";
+import type {
+  Filter,
+  PageInfo,
+  PriceRange,
+  ProductCard as ProductCardType,
+} from "@/lib/types";
 import { RESULTS_PER_PAGE } from "@/lib/utils";
 
 export interface SearchResultsData {
   products: ProductCardType[];
   total: number;
   pageInfo: PageInfo;
-  transformedFilters: TransformedFilters;
+  transformedFilters: { filters: Filter[]; priceRange?: PriceRange };
   activeFilters: Record<string, string | string[] | undefined>;
   filters: ProductFilter[];
   query?: string;
@@ -56,14 +59,14 @@ export async function getSearchResultsData({
       filters: shopifyFilters,
       locale,
     }),
-    getSearchFacets({ query, collection, filters: shopifyFilters, locale }),
+    getSearchFacets({ activeFilters, query, collection, filters: shopifyFilters, locale }),
   ]);
 
   return {
     products: results.products,
     total: facets.total,
     pageInfo: results.pageInfo,
-    transformedFilters: transformShopifyFilters(facets.filters, { activeFilters }),
+    transformedFilters: { filters: facets.filters, priceRange: facets.priceRange },
     activeFilters,
     filters: shopifyFilters,
     query,

--- a/apps/template/lib/agent/tools/get-product-details.ts
+++ b/apps/template/lib/agent/tools/get-product-details.ts
@@ -22,6 +22,13 @@ You can get handles from search results or the current page context.`,
       try {
         const product = await getProduct(handle, user.locale);
 
+        if (!product) {
+          return {
+            success: false,
+            error: `Product not found: ${handle}`,
+          };
+        }
+
         return {
           success: true,
           product: {

--- a/apps/template/lib/agent/tools/get-product-details.ts
+++ b/apps/template/lib/agent/tools/get-product-details.ts
@@ -20,7 +20,7 @@ You can get handles from search results or the current page context.`,
       const { user } = getAgentContext();
 
       try {
-        const product = await getProduct(handle, user.locale);
+        const product = await getProduct({ handle, locale: user.locale });
 
         if (!product) {
           return {

--- a/apps/template/lib/agent/tools/get-recommendations.ts
+++ b/apps/template/lib/agent/tools/get-recommendations.ts
@@ -17,7 +17,7 @@ Returns AI-powered recommendations from Shopify.`,
       const { user } = getAgentContext();
 
       try {
-        const recommendations = await getProductRecommendations(handle, user.locale);
+        const recommendations = await getProductRecommendations({ handle, locale: user.locale });
 
         return {
           success: true,

--- a/apps/template/lib/cart/action.ts
+++ b/apps/template/lib/cart/action.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { isEnabledLocale } from "@/lib/i18n";
+import { withFallback } from "@/lib/shopify/errors";
 import {
   addToCart,
   getCart,
@@ -252,12 +253,6 @@ export async function buyNowAction(
 export async function prepareCheckoutAction(): Promise<{
   checkoutUrl: string | null;
 }> {
-  try {
-    const cart = await getCart();
-    return { checkoutUrl: cart?.checkoutUrl ?? null };
-  } catch (error) {
-    console.error("Prepare checkout failed:", error);
-    const cart = await getCart();
-    return { checkoutUrl: cart?.checkoutUrl ?? null };
-  }
+  const cart = await withFallback(getCart(), undefined);
+  return { checkoutUrl: cart?.checkoutUrl ?? null };
 }

--- a/apps/template/lib/cart/action.ts
+++ b/apps/template/lib/cart/action.ts
@@ -27,15 +27,7 @@ export async function removeFromCartAction(itemId: string): Promise<CartActionRe
   }
 
   try {
-    const result = await removeFromCart([itemId]);
-
-    if (!result) {
-      return {
-        success: false,
-        error: "Failed to remove item from cart",
-      };
-    }
-
+    await removeFromCart([itemId]);
     const updatedCart = await getCart();
 
     return {
@@ -86,21 +78,13 @@ export async function updateCartQuantityAction(
       };
     }
 
-    const result = await updateCart([
+    await updateCart([
       {
         id: itemId,
         merchandiseId: item.merchandise.id,
         quantity,
       },
     ]);
-
-    if (!result) {
-      return {
-        success: false,
-        error: "Failed to update item quantity",
-      };
-    }
-
     const updatedCart = await getCart();
 
     return {
@@ -135,15 +119,7 @@ export async function addToCartAction(
   }
 
   try {
-    const result = await addToCart([{ merchandiseId, quantity }]);
-
-    if (!result) {
-      return {
-        success: false,
-        error: "Failed to add item to cart",
-      };
-    }
-
+    await addToCart([{ merchandiseId, quantity }]);
     const updatedCart = await getCart();
 
     return {
@@ -191,18 +167,11 @@ export async function syncCartLocaleAction(locale: string): Promise<CartActionRe
 
 export async function updateCartNoteAction(note: string): Promise<CartActionResult> {
   try {
-    const result = await updateCartNote(note);
-
-    if (!result) {
-      return {
-        success: false,
-        error: "Failed to update cart note",
-      };
-    }
+    const cart = await updateCartNote(note);
 
     return {
       success: true,
-      cart: result,
+      cart,
     };
   } catch (error) {
     console.error("Update cart note failed:", error);

--- a/apps/template/lib/cart/server.ts
+++ b/apps/template/lib/cart/server.ts
@@ -1,5 +1,29 @@
 import "server-only";
 import { revalidateTag, updateTag } from "next/cache";
+import { cookies } from "next/headers";
+
+const CART_ID_COOKIE = "shopify_cartId";
+const CART_ID_COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+
+export async function getCartIdFromCookie(): Promise<string | undefined> {
+  return (await cookies()).get(CART_ID_COOKIE)?.value;
+}
+
+export async function setCartIdCookie(id: string): Promise<void> {
+  (await cookies()).set(CART_ID_COOKIE, id, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "strict",
+    maxAge: CART_ID_COOKIE_MAX_AGE,
+    path: "/",
+  });
+}
+
+/** Streaming contexts can't call cookies().set(); they must emit Set-Cookie via response headers. */
+export function buildCartIdSetCookieHeader(id: string): string {
+  const secure = process.env.NODE_ENV === "production";
+  return `${CART_ID_COOKIE}=${id}; Path=/; HttpOnly; SameSite=Strict; Max-Age=${CART_ID_COOKIE_MAX_AGE}${secure ? "; Secure" : ""}`;
+}
 
 export function invalidateCartCache(): void {
   try {

--- a/apps/template/lib/collections/server.ts
+++ b/apps/template/lib/collections/server.ts
@@ -7,9 +7,8 @@ import {
   getSearchFacets,
   searchIndexProducts,
 } from "@/lib/shopify/operations/products";
-import { type TransformedFilters, transformShopifyFilters } from "@/lib/shopify/transforms/filters";
 import type { ProductFilter } from "@/lib/shopify/types/filters";
-import type { Collection } from "@/lib/types";
+import type { Collection, Filter, PriceRange } from "@/lib/types";
 import { RESULTS_PER_PAGE, parseFiltersFromSearchParams } from "@/lib/utils";
 
 // Shopify's /collections/all is a Liquid-storefront convention with no Storefront API
@@ -29,7 +28,7 @@ export interface CollectionResultsData {
   sort?: string;
   filters: ProductFilter[];
   result: Awaited<ReturnType<typeof getCollectionProducts>>;
-  transformedFilters: TransformedFilters;
+  transformedFilters: { filters: Filter[]; priceRange?: PriceRange };
 }
 
 export async function getCollectionSearchState(
@@ -55,6 +54,7 @@ export async function getCollectionResultsData({
   const [handle, { activeFilters, sort }] = await Promise.all([handlePromise, searchStatePromise]);
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
   const result = await getCollectionProducts({
+    activeFilters,
     collection: handle,
     sortKey: sort,
     limit: RESULTS_PER_PAGE,
@@ -68,9 +68,7 @@ export async function getCollectionResultsData({
     sort,
     filters: shopifyFilters,
     result,
-    transformedFilters: transformShopifyFilters(result.filters, {
-      activeFilters,
-    }),
+    transformedFilters: { filters: result.filters, priceRange: result.priceRange },
   };
 }
 
@@ -121,7 +119,7 @@ export async function getAllProductsResultsData({
       filters: shopifyFilters,
       locale,
     }),
-    getSearchFacets({ filters: shopifyFilters, locale }),
+    getSearchFacets({ activeFilters, filters: shopifyFilters, locale }),
   ]);
 
   return {
@@ -133,7 +131,8 @@ export async function getAllProductsResultsData({
       products: products.products,
       pageInfo: products.pageInfo,
       filters: facets.filters,
+      priceRange: facets.priceRange,
     },
-    transformedFilters: transformShopifyFilters(facets.filters, { activeFilters }),
+    transformedFilters: { filters: facets.filters, priceRange: facets.priceRange },
   };
 }

--- a/apps/template/lib/search/action.ts
+++ b/apps/template/lib/search/action.ts
@@ -14,7 +14,7 @@ export async function predictiveSearchAction(
     return { products: [], collections: [], queries: [] };
   }
 
-  return predictiveSearch(query.trim(), locale, 4);
+  return predictiveSearch({ query: query.trim(), locale, limit: 4 });
 }
 
 export async function loadMoreSearchProducts(params: {

--- a/apps/template/lib/shopify/errors.ts
+++ b/apps/template/lib/shopify/errors.ts
@@ -5,3 +5,33 @@ export async function withFallback<T>(promise: Promise<T>, fallback: T): Promise
     return fallback;
   }
 }
+
+export interface UserError {
+  field?: string[] | null;
+  message: string;
+}
+
+export interface CartMutationPayload<T> {
+  cart: T | null;
+  userErrors: UserError[];
+}
+
+export class ShopifyUserError extends Error {
+  constructor(
+    public readonly errors: UserError[],
+    public readonly operation: string,
+  ) {
+    super(errors.map((e) => e.message).join("; "));
+    this.name = "ShopifyUserError";
+  }
+}
+
+export function unwrapCartMutation<T>(payload: CartMutationPayload<T>, operation: string): T {
+  if (payload.userErrors && payload.userErrors.length > 0) {
+    throw new ShopifyUserError(payload.userErrors, operation);
+  }
+  if (!payload.cart) {
+    throw new Error(`Shopify ${operation}: cart missing from response`);
+  }
+  return payload.cart;
+}

--- a/apps/template/lib/shopify/errors.ts
+++ b/apps/template/lib/shopify/errors.ts
@@ -1,0 +1,7 @@
+export async function withFallback<T>(promise: Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await promise;
+  } catch {
+    return fallback;
+  }
+}

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -57,6 +57,92 @@ export const METAFIELD_FRAGMENT = `
   }
 `;
 
+export const CART_FRAGMENT = `
+  ${IMAGE_FRAGMENT}
+  ${MONEY_FRAGMENT}
+  fragment CartFields on Cart {
+    id
+    checkoutUrl
+    totalQuantity
+    note
+    lines(first: 50) {
+      edges {
+        node {
+          id
+          quantity
+          cost {
+            totalAmount {
+              ...MoneyFields
+            }
+          }
+          merchandise {
+            ... on ProductVariant {
+              id
+              title
+              selectedOptions {
+                name
+                value
+              }
+              image {
+                ...ImageFields
+              }
+              price {
+                ...MoneyFields
+              }
+              product {
+                id
+                title
+                handle
+                featuredImage {
+                  ...ImageFields
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    cost {
+      totalAmount {
+        ...MoneyFields
+      }
+      subtotalAmount {
+        ...MoneyFields
+      }
+      totalTaxAmount {
+        ...MoneyFields
+      }
+    }
+    deliveryGroups(first: 5) {
+      nodes {
+        selectedDeliveryOption {
+          title
+          estimatedCost {
+            ...MoneyFields
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const COLLECTION_FIELDS_FRAGMENT = `
+  ${IMAGE_FRAGMENT}
+  fragment CollectionFields on Collection {
+    handle
+    title
+    description
+    image {
+      ...ImageFields
+    }
+    updatedAt
+    seo {
+      title
+      description
+    }
+  }
+`;
+
 export const PRODUCT_FRAGMENT = `
   ${IMAGE_FRAGMENT}
   ${PRODUCT_VARIANT_FRAGMENT}

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -4,6 +4,7 @@ import { invalidateCartCache } from "@/lib/cart/server";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import type { Cart } from "@/lib/types";
 
+import { type CartMutationPayload, unwrapCartMutation } from "../errors";
 import { shopifyFetch } from "../fetch";
 import { type ShopifyCart, transformShopifyCart } from "../transforms/cart";
 
@@ -118,7 +119,7 @@ export async function createCartWithoutCookie(locale: string = defaultLocale): P
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 
-  const data = await shopifyFetch<{ cartCreate: { cart: ShopifyCart } }>({
+  const data = await shopifyFetch<{ cartCreate: CartMutationPayload<ShopifyCart> }>({
     operation: "cartCreate",
     query: `
       ${CART_FRAGMENT}
@@ -126,6 +127,10 @@ export async function createCartWithoutCookie(locale: string = defaultLocale): P
         cartCreate(input: $input) {
           cart {
             ...CartFields
+          }
+          userErrors {
+            field
+            message
           }
         }
       }
@@ -141,7 +146,7 @@ export async function createCartWithoutCookie(locale: string = defaultLocale): P
     },
   });
 
-  const cart = transformShopifyCart(data.cartCreate.cart);
+  const cart = transformShopifyCart(unwrapCartMutation(data.cartCreate, "cartCreate"));
   invalidateCartCache();
   return cart;
 }
@@ -176,7 +181,7 @@ export async function addToCart(
     cartId = cart.id;
   }
 
-  const data = await shopifyFetch<{ cartLinesAdd: { cart: ShopifyCart } }>({
+  const data = await shopifyFetch<{ cartLinesAdd: CartMutationPayload<ShopifyCart> }>({
     operation: "cartLinesAdd",
     query: `
       ${CART_FRAGMENT}
@@ -185,13 +190,17 @@ export async function addToCart(
           cart {
             ...CartFields
           }
+          userErrors {
+            field
+            message
+          }
         }
       }
     `,
     variables: { cartId, lines },
   });
 
-  const cart = transformShopifyCart(data.cartLinesAdd.cart);
+  const cart = transformShopifyCart(unwrapCartMutation(data.cartLinesAdd, "cartLinesAdd"));
   invalidateCartCache();
   return cart;
 }
@@ -204,7 +213,7 @@ export async function updateCart(
   if (!cartId) throw new Error("Cart ID not found");
 
   const data = await shopifyFetch<{
-    cartLinesUpdate: { cart: ShopifyCart };
+    cartLinesUpdate: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartLinesUpdate",
     query: `
@@ -213,6 +222,10 @@ export async function updateCart(
         cartLinesUpdate(cartId: $cartId, lines: $lines) {
           cart {
             ...CartFields
+          }
+          userErrors {
+            field
+            message
           }
         }
       }
@@ -223,7 +236,7 @@ export async function updateCart(
     },
   });
 
-  const cart = transformShopifyCart(data.cartLinesUpdate.cart);
+  const cart = transformShopifyCart(unwrapCartMutation(data.cartLinesUpdate, "cartLinesUpdate"));
   invalidateCartCache();
   return cart;
 }
@@ -233,7 +246,7 @@ export async function removeFromCart(lineIds: string[], cartIdOverride?: string)
   if (!cartId) throw new Error("Cart ID not found");
 
   const data = await shopifyFetch<{
-    cartLinesRemove: { cart: ShopifyCart };
+    cartLinesRemove: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartLinesRemove",
     query: `
@@ -243,13 +256,17 @@ export async function removeFromCart(lineIds: string[], cartIdOverride?: string)
           cart {
             ...CartFields
           }
+          userErrors {
+            field
+            message
+          }
         }
       }
     `,
     variables: { cartId, lineIds },
   });
 
-  const cart = transformShopifyCart(data.cartLinesRemove.cart);
+  const cart = transformShopifyCart(unwrapCartMutation(data.cartLinesRemove, "cartLinesRemove"));
   invalidateCartCache();
   return cart;
 }
@@ -264,10 +281,7 @@ export async function updateCartBuyerIdentity(
   const country = countryCode ?? getCountryCode(locale);
 
   const data = await shopifyFetch<{
-    cartBuyerIdentityUpdate: {
-      cart: ShopifyCart | null;
-      userErrors: Array<{ field?: string[]; message: string }>;
-    };
+    cartBuyerIdentityUpdate: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartBuyerIdentityUpdate",
     query: `
@@ -292,9 +306,9 @@ export async function updateCartBuyerIdentity(
     },
   });
 
-  if (!data.cartBuyerIdentityUpdate.cart) return undefined;
-
-  const cart = transformShopifyCart(data.cartBuyerIdentityUpdate.cart);
+  const cart = transformShopifyCart(
+    unwrapCartMutation(data.cartBuyerIdentityUpdate, "cartBuyerIdentityUpdate"),
+  );
   invalidateCartCache();
   return cart;
 }
@@ -307,10 +321,7 @@ export async function linkCartToCustomer(
   if (!cartId) return undefined;
 
   const data = await shopifyFetch<{
-    cartBuyerIdentityUpdate: {
-      cart: ShopifyCart | null;
-      userErrors: Array<{ field?: string[]; message: string }>;
-    };
+    cartBuyerIdentityUpdate: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartBuyerIdentityUpdate",
     query: `
@@ -335,9 +346,9 @@ export async function linkCartToCustomer(
     },
   });
 
-  if (!data.cartBuyerIdentityUpdate.cart) return undefined;
-
-  const cart = transformShopifyCart(data.cartBuyerIdentityUpdate.cart);
+  const cart = transformShopifyCart(
+    unwrapCartMutation(data.cartBuyerIdentityUpdate, "cartBuyerIdentityUpdate"),
+  );
   invalidateCartCache();
   return cart;
 }
@@ -350,10 +361,7 @@ export async function updateCartNote(
   if (!cartId) return undefined;
 
   const data = await shopifyFetch<{
-    cartNoteUpdate: {
-      cart: ShopifyCart | null;
-      userErrors: Array<{ field?: string[]; message: string }>;
-    };
+    cartNoteUpdate: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartNoteUpdate",
     query: `
@@ -376,9 +384,7 @@ export async function updateCartNote(
     },
   });
 
-  if (!data.cartNoteUpdate.cart) return undefined;
-
-  const cart = transformShopifyCart(data.cartNoteUpdate.cart);
+  const cart = transformShopifyCart(unwrapCartMutation(data.cartNoteUpdate, "cartNoteUpdate"));
   invalidateCartCache();
   return cart;
 }
@@ -428,10 +434,7 @@ export async function addCartDeliveryAddress(address: {
       };
 
   const data = await shopifyFetch<{
-    cartDeliveryAddressesAdd: {
-      cart: ShopifyCart | null;
-      userErrors: Array<{ field?: string[]; message: string }>;
-    };
+    cartDeliveryAddressesAdd: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartDeliveryAddressesAdd",
     query: `
@@ -461,9 +464,9 @@ export async function addCartDeliveryAddress(address: {
     },
   });
 
-  if (!data.cartDeliveryAddressesAdd.cart) return undefined;
-
-  const cart = transformShopifyCart(data.cartDeliveryAddressesAdd.cart);
+  const cart = transformShopifyCart(
+    unwrapCartMutation(data.cartDeliveryAddressesAdd, "cartDeliveryAddressesAdd"),
+  );
   invalidateCartCache();
   return cart;
 }
@@ -554,10 +557,7 @@ export async function updateCartDeliveryAddress(
       };
 
   const data = await shopifyFetch<{
-    cartDeliveryAddressesUpdate: {
-      cart: ShopifyCart | null;
-      userErrors: Array<{ field?: string[]; message: string }>;
-    };
+    cartDeliveryAddressesUpdate: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartDeliveryAddressesUpdate",
     query: `
@@ -587,9 +587,9 @@ export async function updateCartDeliveryAddress(
     },
   });
 
-  if (!data.cartDeliveryAddressesUpdate.cart) return undefined;
-
-  const cart = transformShopifyCart(data.cartDeliveryAddressesUpdate.cart);
+  const cart = transformShopifyCart(
+    unwrapCartMutation(data.cartDeliveryAddressesUpdate, "cartDeliveryAddressesUpdate"),
+  );
   invalidateCartCache();
   return cart;
 }

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -92,27 +92,22 @@ export async function getCart(cartId?: string): Promise<Cart | undefined> {
   }
   if (!cartId) return undefined;
 
-  try {
-    const data = await shopifyFetch<{ cart: ShopifyCart | null }>({
-      operation: "getCart",
-      query: `
-        ${CART_FRAGMENT}
-        query getCart($cartId: ID!) {
-          cart(id: $cartId) {
-            ...CartFields
-          }
+  const data = await shopifyFetch<{ cart: ShopifyCart | null }>({
+    operation: "getCart",
+    query: `
+      ${CART_FRAGMENT}
+      query getCart($cartId: ID!) {
+        cart(id: $cartId) {
+          ...CartFields
         }
-      `,
-      variables: { cartId },
-    });
+      }
+    `,
+    variables: { cartId },
+  });
 
-    if (!data.cart) return undefined;
+  if (!data.cart) return undefined;
 
-    return transformShopifyCart(data.cart);
-  } catch (error) {
-    console.error("getCart failed:", error);
-    return undefined;
-  }
+  return transformShopifyCart(data.cart);
 }
 
 /**
@@ -483,61 +478,57 @@ export async function getCartDeliveryOptions(): Promise<CartShippingOption[]> {
   const cartId = (await cookies()).get("shopify_cartId")?.value;
   if (!cartId) return [];
 
-  try {
-    const data = await shopifyFetch<{
-      cart: {
-        deliveryGroups: {
-          nodes: Array<{
-            deliveryOptions: Array<{
-              title: string | null;
-              estimatedCost: { amount: string; currencyCode: string };
-              deliveryMethodType: string;
-            }>;
+  const data = await shopifyFetch<{
+    cart: {
+      deliveryGroups: {
+        nodes: Array<{
+          deliveryOptions: Array<{
+            title: string | null;
+            estimatedCost: { amount: string; currencyCode: string };
+            deliveryMethodType: string;
           }>;
-        };
-      } | null;
-    }>({
-      operation: "getCartDeliveryOptions",
-      query: `
-        query getCartDeliveryOptions($cartId: ID!) {
-          cart(id: $cartId) {
-            deliveryGroups(first: 5) {
-              nodes {
-                deliveryOptions {
-                  title
-                  estimatedCost {
-                    amount
-                    currencyCode
-                  }
-                  deliveryMethodType
+        }>;
+      };
+    } | null;
+  }>({
+    operation: "getCartDeliveryOptions",
+    query: `
+      query getCartDeliveryOptions($cartId: ID!) {
+        cart(id: $cartId) {
+          deliveryGroups(first: 5) {
+            nodes {
+              deliveryOptions {
+                title
+                estimatedCost {
+                  amount
+                  currencyCode
                 }
+                deliveryMethodType
               }
             }
           }
         }
-      `,
-      variables: { cartId },
-    });
+      }
+    `,
+    variables: { cartId },
+  });
 
-    if (!data.cart) return [];
+  if (!data.cart) return [];
 
-    const seen = new Set<string>();
-    return data.cart.deliveryGroups.nodes
-      .flatMap((group) => group.deliveryOptions)
-      .filter((opt) => {
-        const key = opt.title ?? opt.deliveryMethodType;
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      })
-      .map((opt) => ({
-        title: opt.title ?? opt.deliveryMethodType,
-        estimatedCost: opt.estimatedCost,
-        deliveryMethodType: opt.deliveryMethodType,
-      }));
-  } catch {
-    return [];
-  }
+  const seen = new Set<string>();
+  return data.cart.deliveryGroups.nodes
+    .flatMap((group) => group.deliveryOptions)
+    .filter((opt) => {
+      const key = opt.title ?? opt.deliveryMethodType;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .map((opt) => ({
+      title: opt.title ?? opt.deliveryMethodType,
+      estimatedCost: opt.estimatedCost,
+      deliveryMethodType: opt.deliveryMethodType,
+    }));
 }
 
 export async function updateCartDeliveryAddress(

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -6,82 +6,162 @@ import type { Cart } from "@/lib/types";
 
 import { type CartMutationPayload, unwrapCartMutation } from "../errors";
 import { shopifyFetch } from "../fetch";
+import { CART_FRAGMENT } from "../fragments";
 import { type ShopifyCart, transformShopifyCart } from "../transforms/cart";
 
-const CART_FRAGMENT = `
-  fragment CartFields on Cart {
-    id
-    checkoutUrl
-    totalQuantity
-    note
-    lines(first: 50) {
-      edges {
-        node {
-          id
-          quantity
-          cost {
-            totalAmount {
+const GET_CART_QUERY = `
+  ${CART_FRAGMENT}
+  query getCart($cartId: ID!) {
+    cart(id: $cartId) {
+      ...CartFields
+    }
+  }
+`;
+
+const CART_CREATE_MUTATION = `
+  ${CART_FRAGMENT}
+  mutation cartCreate($input: CartInput, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    cartCreate(input: $input) {
+      cart {
+        ...CartFields
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+const CART_LINES_ADD_MUTATION = `
+  ${CART_FRAGMENT}
+  mutation cartLinesAdd($cartId: ID!, $lines: [CartLineInput!]!) {
+    cartLinesAdd(cartId: $cartId, lines: $lines) {
+      cart {
+        ...CartFields
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+const CART_LINES_UPDATE_MUTATION = `
+  ${CART_FRAGMENT}
+  mutation cartLinesUpdate($cartId: ID!, $lines: [CartLineUpdateInput!]!) {
+    cartLinesUpdate(cartId: $cartId, lines: $lines) {
+      cart {
+        ...CartFields
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+const CART_LINES_REMOVE_MUTATION = `
+  ${CART_FRAGMENT}
+  mutation cartLinesRemove($cartId: ID!, $lineIds: [ID!]!) {
+    cartLinesRemove(cartId: $cartId, lineIds: $lineIds) {
+      cart {
+        ...CartFields
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+const CART_BUYER_IDENTITY_UPDATE_MUTATION = `
+  ${CART_FRAGMENT}
+  mutation cartBuyerIdentityUpdate($cartId: ID!, $buyerIdentity: CartBuyerIdentityInput!) {
+    cartBuyerIdentityUpdate(cartId: $cartId, buyerIdentity: $buyerIdentity) {
+      cart {
+        ...CartFields
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+const CART_NOTE_UPDATE_MUTATION = `
+  ${CART_FRAGMENT}
+  mutation cartNoteUpdate($cartId: ID!, $note: String!) {
+    cartNoteUpdate(cartId: $cartId, note: $note) {
+      cart {
+        ...CartFields
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+const GET_CART_SELECTABLE_ADDRESSES_QUERY = `
+  query getCartSelectableAddresses($cartId: ID!) {
+    cart(id: $cartId) {
+      selectableAddresses {
+        id
+      }
+    }
+  }
+`;
+
+const CART_DELIVERY_ADDRESSES_ADD_MUTATION = `
+  ${CART_FRAGMENT}
+  mutation cartDeliveryAddressesAdd($cartId: ID!, $addresses: [CartSelectableAddressInput!]!) {
+    cartDeliveryAddressesAdd(cartId: $cartId, addresses: $addresses) {
+      cart {
+        ...CartFields
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+const GET_CART_DELIVERY_OPTIONS_QUERY = `
+  query getCartDeliveryOptions($cartId: ID!) {
+    cart(id: $cartId) {
+      deliveryGroups(first: 5) {
+        nodes {
+          deliveryOptions {
+            title
+            estimatedCost {
               amount
               currencyCode
             }
-          }
-          merchandise {
-            ... on ProductVariant {
-              id
-              title
-              selectedOptions {
-                name
-                value
-              }
-              image {
-                url
-                altText
-                width
-                height
-              }
-              price {
-                amount
-                currencyCode
-              }
-              product {
-                id
-                title
-                handle
-                featuredImage {
-                  url
-                  altText
-                  width
-                  height
-                }
-              }
-            }
+            deliveryMethodType
           }
         }
       }
     }
-    cost {
-      totalAmount {
-        amount
-        currencyCode
+  }
+`;
+
+const CART_DELIVERY_ADDRESSES_UPDATE_MUTATION = `
+  ${CART_FRAGMENT}
+  mutation cartDeliveryAddressesUpdate($cartId: ID!, $addresses: [CartSelectableAddressUpdateInput!]!) {
+    cartDeliveryAddressesUpdate(cartId: $cartId, addresses: $addresses) {
+      cart {
+        ...CartFields
       }
-      subtotalAmount {
-        amount
-        currencyCode
-      }
-      totalTaxAmount {
-        amount
-        currencyCode
-      }
-    }
-    deliveryGroups(first: 5) {
-      nodes {
-        selectedDeliveryOption {
-          title
-          estimatedCost {
-            amount
-            currencyCode
-          }
-        }
+      userErrors {
+        field
+        message
       }
     }
   }
@@ -95,14 +175,7 @@ export async function getCart(cartId?: string): Promise<Cart | undefined> {
 
   const data = await shopifyFetch<{ cart: ShopifyCart | null }>({
     operation: "getCart",
-    query: `
-      ${CART_FRAGMENT}
-      query getCart($cartId: ID!) {
-        cart(id: $cartId) {
-          ...CartFields
-        }
-      }
-    `,
+    query: GET_CART_QUERY,
     variables: { cartId },
   });
 
@@ -121,20 +194,7 @@ export async function createCartWithoutCookie(locale: string = defaultLocale): P
 
   const data = await shopifyFetch<{ cartCreate: CartMutationPayload<ShopifyCart> }>({
     operation: "cartCreate",
-    query: `
-      ${CART_FRAGMENT}
-      mutation cartCreate($input: CartInput, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
-        cartCreate(input: $input) {
-          cart {
-            ...CartFields
-          }
-          userErrors {
-            field
-            message
-          }
-        }
-      }
-    `,
+    query: CART_CREATE_MUTATION,
     variables: {
       input: {
         buyerIdentity: {
@@ -183,20 +243,7 @@ export async function addToCart(
 
   const data = await shopifyFetch<{ cartLinesAdd: CartMutationPayload<ShopifyCart> }>({
     operation: "cartLinesAdd",
-    query: `
-      ${CART_FRAGMENT}
-      mutation cartLinesAdd($cartId: ID!, $lines: [CartLineInput!]!) {
-        cartLinesAdd(cartId: $cartId, lines: $lines) {
-          cart {
-            ...CartFields
-          }
-          userErrors {
-            field
-            message
-          }
-        }
-      }
-    `,
+    query: CART_LINES_ADD_MUTATION,
     variables: { cartId, lines },
   });
 
@@ -216,20 +263,7 @@ export async function updateCart(
     cartLinesUpdate: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartLinesUpdate",
-    query: `
-      ${CART_FRAGMENT}
-      mutation cartLinesUpdate($cartId: ID!, $lines: [CartLineUpdateInput!]!) {
-        cartLinesUpdate(cartId: $cartId, lines: $lines) {
-          cart {
-            ...CartFields
-          }
-          userErrors {
-            field
-            message
-          }
-        }
-      }
-    `,
+    query: CART_LINES_UPDATE_MUTATION,
     variables: {
       cartId,
       lines: lines.map((line) => ({ id: line.id, quantity: line.quantity })),
@@ -249,20 +283,7 @@ export async function removeFromCart(lineIds: string[], cartIdOverride?: string)
     cartLinesRemove: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartLinesRemove",
-    query: `
-      ${CART_FRAGMENT}
-      mutation cartLinesRemove($cartId: ID!, $lineIds: [ID!]!) {
-        cartLinesRemove(cartId: $cartId, lineIds: $lineIds) {
-          cart {
-            ...CartFields
-          }
-          userErrors {
-            field
-            message
-          }
-        }
-      }
-    `,
+    query: CART_LINES_REMOVE_MUTATION,
     variables: { cartId, lineIds },
   });
 
@@ -284,20 +305,7 @@ export async function updateCartBuyerIdentity(
     cartBuyerIdentityUpdate: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartBuyerIdentityUpdate",
-    query: `
-      ${CART_FRAGMENT}
-      mutation cartBuyerIdentityUpdate($cartId: ID!, $buyerIdentity: CartBuyerIdentityInput!) {
-        cartBuyerIdentityUpdate(cartId: $cartId, buyerIdentity: $buyerIdentity) {
-          cart {
-            ...CartFields
-          }
-          userErrors {
-            field
-            message
-          }
-        }
-      }
-    `,
+    query: CART_BUYER_IDENTITY_UPDATE_MUTATION,
     variables: {
       cartId,
       buyerIdentity: {
@@ -324,20 +332,7 @@ export async function linkCartToCustomer(
     cartBuyerIdentityUpdate: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartBuyerIdentityUpdate",
-    query: `
-      ${CART_FRAGMENT}
-      mutation cartBuyerIdentityUpdate($cartId: ID!, $buyerIdentity: CartBuyerIdentityInput!) {
-        cartBuyerIdentityUpdate(cartId: $cartId, buyerIdentity: $buyerIdentity) {
-          cart {
-            ...CartFields
-          }
-          userErrors {
-            field
-            message
-          }
-        }
-      }
-    `,
+    query: CART_BUYER_IDENTITY_UPDATE_MUTATION,
     variables: {
       cartId,
       buyerIdentity: {
@@ -364,20 +359,7 @@ export async function updateCartNote(
     cartNoteUpdate: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartNoteUpdate",
-    query: `
-      ${CART_FRAGMENT}
-      mutation cartNoteUpdate($cartId: ID!, $note: String!) {
-        cartNoteUpdate(cartId: $cartId, note: $note) {
-          cart {
-            ...CartFields
-          }
-          userErrors {
-            field
-            message
-          }
-        }
-      }
-    `,
+    query: CART_NOTE_UPDATE_MUTATION,
     variables: {
       cartId,
       note,
@@ -399,15 +381,7 @@ export async function getCartSelectableAddressId(): Promise<string | undefined> 
     } | null;
   }>({
     operation: "getCartSelectableAddresses",
-    query: `
-      query getCartSelectableAddresses($cartId: ID!) {
-        cart(id: $cartId) {
-          selectableAddresses {
-            id
-          }
-        }
-      }
-    `,
+    query: GET_CART_SELECTABLE_ADDRESSES_QUERY,
     variables: { cartId },
   });
 
@@ -437,20 +411,7 @@ export async function addCartDeliveryAddress(address: {
     cartDeliveryAddressesAdd: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartDeliveryAddressesAdd",
-    query: `
-      ${CART_FRAGMENT}
-      mutation cartDeliveryAddressesAdd($cartId: ID!, $addresses: [CartSelectableAddressInput!]!) {
-        cartDeliveryAddressesAdd(cartId: $cartId, addresses: $addresses) {
-          cart {
-            ...CartFields
-          }
-          userErrors {
-            field
-            message
-          }
-        }
-      }
-    `,
+    query: CART_DELIVERY_ADDRESSES_ADD_MUTATION,
     variables: {
       cartId,
       addresses: [
@@ -495,24 +456,7 @@ export async function getCartDeliveryOptions(): Promise<CartShippingOption[]> {
     } | null;
   }>({
     operation: "getCartDeliveryOptions",
-    query: `
-      query getCartDeliveryOptions($cartId: ID!) {
-        cart(id: $cartId) {
-          deliveryGroups(first: 5) {
-            nodes {
-              deliveryOptions {
-                title
-                estimatedCost {
-                  amount
-                  currencyCode
-                }
-                deliveryMethodType
-              }
-            }
-          }
-        }
-      }
-    `,
+    query: GET_CART_DELIVERY_OPTIONS_QUERY,
     variables: { cartId },
   });
 
@@ -560,20 +504,7 @@ export async function updateCartDeliveryAddress(
     cartDeliveryAddressesUpdate: CartMutationPayload<ShopifyCart>;
   }>({
     operation: "cartDeliveryAddressesUpdate",
-    query: `
-      ${CART_FRAGMENT}
-      mutation cartDeliveryAddressesUpdate($cartId: ID!, $addresses: [CartSelectableAddressUpdateInput!]!) {
-        cartDeliveryAddressesUpdate(cartId: $cartId, addresses: $addresses) {
-          cart {
-            ...CartFields
-          }
-          userErrors {
-            field
-            message
-          }
-        }
-      }
-    `,
+    query: CART_DELIVERY_ADDRESSES_UPDATE_MUTATION,
     variables: {
       cartId,
       addresses: [

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -1,6 +1,8 @@
-import { cookies } from "next/headers";
-
-import { invalidateCartCache } from "@/lib/cart/server";
+import {
+  getCartIdFromCookie,
+  invalidateCartCache,
+  setCartIdCookie,
+} from "@/lib/cart/server";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import type { Cart } from "@/lib/types";
 
@@ -169,7 +171,7 @@ const CART_DELIVERY_ADDRESSES_UPDATE_MUTATION = `
 
 export async function getCart(cartId?: string): Promise<Cart | undefined> {
   if (!cartId) {
-    cartId = (await cookies()).get("shopify_cartId")?.value;
+    cartId = await getCartIdFromCookie();
   }
   if (!cartId) return undefined;
 
@@ -215,13 +217,7 @@ export async function createCart(locale: string = defaultLocale): Promise<Cart> 
   const cart = await createCartWithoutCookie(locale);
 
   if (cart.id) {
-    (await cookies()).set("shopify_cartId", cart.id, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "strict",
-      maxAge: 60 * 60 * 24 * 7, // 7 days
-      path: "/",
-    });
+    await setCartIdCookie(cart.id);
   }
 
   return cart;
@@ -233,7 +229,7 @@ export async function addToCart(
   locale: string = defaultLocale,
 ): Promise<Cart> {
   if (!cartId) {
-    cartId = (await cookies()).get("shopify_cartId")?.value;
+    cartId = await getCartIdFromCookie();
   }
 
   if (!cartId) {
@@ -256,7 +252,7 @@ export async function updateCart(
   lines: { id: string; merchandiseId: string; quantity: number }[],
   cartIdOverride?: string,
 ): Promise<Cart> {
-  const cartId = cartIdOverride || (await cookies()).get("shopify_cartId")?.value;
+  const cartId = cartIdOverride || (await getCartIdFromCookie());
   if (!cartId) throw new Error("Cart ID not found");
 
   const data = await shopifyFetch<{
@@ -276,7 +272,7 @@ export async function updateCart(
 }
 
 export async function removeFromCart(lineIds: string[], cartIdOverride?: string): Promise<Cart> {
-  const cartId = cartIdOverride || (await cookies()).get("shopify_cartId")?.value;
+  const cartId = cartIdOverride || (await getCartIdFromCookie());
   if (!cartId) throw new Error("Cart ID not found");
 
   const data = await shopifyFetch<{
@@ -296,7 +292,7 @@ export async function updateCartBuyerIdentity(
   locale: string,
   countryCode?: string,
 ): Promise<Cart | undefined> {
-  const cartId = (await cookies()).get("shopify_cartId")?.value;
+  const cartId = await getCartIdFromCookie();
   if (!cartId) return undefined;
 
   const country = countryCode ?? getCountryCode(locale);
@@ -325,7 +321,7 @@ export async function linkCartToCustomer(
   customerAccessToken: string,
   cartIdOverride?: string,
 ): Promise<Cart | undefined> {
-  const cartId = cartIdOverride || (await cookies()).get("shopify_cartId")?.value;
+  const cartId = cartIdOverride || (await getCartIdFromCookie());
   if (!cartId) return undefined;
 
   const data = await shopifyFetch<{
@@ -352,7 +348,7 @@ export async function updateCartNote(
   note: string,
   cartIdOverride?: string,
 ): Promise<Cart | undefined> {
-  const cartId = cartIdOverride || (await cookies()).get("shopify_cartId")?.value;
+  const cartId = cartIdOverride || (await getCartIdFromCookie());
   if (!cartId) return undefined;
 
   const data = await shopifyFetch<{
@@ -372,7 +368,7 @@ export async function updateCartNote(
 }
 
 export async function getCartSelectableAddressId(): Promise<string | undefined> {
-  const cartId = (await cookies()).get("shopify_cartId")?.value;
+  const cartId = await getCartIdFromCookie();
   if (!cartId) return undefined;
 
   const data = await shopifyFetch<{
@@ -394,7 +390,7 @@ export async function addCartDeliveryAddress(address: {
   zip?: string;
   customerAddressId?: string;
 }): Promise<Cart | undefined> {
-  const cartId = (await cookies()).get("shopify_cartId")?.value;
+  const cartId = await getCartIdFromCookie();
   if (!cartId) return undefined;
 
   const addressInput = address.customerAddressId
@@ -439,7 +435,7 @@ export type CartShippingOption = {
 };
 
 export async function getCartDeliveryOptions(): Promise<CartShippingOption[]> {
-  const cartId = (await cookies()).get("shopify_cartId")?.value;
+  const cartId = await getCartIdFromCookie();
   if (!cartId) return [];
 
   const data = await shopifyFetch<{
@@ -487,7 +483,7 @@ export async function updateCartDeliveryAddress(
     customerAddressId?: string;
   },
 ): Promise<Cart | undefined> {
-  const cartId = (await cookies()).get("shopify_cartId")?.value;
+  const cartId = await getCartIdFromCookie();
   if (!cartId) return undefined;
 
   const addressInput = address.customerAddressId

--- a/apps/template/lib/shopify/operations/collections.ts
+++ b/apps/template/lib/shopify/operations/collections.ts
@@ -4,6 +4,7 @@ import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import type { Collection } from "@/lib/types";
 
 import { shopifyFetch } from "../fetch";
+import { COLLECTION_FIELDS_FRAGMENT } from "../fragments";
 import {
   type ShopifyCollection,
   transformShopifyCollection,
@@ -18,6 +19,28 @@ type CollectionResponse = {
   collection: ShopifyCollection | null;
 };
 
+const GET_COLLECTIONS_QUERY = `
+  ${COLLECTION_FIELDS_FRAGMENT}
+  query getCollections($first: Int!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    collections(first: $first) {
+      edges {
+        node {
+          ...CollectionFields
+        }
+      }
+    }
+  }
+`;
+
+const GET_COLLECTION_QUERY = `
+  ${COLLECTION_FIELDS_FRAGMENT}
+  query getCollection($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    collection(handle: $handle) {
+      ...CollectionFields
+    }
+  }
+`;
+
 export async function getCollections({
   limit = 250,
   locale = defaultLocale,
@@ -31,30 +54,7 @@ export async function getCollections({
 
   const data = await shopifyFetch<CollectionsResponse>({
     operation: "getCollections",
-    query: `
-      query getCollections($first: Int!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
-        collections(first: $first) {
-          edges {
-            node {
-              handle
-              title
-              description
-              image {
-                url
-                altText
-                width
-                height
-              }
-              updatedAt
-              seo {
-                title
-                description
-              }
-            }
-          }
-        }
-      }
-    `,
+    query: GET_COLLECTIONS_QUERY,
     variables: { first: limit, country, language },
   });
 
@@ -78,26 +78,7 @@ export async function getCollection({
 
   const data = await shopifyFetch<CollectionResponse>({
     operation: "getCollection",
-    query: `
-      query getCollection($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
-        collection(handle: $handle) {
-          handle
-          title
-          description
-          image {
-            url
-            altText
-            width
-            height
-          }
-          updatedAt
-          seo {
-            title
-            description
-          }
-        }
-      }
-    `,
+    query: GET_COLLECTION_QUERY,
     variables: { handle, country, language },
   });
 

--- a/apps/template/lib/shopify/operations/collections.ts
+++ b/apps/template/lib/shopify/operations/collections.ts
@@ -62,10 +62,13 @@ export async function getCollections({
   return transformShopifyCollections(rawCollections);
 }
 
-export async function getCollection(
-  handle: string,
-  locale: string = defaultLocale,
-): Promise<Collection | undefined> {
+export async function getCollection({
+  handle,
+  locale = defaultLocale,
+}: {
+  handle: string;
+  locale?: string;
+}): Promise<Collection | undefined> {
   "use cache";
   cacheLife("max");
   cacheTag("collections", `collection-${handle}`);

--- a/apps/template/lib/shopify/operations/menu.ts
+++ b/apps/template/lib/shopify/operations/menu.ts
@@ -91,15 +91,11 @@ export async function getMenu(
   cacheLife("max");
   cacheTag("menus");
 
-  try {
-    const data = await shopifyFetch<ShopifyMenuResponse>({
-      operation: "getMenu",
-      query: GET_MENU_QUERY,
-      variables: { handle },
-    });
+  const data = await shopifyFetch<ShopifyMenuResponse>({
+    operation: "getMenu",
+    query: GET_MENU_QUERY,
+    variables: { handle },
+  });
 
-    return transformMenu(data.menu);
-  } catch {
-    return null;
-  }
+  return transformMenu(data.menu);
 }

--- a/apps/template/lib/shopify/operations/menu.ts
+++ b/apps/template/lib/shopify/operations/menu.ts
@@ -1,29 +1,8 @@
 import { cacheLife, cacheTag } from "next/cache";
 
 import { shopifyFetch } from "../fetch";
-import type { Menu, MenuItem, MenuItemType } from "../types/menu";
-import { transformShopifyMenuItemUrl } from "../utils";
-
-type ShopifyMenuItem = {
-  id: string;
-  title: string;
-  url: string | null;
-  type: MenuItemType;
-  tags: string[];
-  resource: {
-    handle?: string;
-  } | null;
-  items: ShopifyMenuItem[];
-};
-
-type ShopifyMenuResponse = {
-  menu: {
-    id: string;
-    handle: string;
-    title: string;
-    items: ShopifyMenuItem[];
-  } | null;
-};
+import { type ShopifyMenuResponse, transformShopifyMenu } from "../transforms/menu";
+import type { Menu } from "../types/menu";
 
 const MENU_ITEM_FIELDS_FRAGMENT = `
   fragment MenuItemFields on MenuItem {
@@ -60,27 +39,6 @@ const GET_MENU_QUERY = `
   ${MENU_ITEM_FIELDS_FRAGMENT}
 `;
 
-function transformMenuItem(item: ShopifyMenuItem): MenuItem {
-  return {
-    id: item.id,
-    title: item.title,
-    url: transformShopifyMenuItemUrl(item.url, item.type),
-    type: item.type,
-    items: (item.items ?? []).map(transformMenuItem),
-  };
-}
-
-function transformMenu(menu: ShopifyMenuResponse["menu"]): Menu | null {
-  if (!menu) return null;
-
-  return {
-    id: menu.id,
-    handle: menu.handle,
-    title: menu.title,
-    items: menu.items.map(transformMenuItem),
-  };
-}
-
 export async function getMenu({ handle }: { handle: string }): Promise<Menu | null> {
   "use cache";
   cacheLife("max");
@@ -92,5 +50,5 @@ export async function getMenu({ handle }: { handle: string }): Promise<Menu | nu
     variables: { handle },
   });
 
-  return transformMenu(data.menu);
+  return transformShopifyMenu(data.menu);
 }

--- a/apps/template/lib/shopify/operations/menu.ts
+++ b/apps/template/lib/shopify/operations/menu.ts
@@ -1,7 +1,5 @@
 import { cacheLife, cacheTag } from "next/cache";
 
-import { defaultLocale } from "@/lib/i18n";
-
 import { shopifyFetch } from "../fetch";
 import type { Menu, MenuItem, MenuItemType } from "../types/menu";
 import { transformShopifyMenuItemUrl } from "../utils";
@@ -83,10 +81,7 @@ function transformMenu(menu: ShopifyMenuResponse["menu"]): Menu | null {
   };
 }
 
-export async function getMenu(
-  handle: string,
-  _locale: string = defaultLocale,
-): Promise<Menu | null> {
+export async function getMenu({ handle }: { handle: string }): Promise<Menu | null> {
   "use cache";
   cacheLife("max");
   cacheTag("menus");

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -1,10 +1,11 @@
 import { cacheLife, cacheTag } from "next/cache";
 
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
-import type { PageInfo, ProductCard, ProductDetails } from "@/lib/types";
+import type { Filter, PageInfo, PriceRange, ProductCard, ProductDetails } from "@/lib/types";
 
 import { shopifyFetch } from "../fetch";
 import { PRODUCT_CARD_FRAGMENT, PRODUCT_FRAGMENT } from "../fragments";
+import { transformShopifyFilters } from "../transforms/filters";
 import {
   type ShopifyProduct,
   type ShopifyProductCard,
@@ -13,6 +14,8 @@ import {
 } from "../transforms/product";
 import type { ProductFilter, ShopifyFilter } from "../types/filters";
 import { getNumericShopifyId } from "../utils";
+
+type ActiveFilters = Record<string, string | string[] | undefined>;
 
 function productIdTag(gid: string): string | null {
   const numericId = getNumericShopifyId(gid);
@@ -405,16 +408,23 @@ export async function getFilteredCatalogProducts(
 }
 
 export async function getSearchFacets(params: {
+  activeFilters?: ActiveFilters;
   query?: string;
   collection?: string;
   filters?: ProductFilter[];
   locale?: string;
-}): Promise<{ filters: ShopifyFilter[]; total: number }> {
+}): Promise<{ filters: Filter[]; priceRange?: PriceRange; total: number }> {
   "use cache: remote";
   cacheLife("max");
   cacheTag("products");
 
-  const { query, collection, filters = [], locale = defaultLocale } = params;
+  const {
+    activeFilters = {},
+    query,
+    collection,
+    filters = [],
+    locale = defaultLocale,
+  } = params;
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 
@@ -439,8 +449,11 @@ export async function getSearchFacets(params: {
     },
   });
 
+  const transformed = transformShopifyFilters(data.search.productFilters, { activeFilters });
+
   return {
-    filters: data.search.productFilters,
+    filters: transformed.filters,
+    priceRange: transformed.priceRange,
     total: data.search.totalCount,
   };
 }
@@ -567,6 +580,7 @@ const COLLECTION_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolea
 };
 
 export async function getCollectionProducts(params: {
+  activeFilters?: ActiveFilters;
   collection: string;
   limit?: number;
   sortKey?: string;
@@ -576,13 +590,15 @@ export async function getCollectionProducts(params: {
 }): Promise<{
   products: ProductCard[];
   pageInfo: PageInfo;
-  filters: ShopifyFilter[];
+  filters: Filter[];
+  priceRange?: PriceRange;
 }> {
   "use cache: remote";
   cacheLife("max");
   cacheTag("products", "collections", `collection-${params.collection}`);
 
   const {
+    activeFilters = {},
     collection,
     sortKey: rawSortKey = "best-matches",
     limit = 50,
@@ -636,11 +652,13 @@ export async function getCollectionProducts(params: {
   tagProducts(shopifyProducts);
 
   const products = shopifyProducts.map(transformShopifyProductCard);
+  const transformed = transformShopifyFilters(data.collection.products.filters, { activeFilters });
 
   return {
     products,
     pageInfo: data.collection.products.pageInfo,
-    filters: data.collection.products.filters,
+    filters: transformed.filters,
+    priceRange: transformed.priceRange,
   };
 }
 

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -37,10 +37,13 @@ const GET_PRODUCT_BY_HANDLE_QUERY = `
   }
 `;
 
-export async function getProduct(
-  handle: string,
-  locale: string = defaultLocale,
-): Promise<ProductDetails | undefined> {
+export async function getProduct({
+  handle,
+  locale = defaultLocale,
+}: {
+  handle: string;
+  locale?: string;
+}): Promise<ProductDetails | undefined> {
   "use cache";
   cacheLife("max");
   cacheTag("products", `product-${handle}`);
@@ -650,10 +653,13 @@ const PRODUCT_RECOMMENDATIONS_QUERY = `
   }
 `;
 
-export async function getProductRecommendations(
-  handle: string,
-  locale: string = defaultLocale,
-): Promise<ProductCard[]> {
+export async function getProductRecommendations({
+  handle,
+  locale = defaultLocale,
+}: {
+  handle: string;
+  locale?: string;
+}): Promise<ProductCard[]> {
   "use cache";
   cacheLife("max");
   cacheTag("products", `recommendations-${handle}`);
@@ -661,7 +667,7 @@ export async function getProductRecommendations(
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 
-  const product = await getProduct(handle, locale);
+  const product = await getProduct({ handle, locale });
   if (!product) {
     return [];
   }
@@ -723,10 +729,13 @@ function decodeShopifyId(id: string): string {
   return Buffer.from(id, "base64").toString("utf-8");
 }
 
-export async function getProductById(
-  id: string,
-  locale: string = defaultLocale,
-): Promise<ProductDetails | undefined> {
+export async function getProductById({
+  id,
+  locale = defaultLocale,
+}: {
+  id: string;
+  locale?: string;
+}): Promise<ProductDetails | undefined> {
   "use cache";
   cacheLife("max");
   cacheTag("products", `product-id-${id}`);
@@ -752,10 +761,13 @@ export async function getProductById(
 }
 
 /** Results are returned in the same order as the input IDs. */
-export async function getProductsByIds(
-  ids: string[],
-  locale: string = defaultLocale,
-): Promise<ProductCard[]> {
+export async function getProductsByIds({
+  ids,
+  locale = defaultLocale,
+}: {
+  ids: string[];
+  locale?: string;
+}): Promise<ProductCard[]> {
   "use cache";
   cacheLife("max");
   cacheTag("products");
@@ -782,10 +794,13 @@ export async function getProductsByIds(
 }
 
 /** Results are reordered to match the input handle order. */
-export async function getProductsByHandles(
-  handles: string[],
-  locale: string = defaultLocale,
-): Promise<ProductCard[]> {
+export async function getProductsByHandles({
+  handles,
+  locale = defaultLocale,
+}: {
+  handles: string[];
+  locale?: string;
+}): Promise<ProductCard[]> {
   "use cache";
   cacheLife("max");
   cacheTag("products");

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -738,7 +738,7 @@ export async function getProductById({
 }): Promise<ProductDetails | undefined> {
   "use cache";
   cacheLife("max");
-  cacheTag("products", `product-id-${id}`);
+  cacheTag("products");
 
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
@@ -755,6 +755,7 @@ export async function getProductById({
     return undefined;
   }
 
+  cacheTag(`product-${product.handle}`);
   tagProducts([product]);
 
   return transformShopifyProductDetails(product);

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -37,7 +37,10 @@ const GET_PRODUCT_BY_HANDLE_QUERY = `
   }
 `;
 
-export async function getProduct(handle: string, locale: string = defaultLocale) {
+export async function getProduct(
+  handle: string,
+  locale: string = defaultLocale,
+): Promise<ProductDetails | undefined> {
   "use cache";
   cacheLife("max");
   cacheTag("products", `product-${handle}`);
@@ -53,7 +56,7 @@ export async function getProduct(handle: string, locale: string = defaultLocale)
   });
 
   if (!data.productByHandle) {
-    throw new Error(`Product not found: ${handle}`);
+    return undefined;
   }
 
   tagProducts([data.productByHandle]);
@@ -723,7 +726,7 @@ function decodeShopifyId(id: string): string {
 export async function getProductById(
   id: string,
   locale: string = defaultLocale,
-): Promise<ProductDetails> {
+): Promise<ProductDetails | undefined> {
   "use cache";
   cacheLife("max");
   cacheTag("products", `product-id-${id}`);
@@ -740,7 +743,7 @@ export async function getProductById(
 
   const product = data.node;
   if (!product) {
-    throw new Error(`Product not found: ${id}`);
+    return undefined;
   }
 
   tagProducts([product]);

--- a/apps/template/lib/shopify/operations/search.ts
+++ b/apps/template/lib/shopify/operations/search.ts
@@ -50,11 +50,15 @@ const PREDICTIVE_SEARCH_QUERY = `
   }
 `;
 
-export async function predictiveSearch(
-  query: string,
-  locale: string = defaultLocale,
+export async function predictiveSearch({
   limit = 4,
-): Promise<PredictiveSearchResult> {
+  locale = defaultLocale,
+  query,
+}: {
+  limit?: number;
+  locale?: string;
+  query: string;
+}): Promise<PredictiveSearchResult> {
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 

--- a/apps/template/lib/shopify/transforms/filters.ts
+++ b/apps/template/lib/shopify/transforms/filters.ts
@@ -134,7 +134,7 @@ export function transformShopifyFilters(
 
   return {
     filters,
-    priceRange: priceFilter ? extractPriceRange(priceFilter) : { min: 0, max: 1000 },
+    priceRange: priceFilter ? extractPriceRange(priceFilter) : undefined,
   };
 }
 

--- a/apps/template/lib/shopify/transforms/menu.ts
+++ b/apps/template/lib/shopify/transforms/menu.ts
@@ -1,0 +1,44 @@
+import type { Menu, MenuItem, MenuItemType } from "../types/menu";
+import { transformShopifyMenuItemUrl } from "../utils";
+
+export type ShopifyMenuItem = {
+  id: string;
+  title: string;
+  url: string | null;
+  type: MenuItemType;
+  tags: string[];
+  resource: {
+    handle?: string;
+  } | null;
+  items: ShopifyMenuItem[];
+};
+
+export type ShopifyMenuResponse = {
+  menu: {
+    id: string;
+    handle: string;
+    title: string;
+    items: ShopifyMenuItem[];
+  } | null;
+};
+
+function transformMenuItem(item: ShopifyMenuItem): MenuItem {
+  return {
+    id: item.id,
+    title: item.title,
+    url: transformShopifyMenuItemUrl(item.url, item.type),
+    type: item.type,
+    items: (item.items ?? []).map(transformMenuItem),
+  };
+}
+
+export function transformShopifyMenu(menu: ShopifyMenuResponse["menu"]): Menu | null {
+  if (!menu) return null;
+
+  return {
+    id: menu.id,
+    handle: menu.handle,
+    title: menu.title,
+    items: menu.items.map(transformMenuItem),
+  };
+}

--- a/packages/plugin/skills/enable-shopify-cms/SKILL.md
+++ b/packages/plugin/skills/enable-shopify-cms/SKILL.md
@@ -51,20 +51,28 @@ Add Shopify metaobject-based CMS support to the shop template. This replaces the
 Implement three operations that return domain types from `lib/types.ts`:
 
 ```ts
-import { shopifyFetch } from "@/lib/shopify/client";
+import { defaultLocale } from "@/lib/i18n";
+import { shopifyFetch } from "@/lib/shopify/fetch";
 import type { Homepage, MarketingPage } from "@/lib/types";
 
-export async function getHomepage(locale: string): Promise<Homepage | null> {
+export async function getHomepage({
+  locale = defaultLocale,
+}: {
+  locale?: string;
+} = {}): Promise<Homepage | null> {
   "use cache";
   cacheLife("max");
   cacheTag("cms-content");
   // Query cms_homepage metaobject, transform to Homepage type
 }
 
-export async function getMarketingPage(
-  slug: string,
-  locale: string,
-): Promise<MarketingPage | null> {
+export async function getMarketingPage({
+  slug,
+  locale = defaultLocale,
+}: {
+  slug: string;
+  locale?: string;
+}): Promise<MarketingPage | null> {
   "use cache";
   cacheLife("max");
   cacheTag("cms-content");

--- a/packages/plugin/skills/enable-shopify-markets/SKILL.md
+++ b/packages/plugin/skills/enable-shopify-markets/SKILL.md
@@ -323,7 +323,7 @@ export default getRequestConfig(async () => {
 
 ### Scope menu queries for markets
 
-The base template keeps [`lib/shopify/operations/menu.ts`](../../lib/shopify/operations/menu.ts) unscoped so menus load before Shopify Markets is configured. When enabling markets, update `getMenu` to derive `country` and `language` from the active locale and query `menu` with `@inContext(country: $country, language: $language)`. Without that change, quick links and footer menu stay pinned to the default market. If the `enable-shopify-menus` skill has been run, the megamenu will also need this scoping.
+The base template keeps [`lib/shopify/operations/menu.ts`](../../lib/shopify/operations/menu.ts) unscoped (it takes only `{ handle }`) so menus load before Shopify Markets is configured. When enabling markets, extend `getMenu` to accept the active locale (e.g. `getMenu({ handle, locale })`), derive `country` and `language` from that locale, and query `menu` with `@inContext(country: $country, language: $language)`. Without that change, quick links and footer menu stay pinned to the default market. If the `enable-shopify-menus` skill has been run, the megamenu will also need this scoping.
 
 ---
 

--- a/packages/plugin/skills/enable-shopify-menus/SKILL.md
+++ b/packages/plugin/skills/enable-shopify-menus/SKILL.md
@@ -38,7 +38,7 @@ import { getMenu } from "@/lib/shopify/operations/menu";
 Inside `Nav`, replace `const items = navItems;` with:
 
 ```tsx
-const menu = await getMenu("NAV_HANDLE", locale);
+const menu = await getMenu({ handle: "NAV_HANDLE" });
 const items = menu?.items ?? navItems;
 ```
 
@@ -59,7 +59,7 @@ import { getMenu } from "@/lib/shopify/operations/menu";
 Change the signature to `async` and replace `const items = footerItems;` with:
 
 ```tsx
-const menu = await getMenu("FOOTER_HANDLE", locale);
+const menu = await getMenu({ handle: "FOOTER_HANDLE" });
 const items = menu?.items ?? footerItems;
 ```
 

--- a/packages/plugin/skills/shopify-graphql-reference/references/REFERENCE.md
+++ b/packages/plugin/skills/shopify-graphql-reference/references/REFERENCE.md
@@ -22,12 +22,19 @@ Every read operation should follow this pattern:
 
 ```tsx
 import { cacheLife, cacheTag } from "next/cache";
-import { getCountryCode, getLanguageCode } from "@/lib/i18n";
-import { shopifyFetch } from "@/lib/shopify/client";
+import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
+import { shopifyFetch } from "@/lib/shopify/fetch";
 import { PRODUCT_FRAGMENT } from "@/lib/shopify/fragments";
 import { transformShopifyProductDetails } from "@/lib/shopify/transforms/product";
+import type { ProductDetails } from "@/lib/types";
 
-export async function getProduct(handle: string, locale: string) {
+export async function getProduct({
+  handle,
+  locale = defaultLocale,
+}: {
+  handle: string;
+  locale?: string;
+}): Promise<ProductDetails | undefined> {
   "use cache";
   cacheLife("max");
   cacheTag("products");
@@ -36,15 +43,21 @@ export async function getProduct(handle: string, locale: string) {
     operation: "GetProduct",
     query: `
       ${PRODUCT_FRAGMENT}
-      query GetProduct($handle: String!)
-        @inContext(country: ${getCountryCode(locale)}, language: ${getLanguageCode(locale)}) {
+      query GetProduct($handle: String!, $country: CountryCode, $language: LanguageCode)
+        @inContext(country: $country, language: $language) {
         product(handle: $handle) {
           ...ProductFields
         }
       }
     `,
-    variables: { handle },
+    variables: {
+      handle,
+      country: getCountryCode(locale),
+      language: getLanguageCode(locale),
+    },
   });
+
+  if (!data.product) return undefined;
 
   return transformShopifyProductDetails(data.product);
 }

--- a/packages/plugin/skills/shopify-graphql-reference/references/REFERENCE.md
+++ b/packages/plugin/skills/shopify-graphql-reference/references/REFERENCE.md
@@ -9,7 +9,7 @@ Schema validation for this skill comes from the installed `Shopify/shopify-ai-to
 | Resource | Role |
 |------|------|
 | `Shopify/shopify-ai-toolkit` | Live Storefront and Customer Account schema inspection |
-| `lib/shopify/client.ts` | `shopifyFetch()` GraphQL client |
+| `lib/shopify/fetch.ts` | `shopifyFetch()` GraphQL client |
 | `lib/shopify/fragments.ts` | Shared fragments (`PRODUCT_FRAGMENT`, `PRODUCT_CARD_FRAGMENT`, money, images, metafields) |
 | `lib/shopify/utils.ts` | `flattenEdges()` connection helper |
 | `lib/shopify/operations/*.ts` | Query and mutation entry points |


### PR DESCRIPTION
Standardize `lib/shopify/operations/*` across seven axes.

1. **Errors**: operations throw on transport/GraphQL failure, return `undefined`/`null`/`[]` on missing. New `withFallback(promise, fallback)` for render-tolerant callers.
2. **`userErrors`**: every cart mutation inspects them via `unwrapCartMutation`; throws typed `ShopifyUserError` on non-empty. Removes 4 dead `if (!result)` branches in `lib/cart/action.ts`.
3. **Locale calling convention**: all 8 read ops take a single params object; drops unused `_locale` on `getMenu`.
4. **Cache tags**: `getProductById`'s `product-id-${id}` tag was never pushed by the webhook — replaced with `product-${handle}`.
5. **Transforms**: menu transforms move to `transforms/menu.ts`; `getCollectionProducts`/`getSearchFacets` now run `transformShopifyFilters` internally and return domain `Filter[] + PriceRange?`.
6. **Fragments**: `CART_FRAGMENT` + new `COLLECTION_FIELDS_FRAGMENT` move to `fragments.ts`. All inline queries hoisted to top-level consts.
7. **Cart cookies**: name and attributes centralized in `lib/cart/server.ts` helpers (`getCartIdFromCookie`, `setCartIdCookie`, `buildCartIdSetCookieHeader`).

**Behavior shifts**
- PDP returns 500 on Shopify transport failure (was: silent 404).
- Cart actions surface transport failures as `{ success: false, error }` (was: silent `{ success: true, cart: undefined }`).
- Out-of-stock add-to-cart surfaces the Shopify userError message (was: silent NPE in the transformer).
- Filter sidebar hides the price slider when Shopify returns no price filter (was: placeholder 0-1000 range).
- `getProductById` cache entries now invalidate on product webhooks.

Typecheck clean throughout.