### PR TITLE
[template] drop unstable_instant/unstable_prefetch route configs

### DIFF
--- a/apps/docs/content/docs/skills/enable-i18n.mdx
+++ b/apps/docs/content/docs/skills/enable-i18n.mdx
@@ -59,65 +59,13 @@ next-intl docs sometimes show `setRequestLocale(locale)` calls in layouts/pages.
 
 ### C. Don't swap `next/link` to next-intl's `<Link>`
 
-The straightforward instinct is to replace every `import Link from "next/link"` with `import { Link } from "@/lib/i18n/navigation"`. **Don't.** next-intl's Link reads request context (locale) on render; in a server-component tree under cacheComponents, that triggers:
-
-```
-Error: Route "/[locale]/..." accessed [...] which is not defined in the `samples` of `unstable_instant`.
-```
-
-or a generic "blocking route" prerender failure.
+The straightforward instinct is to replace every `import Link from "next/link"` with `import { Link } from "@/lib/i18n/navigation"`. **Don't.** next-intl's Link reads request context (locale) on render; in a server-component tree under cacheComponents, that triggers a "blocking route" prerender failure — the route tries to read request data while being statically prerendered.
 
 **Do this instead:** keep `next/link` and let `proxy.ts` middleware redirect unprefixed paths (`/products/foo` → `/en-US/products/foo`). Internal links work; there's a one-time middleware redirect on click for unprefixed hrefs. Trade a few redirects for a clean prerender.
 
 If you must locale-prefix a programmatic URL (server actions, `redirect()`, `permanentRedirect()`), build the path yourself: `` `/${await getLocale()}/account/login` ``.
 
-### D. `unstable_instant` samples need `locale` in `params`
-
-Any route that exports `unstable_instant` (currently: products `[handle]`, collections `[handle]`, search) needs `locale` added to every sample, or the build fails:
-
-```
-Error: Route "/[locale]/products/[handle]" accessed root param "locale"
-       which is not defined in the `samples` of `unstable_instant`.
-```
-
-Fix:
-
-```ts
-export const unstable_instant = {
-  samples: [
-    {
-      params: { locale: "en-US", handle: "__placeholder__" }, // ← add locale
-      searchParams: { variant: "1" },
-      cookies: [{ name: "shopify_cartId", value: null }],
-    },
-  ],
-};
-```
-
-### E. `unstable_instant` samples need `headers` declarations if any layout-level server component reads `headers()`
-
-This is easy to forget. If you (or a downstream skill) adds a server component to the layout that calls `headers()` — e.g. a "Shipping to {postal}" bar reading `x-vercel-ip-postal-code` — every `unstable_instant` sample in the app must declare the headers it might access:
-
-```ts
-samples: [
-  {
-    params: { locale: "en-US", handle: "__placeholder__" },
-    searchParams: { variant: "1" },
-    cookies: [{ name: "shopify_cartId", value: null }],
-    headers: [["x-vercel-ip-postal-code", null]], // ← add this
-  },
-],
-```
-
-`null` means "header may be absent." If you forget, the build error is explicit:
-
-```
-Error: Route "..." accessed header "x-vercel-ip-postal-code" which is not
-       defined in the `samples` of `unstable_instant`. Add it to the
-       sample's `headers` array, or `["...", null]` if it should be absent.
-```
-
-### F. `redirect()` from next-intl doesn't return `never`
+### D. `redirect()` from next-intl doesn't return `never`
 
 ```ts
 // BREAKS: TS doesn't narrow `session` after redirect
@@ -210,9 +158,8 @@ const messageLoaders: Record<string, () => Promise<{ default: typeof enMessages 
 // We intentionally do NOT destructure `{ locale }` from the callback args.
 // next-intl populates that arg from the `x-next-intl-locale` request header,
 // and reading request headers from inside a cached tree forces the route
-// dynamic — every `unstable_instant` sample then needs an explicit
-// `headers: [["x-next-intl-locale", null]]` declaration. Going straight to
-// `getLocale()` (which reads `next/root-params`) keeps the lookup cacheable.
+// dynamic, defeating the cache. Going straight to `getLocale()` (which reads
+// `next/root-params`) keeps the lookup cacheable.
 export default getRequestConfig(async () => {
   const requested = await getLocale();
   const locale = hasLocale(routing.locales, requested) ? requested : routing.defaultLocale;
@@ -334,23 +281,7 @@ export const generateStaticParams = async () => {
 };
 ```
 
