### PR TITLE
Upgrade Next.js to 16.3.0-canary.47; migrate stabilized instant/prefetch route config

### DIFF
--- a/apps/docs/content/docs/skills/enable-i18n.mdx
+++ b/apps/docs/content/docs/skills/enable-i18n.mdx
@@ -62,7 +62,7 @@ next-intl docs sometimes show `setRequestLocale(locale)` calls in layouts/pages.
 The straightforward instinct is to replace every `import Link from "next/link"` with `import { Link } from "@/lib/i18n/navigation"`. **Don't.** next-intl's Link reads request context (locale) on render; in a server-component tree under cacheComponents, that triggers:
 
 ```
-Error: Route "/[locale]/..." accessed [...] which is not defined in the `samples` of `unstable_instant`.
+Error: Route "/[locale]/..." accessed [...] which is not defined in the `unstable_samples` of `instant`.
 ```
 
 or a generic "blocking route" prerender failure.
@@ -71,20 +71,20 @@ or a generic "blocking route" prerender failure.
 
 If you must locale-prefix a programmatic URL (server actions, `redirect()`, `permanentRedirect()`), build the path yourself: `` `/${await getLocale()}/account/login` ``.
 
-### D. `unstable_instant` samples need `locale` in `params`
+### D. `instant` samples need `locale` in `params`
 
-Any route that exports `unstable_instant` (currently: products `[handle]`, collections `[handle]`, search) needs `locale` added to every sample, or the build fails:
+Any route that exports `instant` (currently: products `[handle]`, collections `[handle]`, search) needs `locale` added to every sample, or the build fails:
 
 ```
 Error: Route "/[locale]/products/[handle]" accessed root param "locale"
-       which is not defined in the `samples` of `unstable_instant`.
+       which is not defined in the `unstable_samples` of `instant`.
 ```
 
 Fix:
 
 ```ts
-export const unstable_instant = {
-  samples: [
+export const instant = {
+  unstable_samples: [
     {
       params: { locale: "en-US", handle: "__placeholder__" }, // ← add locale
       searchParams: { variant: "1" },
@@ -94,12 +94,12 @@ export const unstable_instant = {
 };
 ```
 
-### E. `unstable_instant` samples need `headers` declarations if any layout-level server component reads `headers()`
+### E. `instant` samples need `headers` declarations if any layout-level server component reads `headers()`
 
-This is easy to forget. If you (or a downstream skill) adds a server component to the layout that calls `headers()` — e.g. a "Shipping to {postal}" bar reading `x-vercel-ip-postal-code` — every `unstable_instant` sample in the app must declare the headers it might access:
+This is easy to forget. If you (or a downstream skill) adds a server component to the layout that calls `headers()` — e.g. a "Shipping to {postal}" bar reading `x-vercel-ip-postal-code` — every `instant` sample in the app must declare the headers it might access:
 
 ```ts
-samples: [
+unstable_samples: [
   {
     params: { locale: "en-US", handle: "__placeholder__" },
     searchParams: { variant: "1" },
@@ -113,7 +113,7 @@ samples: [
 
 ```
 Error: Route "..." accessed header "x-vercel-ip-postal-code" which is not
-       defined in the `samples` of `unstable_instant`. Add it to the
+       defined in the `unstable_samples` of `instant`. Add it to the
        sample's `headers` array, or `["...", null]` if it should be absent.
 ```
 
@@ -210,7 +210,7 @@ const messageLoaders: Record<string, () => Promise<{ default: typeof enMessages 
 // We intentionally do NOT destructure `{ locale }` from the callback args.
 // next-intl populates that arg from the `x-next-intl-locale` request header,
 // and reading request headers from inside a cached tree forces the route
-// dynamic — every `unstable_instant` sample then needs an explicit
+// dynamic — every `instant` sample then needs an explicit
 // `headers: [["x-next-intl-locale", null]]` declaration. Going straight to
 // `getLocale()` (which reads `next/root-params`) keeps the lookup cacheable.
 export default getRequestConfig(async () => {
@@ -334,9 +334,9 @@ export const generateStaticParams = async () => {
 };
 ```
 
