### PR TITLE
fix: lint warnings and format issues across template + docs

### DIFF
--- a/apps/docs/.oxlintrc.json
+++ b/apps/docs/.oxlintrc.json
@@ -7,6 +7,7 @@
   "ignorePatterns": [".next/**", "dist/**", "build/**", ".claude/**"],
   "plugins": ["typescript", "react", "nextjs"],
   "rules": {
+    "no-underscore-dangle": ["warn", { "allow": ["__dirname", "__registerFileInput"] }],
     "no-unused-vars": "off",
     "react/react-in-jsx-scope": "off"
   },

--- a/apps/docs/content/docs/anatomy/webhooks.mdx
+++ b/apps/docs/content/docs/anatomy/webhooks.mdx
@@ -35,11 +35,11 @@ Product topics also try to derive a numeric product tag from `admin_graphql_api_
 
 Metaobject topics inspect the payload's `type` field to invalidate narrower CMS tags. The exact mapping follows the conventions used by [Shopify CMS](/docs/skills/enable-shopify-cms):
 
-| Metaobject `type`            | Additional tags                  |
-| ---------------------------- | -------------------------------- |
-| `cms_page`                   | `cms:pages`, `cms:page:{slug}`   |
-| `cms_homepage`               | `cms:homepage`                   |
-| `cms_section`, `cms_hero`    | `cms:pages`, `cms:homepage`      |
+| Metaobject `type`         | Additional tags                |
+| ------------------------- | ------------------------------ |
+| `cms_page`                | `cms:pages`, `cms:page:{slug}` |
+| `cms_homepage`            | `cms:homepage`                 |
+| `cms_section`, `cms_hero` | `cms:pages`, `cms:homepage`    |
 
 All metaobject topics also invalidate the broad `cms:all` tag as a safety net for unrecognized types.
 
@@ -70,9 +70,9 @@ You can register only the topics you care about. Skipping `inventory_levels/*`, 
 
 ## Environment variables
 
-| Variable                  | When to set                                                                        |
-| ------------------------- | ---------------------------------------------------------------------------------- |
-| `SHOPIFY_WEBHOOK_SECRET`  | Required in any environment where Shopify posts to `/api/webhooks/shopify`. Without it, signature verification is skipped — fine for local testing, unsafe for production. |
+| Variable                 | When to set                                                                                                                                                                |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SHOPIFY_WEBHOOK_SECRET` | Required in any environment where Shopify posts to `/api/webhooks/shopify`. Without it, signature verification is skipped — fine for local testing, unsafe for production. |
 
 See [Environment Variables](/docs/reference/env-vars) for the full reference.
 

--- a/apps/docs/content/docs/getting-started/extending-with-agents.mdx
+++ b/apps/docs/content/docs/getting-started/extending-with-agents.mdx
@@ -57,10 +57,10 @@ The owning tool can overwrite the content between `BEGIN` and `END` on upgrade w
 
 The template ships with two blocks:
 
-| Block                | Owner       | What it contains                                                                                                                                                                                       |
-| -------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `nextjs-agent-rules` | Next.js     | Reminds agents this Next.js version has breaking changes and to read bundled docs before writing code. Refreshed on Next.js upgrade.                                                                   |
-| `vercel-shop-style`  | Vercel Shop | Code style conventions: alphabetized exports and keys, no barrel files, push `"use client"` to leaves, naming rules, Tailwind patterns. Remove the block if your team prefers different conventions.   |
+| Block                | Owner       | What it contains                                                                                                                                                                                     |
+| -------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nextjs-agent-rules` | Next.js     | Reminds agents this Next.js version has breaking changes and to read bundled docs before writing code. Refreshed on Next.js upgrade.                                                                 |
+| `vercel-shop-style`  | Vercel Shop | Code style conventions: alphabetized exports and keys, no barrel files, push `"use client"` to leaves, naming rules, Tailwind patterns. Remove the block if your team prefers different conventions. |
 
 Everything outside these markers is yours. Add team conventions or domain constraints anywhere else and no upgrade will overwrite them.
 

--- a/apps/template/.oxlintrc.json
+++ b/apps/template/.oxlintrc.json
@@ -7,6 +7,7 @@
   "ignorePatterns": [".next/**", "dist/**", "build/**", ".claude/**", "app/.well-known/**"],
   "plugins": ["typescript", "react", "nextjs"],
   "rules": {
+    "no-underscore-dangle": ["warn", { "allow": ["__typename"] }],
     "no-unused-vars": "off",
     "react/react-in-jsx-scope": "off"
   },

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -38,7 +38,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 ### Ordering & Organization
 
-- Alphabetize named export specifiers, i18n JSON keys (within each section and at the top level), string union type members, and config object keys.
+- Alphabetize named export specifiers, object destructuring patterns, interface and type properties, config object keys, i18n JSON keys (within each section and at the top level), and string union type members.
 - No barrel files — never create an `index.ts` that only re-exports. Import from the source file directly.
 - oxfmt handles import sorting automatically via `pnpm format`.
 

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -5,6 +5,7 @@ import {
   createUIMessageStreamResponse,
   safeValidateUIMessages,
 } from "ai";
+
 import { createAgent, type PageContext, type User, withAgentContext } from "@/lib/agent/server";
 import { buildCartIdSetCookieHeader, getCartIdFromCookie } from "@/lib/cart/server";
 import { agent as agentConfig } from "@/lib/config";

--- a/apps/template/app/cart/page.tsx
+++ b/apps/template/app/cart/page.tsx
@@ -43,10 +43,7 @@ export default async function CartPage() {
 }
 
 async function CartContent({ locale }: { locale: Locale }) {
-  const [cart, messages] = await Promise.all([
-    withFallback(getCart(), undefined),
-    getMessages(),
-  ]);
+  const [cart, messages] = await Promise.all([withFallback(getCart(), undefined), getMessages()]);
 
   return (
     <NextIntlClientProvider messages={{ cart: messages.cart }}>

--- a/apps/template/components/agent/agent-panel.tsx
+++ b/apps/template/components/agent/agent-panel.tsx
@@ -398,7 +398,7 @@ export function AgentPanel({ open, onOpenChange, triggerRef }: AgentPanelProps) 
       document.removeEventListener("mousedown", handleClickOutside);
       document.removeEventListener("keydown", handleEscape);
     };
-  }, [open]);
+  }, [open, onOpenChange, triggerRef]);
 
   useScrollContain(panelRef, open);
 

--- a/apps/template/components/cart/context.tsx
+++ b/apps/template/components/cart/context.tsx
@@ -484,11 +484,13 @@ export function CartProvider({
         clearTimeout(debounce.timer);
       }
 
+      // oxlint-disable-next-line react-hooks/exhaustive-deps -- clear timers held at unmount, not at effect setup
       for (const [, pending] of lineOpsRef.current) {
         if (pending.timer !== null) {
           clearTimeout(pending.timer);
         }
       }
+      // oxlint-disable-next-line react-hooks/exhaustive-deps -- clear the latest request-id map at unmount
       latestLineRequestIdRef.current.clear();
     };
   }, []);

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -16,12 +16,7 @@ import {
   searchIndexProducts,
 } from "@/lib/shopify/operations/products";
 import type { ProductFilter } from "@/lib/shopify/types/filters";
-import type {
-  Filter,
-  PageInfo,
-  PriceRange,
-  ProductCard as ProductCardType,
-} from "@/lib/types";
+import type { Filter, PageInfo, PriceRange, ProductCard as ProductCardType } from "@/lib/types";
 import { RESULTS_PER_PAGE } from "@/lib/utils";
 
 export interface SearchResultsData {

--- a/apps/template/hooks/use-scroll-contain.ts
+++ b/apps/template/hooks/use-scroll-contain.ts
@@ -46,7 +46,6 @@ export function useScrollContain(
     e.preventDefault();
   });
 
-  // oxlint-disable-next-line react/exhaustive-deps -- ref is stable; enabled changing to true coincides with the panel mounting
   useEffect(() => {
     if (!enabled) return;
     const panel = ref.current;
@@ -61,5 +60,5 @@ export function useScrollContain(
       panel.removeEventListener("touchstart", onTouchStart);
       panel.removeEventListener("touchmove", onTouchMove);
     };
-  }, [enabled]);
+  }, [enabled, ref]);
 }

--- a/apps/template/lib/cart/action.ts
+++ b/apps/template/lib/cart/action.ts
@@ -231,9 +231,7 @@ export async function applyDiscountCodeAction(code: string): Promise<CartActionR
 
     // Shopify accepts unknown codes and marks them applicable:false. Reject those
     // (undo the apply, surface the warning as a form error — no chip, no banner).
-    const applied = result.cart.discountCodes.find(
-      (d) => d.code.toUpperCase() === normalized,
-    );
+    const applied = result.cart.discountCodes.find((d) => d.code.toUpperCase() === normalized);
     if (applied && !applied.applicable) {
       const reverted = await updateCartDiscountCodes(existing);
       const errorMessage =

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -446,8 +446,8 @@ export async function getCartSelectableAddressId(): Promise<string | undefined> 
 export async function addCartDeliveryAddress(address: {
   city?: string;
   countryCode: string;
-  zip?: string;
   customerAddressId?: string;
+  zip?: string;
 }): Promise<CartMutationResult | undefined> {
   const cartId = await getCartIdFromCookie();
   if (!cartId) return undefined;
@@ -486,9 +486,9 @@ export async function addCartDeliveryAddress(address: {
 }
 
 export type CartShippingOption = {
-  title: string;
-  estimatedCost: { amount: string; currencyCode: string };
   deliveryMethodType: string;
+  estimatedCost: { amount: string; currencyCode: string };
+  title: string;
 };
 
 export async function getCartDeliveryOptions(): Promise<CartShippingOption[]> {
@@ -500,9 +500,9 @@ export async function getCartDeliveryOptions(): Promise<CartShippingOption[]> {
       deliveryGroups: {
         nodes: Array<{
           deliveryOptions: Array<{
-            title: string | null;
-            estimatedCost: { amount: string; currencyCode: string };
             deliveryMethodType: string;
+            estimatedCost: { amount: string; currencyCode: string };
+            title: string | null;
           }>;
         }>;
       };
@@ -525,9 +525,9 @@ export async function getCartDeliveryOptions(): Promise<CartShippingOption[]> {
       return true;
     })
     .map((opt) => ({
-      title: opt.title ?? opt.deliveryMethodType,
-      estimatedCost: opt.estimatedCost,
       deliveryMethodType: opt.deliveryMethodType,
+      estimatedCost: opt.estimatedCost,
+      title: opt.title ?? opt.deliveryMethodType,
     }));
 }
 
@@ -536,8 +536,8 @@ export async function updateCartDeliveryAddress(
   address: {
     city?: string;
     countryCode: string;
-    zip?: string;
     customerAddressId?: string;
+    zip?: string;
   },
 ): Promise<CartMutationResult | undefined> {
   const cartId = await getCartIdFromCookie();

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -1,8 +1,4 @@
-import {
-  getCartIdFromCookie,
-  invalidateCartCache,
-  setCartIdCookie,
-} from "@/lib/cart/server";
+import { getCartIdFromCookie, invalidateCartCache, setCartIdCookie } from "@/lib/cart/server";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import type { Cart, CartWarning } from "@/lib/types";
 
@@ -203,7 +199,10 @@ const CART_DELIVERY_ADDRESSES_UPDATE_MUTATION = `
 
 export type CartMutationResult = { cart: Cart; warnings: CartWarning[] };
 
-function applyMutation(payload: CartMutationPayload<ShopifyCart>, operation: string): CartMutationResult {
+function applyMutation(
+  payload: CartMutationPayload<ShopifyCart>,
+  operation: string,
+): CartMutationResult {
   const { cart, warnings } = unwrapCartMutation(payload, operation);
   return { cart: transformShopifyCart(cart), warnings };
 }
@@ -229,7 +228,9 @@ export async function getCart(cartId?: string): Promise<Cart | undefined> {
  * Use in streaming contexts (e.g., the AI agent) where `cookies().set()` won't work.
  * The caller is responsible for setting the cookie via response headers.
  */
