### PR TITLE
[template] PLP: show filter-aware item count on /collections/[handle]

### DIFF
--- a/apps/template/components/collections/collection-page.tsx
+++ b/apps/template/components/collections/collection-page.tsx
@@ -74,6 +74,11 @@ export async function CollectionDetailPage({
                   </FilterPendingScope>
                 </FilterSidebarSheet>
               }
+              resultCount={
+                <Suspense fallback={<Skeleton className="h-4 w-20" />}>
+                  <CollectionResultCount dataPromise={collectionResultsDataPromise} />
+                </Suspense>
+              }
               sortSelect={
                 <Suspense fallback={<SortSelectFallback label={sortByLabel} />}>
                   <CollectionsSortSelect exclude={sortExclude} />
@@ -138,6 +143,16 @@ function CollectionHeaderFallback() {
       <Skeleton className="h-9 w-72 sm:h-10 md:h-12" />
     </div>
   );
+}
+
+async function CollectionResultCount({
+  dataPromise,
+}: {
+  dataPromise: Promise<CollectionResultsData>;
+}) {
+  const [data, t] = await Promise.all([dataPromise, getTranslations("search")]);
+  if (data.total === 0) return null;
+  return t("resultCount", { count: data.total });
 }
 
 async function CollectionFilterCountBadge({

--- a/apps/template/lib/collections/server.ts
+++ b/apps/template/lib/collections/server.ts
@@ -28,6 +28,7 @@ export interface CollectionResultsData {
   sort?: string;
   filters: ProductFilter[];
   result: Awaited<ReturnType<typeof getCollectionProducts>>;
+  total: number;
   transformedFilters: { filters: Filter[]; priceRange?: PriceRange };
 }
 
@@ -53,14 +54,17 @@ export async function getCollectionResultsData({
 }): Promise<CollectionResultsData> {
   const [handle, { activeFilters, sort }] = await Promise.all([handlePromise, searchStatePromise]);
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
-  const result = await getCollectionProducts({
-    activeFilters,
-    collection: handle,
-    sortKey: sort,
-    limit: RESULTS_PER_PAGE,
-    filters: shopifyFilters,
-    locale,
-  });
+  const [result, facets] = await Promise.all([
+    getCollectionProducts({
+      activeFilters,
+      collection: handle,
+      sortKey: sort,
+      limit: RESULTS_PER_PAGE,
+      filters: shopifyFilters,
+      locale,
+    }),
+    getSearchFacets({ activeFilters, collection: handle, filters: shopifyFilters, locale }),
+  ]);
 
   return {
     activeFilters,
@@ -68,20 +72,9 @@ export async function getCollectionResultsData({
     sort,
     filters: shopifyFilters,
     result,
+    total: facets.total,
     transformedFilters: { filters: result.filters, priceRange: result.priceRange },
   };
-}
-
-export function getExactCollectionResultCount({
-  result,
-}: {
-  result: Awaited<ReturnType<typeof getCollectionProducts>>;
-}): number | undefined {
-  if (result.pageInfo.hasNextPage) {
-    return undefined;
-  }
-
-  return result.products.length;
 }
 
 function getSingleSearchParam(value: string | string[] | undefined): string | undefined {
@@ -133,6 +126,7 @@ export async function getAllProductsResultsData({
       filters: facets.filters,
       priceRange: facets.priceRange,
     },
+    total: facets.total,
     transformedFilters: { filters: facets.filters, priceRange: facets.priceRange },
   };
 }

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -418,13 +418,10 @@ export async function getSearchFacets(params: {
   cacheLife("max");
   cacheTag("products");
 
-  const {
-    activeFilters = {},
-    query,
-    collection,
-    filters = [],
-    locale = defaultLocale,
-  } = params;
+  const { activeFilters = {}, query, collection, filters = [], locale = defaultLocale } = params;
+  if (collection) {
+    cacheTag(`collection-${collection}`);
+  }
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 

--- a/packages/plugin/template-rollout-log/2026-06-03-plp-collection-result-count.md
+++ b/packages/plugin/template-rollout-log/2026-06-03-plp-collection-result-count.md
@@ -1,0 +1,48 @@
+---
+title: Collection PLP — surface filter-aware result count in the toolbar
+changeKey: plp-collection-result-count
+introducedOn: 2026-06-03
+changeType: feature
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/collections/server.ts
+  - apps/template/lib/shopify/operations/products.ts
+  - apps/template/components/collections/collection-page.tsx
+---
+
+## Summary
+
+`/collections/[handle]` now shows the same toolbar item count that `/search` and `/collections/all` already render ("N Items", hidden on mobile via the existing `hidden sm:flex` in `CollectionToolbar`). The count reflects active filters.
+
+Concretely:
+
+- `CollectionResultsData` gains a top-level `total: number`.
+- `getCollectionResultsData` runs `getCollectionProducts(...)` and `getSearchFacets({ collection: handle, ... })` in parallel and threads `facets.total` into `total`. `getAllProductsResultsData` does the same with the `facets` it was already awaiting.
+- `getSearchFacets` now also calls `cacheTag(\`collection-${collection}\`)` when given a collection handle, mirroring `getCollectionProducts` so a collection-scoped webhook invalidation busts the count alongside the product list.
+- `CollectionDetailPage` wires a Suspense'd `<CollectionResultCount>` into the toolbar's `resultCount` slot, mirroring `app/search/page.tsx`'s `SearchResultCount`. The fallback is a `Skeleton className="h-4 w-20"` so the toolbar row doesn't shift when the count streams in.
+- The dead `getExactCollectionResultCount` helper is removed (only useful when the entire collection fit on one page; superseded by the real total).
+
+## Why it matters
+
+The Storefront API's `collection.products` connection has no `totalCount`, which is why the count was previously absent. The top-level `search` field does expose `totalCount` and accepts `productFilters`, so routing a `collection:'<handle>'` query through it (which `getSearchFacets` already encodes) yields a filter-aware total. Reusing the existing helper keeps the data layer DRY and means `/search`, `/collections/all`, and `/collections/[handle]` now all source their counts from the same operation.
+
+The cache-tag fix to `getSearchFacets` is independently useful — any future caller that scopes facets to a collection now benefits from precise webhook invalidation.
+
+## Apply when
+
+- The storefront still uses `CollectionToolbar` and `CollectionDetailPage` largely as shipped.
+- The storefront's catalog is search-indexed by Shopify (the default — rules-based and most manual collections).
+
+## Safe to skip when
+
+- The storefront has replaced the PLP toolbar with a custom layout that already shows a count from its own source.
+- The storefront uses manually curated collections containing products that are intentionally excluded from the search index. In that case the search-derived total can drift slightly from the connection-derived grid; either keep the count off, or replace `getCollectionProducts` with a `search(query: "collection:handle")` call (loses `COLLECTION_DEFAULT` ordering).
+
+## Validation
+
+1. `pnpm --filter template dev`. Visit a `/collections/[handle]` with > 20 products and confirm "N Items" renders in the toolbar on desktop and is hidden on mobile.
+2. Apply a filter via URL (`?filter.v.availability=1`) or the sidebar; confirm the count updates and the Skeleton placeholder briefly holds the row height during the transition.
+3. Confirm `/collections/all` and `/search` still render counts unchanged.
+4. `pnpm --filter template lint` / `pnpm --filter template format --check` are clean.


### PR DESCRIPTION
## Summary

- `/collections/[handle]` now renders the "N Items" toolbar count that `/search` and `/collections/all` already show, and it reacts to active filters.
- The Storefront API's `collection.products` connection has no `totalCount`, so the count comes from the top-level `search` field via the existing `getSearchFacets` helper (`collection:'<handle>'` query + `productFilters`) — fetched in parallel with `getCollectionProducts`. `getAllProductsResultsData` now surfaces the total it was already fetching.
- `getSearchFacets` adds `cacheTag(\`collection-${collection}\`)` when scoped to a collection so webhook invalidation busts the count alongside the product list. The unused `getExactCollectionResultCount` helper is removed.
- Rollout log entry added at `packages/plugin/template-rollout-log/2026-06-03-plp-collection-result-count.md` with the search-index drift caveat for hand-curated collections.

## Test plan

- [ ] `pnpm --filter template dev`. Visit a `/collections/[handle]` with > 20 products → toolbar shows "N Items" on desktop, hidden on mobile.
- [ ] Apply a filter (`?filter.v.availability=1` or via the sidebar) → count updates; Skeleton fallback briefly holds the row height during the transition.
- [ ] `/collections/all` and `/search` counts still render and weren't regressed.
- [ ] `pnpm --filter template lint` and `pnpm --filter template format --check` clean for the edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)