-### Step 12: Patch `unstable_instant` samples
+### Step 12: Patch `instant` samples
 
-Walk every route file that exports `unstable_instant` and add `locale` to each sample's `params`:
+Walk every route file that exports `instant` and add `locale` to each sample's `params`:
 
 ```ts
 params: { locale: "en-US", handle: "__placeholder__" }
@@ -345,7 +345,7 @@ params: { locale: "en-US", handle: "__placeholder__" }
 If any layout-level server component (e.g. a shipping/postal banner, geo-aware nav) reads `headers()`, also add a `headers` array to every sample:
 
 ```ts
-headers: [["x-vercel-ip-postal-code", null]];
+headers: [["x-vercel-ip-postal-code", null]]
 ```
 
 (See "Cache Components compatibility D/E" at the top.)

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -37,7 +37,7 @@
     "lucide-react": "1.17.0",
     "motion": "12.40.0",
     "nanoid": "5.1.11",
-    "next": "16.3.0-canary.46",
+    "next": "16.3.0-canary.47",
     "next-mdx-remote": "6.0.0",
     "next-themes": "0.4.6",
     "oxfmt": "0.53.0",

--- a/apps/template/app/collections/[handle]/page.tsx
+++ b/apps/template/app/collections/[handle]/page.tsx
@@ -83,9 +83,9 @@ export async function generateMetadata({
   };
 }
 
-export const unstable_instant = true;
+export const instant = true;
 
-export const unstable_prefetch = "force-runtime";
+export const prefetch = "allow-runtime";
 
 export default async function CollectionPage({
   params,

--- a/apps/template/app/collections/all/page.tsx
+++ b/apps/template/app/collections/all/page.tsx
@@ -37,9 +37,9 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export const unstable_instant = true;
+export const instant = true;
 
-export const unstable_prefetch = "force-runtime";
+export const prefetch = "allow-runtime";
 
 // Storefront `search()` only supports RELEVANCE and PRICE sort keys.
 const ALL_PRODUCTS_SORT_EXCLUDE = [

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -73,7 +73,7 @@ export async function generateMetadata({
   return buildProductMetadata(handle, locale, `/products/${handle}`);
 }
 
-export const unstable_instant = true;
+export const instant = true;
 
 export default async function ProductPage({
   params,

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -64,9 +64,9 @@ export async function generateMetadata({ searchParams }: PageProps<"/search">): 
   };
 }
 
-export const unstable_instant = true;
+export const instant = true;
 
-export const unstable_prefetch = "force-runtime";
+export const prefetch = "allow-runtime";
 
 export default async function SearchPage({ searchParams }: PageProps<"/search">) {
   const [locale, t] = await Promise.all([getLocale(), getTranslations("search")]);

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -29,7 +29,6 @@ if (process.env.NEXT_PUBLIC_ENABLE_AUTH === "1") {
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
-    appShells: true,
     inlineCss: true,
     turbopackFileSystemCacheForDev: true,
   },

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -29,7 +29,7 @@
     "cmdk": "1.1.1",
     "lucide-react": "1.17.0",
     "nanoid": "5.1.11",
-    "next": "16.3.0-canary.46",
+    "next": "16.3.0-canary.47",
     "next-intl": "4.13.0",
     "oxfmt": "0.53.0",
     "oxlint": "1.68.0",

--- a/packages/plugin/skills/enable-i18n/SKILL.md
+++ b/packages/plugin/skills/enable-i18n/SKILL.md
@@ -57,7 +57,7 @@ next-intl docs sometimes show `setRequestLocale(locale)` calls in layouts/pages.
 The straightforward instinct is to replace every `import Link from "next/link"` with `import { Link } from "@/lib/i18n/navigation"`. **Don't.** next-intl's Link reads request context (locale) on render; in a server-component tree under cacheComponents, that triggers:
 
 ```
