### PR TITLE
chore: fix oxfmt formatting drift

### DIFF
--- a/apps/docs/content/docs/skills/enable-i18n.mdx
+++ b/apps/docs/content/docs/skills/enable-i18n.mdx
@@ -345,7 +345,7 @@ params: { locale: "en-US", handle: "__placeholder__" }
 If any layout-level server component (e.g. a shipping/postal banner, geo-aware nav) reads `headers()`, also add a `headers` array to every sample:
 
 ```ts
-headers: [["x-vercel-ip-postal-code", null]]
+headers: [["x-vercel-ip-postal-code", null]];
 ```
 
 (See "Cache Components compatibility D/E" at the top.)


### PR DESCRIPTION
Runs `pnpm format` across the template and docs apps so `main` passes `oxfmt --check` cleanly. Only one file had drifted: `apps/docs/content/docs/skills/enable-i18n.mdx`.

Landing this first keeps formatting churn out of feature PRs (notably the multi-variant PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)