### PR TITLE
chore: expand alphabetization rule, apply to shopify operations

### DIFF
--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -38,7 +38,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 ### Ordering & Organization
 
-- Alphabetize named export specifiers, i18n JSON keys (within each section and at the top level), string union type members, and config object keys.
+- Alphabetize named export specifiers, object destructuring patterns, interface and type properties, config object keys, i18n JSON keys (within each section and at the top level), and string union type members.
 - No barrel files — never create an `index.ts` that only re-exports. Import from the source file directly.
 - oxfmt handles import sorting automatically via `pnpm format`.
 

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -446,8 +446,8 @@ export async function getCartSelectableAddressId(): Promise<string | undefined> 
 export async function addCartDeliveryAddress(address: {
   city?: string;
   countryCode: string;
-  zip?: string;
   customerAddressId?: string;
+  zip?: string;
 }): Promise<CartMutationResult | undefined> {
   const cartId = await getCartIdFromCookie();
   if (!cartId) return undefined;
@@ -486,9 +486,9 @@ export async function addCartDeliveryAddress(address: {
 }
 
 export type CartShippingOption = {
-  title: string;
-  estimatedCost: { amount: string; currencyCode: string };
   deliveryMethodType: string;
+  estimatedCost: { amount: string; currencyCode: string };
+  title: string;
 };
 
 export async function getCartDeliveryOptions(): Promise<CartShippingOption[]> {
@@ -500,9 +500,9 @@ export async function getCartDeliveryOptions(): Promise<CartShippingOption[]> {
       deliveryGroups: {
         nodes: Array<{
           deliveryOptions: Array<{
-            title: string | null;
-            estimatedCost: { amount: string; currencyCode: string };
             deliveryMethodType: string;
+            estimatedCost: { amount: string; currencyCode: string };
+            title: string | null;
           }>;
         }>;
       };
@@ -525,9 +525,9 @@ export async function getCartDeliveryOptions(): Promise<CartShippingOption[]> {
       return true;
     })
     .map((opt) => ({
-      title: opt.title ?? opt.deliveryMethodType,
-      estimatedCost: opt.estimatedCost,
       deliveryMethodType: opt.deliveryMethodType,
+      estimatedCost: opt.estimatedCost,
+      title: opt.title ?? opt.deliveryMethodType,
     }));
 }
 
@@ -536,8 +536,8 @@ export async function updateCartDeliveryAddress(
   address: {
     city?: string;
     countryCode: string;
-    zip?: string;
     customerAddressId?: string;
+    zip?: string;
   },
 ): Promise<CartMutationResult | undefined> {
   const cartId = await getCartIdFromCookie();

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -192,9 +192,9 @@ function joinOr(field: string, values: string[]): string {
 
 // QueryRoot.products has no productFilters arg, so filters are encoded into the query string; variantOption/productMetafield are dropped.
 function buildCatalogQuery(args: {
-  query?: string;
   collection?: string;
   filters: ProductFilter[];
+  query?: string;
 }): string {
   const parts: string[] = [];
 
@@ -321,8 +321,8 @@ export function buildProductFiltersFromParams(
 }
 
 type CatalogProductsResult = {
-  products: ProductCard[];
   pageInfo: PageInfo;
+  products: ProductCard[];
 };
 
 type CatalogProductsParams = {
@@ -331,21 +331,21 @@ type CatalogProductsParams = {
 };
 
 type FilteredCatalogProductsParams = CatalogProductsParams & {
-  query?: string;
   collection?: string;
-  sortKey?: string;
   cursor?: string;
   filters?: ProductFilter[];
+  query?: string;
+  sortKey?: string;
 };
 
 async function fetchCatalogProducts({
-  query,
   collection,
-  sortKey: rawSortKey = "best-matches",
-  limit = 50,
   cursor,
   filters = [],
+  limit = 50,
   locale = defaultLocale,
+  query,
+  sortKey: rawSortKey = "best-matches",
 }: FilteredCatalogProductsParams): Promise<CatalogProductsResult> {
   const sortConfig = CATALOG_SORT_KEY_MAP[rawSortKey] ?? CATALOG_SORT_KEY_MAP["best-matches"];
   const country = getCountryCode(locale);
@@ -382,8 +382,8 @@ async function fetchCatalogProducts({
   tagProducts(shopifyProducts);
 
   return {
-    products: shopifyProducts.map(transformShopifyProductCard),
     pageInfo: data.products.pageInfo,
+    products: shopifyProducts.map(transformShopifyProductCard),
   };
 }
 
@@ -409,16 +409,16 @@ export async function getFilteredCatalogProducts(
 
 export async function getSearchFacets(params: {
   activeFilters?: ActiveFilters;
-  query?: string;
   collection?: string;
   filters?: ProductFilter[];
   locale?: string;
+  query?: string;
 }): Promise<{ filters: Filter[]; priceRange?: PriceRange; total: number }> {
   "use cache: remote";
   cacheLife("max");
   cacheTag("products");
 
-  const { activeFilters = {}, query, collection, filters = [], locale = defaultLocale } = params;
+  const { activeFilters = {}, collection, filters = [], locale = defaultLocale, query } = params;
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 
@@ -456,26 +456,26 @@ export async function getSearchFacets(params: {
 // (variant options, metafields, etc.) — the products(...) query string in getCatalogProducts
 // silently drops variantOption/productMetafield, so /search uses this path even for no-query browse.
 export async function searchIndexProducts(params: {
-  query?: string;
   collection?: string;
-  sortKey?: string;
-  limit?: number;
   cursor?: string;
   filters?: ProductFilter[];
+  limit?: number;
   locale?: string;
-}): Promise<{ products: ProductCard[]; total: number; pageInfo: PageInfo }> {
+  query?: string;
+  sortKey?: string;
+}): Promise<{ pageInfo: PageInfo; products: ProductCard[]; total: number }> {
   "use cache: remote";
   cacheLife("max");
   cacheTag("products");
 
   const {
-    query,
     collection,
-    sortKey: rawSortKey = "best-matches",
-    limit = 50,
     cursor,
     filters = [],
+    limit = 50,
     locale = defaultLocale,
+    query,
+    sortKey: rawSortKey = "best-matches",
   } = params;
 
   const sortConfig = SEARCH_SORT_KEY_MAP[rawSortKey] ?? SEARCH_SORT_KEY_MAP["best-matches"];
@@ -516,9 +516,9 @@ export async function searchIndexProducts(params: {
   tagProducts(shopifyProducts);
 
   return {
+    pageInfo: data.search.pageInfo,
     products: shopifyProducts.map(transformShopifyProductCard),
     total: data.search.totalCount,
-    pageInfo: data.search.pageInfo,
   };
 }
 
@@ -576,16 +576,16 @@ const COLLECTION_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolea
 export async function getCollectionProducts(params: {
   activeFilters?: ActiveFilters;
   collection: string;
-  limit?: number;
-  sortKey?: string;
   cursor?: string;
   filters?: ProductFilter[];
+  limit?: number;
   locale?: string;
+  sortKey?: string;
 }): Promise<{
-  products: ProductCard[];
-  pageInfo: PageInfo;
   filters: Filter[];
+  pageInfo: PageInfo;
   priceRange?: PriceRange;
+  products: ProductCard[];
 }> {
   "use cache: remote";
   cacheLife("max");
@@ -594,11 +594,11 @@ export async function getCollectionProducts(params: {
   const {
     activeFilters = {},
     collection,
-    sortKey: rawSortKey = "best-matches",
-    limit = 50,
     cursor,
     filters = [],
+    limit = 50,
     locale = defaultLocale,
+    sortKey: rawSortKey = "best-matches",
   } = params;
 
   const sortConfig = COLLECTION_SORT_KEY_MAP[rawSortKey] ?? COLLECTION_SORT_KEY_MAP["best-matches"];
@@ -630,14 +630,14 @@ export async function getCollectionProducts(params: {
 
   if (!data.collection) {
     return {
-      products: [],
+      filters: [],
       pageInfo: {
         hasNextPage: false,
         hasPreviousPage: false,
         startCursor: null,
         endCursor: null,
       },
-      filters: [],
+      products: [],
     };
   }
 
@@ -649,10 +649,10 @@ export async function getCollectionProducts(params: {
   const transformed = transformShopifyFilters(data.collection.products.filters, { activeFilters });
 
   return {
-    products,
-    pageInfo: data.collection.products.pageInfo,
     filters: transformed.filters,
+    pageInfo: data.collection.products.pageInfo,
     priceRange: transformed.priceRange,
+    products,
   };
 }
 

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -23,68 +23,68 @@ export interface Money {
 }
 
 export interface Image {
-  url: string;
   altText: string;
-  width: number;
   height: number;
+  url: string;
+  width: number;
 }
 
 export interface Video {
-  url: string;
-  previewImage: Image | null;
-  width: number;
   height: number;
+  previewImage: Image | null;
+  url: string;
+  width: number;
 }
 
 export interface SEO {
-  title: string;
   description: string;
+  title: string;
 }
 
 export interface ProductCard {
-  id: string;
-  handle: string;
-  title: string;
-  featuredImage: Image | null;
-  price: Money;
-  compareAtPrice?: Money;
-  vendor?: string;
   availableForSale: boolean;
+  compareAtPrice?: Money;
   defaultVariantId?: string;
   defaultVariantNumericId?: string;
   defaultVariantSelectedOptions?: SelectedOption[];
+  featuredImage: Image | null;
+  handle: string;
+  id: string;
+  price: Money;
+  title: string;
+  vendor?: string;
 }
 
 export interface ProductDetails extends ProductCard {
+  category?: Category | null;
+  categoryId?: string;
+  collectionHandles: string[];
+  currencyCode: string;
   description: string;
   descriptionHtml: string;
   images: Image[];
-  videos: Video[];
-  variants: ProductVariant[];
-  options: ProductOption[];
-  tags: string[];
-  seo: SEO;
-  category?: Category | null;
-  updatedAt: string;
-  priceRange: {
-    minVariantPrice: Money;
-    maxVariantPrice: Money;
-  };
-  currencyCode: string;
   manufacturerName: string;
-  categoryId?: string;
-  collectionHandles: string[];
   metafields?: Metafield[];
+  options: ProductOption[];
+  priceRange: {
+    maxVariantPrice: Money;
+    minVariantPrice: Money;
+  };
+  seo: SEO;
+  tags: string[];
+  updatedAt: string;
+  variants: ProductVariant[];
+  videos: Video[];
 }
 
 export interface ProductVariant {
-  id: string;
-  title: string;
   availableForSale: boolean;
-  price: Money;
   compareAtPrice?: Money;
-  selectedOptions: SelectedOption[];
+  id: string;
   image: Image | null;
+  price: Money;
+  selectedOptions: SelectedOption[];
+  title: string;
 }
 
 export interface ProductOption {
@@ -116,41 +116,41 @@ export interface Metafield {
 }
 
 export interface Category {
+  ancestors: Category[];
   id: string;
   name: string;
-  ancestors: Category[];
 }
 
 export interface Cart {
-  id: string | undefined;
+  appliedGiftCards: AppliedGiftCard[];
   checkoutUrl: string;
-  totalQuantity: number;
-  note: string | null;
   cost: {
     subtotalAmount: Money;
     totalAmount: Money;
     totalTaxAmount: Money;
   };
-  lines: CartLine[];
-  shippingCost: Money | null;
-  discountCodes: DiscountCode[];
   discountAllocations: DiscountAllocation[];
-  appliedGiftCards: AppliedGiftCard[];
+  discountCodes: DiscountCode[];
+  id: string | undefined;
+  lines: CartLine[];
+  note: string | null;
+  shippingCost: Money | null;
+  totalQuantity: number;
 }
 
 export interface CartLine {
-  id: string | undefined;
-  quantity: number;
   cost: {
     totalAmount: Money;
   };
-  merchandise: CartMerchandise;
   discountAllocations: DiscountAllocation[];
+  id: string | undefined;
+  merchandise: CartMerchandise;
+  quantity: number;
 }
 
 export interface DiscountCode {
-  code: string;
   applicable: boolean;
+  code: string;
 }
 
 export type DiscountAllocation =
@@ -172,90 +172,90 @@ export interface CartWarning {
 
 export interface CartMerchandise {
   id: string;
-  title: string;
   image?: Image;
   price?: Money;
-  selectedOptions: SelectedOption[];
   product: CartProduct;
+  selectedOptions: SelectedOption[];
+  title: string;
 }
 
 export interface CartProduct {
-  id: string;
-  handle: string;
-  title: string;
   featuredImage: Image;
+  handle: string;
+  id: string;
+  title: string;
 }
 
 export interface Collection {
-  handle: string;
-  title: string;
   description: string;
+  handle: string;
   image?: Image | null;
-  seo: SEO;
   path: string;
+  seo: SEO;
+  title: string;
   updatedAt: string;
 }
 
-export type FilterType = "list" | "price" | "boolean";
+export type FilterType = "boolean" | "list" | "price";
 
 export interface FilterValue {
+  count: number;
   id: string;
   label: string;
   value: string;
-  count: number;
 }
 
 export interface Filter {
   id: string;
   label: string;
-  type: FilterType;
   paramKey: string;
+  type: FilterType;
   values: FilterValue[];
 }
 
 export interface PriceRange {
-  min: number;
   max: number;
+  min: number;
 }
 
 export interface CategoryNavItem {
+  count: number;
+  href: string;
   id: string;
   label: string;
   slug: string;
-  count: number;
-  href: string;
 }
 
 export interface PageInfo {
+  endCursor: string | null;
   hasNextPage: boolean;
   hasPreviousPage: boolean;
-  endCursor: string | null;
   startCursor: string | null;
 }
 
 export interface ProductListResult {
-  products: ProductCard[];
-  totalCount: number;
-  pageInfo: PageInfo;
   filters?: Filter[];
+  pageInfo: PageInfo;
   priceRange?: PriceRange;
+  products: ProductCard[];
   subcategories?: CategoryNavItem[];
+  totalCount: number;
 }
 
 export interface PredictiveSearchProduct {
-  id: string;
-  handle: string;
-  title: string;
-  featuredImage: Image | null;
-  price: Money;
-  compareAtPrice?: Money;
-  vendor?: string;
   availableForSale: boolean;
+  compareAtPrice?: Money;
+  featuredImage: Image | null;
+  handle: string;
+  id: string;
+  price: Money;
+  title: string;
+  vendor?: string;
 }
 
 export interface SearchSuggestion {
-  text: string;
   styledText: string;
+  text: string;
 }
 
 export interface PredictiveSearchCollection {
@@ -264,29 +264,29 @@ export interface PredictiveSearchCollection {
 }
 
 export interface PredictiveSearchResult {
-  products: PredictiveSearchProduct[];
   collections: PredictiveSearchCollection[];
+  products: PredictiveSearchProduct[];
   queries: SearchSuggestion[];
 }
 
 export interface MarketingImage {
-  url: string;
   alt: string;
-  width?: number;
   height?: number;
+  url: string;
+  width?: number;
 }
 
 export interface MarketingVideo {
-  url: string;
   previewImage?: MarketingImage | null;
+  url: string;
 }
 
 export interface BannerSection {
-  id: string;
-  headline: string;
-  subheadline: string | null;
   backgroundImage?: MarketingImage | StaticImageData | null;
   backgroundVideo?: MarketingVideo | null;
-  ctaText: string | null;
   ctaLink: string | null;
+  ctaText: string | null;
+  headline: string;
+  id: string;
+  subheadline: string | null;
 }


### PR DESCRIPTION
## Summary

Stacked on #318.

The Ordering rule in `apps/template/AGENTS.md` previously named four things to alphabetize — export specifiers, i18n JSON keys, string union members, config object keys — and left **object destructuring patterns** and **interface/type properties** unsaid. The shop template had drifted accordingly.

- Expanded the rule wording to cover both.
- Brought `lib/shopify/operations/products.ts` and `lib/shopify/operations/cart.ts` into compliance: parameter types, destructure patterns, and the return-shape literals that mirror them.
- Brought `lib/types.ts` into compliance: every interface alphabetized internally, plus the `FilterType` string union (which the existing rule already covered).

## Notes

- Did **not** touch GraphQL `variables: { ... }` payloads — those mirror query variable order, which is a meaningful sequence.
- Pure interface/type property reordering has no runtime effect; TypeScript doesn't require object-literal field order to match the type declaration order, so callers and existing literals across the codebase are unaffected.
- Other operations files (`collections.ts`, `search.ts`, `menu.ts`, `sitemap.ts`) were already alphabetized — no changes needed.

## Test plan

- [ ] `pnpm lint` passes.
- [ ] `pnpm build` succeeds.
- [ ] PLP, PDP, search, collection, and cart pages render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)