-Error: Route "/[locale]/..." accessed [...] which is not defined in the `samples` of `unstable_instant`.
+Error: Route "/[locale]/..." accessed [...] which is not defined in the `unstable_samples` of `instant`.
 ```
 
 or a generic "blocking route" prerender failure.
@@ -66,20 +66,20 @@ or a generic "blocking route" prerender failure.
 
 If you must locale-prefix a programmatic URL (server actions, `redirect()`, `permanentRedirect()`), build the path yourself: `` `/${await getLocale()}/account/login` ``.
 
-### D. `unstable_instant` samples need `locale` in `params`
+### D. `instant` samples need `locale` in `params`
 
-Any route that exports `unstable_instant` (currently: products `[handle]`, collections `[handle]`, search) needs `locale` added to every sample, or the build fails:
+Any route that exports `instant` (currently: products `[handle]`, collections `[handle]`, search) needs `locale` added to every sample, or the build fails:
 
 ```
 Error: Route "/[locale]/products/[handle]" accessed root param "locale"
-       which is not defined in the `samples` of `unstable_instant`.
+       which is not defined in the `unstable_samples` of `instant`.
 ```
 
 Fix:
 
 ```ts
-export const unstable_instant = {
-  samples: [
+export const instant = {
+  unstable_samples: [
     {
       params: { locale: "en-US", handle: "__placeholder__" }, // ← add locale
       searchParams: { variant: "1" },
@@ -89,12 +89,12 @@ export const unstable_instant = {
 };
 ```
 
-### E. `unstable_instant` samples need `headers` declarations if any layout-level server component reads `headers()`
+### E. `instant` samples need `headers` declarations if any layout-level server component reads `headers()`
 
-This is easy to forget. If you (or a downstream skill) adds a server component to the layout that calls `headers()` — e.g. a "Shipping to {postal}" bar reading `x-vercel-ip-postal-code` — every `unstable_instant` sample in the app must declare the headers it might access:
+This is easy to forget. If you (or a downstream skill) adds a server component to the layout that calls `headers()` — e.g. a "Shipping to {postal}" bar reading `x-vercel-ip-postal-code` — every `instant` sample in the app must declare the headers it might access:
 
 ```ts
-samples: [
+unstable_samples: [
   {
     params: { locale: "en-US", handle: "__placeholder__" },
     searchParams: { variant: "1" },
@@ -108,7 +108,7 @@ samples: [
 
 ```
 Error: Route "..." accessed header "x-vercel-ip-postal-code" which is not
-       defined in the `samples` of `unstable_instant`. Add it to the
+       defined in the `unstable_samples` of `instant`. Add it to the
        sample's `headers` array, or `["...", null]` if it should be absent.
 ```
 
@@ -205,7 +205,7 @@ const messageLoaders: Record<string, () => Promise<{ default: typeof enMessages 
 // We intentionally do NOT destructure `{ locale }` from the callback args.
 // next-intl populates that arg from the `x-next-intl-locale` request header,
 // and reading request headers from inside a cached tree forces the route
-// dynamic — every `unstable_instant` sample then needs an explicit
+// dynamic — every `instant` sample then needs an explicit
 // `headers: [["x-next-intl-locale", null]]` declaration. Going straight to
 // `getLocale()` (which reads `next/root-params`) keeps the lookup cacheable.
 export default getRequestConfig(async () => {
@@ -329,9 +329,9 @@ export const generateStaticParams = async () => {
 };
 ```
 
-### Step 12: Patch `unstable_instant` samples
+### Step 12: Patch `instant` samples
 
-Walk every route file that exports `unstable_instant` and add `locale` to each sample's `params`:
+Walk every route file that exports `instant` and add `locale` to each sample's `params`:
 
 ```ts
 params: { locale: "en-US", handle: "__placeholder__" }

--- a/packages/plugin/template-rollout-log/2026-06-09-next-canary-47-instant-prefetch-stable.md
+++ b/packages/plugin/template-rollout-log/2026-06-09-next-canary-47-instant-prefetch-stable.md
@@ -1,0 +1,46 @@
+---
+title: Next 16.3.0-canary.47 — stabilize instant/prefetch route config, drop explicit appShells
+changeKey: next-canary-47-instant-prefetch-stable
+introducedInVersion: 0.1.0
+introducedOn: 2026-06-09
+changeType: dependency
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/next.config.ts
+  - apps/template/app/products/[handle]/page.tsx
+  - apps/template/app/search/page.tsx
+  - apps/template/app/collections/[handle]/page.tsx
+  - apps/template/app/collections/all/page.tsx
+relatedSkills:
+  - /vercel-shop:enable-i18n
+---
+
+## Summary
+
+Bumped `next` from `16.3.0-canary.46` to `16.3.0-canary.47` and migrated the route segment config APIs that canary.47 stabilized/renamed:
+
+- `export const unstable_instant = true` → `export const instant = true`
+- `export const unstable_prefetch = "force-runtime"` → `export const prefetch = "allow-runtime"`
+- Removed `experimental.appShells: true` from `next.config.ts` — App Shells is now enabled by default whenever `cacheComponents` is on, so the explicit flag is redundant.
+
+The object form of the instant config also renamed its build-validation samples property: `instant = { samples: [...] }` → `instant = { unstable_samples: [...] }`. The template uses the boolean form, so only the `enable-i18n` skill (which uses the object form) was affected.
+
+## Why it matters
+
+The old export names and the `force-runtime` value are no longer recognized in canary.47 — Next reads only `instant`, `prefetch`/`allow-runtime`, and `instant.unstable_samples`. Leaving the old names in place silently drops the instant/prefetch route configuration (the validation and runtime prefetching stop applying) rather than erroring, so the regression is easy to miss.
+
+## Apply when
+
+The downstream storefront is upgrading `next` to `16.3.0-canary.47` or later and copied any of the affected route segment exports or the `appShells` config.
+
+## Safe to skip when
+
+Still pinned to `16.3.0-canary.46` or earlier — the old names are required there. Adopt this only together with the Next upgrade.
+
+## Validation
+
+- `pnpm build` in `apps/template` compiles with no warnings about `instant`, `prefetch`, or `appShells`.
+- `grep -rn "unstable_instant\|unstable_prefetch\|force-runtime" app/` returns nothing.
+- Collection, product, and search routes still report Partial Prerender (◐) in the build route table.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,10 +55,10 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0-canary.46(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.1(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.0-canary.46(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.0(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.197
         version: 6.0.197(zod@4.4.3)
@@ -82,10 +82,10 @@ importers:
         version: 5.2.1
       fromsrc:
         specifier: 0.0.31
-        version: 0.0.31(@types/react@19.2.17)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.0.31(@types/react@19.2.17)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       geist:
         specifier: 1.7.2
-        version: 1.7.2(next@16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 1.7.2(next@16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       jotai:
         specifier: 2.20.0
         version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.7)
@@ -99,8 +99,8 @@ importers:
         specifier: 5.1.11
         version: 5.1.11
       next:
-        specifier: 16.3.0-canary.46
-        version: 16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 16.3.0-canary.47
+        version: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-mdx-remote:
         specifier: 6.0.0
         version: 6.0.0(@types/react@19.2.17)(react@19.2.7)
@@ -187,10 +187,10 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0-canary.46(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.1(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.0-canary.46(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.0(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.197
         version: 6.0.197(zod@4.4.3)
@@ -199,7 +199,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.6.14
-        version: 1.6.14(@opentelemetry/api@1.9.0)(next@16.3.0-canary.46(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
+        version: 1.6.14(@opentelemetry/api@1.9.0)(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -216,11 +216,11 @@ importers:
         specifier: 5.1.11
         version: 5.1.11
       next:
-        specifier: 16.3.0-canary.46
-        version: 16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 16.3.0-canary.47
+        version: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: 4.13.0
-        version: 4.13.0(next@16.3.0-canary.46(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 4.13.0(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       oxfmt:
         specifier: 0.53.0
         version: 0.53.0
@@ -775,57 +775,57 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@next/env@16.3.0-canary.46':
-    resolution: {integrity: sha512-4v/ZFlxfe6e7lTjIby2RGXXwK15Yhu5hgnLuDYil/EgFiMkhiFcfS0HeuwqksfLip76Rfhnz+juXa65JXjGd0w==}
+  '@next/env@16.3.0-canary.47':
+    resolution: {integrity: sha512-3JAlQVYzN0OADXTHttDbX3QFIXVAnfuNmkx4s6bzoeBhqJan8UlX1oHbOtwWS4ZnMzBIn1wYMQRhO/bZdRbpmg==}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.46':
-    resolution: {integrity: sha512-7oLPqoUSq1ppj1tczv6NeMhLioYgiZMKxZf753vRHAo/R5+vDqxhcBkp+NFKZxIlR7QLtCGpR0vjWaYSj4LEKQ==}
+  '@next/swc-darwin-arm64@16.3.0-canary.47':
+    resolution: {integrity: sha512-w3+zOP74ByaD1eJ+ikJSUc3oIMUeyGI39Xzglfuih1PI9K25ZNh2OGz549ZywLbZQRWLuLB9gQ7hK1Da5wvOKA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.3.0-canary.46':
-    resolution: {integrity: sha512-IMmu6f8x6LtO66F+B7Cl8E7IxRy0++3J0gKIHjB9Y+3mJi0c/p2F976X8Ng1ez+iMzlV5C0xy1QIYzHrpyE2eA==}
+  '@next/swc-darwin-x64@16.3.0-canary.47':
+    resolution: {integrity: sha512-PqcvORPTeT6U8nYuFRLta5E75+qUzZ39r6FI3xu8jeWwTmKEUfSacRq1vC6YIjMBQLx/Y9GKV6R+xnPovwM80A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.46':
-    resolution: {integrity: sha512-jVAHJ1uc0sMDlgdGUdWiUBdMNK8KWVXmYCugf2OmtVLdG6SaoWWCuYtmFqQK6AJemORKT61VnlxO/IfGscw9GQ==}
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.47':
+    resolution: {integrity: sha512-KWwCeDsuzuB7pmif7BJ4SNwoHH96UnIVyy7A0ui06cSq7k/fr2Ep7Lb4Zp7PT4HSmC2GA+0frRdg0ibw4rE28Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.46':
-    resolution: {integrity: sha512-INhYDUTLLAYsfVge6yDbfUQWpy6GFGbMGbIVvHBTgs3HKY2WrxgNxvKitC54gUlicZUlsbTkOm75zMHyjbObFg==}
+  '@next/swc-linux-arm64-musl@16.3.0-canary.47':
+    resolution: {integrity: sha512-WMB8D44BTewt4xV//3C1oCb2akadNppRJmC4TF0X66FVVn+BB/I3KjAOTciZui402KQoHes1nfH/Ixp1Xmartw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.46':
-    resolution: {integrity: sha512-dw5m7kvSodjk3fhVgKSDNo4q3nGphTlJxsHAsqOPugjbPV0Q1JwdvFriy5W8TRJu7LqLN9hYrUrwUJ05f/4qTg==}
+  '@next/swc-linux-x64-gnu@16.3.0-canary.47':
+    resolution: {integrity: sha512-g1OPPuukkAbmAtveUnK9VbHy8UWu/xZ0B0tkp21k9NtQ0SbWD9IBY/1yKQ2M1GWeynDKEX9Q/uOfOTN9z5dwcg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.46':
-    resolution: {integrity: sha512-hiGW1CuBLBX5rpPeOMPjt6SghyqgRvUi2giLUMPYiR1hAyXLyJVD1rApQgNdcvxbVkWBzzbG2GQMiR93+3tsUw==}
+  '@next/swc-linux-x64-musl@16.3.0-canary.47':
+    resolution: {integrity: sha512-ZpA9WmHfLaMsbOa0EbQbd3Mtmu9Jm2vwLGLPuVn6ML+R9jw2UhMtrd43SoDQFUszAQtkk/uhFJqzHoh2AmXs+w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.46':
-    resolution: {integrity: sha512-wZfwMEpjSGUndfx6wcU7YBNZ3n54pjvuVK9pRSsU5zqnoBtWVM+gvYtfWW+s72Gm7bQx+nhH1U98RzcJdmLIQQ==}
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.47':
+    resolution: {integrity: sha512-BpvF6JJUcUtnttcydmJCjwq/jmEFODn39drU1yR77C+LUkMGXQi/usVqnZdBrTJfSrLfOC4/QydDrngB4fuxCA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.46':
-    resolution: {integrity: sha512-1uy7sZMHjn/yiGNwG8v/h9ky6cDGniKllvVbq/cW1vY/nUNEt7S6tE0zCyyIHUINZXO0AfS+hDMv1enUjZC8WA==}
+  '@next/swc-win32-x64-msvc@16.3.0-canary.47':
+    resolution: {integrity: sha512-86hTuZxlNj9hcikeO1RtddZan7/1pbjTuZPl9ZhyNiIc9qdvy95pi0Mj/MLW4kU+PboW7pyxlNU9CVgKMzT4dA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3580,8 +3580,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.3.0-canary.46:
-    resolution: {integrity: sha512-ViIUEZSTq6ZXGI6KHPoS6Rpux6kxaQ1tXZj6M1xHcikn+0RqnlKCyVryWtdHBccShoHnQYVMbSqwdzxsyqcmnQ==}
+  next@16.3.0-canary.47:
+    resolution: {integrity: sha512-/eFNin0/SVyWxUHnWrxhEApWAH6FcGpcZTOZ5V6rfCXlFe6Cy6dNV9Zgd3Ju8dJYl5q1CirxILYbIq4nIJVBog==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4885,30 +4885,30 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@next/env@16.3.0-canary.46': {}
+  '@next/env@16.3.0-canary.47': {}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.46':
+  '@next/swc-darwin-arm64@16.3.0-canary.47':
     optional: true
 
-  '@next/swc-darwin-x64@16.3.0-canary.46':
+  '@next/swc-darwin-x64@16.3.0-canary.47':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.46':
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.47':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.46':
+  '@next/swc-linux-arm64-musl@16.3.0-canary.47':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.46':
+  '@next/swc-linux-x64-gnu@16.3.0-canary.47':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.46':
+  '@next/swc-linux-x64-musl@16.3.0-canary.47':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.46':
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.47':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.46':
+  '@next/swc-win32-x64-msvc@16.3.0-canary.47':
     optional: true
 
   '@noble/ciphers@2.2.0': {}
@@ -6253,17 +6253,17 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(next@16.3.0-canary.46(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       vue: 3.5.30(typescript@6.0.3)
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.46(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       vue: 3.5.30(typescript@6.0.3)
 
@@ -6370,7 +6370,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.7: {}
 
-  better-auth@1.6.14(@opentelemetry/api@1.9.0)(next@16.3.0-canary.46(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3)):
+  better-auth@1.6.14(@opentelemetry/api@1.9.0)(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3)):
     dependencies:
       '@better-auth/core': 1.6.14(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.14(@better-auth/core@1.6.14(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
@@ -6390,7 +6390,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      next: 16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       vue: 3.5.30(typescript@6.0.3)
@@ -6855,13 +6855,13 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  fromsrc@0.0.31(@types/react@19.2.17)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  fromsrc@0.0.31(@types/react@19.2.17)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@shikijs/rehype': 3.23.0
       '@shikijs/transformers': 3.23.0
       gray-matter: 4.0.3
-      next: 16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-mdx-remote: 6.0.0(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       remark-gfm: 4.0.1
@@ -6887,9 +6887,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
-  geist@1.7.2(next@16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
+  geist@1.7.2(next@16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
     dependencies:
-      next: 16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   gensync@1.0.0-beta.2:
     optional: true
@@ -7771,14 +7771,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.0: {}
 
-  next-intl@4.13.0(next@16.3.0-canary.46(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
+  next-intl@4.13.0(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.18
       icu-minify: 4.13.0
       negotiator: 1.0.0
-      next: 16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl-swc-plugin-extractor: 4.13.0
       po-parser: 2.1.1
       react: 19.2.7
@@ -7807,9 +7807,9 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@16.3.0-canary.46(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 16.3.0-canary.46
+      '@next/env': 16.3.0-canary.47
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.7
       caniuse-lite: 1.0.30001778
@@ -7818,14 +7818,14 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.3.0-canary.46
-      '@next/swc-darwin-x64': 16.3.0-canary.46
-      '@next/swc-linux-arm64-gnu': 16.3.0-canary.46
-      '@next/swc-linux-arm64-musl': 16.3.0-canary.46
-      '@next/swc-linux-x64-gnu': 16.3.0-canary.46
-      '@next/swc-linux-x64-musl': 16.3.0-canary.46
-      '@next/swc-win32-arm64-msvc': 16.3.0-canary.46
-      '@next/swc-win32-x64-msvc': 16.3.0-canary.46
+      '@next/swc-darwin-arm64': 16.3.0-canary.47
+      '@next/swc-darwin-x64': 16.3.0-canary.47
+      '@next/swc-linux-arm64-gnu': 16.3.0-canary.47
+      '@next/swc-linux-arm64-musl': 16.3.0-canary.47
+      '@next/swc-linux-x64-gnu': 16.3.0-canary.47
+      '@next/swc-linux-x64-musl': 16.3.0-canary.47
+      '@next/swc-win32-arm64-msvc': 16.3.0-canary.47
+      '@next/swc-win32-x64-msvc': 16.3.0-canary.47
       '@opentelemetry/api': 1.9.0
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5


### PR DESCRIPTION
## Summary

Upgrades `next` from `16.3.0-canary.46` → `16.3.0-canary.47` and migrates the route segment config APIs that canary.47 stabilized/renamed. Each rename was verified against the installed build (`node_modules/next/dist`), not from memory.

| Old | New | Where |
|-----|-----|-------|
| `export const unstable_instant = true` | `export const instant = true` | products, search, collections/[handle], collections/all |
| `export const unstable_prefetch = "force-runtime"` | `export const prefetch = "allow-runtime"` | search, collections/[handle], collections/all |
| `experimental.appShells: true` | _removed_ — now default-on with `cacheComponents` | `next.config.ts` |

The old export names and the `force-runtime` value are **no longer recognized** in canary.47 (Next reads only `instant`, `prefetch=allow-runtime`, and `instant.unstable_samples`). Leaving them in place would *silently drop* the route config rather than error, so the regression would be easy to miss.

### Docs / downstream
- Updated the `enable-i18n` skill — it uses the object form, whose build-validation property also renamed `samples` → `unstable_samples` (confirmed in `instant-config.js`). Synced the docs `.mdx` via `apps/docs/scripts/sync-skills.ts`.
- Added a `template-rollout-log` entry so downstream storefronts can adopt this alongside their own Next upgrade.

### Note on `appShells`
Explicit `appShells: true` now triggers strict validation (E1279) requiring `varyParams`/`optimisticRouting`/`cachedNavigations`. Those default to `true`, so it wouldn't have errored — but dropping the redundant flag keeps the config correct even if `cacheComponents` is later disabled.

## Test plan
- [x] `pnpm build` (apps/template) compiles clean — no `instant`/`prefetch`/`appShells` warnings
- [x] Collection, product, and search routes still report Partial Prerender (◐) in the route table
- [x] `pnpm lint` passes (oxlint + oxfmt)
- [x] `grep` confirms no `unstable_instant` / `unstable_prefetch` / `force-runtime` left in source (only append-only rollout-log history retains them)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)