-export async function createCartWithoutCookie(locale: string = defaultLocale): Promise<CartMutationResult> {
+export async function createCartWithoutCookie(
+  locale: string = defaultLocale,
+): Promise<CartMutationResult> {
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -192,9 +192,9 @@ function joinOr(field: string, values: string[]): string {
 
 // QueryRoot.products has no productFilters arg, so filters are encoded into the query string; variantOption/productMetafield are dropped.
 function buildCatalogQuery(args: {
-  query?: string;
   collection?: string;
   filters: ProductFilter[];
+  query?: string;
 }): string {
   const parts: string[] = [];
 
@@ -321,8 +321,8 @@ export function buildProductFiltersFromParams(
 }
 
 type CatalogProductsResult = {
-  products: ProductCard[];
   pageInfo: PageInfo;
+  products: ProductCard[];
 };
 
 type CatalogProductsParams = {
@@ -331,21 +331,21 @@ type CatalogProductsParams = {
 };
 
 type FilteredCatalogProductsParams = CatalogProductsParams & {
-  query?: string;
   collection?: string;
-  sortKey?: string;
   cursor?: string;
   filters?: ProductFilter[];
+  query?: string;
+  sortKey?: string;
 };
 
 async function fetchCatalogProducts({
-  query,
   collection,
-  sortKey: rawSortKey = "best-matches",
-  limit = 50,
   cursor,
   filters = [],
+  limit = 50,
   locale = defaultLocale,
+  query,
+  sortKey: rawSortKey = "best-matches",
 }: FilteredCatalogProductsParams): Promise<CatalogProductsResult> {
   const sortConfig = CATALOG_SORT_KEY_MAP[rawSortKey] ?? CATALOG_SORT_KEY_MAP["best-matches"];
   const country = getCountryCode(locale);
@@ -382,8 +382,8 @@ async function fetchCatalogProducts({
   tagProducts(shopifyProducts);
 
   return {
-    products: shopifyProducts.map(transformShopifyProductCard),
     pageInfo: data.products.pageInfo,
+    products: shopifyProducts.map(transformShopifyProductCard),
   };
 }
 
@@ -409,16 +409,16 @@ export async function getFilteredCatalogProducts(
 
 export async function getSearchFacets(params: {
   activeFilters?: ActiveFilters;
-  query?: string;
   collection?: string;
   filters?: ProductFilter[];
   locale?: string;
+  query?: string;
 }): Promise<{ filters: Filter[]; priceRange?: PriceRange; total: number }> {
   "use cache: remote";
   cacheLife("max");
   cacheTag("products");
 
-  const { activeFilters = {}, query, collection, filters = [], locale = defaultLocale } = params;
+  const { activeFilters = {}, collection, filters = [], locale = defaultLocale, query } = params;
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 
@@ -456,26 +456,26 @@ export async function getSearchFacets(params: {
 // (variant options, metafields, etc.) — the products(...) query string in getCatalogProducts
 // silently drops variantOption/productMetafield, so /search uses this path even for no-query browse.
 export async function searchIndexProducts(params: {
-  query?: string;
   collection?: string;
-  sortKey?: string;
-  limit?: number;
   cursor?: string;
   filters?: ProductFilter[];
+  limit?: number;
   locale?: string;
-}): Promise<{ products: ProductCard[]; total: number; pageInfo: PageInfo }> {
+  query?: string;
+  sortKey?: string;
+}): Promise<{ pageInfo: PageInfo; products: ProductCard[]; total: number }> {
   "use cache: remote";
   cacheLife("max");
   cacheTag("products");
 
   const {
-    query,
     collection,
-    sortKey: rawSortKey = "best-matches",
-    limit = 50,
     cursor,
     filters = [],
+    limit = 50,
     locale = defaultLocale,
+    query,
+    sortKey: rawSortKey = "best-matches",
   } = params;
 
   const sortConfig = SEARCH_SORT_KEY_MAP[rawSortKey] ?? SEARCH_SORT_KEY_MAP["best-matches"];
@@ -516,9 +516,9 @@ export async function searchIndexProducts(params: {
   tagProducts(shopifyProducts);
 
   return {
+    pageInfo: data.search.pageInfo,
     products: shopifyProducts.map(transformShopifyProductCard),
     total: data.search.totalCount,
-    pageInfo: data.search.pageInfo,
   };
 }
 
@@ -576,16 +576,16 @@ const COLLECTION_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolea
 export async function getCollectionProducts(params: {
   activeFilters?: ActiveFilters;
   collection: string;
-  limit?: number;
-  sortKey?: string;
   cursor?: string;
   filters?: ProductFilter[];
+  limit?: number;
   locale?: string;
+  sortKey?: string;
 }): Promise<{
-  products: ProductCard[];
-  pageInfo: PageInfo;
   filters: Filter[];
+  pageInfo: PageInfo;
   priceRange?: PriceRange;
+  products: ProductCard[];
 }> {
   "use cache: remote";
   cacheLife("max");
@@ -594,11 +594,11 @@ export async function getCollectionProducts(params: {
   const {
     activeFilters = {},
     collection,
-    sortKey: rawSortKey = "best-matches",
-    limit = 50,
     cursor,
     filters = [],
+    limit = 50,
     locale = defaultLocale,
+    sortKey: rawSortKey = "best-matches",
   } = params;
 
   const sortConfig = COLLECTION_SORT_KEY_MAP[rawSortKey] ?? COLLECTION_SORT_KEY_MAP["best-matches"];
@@ -630,14 +630,14 @@ export async function getCollectionProducts(params: {
 
   if (!data.collection) {
     return {
-      products: [],
+      filters: [],
       pageInfo: {
         hasNextPage: false,
         hasPreviousPage: false,
         startCursor: null,
         endCursor: null,
       },
-      filters: [],
+      products: [],
     };
   }
 
@@ -649,10 +649,10 @@ export async function getCollectionProducts(params: {
   const transformed = transformShopifyFilters(data.collection.products.filters, { activeFilters });
 
   return {
-    products,
-    pageInfo: data.collection.products.pageInfo,
     filters: transformed.filters,
+    pageInfo: data.collection.products.pageInfo,
     priceRange: transformed.priceRange,
+    products,
   };
 }
 

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -418,13 +418,7 @@ export async function getSearchFacets(params: {
   cacheLife("max");
   cacheTag("products");
 
-  const {
-    activeFilters = {},
-    query,
-    collection,
-    filters = [],
-    locale = defaultLocale,
-  } = params;
+  const { activeFilters = {}, query, collection, filters = [], locale = defaultLocale } = params;
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -23,68 +23,68 @@ export interface Money {
 }
 
 export interface Image {
-  url: string;
   altText: string;
-  width: number;
   height: number;
+  url: string;
+  width: number;
 }
 
 export interface Video {
-  url: string;
-  previewImage: Image | null;
-  width: number;
   height: number;
+  previewImage: Image | null;
+  url: string;
+  width: number;
 }
 
 export interface SEO {
-  title: string;
   description: string;
+  title: string;
 }
 
 export interface ProductCard {
-  id: string;
-  handle: string;
-  title: string;
-  featuredImage: Image | null;
-  price: Money;
-  compareAtPrice?: Money;
-  vendor?: string;
   availableForSale: boolean;
+  compareAtPrice?: Money;
   defaultVariantId?: string;
   defaultVariantNumericId?: string;
   defaultVariantSelectedOptions?: SelectedOption[];
+  featuredImage: Image | null;
+  handle: string;
+  id: string;
+  price: Money;
+  title: string;
+  vendor?: string;
 }
 
 export interface ProductDetails extends ProductCard {
+  category?: Category | null;
+  categoryId?: string;
+  collectionHandles: string[];
+  currencyCode: string;
   description: string;
   descriptionHtml: string;
   images: Image[];
-  videos: Video[];
-  variants: ProductVariant[];
-  options: ProductOption[];
-  tags: string[];
-  seo: SEO;
-  category?: Category | null;
-  updatedAt: string;
-  priceRange: {
-    minVariantPrice: Money;
-    maxVariantPrice: Money;
-  };
-  currencyCode: string;
   manufacturerName: string;
-  categoryId?: string;
-  collectionHandles: string[];
   metafields?: Metafield[];
+  options: ProductOption[];
+  priceRange: {
+    maxVariantPrice: Money;
+    minVariantPrice: Money;
+  };
+  seo: SEO;
+  tags: string[];
+  updatedAt: string;
+  variants: ProductVariant[];
+  videos: Video[];
 }
 
 export interface ProductVariant {
-  id: string;
-  title: string;
   availableForSale: boolean;
-  price: Money;
   compareAtPrice?: Money;
-  selectedOptions: SelectedOption[];
+  id: string;
   image: Image | null;
+  price: Money;
+  selectedOptions: SelectedOption[];
+  title: string;
 }
 
 export interface ProductOption {
@@ -116,41 +116,41 @@ export interface Metafield {
 }
 
 export interface Category {
+  ancestors: Category[];
   id: string;
   name: string;
-  ancestors: Category[];
 }
 
 export interface Cart {
-  id: string | undefined;
+  appliedGiftCards: AppliedGiftCard[];
   checkoutUrl: string;
-  totalQuantity: number;
-  note: string | null;
   cost: {
     subtotalAmount: Money;
     totalAmount: Money;
     totalTaxAmount: Money;
   };
-  lines: CartLine[];
-  shippingCost: Money | null;
-  discountCodes: DiscountCode[];
   discountAllocations: DiscountAllocation[];
-  appliedGiftCards: AppliedGiftCard[];
+  discountCodes: DiscountCode[];
+  id: string | undefined;
+  lines: CartLine[];
+  note: string | null;
+  shippingCost: Money | null;
+  totalQuantity: number;
 }
 
 export interface CartLine {
-  id: string | undefined;
-  quantity: number;
   cost: {
     totalAmount: Money;
   };
-  merchandise: CartMerchandise;
   discountAllocations: DiscountAllocation[];
+  id: string | undefined;
+  merchandise: CartMerchandise;
+  quantity: number;
 }
 
 export interface DiscountCode {
-  code: string;
   applicable: boolean;
+  code: string;
 }
 
 export type DiscountAllocation =
@@ -172,90 +172,90 @@ export interface CartWarning {
 
 export interface CartMerchandise {
   id: string;
-  title: string;
   image?: Image;
   price?: Money;
-  selectedOptions: SelectedOption[];
   product: CartProduct;
+  selectedOptions: SelectedOption[];
+  title: string;
 }
 
 export interface CartProduct {
-  id: string;
-  handle: string;
-  title: string;
   featuredImage: Image;
+  handle: string;
+  id: string;
+  title: string;
 }
 
 export interface Collection {
-  handle: string;
-  title: string;
   description: string;
+  handle: string;
   image?: Image | null;
-  seo: SEO;
   path: string;
+  seo: SEO;
+  title: string;
   updatedAt: string;
 }
 
-export type FilterType = "list" | "price" | "boolean";
+export type FilterType = "boolean" | "list" | "price";
 
 export interface FilterValue {
+  count: number;
   id: string;
   label: string;
   value: string;
-  count: number;
 }
 
 export interface Filter {
   id: string;
   label: string;
-  type: FilterType;
   paramKey: string;
+  type: FilterType;
   values: FilterValue[];
 }
 
 export interface PriceRange {
-  min: number;
   max: number;
+  min: number;
 }
 
 export interface CategoryNavItem {
+  count: number;
+  href: string;
   id: string;
   label: string;
   slug: string;
-  count: number;
-  href: string;
 }
 
 export interface PageInfo {
+  endCursor: string | null;
   hasNextPage: boolean;
   hasPreviousPage: boolean;
-  endCursor: string | null;
   startCursor: string | null;
 }
 
 export interface ProductListResult {
-  products: ProductCard[];
-  totalCount: number;
-  pageInfo: PageInfo;
   filters?: Filter[];
+  pageInfo: PageInfo;
   priceRange?: PriceRange;
+  products: ProductCard[];
   subcategories?: CategoryNavItem[];
+  totalCount: number;
 }
 
 export interface PredictiveSearchProduct {
-  id: string;
-  handle: string;
-  title: string;
-  featuredImage: Image | null;
-  price: Money;
-  compareAtPrice?: Money;
-  vendor?: string;
   availableForSale: boolean;
+  compareAtPrice?: Money;
+  featuredImage: Image | null;
+  handle: string;
+  id: string;
+  price: Money;
+  title: string;
+  vendor?: string;
 }
 
 export interface SearchSuggestion {
-  text: string;
   styledText: string;
+  text: string;
 }
 
 export interface PredictiveSearchCollection {
@@ -264,29 +264,29 @@ export interface PredictiveSearchCollection {
 }
 
 export interface PredictiveSearchResult {
-  products: PredictiveSearchProduct[];
   collections: PredictiveSearchCollection[];
+  products: PredictiveSearchProduct[];
   queries: SearchSuggestion[];
 }
 
 export interface MarketingImage {
-  url: string;
   alt: string;
-  width?: number;
   height?: number;
+  url: string;
+  width?: number;
 }
 
 export interface MarketingVideo {
-  url: string;
   previewImage?: MarketingImage | null;
+  url: string;
 }
 
 export interface BannerSection {
-  id: string;
-  headline: string;
-  subheadline: string | null;
   backgroundImage?: MarketingImage | StaticImageData | null;
   backgroundVideo?: MarketingVideo | null;
-  ctaText: string | null;
   ctaLink: string | null;
+  ctaText: string | null;
+  headline: string;
+  id: string;
+  subheadline: string | null;
 }


### PR DESCRIPTION
## Summary

Fixes everything `pnpm lint` complained about that was within our control. The branch was previously blocked by 6 oxfmt format violations and surfaced 12 oxlint warnings, most of which were spurious (Shopify's `__typename`, Node's `__dirname`, etc.).

- **Format**: ran `oxfmt` on 6 template files and 2 docs MDX files. (The MDX issues only surfaced once template stopped failing — turbo had been killing the docs job mid-check.)
- **Allow lists**: added `no-underscore-dangle` overrides so we stop warning about names we don't control: `__typename` (Shopify GraphQL), `__dirname` (Node builtin), `__registerFileInput` (vendored AI Elements).
- **Real hook-deps fixes** in template-owned code:
  - `components/agent/agent-panel.tsx` — include `onOpenChange` and `triggerRef` in the outside-click effect's deps.
  - `hooks/use-scroll-contain.ts` — include `ref` in deps (refs are stable; replaced a stale `oxlint-disable` comment that used the wrong rule path and no longer matched where oxlint reports the warning).
  - `components/cart/context.tsx` — `oxlint-disable` comments on the unmount cleanup that intentionally reads `ref.current` at teardown time.

After this PR, the only remaining warnings are 2 in vendored `components/ai-elements/message.tsx` files, intentionally left alone.

## Test plan

- [ ] `pnpm lint` passes (exit 0).
- [ ] `pnpm build` succeeds.
- [ ] Agent panel still closes on outside click / Escape.
- [ ] Cart adjustments + debounced timers still cancel cleanly on navigation.
- [ ] Scroll containment still blocks page scroll when the agent panel is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)