### PR TITLE
[template] PDP: only echo active value next to picker label when values aren't visible inline

### DIFF
--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -72,26 +72,14 @@ export function ColorPicker({
             </div>
           );
 
-          const label = imageUrl ? (
-            <span
-              className={cn(
-                "text-sm font-medium transition-opacity text-center",
-                isSelected ? "text-foreground" : "text-foreground/50",
-              )}
-            >
-              {value.name}
-            </span>
-          ) : null;
-
           if (!isAvailable) {
             return (
               <span
                 key={value.id}
-                className="flex flex-col items-center gap-2 opacity-40 cursor-not-allowed"
+                className="block opacity-40 cursor-not-allowed"
                 aria-label={`${option.name}: ${value.name} (unavailable)`}
               >
                 {swatch}
-                {label}
               </span>
             );
           }
@@ -101,11 +89,10 @@ export function ColorPicker({
               key={value.id}
               href={href}
               scroll={false}
-              className="flex flex-col items-center gap-2"
+              className="block"
               aria-label={`Select ${option.name}: ${value.name}`}
             >
               {swatch}
-              {label}
             </Link>
           );
         })}

--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -72,7 +72,7 @@ export function ColorPicker({
             </div>
           );
 
-          const label = (
+          const label = imageUrl ? (
             <span
               className={cn(
                 "text-sm font-medium transition-opacity text-center",
@@ -81,7 +81,7 @@ export function ColorPicker({
             >
               {value.name}
             </span>
-          );
+          ) : null;
 
           if (!isAvailable) {
             return (

--- a/apps/template/components/product-detail/option-picker.tsx
+++ b/apps/template/components/product-detail/option-picker.tsx
@@ -24,9 +24,7 @@ export function OptionPicker({
 }: OptionPickerProps) {
   return (
     <div className={cn("grid gap-2.5", className)} {...props}>
-      <p className="text-sm font-medium text-foreground/70">
-        {option.name}: <span className="text-foreground">{selectedValue}</span>
-      </p>
+      <p className="text-sm font-medium text-foreground/70">{option.name}</p>
       <div className="flex flex-wrap gap-2">
         {option.values.map((value) => {
           const isSelected = selectedValue === value.name;

--- a/packages/plugin/template-rollout-log/2026-06-06-pdp-picker-active-value-display.md
+++ b/packages/plugin/template-rollout-log/2026-06-06-pdp-picker-active-value-display.md
@@ -1,0 +1,50 @@
+---
+title: PDP — only show the active value next to the picker label when values aren't visible inline
+changeKey: pdp-picker-active-value-display
+introducedOn: 2026-06-06
+changeType: enhancement
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-detail/option-picker.tsx
+  - apps/template/components/product-detail/color-picker.tsx
+---
+
+## Summary
+
+Both pickers previously rendered a `Name: Value` heading echoing the active variant's value. For the text-button `OptionPicker` that value is redundant — the selected value is already legible as the highlighted button. The redundancy only earns its place when the chooser itself doesn't spell out the value.
+
+The active value now shows next to the label only when the values aren't visible inline:
+
+- `OptionPicker` (text buttons): heading is now just `Name` (e.g. `Size`). The selected value reads off the highlighted button.
+- `ColorPicker`: heading keeps `Name: Value`, since a color square doesn't name itself.
+- Single-value options (the label-only row from `pdp-single-value-option-labels`): unchanged — still `Name: Value`, the only place that value appears.
+
+The same "is the value visible inline?" principle drives the per-value label inside `ColorPicker`. A value rendered as an **image thumbnail** keeps its text label underneath; a value rendered as a **color square** drops it. The label is gated on `imageUrl` being truthy (`value.swatch.image` or the variant's product image, and not `hideImages`), so a mixed option shows labels under its image values and bare squares for its color values. The `aria-label` on each link/span already carries the value name, so dropping the visible label doesn't cost accessibility.
+
+## Why it matters
+
+- Removes a redundant readout above button pickers; the highlighted button is the source of truth.
+- Keeps the value visible where the chooser can't convey it (color squares), preserving the quick "Color: Sage" readout.
+- Makes the per-swatch label rule legible: text under a swatch means "this square is an image"; a bare square means "read the heading."
+
+## Apply when
+
+- The storefront still uses `components/product-detail/option-picker.tsx` and `color-picker.tsx` largely as shipped.
+
+## Safe to skip when
+
+- The storefront has its own picker markup or deliberately wants the active value echoed above every chooser.
+
+## Validation
+
+1. `pnpm --filter template dev`.
+2. PDP with a text-button option (e.g. `Size`): heading reads `Size` with no value; the selected size is the highlighted button.
+3. PDP with a color option backed by **color swatches**: heading reads `Color: <value>`, swatches render as bare squares with no text labels.
+4. PDP with a color option backed by **swatch/variant images**: heading reads `Color: <value>` and each thumbnail keeps its text label underneath.
+5. Single-value non-Title option (e.g. `Finish: Natural White Oak`): unchanged — still renders as the inline `Name: Value` label.
+
+## See also
+
+- `pdp-single-value-option-labels` (2026-06-02) — the single-value label row that this entry leaves intact.

--- a/packages/plugin/template-rollout-log/2026-06-06-pdp-picker-active-value-display.md
+++ b/packages/plugin/template-rollout-log/2026-06-06-pdp-picker-active-value-display.md
@@ -18,16 +18,16 @@ Both pickers previously rendered a `Name: Value` heading echoing the active vari
 The active value now shows next to the label only when the values aren't visible inline:
 
 - `OptionPicker` (text buttons): heading is now just `Name` (e.g. `Size`). The selected value reads off the highlighted button.
-- `ColorPicker`: heading keeps `Name: Value`, since a color square doesn't name itself.
+- `ColorPicker`: heading keeps `Name: Value`, since a swatch (color or image) doesn't name itself, and the per-value text caption under each swatch is removed entirely. The grid is now bare swatches/thumbnails with the active value shown only in the heading.
 - Single-value options (the label-only row from `pdp-single-value-option-labels`): unchanged — still `Name: Value`, the only place that value appears.
 
-The same "is the value visible inline?" principle drives the per-value label inside `ColorPicker`. A value rendered as an **image thumbnail** keeps its text label underneath; a value rendered as a **color square** drops it. The label is gated on `imageUrl` being truthy (`value.swatch.image` or the variant's product image, and not `hideImages`), so a mixed option shows labels under its image values and bare squares for its color values. The `aria-label` on each link/span already carries the value name, so dropping the visible label doesn't cost accessibility.
+`ColorPicker` no longer renders a caption under either color squares or image thumbnails. The `aria-label` on each link/span still carries the value name, so dropping the visible caption doesn't cost accessibility.
 
 ## Why it matters
 
 - Removes a redundant readout above button pickers; the highlighted button is the source of truth.
-- Keeps the value visible where the chooser can't convey it (color squares), preserving the quick "Color: Sage" readout.
-- Makes the per-swatch label rule legible: text under a swatch means "this square is an image"; a bare square means "read the heading."
+- Keeps the value visible where the chooser can't convey it (swatches), preserving the quick "Color: Sage" readout in the heading.
+- Cleans up the swatch grid to a uniform row of color squares/thumbnails with no captions; the heading is the single readout of the active value.
 
 ## Apply when
 
@@ -41,8 +41,8 @@ The same "is the value visible inline?" principle drives the per-value label ins
 
 1. `pnpm --filter template dev`.
 2. PDP with a text-button option (e.g. `Size`): heading reads `Size` with no value; the selected size is the highlighted button.
-3. PDP with a color option backed by **color swatches**: heading reads `Color: <value>`, swatches render as bare squares with no text labels.
-4. PDP with a color option backed by **swatch/variant images**: heading reads `Color: <value>` and each thumbnail keeps its text label underneath.
+3. PDP with a color option backed by **color swatches**: heading reads `Color: <value>`, swatches render as bare squares with no captions.
+4. PDP with a color option backed by **swatch/variant images**: heading reads `Color: <value>` and thumbnails render with no captions either.
 5. Single-value non-Title option (e.g. `Finish: Natural White Oak`): unchanged — still renders as the inline `Name: Value` label.
 
 ## See also


### PR DESCRIPTION
## Summary

On the PDP variant pickers, the active variant's value is shown next to the option label **only when the value isn't already visible inline**:

- **OptionPicker** (text buttons): heading is now just the option name (e.g. `Size`). The selected value reads off the highlighted button, so the `: Value` echo was redundant.
- **ColorPicker**: heading keeps `Name: Value` — a swatch can't name itself — and the per-value text caption under each swatch is removed entirely. The grid is now bare color squares / image thumbnails with the active value shown only in the heading.
- **Single-value option** label row (`Name: Value`): unchanged.

The `aria-label` on each swatch link/span still carries the value name, so dropping the visible caption doesn't cost accessibility.

Added a `template-rollout-log` entry (`pdp-picker-active-value-display`) per AGENTS.md. Docs needed no change — `pdp.mdx` only documents the single-value label, which is untouched.

## Test plan

- [ ] PDP with a text-button option (e.g. `Size`): heading reads `Size`, no value; selection is the highlighted button.
- [ ] PDP with color **swatches**: heading reads `Color: <value>`, swatches are bare squares (no captions).
- [ ] PDP with swatch/variant **images**: heading reads `Color: <value>`, thumbnails render with no captions either.
- [ ] Single-value non-Title option still renders the inline `Name: Value` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)