### PR TITLE
[template] home: source products grid from full catalog

### DIFF
--- a/apps/docs/components/fake-browser/home-browser.tsx
+++ b/apps/docs/components/fake-browser/home-browser.tsx
@@ -31,7 +31,7 @@ export const HomeBrowser = () => (
         </div>
       </div>
 
-      {/* Featured products carousel */}
+      {/* Products grid */}
       <DynamicBoundary label="Products" className="mb-3">
         <div className="mb-2 h-3 w-28 rounded bg-black/10 dark:bg-white/10" />
         <div className="grid grid-cols-5 gap-2">

--- a/apps/docs/content/docs/anatomy/pages/home.mdx
+++ b/apps/docs/content/docs/anatomy/pages/home.mdx
@@ -1,18 +1,18 @@
 ---
 title: Home
-description: The storefront landing page - hero, featured products, and promotional content.
+description: The storefront landing page - hero, products, and promotional content.
 type: guide
 ---
 
 <HomeBrowser />
 
-The home page is a server component that renders a hero banner and a featured products grid. Product data is fetched server-side from Shopify.
+The home page is a server component that renders a hero banner and a products grid. Product data is fetched server-side from Shopify.
 
 ## Hero section
 
 A full-width banner with a background image or autoplaying background video, gradient overlay, headline, subheadline, and a CTA link. On mobile, the hero height comes from its vertical padding; on medium screens and up, it keeps a wide `3 / 1` aspect ratio.
 
-By default, when no `backgroundImage` or `backgroundVideo` is provided, the hero renders with no background — the headline and subheadline use `text-foreground` and the CTA uses the default (primary) button variant, so the banner blends into the page above the featured products grid. When media is present, the banner switches to a dark `bg-foreground` container with the existing gradient overlay, white text, and a light CTA so the copy stays legible against the image or video. To add a background image, pass a `backgroundImage` prop — either a static import (`import myHero from "@/public/my-hero.jpg"`), which enables automatic blur placeholders and prevents layout shift, or a remote URL object (`{ url: "https://...", alt: "..." }`).
+By default, when no `backgroundImage` or `backgroundVideo` is provided, the hero renders with no background — the headline and subheadline use `text-foreground` and the CTA uses the default (primary) button variant, so the banner blends into the page above the products grid. When media is present, the banner switches to a dark `bg-foreground` container with the existing gradient overlay, white text, and a light CTA so the copy stays legible against the image or video. To add a background image, pass a `backgroundImage` prop — either a static import (`import myHero from "@/public/my-hero.jpg"`), which enables automatic blur placeholders and prevents layout shift, or a remote URL object (`{ url: "https://...", alt: "..." }`).
 
 To use a video hero, pass `backgroundVideo: { url: "https://...", previewImage: { url: "https://...", alt: "..." } }`. Videos use the shared `AutoPlayVideo` component, so they autoplay when visible and pause when off-screen. When both `backgroundVideo` and `backgroundImage` are present, the video is used.
 
@@ -20,9 +20,9 @@ The headline and CTA are configurable through the `BannerSection` component's `h
 
 On mobile, the subheadline and CTA text are hidden to keep the banner compact.
 
-## Featured products grid
+## Products grid
 
-A responsive grid showing up to 8 products fetched via `getProducts()`. The grid uses the `ProductsGrid` component with a section title and a link to the full catalog. Each item is a [product card](/docs/anatomy/product-card) with:
+A responsive grid showing the top 8 products fetched via `getCatalogProducts()`. The grid uses the `ProductsGrid` component with a section title and a link to the full catalog. Each item is a [product card](/docs/anatomy/product-card) with:
 
 - Featured image, with a muted title-text fallback when the product has no image
 - Out-of-stock overlay when unavailable
@@ -32,7 +32,7 @@ The grid is responsive: 2 columns on mobile, 3 on tablet, 4 on desktop. A `Produ
 
 ## Data fetching
 
-Products are fetched server-side with `getCollectionProducts({ collection: "frontpage", limit: 8, locale })`, which pulls from Shopify's default `frontpage` collection so merchants can curate the home page from the Shopify admin. The result is cached with `cacheLife("max")` and product- and collection-level cache tags for granular revalidation. To feature a different collection, change `collectionHandle` (and `collectionUrl`) on the `FeaturedProducts` call in `app/page.tsx`.
+Products are fetched server-side with `getCatalogProducts({ limit: 8, locale })`, which pulls the top products across the entire catalog (best-selling order) rather than a curated collection. The result is cached with `cacheLife("max")` and product-level cache tags for granular revalidation. The section heading and its "view all" link are set by the `title` and `collectionUrl` props on the `ProductsGrid` call in `app/page.tsx`, which point at `/collections/all` by default.
 
 ## Key files
 

--- a/apps/docs/content/docs/reference/routes.mdx
+++ b/apps/docs/content/docs/reference/routes.mdx
@@ -8,7 +8,7 @@ type: reference
 
 | Route                   | File                                | Description                                                                                        |
 | ----------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `/`                     | `app/page.tsx`                      | Home page with hero, featured products, info section                                               |
+| `/`                     | `app/page.tsx`                      | Home page with hero, products grid, info section                                                   |
 | `/products/[handle]`    | `app/products/[handle]/page.tsx`    | Product detail page; `?variant=` selects a specific variant                                        |
 | `/collections/[handle]` | `app/collections/[handle]/page.tsx` | Collection listing with filters, sort, pagination                                                  |
 | `/collections/all`      | `app/collections/[handle]/page.tsx` | Virtual "All Products" listing; synthesized since Shopify's Storefront API has no `all` collection |

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
-import { FeaturedProducts } from "@/components/product/products-grid";
+import { ProductsGrid } from "@/components/product/products-grid";
 import { BannerSection } from "@/components/sections/banner-section";
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
@@ -46,12 +46,11 @@ export default async function HomePage() {
         />
 
         <Container>
-          <FeaturedProducts
-            title="Featured Products"
+          <ProductsGrid
+            title="Products"
             limit={8}
             locale={locale}
-            collectionHandle="frontpage"
-            collectionUrl="/collections/frontpage"
+            collectionUrl="/collections/all"
           />
         </Container>
       </Sections>

--- a/apps/template/components/product/products-grid.tsx
+++ b/apps/template/components/product/products-grid.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 
 import { ProductCard, ProductCardSkeleton } from "@/components/product-card/product-card";
 import type { Locale } from "@/lib/i18n";
-import { getCollectionProducts } from "@/lib/shopify/operations/products";
+import { getCatalogProducts } from "@/lib/shopify/operations/products";
 import { cn } from "@/lib/utils";
 
 interface ProductsGridSkeletonProps {
@@ -22,21 +22,14 @@ export function ProductsGridSkeleton({ count, className }: ProductsGridSkeletonP
   );
 }
 
-interface FeaturedProductsProps {
-  title: string;
+interface ProductsGridProps {
+  collectionUrl?: string;
   limit: number;
   locale: Locale;
-  collectionHandle: string;
-  collectionUrl?: string;
+  title: string;
 }
 
-export async function FeaturedProducts({
-  title,
-  limit,
-  locale,
-  collectionHandle,
-  collectionUrl,
-}: FeaturedProductsProps) {
+export async function ProductsGrid({ collectionUrl, limit, locale, title }: ProductsGridProps) {
   const t = await getTranslations("product");
 
   return (
@@ -53,33 +46,22 @@ export async function FeaturedProducts({
         )}
       </div>
       <Suspense fallback={<ProductsGridSkeleton count={limit} />}>
-        <FeaturedProductsGrid
-          collectionHandle={collectionHandle}
-          limit={limit}
-          locale={locale}
-          outOfStockText={t("outOfStock")}
-        />
+        <ProductsGridContent limit={limit} locale={locale} outOfStockText={t("outOfStock")} />
       </Suspense>
     </div>
   );
 }
 
-async function FeaturedProductsGrid({
-  collectionHandle,
+async function ProductsGridContent({
   limit,
   locale,
   outOfStockText,
 }: {
-  collectionHandle: string;
   limit: number;
   locale: Locale;
   outOfStockText: string;
 }) {
-  const { products } = await getCollectionProducts({
-    collection: collectionHandle,
-    limit,
-    locale,
-  });
+  const { products } = await getCatalogProducts({ limit, locale });
 
   if (products.length === 0) return null;
 

--- a/packages/plugin/template-rollout-log/2026-06-10-home-products-all-catalog.md
+++ b/packages/plugin/template-rollout-log/2026-06-10-home-products-all-catalog.md
@@ -1,0 +1,54 @@
+---
+title: Home grid — source top catalog products instead of the frontpage collection
+changeKey: home-products-all-catalog
+introducedOn: 2026-06-10
+changeType: refactor
+defaultAction: review
+appliesTo:
+  - apps/template/app/page.tsx
+  - apps/template/components/product/products-grid.tsx
+  - apps/docs/content/docs/anatomy/pages/home.mdx
+  - apps/docs/content/docs/reference/routes.mdx
+paths:
+  - apps/template/app/page.tsx
+  - apps/template/components/product/products-grid.tsx
+  - apps/docs/content/docs/anatomy/pages/home.mdx
+  - apps/docs/content/docs/reference/routes.mdx
+  - apps/docs/components/fake-browser/home-browser.tsx
+---
+
+## Summary
+
+The home page product section previously read from Shopify's curated `frontpage` collection via `getCollectionProducts({ collection: "frontpage", limit: 8 })`, titled itself "Featured Products", and linked to `/collections/frontpage`. It now shows the top 8 products across the whole catalog, titled simply "Products", linking to `/collections/all`.
+
+- `app/page.tsx`: the section is titled `"Products"` and its `collectionUrl` points at `/collections/all`. The `collectionHandle="frontpage"` prop is gone.
+- `components/product/products-grid.tsx`: the exported `FeaturedProducts` component is renamed `ProductsGrid` (aligning the code with the name the docs already used) and now fetches through `getCatalogProducts({ limit, locale })` rather than `getCollectionProducts`. The `collectionHandle` prop is dropped; `title`, `limit`, `locale`, and optional `collectionUrl` remain. The shared `ProductsGridSkeleton` export is unchanged (still used by search and collections).
+- With no query, `getCatalogProducts` resolves to `BEST_SELLING` order, so "top 8" means the eight best-selling products.
+- Docs (`home.mdx`, `routes.mdx`) and the `HomeBrowser` doc mock are updated to match.
+
+## Why it matters
+
+- A fresh Shopify store has no `frontpage` collection populated by default, so the old home grid rendered empty until a merchant curated that collection. Sourcing from the full catalog gives every store a populated home page out of the box.
+- The home grid and its "view all" link now point at the same place (`/collections/all`), so the section's data and its destination agree.
+
+## Apply when
+
+- The storefront has not deliberately curated its home page from the Shopify `frontpage` collection and wants the home grid populated from the catalog.
+- The storefront wants the home grid, its heading, and its "view all" link to all reference the full catalog.
+
+## Safe to skip when
+
+- The storefront intentionally curates the home page via the `frontpage` collection in the Shopify admin. Keep `getCollectionProducts({ collection: "frontpage" })` and the `/collections/frontpage` link in that case.
+- The storefront has its own merchandising rules for the home grid order (e.g. manual or seasonal) that `BEST_SELLING` would override.
+
+## Notes
+
+- Downstream code importing `FeaturedProducts` from `@/components/product/products-grid` must switch to `ProductsGrid` and drop the `collectionHandle` prop. `ProductsGridSkeleton` is unaffected.
+- The `frontpage` collection is still fully supported by the data layer — this only changes the home page default. A storefront can pass any handle back through `getCollectionProducts` in a local `ProductsGrid` variant if it wants curation.
+
+## Validation
+
+1. `pnpm --filter template dev`.
+2. Home page: the section heading reads "Products", shows up to 8 product cards, and the "View All" link navigates to `/collections/all`.
+3. Confirm the grid populates on a store with no curated `frontpage` collection.
+4. `pnpm --filter template lint` — no unused imports left from the dropped `getCollectionProducts` / `collectionHandle` references.


### PR DESCRIPTION
## Summary

- Reworks the home page product section to show the **top 8 products across the whole catalog** (`getCatalogProducts`, best-selling order) instead of the curated `frontpage` collection — so a fresh Shopify store gets a populated home page out of the box.
- Renames the `FeaturedProducts` component to `ProductsGrid` (the name the docs already used), drops the now-unused `collectionHandle` prop, and retitles the section **"Products"**.
- Points the section's "view all" link at `/collections/all`, matching its data source.
- Updates the docs (`anatomy/pages/home.mdx`, `reference/routes.mdx`, `HomeBrowser` mock) and adds a `template-rollout-log` entry (`defaultAction: review` — storefronts that intentionally curate `frontpage` should skip).

The shared `ProductsGridSkeleton` export (used by search + collections) is unchanged. The `frontpage` path remains fully supported in the data layer; this only changes the home page default.

## Test plan

- [ ] Home page section heading reads "Products" and renders up to 8 product cards
- [ ] "View All" link navigates to `/collections/all`
- [ ] Grid populates on a store with no curated `frontpage` collection
- [ ] `pnpm --filter template lint` and `tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)