-### Step 12: Patch `unstable_instant` samples
-
-Walk every route file that exports `unstable_instant` and add `locale` to each sample's `params`:
-
-```ts
-params: { locale: "en-US", handle: "__placeholder__" }
-```
-
-If any layout-level server component (e.g. a shipping/postal banner, geo-aware nav) reads `headers()`, also add a `headers` array to every sample:
-
-```ts
-headers: [["x-vercel-ip-postal-code", null]];
-```
-
-(See "Cache Components compatibility D/E" at the top.)
-
-### Step 13: (Conditional) Re-enable `LocaleCurrencySelector` in the megamenu
+### Step 12: (Conditional) Re-enable `LocaleCurrencySelector` in the megamenu
 
 Only if the `enable-shopify-menus` skill has already been run and `components/nav/megamenu/index.tsx` exists. The selector component lives at `components/nav/locale-currency.tsx` (with a fallback at `locale-currency-fallback.tsx`). Wire it into both `MegamenuDesktop` and `MegamenuMobile` per the original instructions.
 

--- a/apps/template/app/collections/[handle]/page.tsx
+++ b/apps/template/app/collections/[handle]/page.tsx
@@ -83,10 +83,6 @@ export async function generateMetadata({
   };
 }
 
-export const unstable_instant = true;
-
-export const unstable_prefetch = "force-runtime";
-
 export default async function CollectionPage({
   params,
   searchParams,

--- a/apps/template/app/collections/all/page.tsx
+++ b/apps/template/app/collections/all/page.tsx
@@ -37,10 +37,6 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export const unstable_instant = true;
-
-export const unstable_prefetch = "force-runtime";
-
 // Storefront `search()` only supports RELEVANCE and PRICE sort keys.
 const ALL_PRODUCTS_SORT_EXCLUDE = [
   "best-selling",

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -73,8 +73,6 @@ export async function generateMetadata({
   return buildProductMetadata(handle, locale, `/products/${handle}`);
 }
 
-export const unstable_instant = true;
-
 export default async function ProductPage({
   params,
   searchParams,

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -64,10 +64,6 @@ export async function generateMetadata({ searchParams }: PageProps<"/search">): 
   };
 }
 
-export const unstable_instant = true;
-
-export const unstable_prefetch = "force-runtime";
-
 export default async function SearchPage({ searchParams }: PageProps<"/search">) {
   const [locale, t] = await Promise.all([getLocale(), getTranslations("search")]);
 

--- a/packages/plugin/skills/enable-i18n/SKILL.md
+++ b/packages/plugin/skills/enable-i18n/SKILL.md
@@ -54,65 +54,13 @@ next-intl docs sometimes show `setRequestLocale(locale)` calls in layouts/pages.
 
 ### C. Don't swap `next/link` to next-intl's `<Link>`
 
-The straightforward instinct is to replace every `import Link from "next/link"` with `import { Link } from "@/lib/i18n/navigation"`. **Don't.** next-intl's Link reads request context (locale) on render; in a server-component tree under cacheComponents, that triggers:
-
-```
-Error: Route "/[locale]/..." accessed [...] which is not defined in the `samples` of `unstable_instant`.
-```
-
-or a generic "blocking route" prerender failure.
+The straightforward instinct is to replace every `import Link from "next/link"` with `import { Link } from "@/lib/i18n/navigation"`. **Don't.** next-intl's Link reads request context (locale) on render; in a server-component tree under cacheComponents, that triggers a "blocking route" prerender failure — the route tries to read request data while being statically prerendered.
 
 **Do this instead:** keep `next/link` and let `proxy.ts` middleware redirect unprefixed paths (`/products/foo` → `/en-US/products/foo`). Internal links work; there's a one-time middleware redirect on click for unprefixed hrefs. Trade a few redirects for a clean prerender.
 
 If you must locale-prefix a programmatic URL (server actions, `redirect()`, `permanentRedirect()`), build the path yourself: `` `/${await getLocale()}/account/login` ``.
 
-### D. `unstable_instant` samples need `locale` in `params`
-
-Any route that exports `unstable_instant` (currently: products `[handle]`, collections `[handle]`, search) needs `locale` added to every sample, or the build fails:
-
-```
-Error: Route "/[locale]/products/[handle]" accessed root param "locale"
-       which is not defined in the `samples` of `unstable_instant`.
-```
-
-Fix:
-
-```ts
-export const unstable_instant = {
-  samples: [
-    {
-      params: { locale: "en-US", handle: "__placeholder__" }, // ← add locale
-      searchParams: { variant: "1" },
-      cookies: [{ name: "shopify_cartId", value: null }],
-    },
-  ],
-};
-```
-
-### E. `unstable_instant` samples need `headers` declarations if any layout-level server component reads `headers()`
-
-This is easy to forget. If you (or a downstream skill) adds a server component to the layout that calls `headers()` — e.g. a "Shipping to {postal}" bar reading `x-vercel-ip-postal-code` — every `unstable_instant` sample in the app must declare the headers it might access:
-
-```ts
-samples: [
-  {
-    params: { locale: "en-US", handle: "__placeholder__" },
-    searchParams: { variant: "1" },
-    cookies: [{ name: "shopify_cartId", value: null }],
-    headers: [["x-vercel-ip-postal-code", null]], // ← add this
-  },
-],
-```
-
-`null` means "header may be absent." If you forget, the build error is explicit:
-
-```
-Error: Route "..." accessed header "x-vercel-ip-postal-code" which is not
-       defined in the `samples` of `unstable_instant`. Add it to the
-       sample's `headers` array, or `["...", null]` if it should be absent.
-```
-
-### F. `redirect()` from next-intl doesn't return `never`
+### D. `redirect()` from next-intl doesn't return `never`
 
 ```ts
 // BREAKS: TS doesn't narrow `session` after redirect
@@ -205,9 +153,8 @@ const messageLoaders: Record<string, () => Promise<{ default: typeof enMessages 
 // We intentionally do NOT destructure `{ locale }` from the callback args.
 // next-intl populates that arg from the `x-next-intl-locale` request header,
 // and reading request headers from inside a cached tree forces the route
-// dynamic — every `unstable_instant` sample then needs an explicit
-// `headers: [["x-next-intl-locale", null]]` declaration. Going straight to
-// `getLocale()` (which reads `next/root-params`) keeps the lookup cacheable.
+// dynamic, defeating the cache. Going straight to `getLocale()` (which reads
+// `next/root-params`) keeps the lookup cacheable.
 export default getRequestConfig(async () => {
   const requested = await getLocale();
   const locale = hasLocale(routing.locales, requested) ? requested : routing.defaultLocale;
@@ -329,23 +276,7 @@ export const generateStaticParams = async () => {
 };
 ```
 
-### Step 12: Patch `unstable_instant` samples
-
-Walk every route file that exports `unstable_instant` and add `locale` to each sample's `params`:
-
-```ts
-params: { locale: "en-US", handle: "__placeholder__" }
-```
-
-If any layout-level server component (e.g. a shipping/postal banner, geo-aware nav) reads `headers()`, also add a `headers` array to every sample:
-
-```ts
-headers: [["x-vercel-ip-postal-code", null]]
-```
-
-(See "Cache Components compatibility D/E" at the top.)
-
-### Step 13: (Conditional) Re-enable `LocaleCurrencySelector` in the megamenu
+### Step 12: (Conditional) Re-enable `LocaleCurrencySelector` in the megamenu
 
 Only if the `enable-shopify-menus` skill has already been run and `components/nav/megamenu/index.tsx` exists. The selector component lives at `components/nav/locale-currency.tsx` (with a fallback at `locale-currency-fallback.tsx`). Wire it into both `MegamenuDesktop` and `MegamenuMobile` per the original instructions.
 

--- a/packages/plugin/template-rollout-log/2026-06-09-remove-runtime-prefetch-opt-ins.md
+++ b/packages/plugin/template-rollout-log/2026-06-09-remove-runtime-prefetch-opt-ins.md
@@ -1,0 +1,51 @@
+---
+title: Remove runtime-prefetch opt-ins (unstable_instant / unstable_prefetch)
+changeKey: remove-runtime-prefetch-opt-ins
+introducedOn: 2026-06-09
+changeType: refactor
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/app/products/[handle]/page.tsx
+  - apps/template/app/search/page.tsx
+  - apps/template/app/collections/all/page.tsx
+  - apps/template/app/collections/[handle]/page.tsx
+relatedSkills:
+  - /vercel-shop:enable-i18n
+---
+
+## Summary
+
+Removes the route-level runtime-prefetch opt-ins from the PDP, search, and both collection routes:
+
+- `unstable_instant = true` — PDP, search, collections (all + `[handle]`)
+- `unstable_prefetch = "force-runtime"` — search, collections (all + `[handle]`)
+
+`partialPrefetching: true` and `experimental.appShells` in `next.config.ts` are unchanged, so `<Link>` still prefetches each route's static shell. What goes away is the per-link runtime server request that warmed dynamic (session/cookie-dependent) content ahead of navigation.
+
+## Why it matters
+
+- `force-runtime` / `unstable_instant` issue a runtime server request per prefetched link. On dense link surfaces (product grids), that multiplies prefetch traffic.
+- Without them, navigation still paints the static shell instantly, but dynamic holes stream in after navigation (Suspense fallbacks reappear briefly) instead of being pre-warmed.
+- This is the trade-off downstream stores should make consciously: fewer prefetch server requests vs. zero-fallback navigation on dynamic routes.
+
+## Apply when
+
+- Prefetch/runtime cost from runtime prefetching outweighs the perceived-instant benefit.
+- The store's PDP/collection/search content is mostly cacheable, so the static shell already covers the visible area.
+
+## Safe to skip when
+
+- The store deliberately wants fallback-free navigation on these dynamic routes and accepts the per-link runtime prefetch cost.
+
+## Validation
+
+1. `pnpm --filter template build && pnpm --filter template start` (automatic prefetch is production-only).
+2. Navigate to PDP / collection / search from in-viewport links; confirm the static shell paints instantly and dynamic content streams in.
+3. `pnpm --filter template lint` clean.
+
+## See also
+
+- `next-canary-12-instant-validation-default` (2026-05-06) — introduced the `unstable_instant` default this entry removes.
+- `skeleton-fallback-color` (2026-06-09) — skeleton/fallback appearance, more visible now that dynamic holes stream again.


### PR DESCRIPTION
## Summary

Removes the runtime-prefetch opt-ins from the four routes that carried them, and updates the docs/skills that referenced them.

**Route configs removed:**
- `app/search/page.tsx` — `unstable_instant`, `unstable_prefetch`
- `app/collections/all/page.tsx` — `unstable_instant`, `unstable_prefetch`
- `app/collections/[handle]/page.tsx` — `unstable_instant`, `unstable_prefetch`
- `app/products/[handle]/page.tsx` — `unstable_instant`

These routes revert to **default partial prefetching** (shell-only). `partialPrefetching: true` and `experimental.appShells` in `next.config.ts` are untouched, so links still prefetch the static shell — but dynamic holes will stream after navigation again instead of being warmed by a runtime server request at prefetch time.

**Docs/skills updated:**
- `packages/plugin/skills/enable-i18n/SKILL.md` — dropped the obsolete `unstable_instant`-sample guidance (cache-components sections D/E and Step 12), re-lettered notes A–D, renumbered steps 1–12, fixed the Step 4 request-config comment.
- `apps/docs/content/docs/skills/enable-i18n.mdx` — synced via `apps/docs/scripts/sync-skills.ts`.
- `packages/plugin/template-rollout-log/2026-06-09-remove-runtime-prefetch-opt-ins.md` — new append-only entry so downstream storefronts can decide whether to drop the opt-ins too. Historical rollout-log entries left as-is.

## Behavioral impact

- Navigation to these routes paints the static shell instantly, then shows Suspense fallbacks for dynamic content until it streams (previously warmed ahead of time).
- Removes the per-link runtime prefetch server requests these configs triggered.

## Verification

- `pnpm --filter template lint` clean (oxlint + oxfmt).
- No remaining `unstable_instant` / `unstable_prefetch` references in `apps/template`, the skill, or the synced docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)