### PR TITLE
[template] product-card: drop ?variant= so PDP prefetches dedupe by route

### DIFF
--- a/apps/docs/content/docs/anatomy/product-card.mdx
+++ b/apps/docs/content/docs/anatomy/product-card.mdx
@@ -8,7 +8,7 @@ Used in the home featured grid, collection (PLP) and search grids, the related-p
 
 ## Composition
 
-`ProductCard` is a server component that wraps the product in a `Link` to `/products/[handle]` (appending `?variant=` when a default variant id is known). Each part — image container, image, content, title, price, optional badge — exposes a `data-slot` attribute (`product-card`, `product-card-image`, etc.) as a stable styling hook.
+`ProductCard` is a server component that wraps the product in a `Link` to `/products/[handle]`. The link omits `?variant=` so prefetches dedupe to one entry per route rather than one per variant; the PDP resolves the first purchasable variant on arrival. Each part — image container, image, content, title, price, optional badge — exposes a `data-slot` attribute (`product-card`, `product-card-image`, etc.) as a stable styling hook.
 
 ## Variants
 

--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -114,12 +114,8 @@ function ClientProductCard({
   locale: string;
   outOfStockText: string;
 }) {
-  const href = product.defaultVariantNumericId
-    ? `/products/${product.handle}?variant=${product.defaultVariantNumericId}`
-    : `/products/${product.handle}`;
-
   return (
-    <Link href={href}>
+    <Link href={`/products/${product.handle}`}>
       <ProductCardRoot>
         <ProductCardImageContainer>
           <ProductCardImage

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -39,14 +39,7 @@ export async function ProductCard({
   const t = isFeatured ? await getTranslations("product") : null;
 
   return (
-    <Link
-      href={
-        product.defaultVariantNumericId
-          ? `/products/${product.handle}?variant=${product.defaultVariantNumericId}`
-          : `/products/${product.handle}`
-      }
-      className={className}
-    >
+    <Link href={`/products/${product.handle}`} className={className}>
       <ProductCardRoot variant={variant}>
         {isFeatured && t && (
           <ProductCardBadge>

--- a/apps/template/lib/product.ts
+++ b/apps/template/lib/product.ts
@@ -51,8 +51,10 @@ export function computeInitialSelectedOptions(
 }
 
 export function getInitialSelectedOptions(variants: ProductVariant[]): SelectedOptions {
+  // Prefer the first purchasable variant so a bare PDP URL opens on a buyable option.
+  const defaultVariant = variants.find((v) => v.availableForSale) ?? variants[0];
   const initial: SelectedOptions = {};
-  for (const option of variants[0]?.selectedOptions ?? []) {
+  for (const option of defaultVariant?.selectedOptions ?? []) {
     initial[option.name] = option.value;
   }
   return initial;

--- a/packages/plugin/template-rollout-log/2026-06-09-product-card-clean-href-prefetch-cardinality.md
+++ b/packages/plugin/template-rollout-log/2026-06-09-product-card-clean-href-prefetch-cardinality.md
@@ -1,0 +1,48 @@
+---
+title: Product cards link to clean /products/[handle] (no ?variant=)
+changeKey: product-card-clean-href-prefetch-cardinality
+introducedOn: 2026-06-09
+changeType: fix
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/components/collections/infinite-product-grid.tsx
+  - apps/template/components/product-card/product-card.tsx
+  - apps/template/lib/product.ts
+---
+
+## Summary
+
+Product cards linked to `/products/[handle]?variant=<defaultVariantNumericId>`, giving every card a distinct href. Combined with the PDP's `unstable_instant` prefetch and the newly-enabled `partialPrefetching`, prefetches key by full URL, so a grid generates one prefetch entry per card instead of collapsing to one shared `/products/[handle]` shell — prefetch-cache cardinality scales with variants, not routes.
+
+Cards now link to the clean `/products/[handle]`. The `?variant=` was only there to open the PDP on the first *purchasable* variant; that responsibility moves to the PDP itself: `getInitialSelectedOptions` (`lib/product.ts`) now defaults to the first `availableForSale` variant (falling back to `variants[0]`) when no `?variant=` is present.
+
+## Why it matters
+
+The variant in the card href served one purpose — landing on a buyable option when `variants[0]` is sold out. Pushing that default into the PDP keeps that behavior, lets prefetches dedupe by route, and also fixes a latent bug: a bare `/products/[handle]` URL (shared link, sitemap, direct nav) previously opened on `variants[0]` even when sold out, and now opens on the first purchasable variant.
+
+The on-PDP picker is unchanged — option selection still navigates to `?variant=` URLs via `getVariantUrl()`.
+
+> Note: the prefetch-cardinality mechanism is inferred from how `unstable_instant` + `partialPrefetching` + per-URL prefetch keys compose, not confirmed against the Next.js canary internals. The href and default-selection changes are correct regardless; the cardinality win is the motivating hypothesis.
+
+## Apply when
+
+- Product cards link with a `?variant=` query (the as-shipped `ProductCard` / `infinite-product-grid` behavior).
+- The storefront uses instant/partial prefetching on the PDP and wants prefetch entries to dedupe per route.
+
+## Safe to skip when
+
+- Cards already link to clean handles, or the storefront deliberately deep-links cards to a specific variant.
+- The PDP's no-param default has been customized away from "first variant".
+
+## Validation
+
+1. `pnpm --filter template dev`.
+2. From a collection/home grid, confirm card links are `/products/[handle]` with no query string.
+3. Open a product whose first variant is out of stock from a card and confirm the PDP still lands on a purchasable variant (not the sold-out `variants[0]`).
+4. Confirm the on-PDP option picker still updates the `?variant=` URL and streams the affected slots.
+
+## Follow-up
+
+`defaultVariantId`, `defaultVariantNumericId`, and `defaultVariantSelectedOptions` on the `ProductCard` type are no longer read after this change (still computed in `lib/shopify/transforms/product.ts`). Left in place as reference-type surface; prune if your fork doesn't use them.


### PR DESCRIPTION
## Summary

Product cards linked to `/products/[handle]?variant=<defaultVariantNumericId>`, giving every card a **distinct href**. Combined with the PDP's `unstable_instant` prefetch and the newly-enabled `partialPrefetching` (#322), prefetches key by full URL — so a collection/home/search grid generates **one prefetch entry per card** instead of collapsing to the shared `/products/[handle]` shell. Prefetch-cache cardinality scaled with variants, not routes.

This PR makes cards link to the clean `/products/[handle]`. The `?variant=` only existed to open the PDP on the first *purchasable* variant, so that responsibility moves into the PDP: `getInitialSelectedOptions` now defaults to the first `availableForSale` variant (fallback `variants[0]`) when no `?variant=` is present.

Changed both card call sites: `components/product-card/product-card.tsx` and `components/collections/infinite-product-grid.tsx`.

## Why

- The variant in the card href served one purpose — landing on a buyable option when `variants[0]` is sold out. Pushing the default into the PDP preserves that, lets prefetches dedupe by route, and **also fixes a latent bug**: a bare `/products/[handle]` URL (shared link, sitemap, direct nav) previously opened on `variants[0]` even when sold out.
- The on-PDP option picker is unchanged — selection still navigates to `?variant=` URLs via `getVariantUrl()`.

## Honesty / confidence

The href and default-selection changes are correct **regardless**. The prefetch-cardinality win is the *motivating hypothesis*: it's inferred from how `unstable_instant` + `partialPrefetching` + per-URL prefetch keys compose, **not** confirmed against Next.js canary internals or observed network traffic. Worth verifying empirically (watch prefetch requests on a grid / check route cardinality in Observability) before treating the perf claim as proven.

## Notes

- `defaultVariantId` / `defaultVariantNumericId` / `defaultVariantSelectedOptions` on the `ProductCard` type are no longer read (still computed in `lib/shopify/transforms/product.ts`). Left as reference-type surface; prune if a fork doesn't use them.
- Docs updated (`anatomy/product-card.mdx`) + rollout-log entry added.

## Test plan

- [ ] `pnpm --filter template dev`; confirm grid card links are `/products/[handle]` with no query string.
- [ ] Open a product whose first variant is out of stock from a card → PDP lands on a purchasable variant, not sold-out `variants[0]`.
- [ ] On-PDP option picker still updates `?variant=` and streams the affected slots.
- [ ] (Optional) Observe prefetch requests on a grid to confirm the cardinality reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)