### PR TITLE
[template] prefetch full content from product cards and menu links

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -37,7 +37,7 @@
     "lucide-react": "1.17.0",
     "motion": "12.40.0",
     "nanoid": "5.1.11",
-    "next": "16.3.0-canary.47",
+    "next": "16.3.0-canary.48",
     "next-mdx-remote": "6.0.0",
     "next-themes": "0.4.6",
     "oxfmt": "0.53.0",

--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -119,7 +119,7 @@ function ClientProductCard({
     : `/products/${product.handle}`;
 
   return (
-    <Link href={href}>
+    <Link href={href} prefetch={true}>
       <ProductCardRoot>
         <ProductCardImageContainer>
           <ProductCardImage

--- a/apps/template/components/footer/index.tsx
+++ b/apps/template/components/footer/index.tsx
@@ -44,7 +44,7 @@ function MenuLink({ url, children, className }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className}>
+    <Link href={url} className={className} prefetch={true}>
       {children}
     </Link>
   );

--- a/apps/template/components/nav/mobile-menu.tsx
+++ b/apps/template/components/nav/mobile-menu.tsx
@@ -36,7 +36,7 @@ function MenuLink({ url, children, className, onClick }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className} onClick={onClick}>
+    <Link href={url} className={className} onClick={onClick} prefetch={true}>
       {children}
     </Link>
   );

--- a/apps/template/components/nav/quick-links.tsx
+++ b/apps/template/components/nav/quick-links.tsx
@@ -21,7 +21,7 @@ function MenuLink({ url, children, className }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className}>
+    <Link href={url} className={className} prefetch={true}>
       {children}
     </Link>
   );

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -46,6 +46,7 @@ export async function ProductCard({
           : `/products/${product.handle}`
       }
       className={className}
+      prefetch={true}
     >
       <ProductCardRoot variant={variant}>
         {isFeatured && t && (

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -29,7 +29,7 @@
     "cmdk": "1.1.1",
     "lucide-react": "1.17.0",
     "nanoid": "5.1.11",
-    "next": "16.3.0-canary.47",
+    "next": "16.3.0-canary.48",
     "next-intl": "4.13.0",
     "oxfmt": "0.53.0",
     "oxlint": "1.68.0",

--- a/packages/plugin/template-rollout-log/2026-06-10-prefetch-product-cards-and-menu-links.md
+++ b/packages/plugin/template-rollout-log/2026-06-10-prefetch-product-cards-and-menu-links.md
@@ -1,0 +1,57 @@
+---
+title: Product cards and menu links — opt into full content prefetch (prefetch={true})
+changeKey: prefetch-product-cards-and-menu-links
+introducedOn: 2026-06-10
+changeType: enhancement
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-card/product-card.tsx
+  - apps/template/components/collections/infinite-product-grid.tsx
+  - apps/template/components/nav/mobile-menu.tsx
+  - apps/template/components/nav/quick-links.tsx
+  - apps/template/components/footer/index.tsx
+relatedSkills: []
+---
+
+## Summary
+
+Add `prefetch={true}` to the `<Link>` in the two product-card components and the three menu-link wrappers:
+
+- `product-card/product-card.tsx` — the server `ProductCard` wrapping link to `/products/[handle]`.
+- `collections/infinite-product-grid.tsx` — the `ClientProductCard` link used in the infinite-scroll collection grid.
+- `nav/quick-links.tsx`, `nav/mobile-menu.tsx`, `footer/index.tsx` — the internal-URL branch of each `MenuLink` wrapper (the external `http` branch still renders a plain `<a>` and is untouched).
+
+With `partialPrefetching: true` on globally (`next.config.ts`), `<Link>` defaults to `prefetch: 'auto'`, which under partial prefetching carries only the per-route App Shell — not the page content. Product-card links target the PDP and menu links target collections, both of which export `prefetch = "allow-runtime"`. `prefetch={true}` opts those in-viewport links into prefetching the destination's runtime content, so the cached product/collection body and resolved metadata arrive before the click instead of after a post-click round-trip.
+
+## Why it matters
+
+- This is the `<Link prefetch>` tuning the `pdp-allow-runtime-prefetch` entry pointed at: `allow-runtime` lets a route *serve* a runtime prefetch, but the link still has to *request* full content. `prefetch={true}` is that request.
+- The destination renders (`getProduct` / collection fetch) are `"use cache"` / `cacheLife("max")`, so each runtime prefetch is a cheap cache hit, and client navigations from grids and nav land on real content + correct title instantly.
+
+## Apply when
+
+- The storefront is on `next@16.3.0-canary.47`+ with `partialPrefetching: true`, and the PDP/collection routes still export `prefetch = "allow-runtime"` (see `pdp-allow-runtime-prefetch`).
+- The product cards and Shopify-menu-driven nav are largely as shipped.
+
+## Safe to skip when
+
+- The storefront wants to minimize runtime-prefetch volume. A dense grid puts many product-card links in the viewport at once; `prefetch={true}` issues one runtime prefetch each. They are cache hits, but it is more prefetch traffic than the `auto` shell-only default. Leave the default (or set `prefetch={false}`) on the highest-fanout grid if prefetch volume is a concern.
+- A menu link points at a route that is not worth prewarming (rarely visited, or uncacheable).
+
+## Notes
+
+- `prefetch` only affects the internal `<Link>` branch of each `MenuLink`; external links are plain anchors and cannot be prefetched.
+- Prefetching is production-only — there is no prefetch traffic in `pnpm dev`. Validate the behavioral win against a production build.
+
+## Validation
+
+1. `pnpm --filter template lint` and `pnpm --filter template build`.
+2. `pnpm --filter template start` (production), then hover/scroll a product grid and the nav menus: the destination prefetches (visible as prefetch requests in the Network panel), and clicking a product card or menu item lands on real content with the correct title, no skeleton flash.
+3. `grep -rn 'prefetch' apps/template/components/{product-card,collections,nav,footer}` → the five links carry `prefetch={true}`.
+
+## See also
+
+- `pdp-allow-runtime-prefetch` (2026-06-10) — added `prefetch = "allow-runtime"` to the PDP and called out `<Link prefetch>` as the per-link tuning knob this change applies.
+- `next-canary-47-instant-prefetch-stable` (2026-06-09) — stabilized the `instant` / `prefetch` route segment config and added `allow-runtime` to collections/search.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,10 +55,10 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.1(next@16.3.0-canary.48(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.0(next@16.3.0-canary.48(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.197
         version: 6.0.197(zod@4.4.3)
@@ -82,10 +82,10 @@ importers:
         version: 5.2.1
       fromsrc:
         specifier: 0.0.31
-        version: 0.0.31(@types/react@19.2.17)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.0.31(@types/react@19.2.17)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       geist:
         specifier: 1.7.2
-        version: 1.7.2(next@16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 1.7.2(next@16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       jotai:
         specifier: 2.20.0
         version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.7)
@@ -99,8 +99,8 @@ importers:
         specifier: 5.1.11
         version: 5.1.11
       next:
-        specifier: 16.3.0-canary.47
-        version: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 16.3.0-canary.48
+        version: 16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-mdx-remote:
         specifier: 6.0.0
         version: 6.0.0(@types/react@19.2.17)(react@19.2.7)
@@ -187,10 +187,10 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.1(next@16.3.0-canary.48(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
+        version: 2.0.0(next@16.3.0-canary.48(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
       ai:
         specifier: 6.0.197
         version: 6.0.197(zod@4.4.3)
@@ -199,7 +199,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.6.14
-        version: 1.6.14(@opentelemetry/api@1.9.0)(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
+        version: 1.6.14(@opentelemetry/api@1.9.0)(next@16.3.0-canary.48(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -216,11 +216,11 @@ importers:
         specifier: 5.1.11
         version: 5.1.11
       next:
-        specifier: 16.3.0-canary.47
-        version: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 16.3.0-canary.48
+        version: 16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: 4.13.0
-        version: 4.13.0(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 4.13.0(next@16.3.0-canary.48(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       oxfmt:
         specifier: 0.53.0
         version: 0.53.0
@@ -775,57 +775,57 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@next/env@16.3.0-canary.47':
-    resolution: {integrity: sha512-3JAlQVYzN0OADXTHttDbX3QFIXVAnfuNmkx4s6bzoeBhqJan8UlX1oHbOtwWS4ZnMzBIn1wYMQRhO/bZdRbpmg==}
+  '@next/env@16.3.0-canary.48':
+    resolution: {integrity: sha512-AWzDxOZSQAG6fIKvP8x4feg1UaT4YRsoheoz0oGxyEynU8Ga7V1NLDfHXubK2Vhn27/63kVo27z0janadFwiHw==}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.47':
-    resolution: {integrity: sha512-w3+zOP74ByaD1eJ+ikJSUc3oIMUeyGI39Xzglfuih1PI9K25ZNh2OGz549ZywLbZQRWLuLB9gQ7hK1Da5wvOKA==}
+  '@next/swc-darwin-arm64@16.3.0-canary.48':
+    resolution: {integrity: sha512-Wr5i5w6dGofG66DxB0eO2+XQyGLiYF4tapaIi9e8YLcK5tEWoybQ16/Vqvu+4c+Ax/2M9Z48B9UDES0keRDo8g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.3.0-canary.47':
-    resolution: {integrity: sha512-PqcvORPTeT6U8nYuFRLta5E75+qUzZ39r6FI3xu8jeWwTmKEUfSacRq1vC6YIjMBQLx/Y9GKV6R+xnPovwM80A==}
+  '@next/swc-darwin-x64@16.3.0-canary.48':
+    resolution: {integrity: sha512-8adaF1TKhRwt5cgjvcVYiaxRtWu0THJNpqzJ1m6pIK9CpylGRbQXXUOMhoKNvC2LDMOQiRWACMbxA60FY9QWsg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.47':
-    resolution: {integrity: sha512-KWwCeDsuzuB7pmif7BJ4SNwoHH96UnIVyy7A0ui06cSq7k/fr2Ep7Lb4Zp7PT4HSmC2GA+0frRdg0ibw4rE28Q==}
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.48':
+    resolution: {integrity: sha512-6j9UvrL+d5brl1EXVWOqE1eWVXhSwuCwKpYzCj5UyeJsiJmjvmi9w8LgAqGKvQ2KJP+Jox5cRwPW1b1ZU4yrCA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.47':
-    resolution: {integrity: sha512-WMB8D44BTewt4xV//3C1oCb2akadNppRJmC4TF0X66FVVn+BB/I3KjAOTciZui402KQoHes1nfH/Ixp1Xmartw==}
+  '@next/swc-linux-arm64-musl@16.3.0-canary.48':
+    resolution: {integrity: sha512-ZAEbRvEwadt+Rvo7ynigbxlmw0whNni3b2vQLdbLexG7LGCEBFDxla+2g4lFRNQl7EgANeh72CK1DcIKfqrfog==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.47':
-    resolution: {integrity: sha512-g1OPPuukkAbmAtveUnK9VbHy8UWu/xZ0B0tkp21k9NtQ0SbWD9IBY/1yKQ2M1GWeynDKEX9Q/uOfOTN9z5dwcg==}
+  '@next/swc-linux-x64-gnu@16.3.0-canary.48':
+    resolution: {integrity: sha512-M7alx5v+0z9AVe2DgoJfzXYYkORq64JMA+flE9aVKbPlGSNFL/N3NXC2xuuwUl1Uvux9jOnAzoylSmQ/UV+jwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.47':
-    resolution: {integrity: sha512-ZpA9WmHfLaMsbOa0EbQbd3Mtmu9Jm2vwLGLPuVn6ML+R9jw2UhMtrd43SoDQFUszAQtkk/uhFJqzHoh2AmXs+w==}
+  '@next/swc-linux-x64-musl@16.3.0-canary.48':
+    resolution: {integrity: sha512-Iyh4ZN6hc4xZDDx0q08veyAJWycB278Igulvb7bRHWIB8OhQxPw3WUXVIOfHkwYWwBUuRCD/kviUz7F8OACxCw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.47':
-    resolution: {integrity: sha512-BpvF6JJUcUtnttcydmJCjwq/jmEFODn39drU1yR77C+LUkMGXQi/usVqnZdBrTJfSrLfOC4/QydDrngB4fuxCA==}
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.48':
+    resolution: {integrity: sha512-EXjPZ2+zbofSRWU55C8rQhuc0zQ9wJG/AAiJky7h6ejxDRp2O4IqI5GNuMwl5x0pvRWUxRkCrhgLEOuTcZHYtQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.47':
-    resolution: {integrity: sha512-86hTuZxlNj9hcikeO1RtddZan7/1pbjTuZPl9ZhyNiIc9qdvy95pi0Mj/MLW4kU+PboW7pyxlNU9CVgKMzT4dA==}
+  '@next/swc-win32-x64-msvc@16.3.0-canary.48':
+    resolution: {integrity: sha512-Dbsyzd5LGib4TDlA2wAhqK8a+HL/Mrg+ZnBPmXH0NfmHYaa4lC8iz2Ck5equ8GoQdGGlAMtIjx2+aUeQIRAkBA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3580,8 +3580,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.3.0-canary.47:
-    resolution: {integrity: sha512-/eFNin0/SVyWxUHnWrxhEApWAH6FcGpcZTOZ5V6rfCXlFe6Cy6dNV9Zgd3Ju8dJYl5q1CirxILYbIq4nIJVBog==}
+  next@16.3.0-canary.48:
+    resolution: {integrity: sha512-Hfg1DGspjUy5UUHKpZpGCaoZLPF2ua9kTvcMPGOdH2Hg+UwTafkBJAKE6lddVbht9bc372+Nn6Qdk7ez9LJl6Q==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4885,30 +4885,30 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@next/env@16.3.0-canary.47': {}
+  '@next/env@16.3.0-canary.48': {}
 
-  '@next/swc-darwin-arm64@16.3.0-canary.47':
+  '@next/swc-darwin-arm64@16.3.0-canary.48':
     optional: true
 
-  '@next/swc-darwin-x64@16.3.0-canary.47':
+  '@next/swc-darwin-x64@16.3.0-canary.48':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.3.0-canary.47':
+  '@next/swc-linux-arm64-gnu@16.3.0-canary.48':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.3.0-canary.47':
+  '@next/swc-linux-arm64-musl@16.3.0-canary.48':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.3.0-canary.47':
+  '@next/swc-linux-x64-gnu@16.3.0-canary.48':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.3.0-canary.47':
+  '@next/swc-linux-x64-musl@16.3.0-canary.48':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.3.0-canary.47':
+  '@next/swc-win32-arm64-msvc@16.3.0-canary.48':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.3.0-canary.47':
+  '@next/swc-win32-x64-msvc@16.3.0-canary.48':
     optional: true
 
   '@noble/ciphers@2.2.0': {}
@@ -6253,17 +6253,17 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(next@16.3.0-canary.48(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       vue: 3.5.30(typescript@6.0.3)
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(next@16.3.0-canary.48(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       vue: 3.5.30(typescript@6.0.3)
 
@@ -6370,7 +6370,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.7: {}
 
-  better-auth@1.6.14(@opentelemetry/api@1.9.0)(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3)):
+  better-auth@1.6.14(@opentelemetry/api@1.9.0)(next@16.3.0-canary.48(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3)):
     dependencies:
       '@better-auth/core': 1.6.14(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.14(@better-auth/core@1.6.14(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
@@ -6390,7 +6390,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       vue: 3.5.30(typescript@6.0.3)
@@ -6855,13 +6855,13 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  fromsrc@0.0.31(@types/react@19.2.17)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  fromsrc@0.0.31(@types/react@19.2.17)(katex@0.16.38)(mermaid@11.13.0)(next@16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@shikijs/rehype': 3.23.0
       '@shikijs/transformers': 3.23.0
       gray-matter: 4.0.3
-      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-mdx-remote: 6.0.0(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       remark-gfm: 4.0.1
@@ -6887,9 +6887,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
-  geist@1.7.2(next@16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
+  geist@1.7.2(next@16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
     dependencies:
-      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   gensync@1.0.0-beta.2:
     optional: true
@@ -7771,14 +7771,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.0: {}
 
-  next-intl@4.13.0(next@16.3.0-canary.47(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
+  next-intl@4.13.0(next@16.3.0-canary.48(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.18
       icu-minify: 4.13.0
       negotiator: 1.0.0
-      next: 16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl-swc-plugin-extractor: 4.13.0
       po-parser: 2.1.1
       react: 19.2.7
@@ -7807,9 +7807,9 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@16.3.0-canary.47(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.3.0-canary.48(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 16.3.0-canary.47
+      '@next/env': 16.3.0-canary.48
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.7
       caniuse-lite: 1.0.30001778
@@ -7818,14 +7818,14 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.3.0-canary.47
-      '@next/swc-darwin-x64': 16.3.0-canary.47
-      '@next/swc-linux-arm64-gnu': 16.3.0-canary.47
-      '@next/swc-linux-arm64-musl': 16.3.0-canary.47
-      '@next/swc-linux-x64-gnu': 16.3.0-canary.47
-      '@next/swc-linux-x64-musl': 16.3.0-canary.47
-      '@next/swc-win32-arm64-msvc': 16.3.0-canary.47
-      '@next/swc-win32-x64-msvc': 16.3.0-canary.47
+      '@next/swc-darwin-arm64': 16.3.0-canary.48
+      '@next/swc-darwin-x64': 16.3.0-canary.48
+      '@next/swc-linux-arm64-gnu': 16.3.0-canary.48
+      '@next/swc-linux-arm64-musl': 16.3.0-canary.48
+      '@next/swc-linux-x64-gnu': 16.3.0-canary.48
+      '@next/swc-linux-x64-musl': 16.3.0-canary.48
+      '@next/swc-win32-arm64-msvc': 16.3.0-canary.48
+      '@next/swc-win32-x64-msvc': 16.3.0-canary.48
       '@opentelemetry/api': 1.9.0
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5


### PR DESCRIPTION
## Summary

Two related changes on this branch:

### 1. Prefetch full content from product cards and menu links

Add `prefetch={true}` to the two product-card links and the internal-URL branch of the three Shopify-menu link wrappers:

- `product-card/product-card.tsx` — server `ProductCard` link to `/products/[handle]`
- `collections/infinite-product-grid.tsx` — `ClientProductCard` link in the infinite-scroll grid
- `nav/quick-links.tsx`, `nav/mobile-menu.tsx`, `footer/index.tsx` — the `<Link>` branch of each `MenuLink` (the external `http` branch stays a plain `<a>`)

With `partialPrefetching: true` on globally, `<Link>` defaults to `prefetch: 'auto'`, which carries only the per-route **App Shell** — not page content. Product cards target the PDP and menu links target collections, both of which already export `prefetch = "allow-runtime"`. `prefetch={true}` opts these in-viewport links into prefetching the destination's **runtime content**, so the cached body and resolved metadata land before the click instead of after a post-click round-trip.

This is the per-link tuning the `pdp-allow-runtime-prefetch` rollout entry pointed at: `allow-runtime` lets a route *serve* a runtime prefetch; `prefetch={true}` is the link *requesting* full content. Destination renders are `"use cache"` / `cacheLife("max")`, so each runtime prefetch is a cheap cache hit. A `template-rollout-log` entry (`defaultAction: review`) documents the change and the trade-off (more prefetch traffic on dense grids) under "Safe to skip when".

### 2. Bump next to 16.3.0-canary.48

Bumps `next` from `16.3.0-canary.47` → `canary.48` in `apps/template` and `apps/docs` (kept in lockstep) plus the lockfile. No code migration: the `instant` / `prefetch` route segment config that stabilized in canary.47 is unchanged in canary.48.

## Test plan

- [x] `pnpm --filter template build` — exit 0; `/products/[handle]`, `/collections/*`, `/search`, and `/` all report Partial Prerender (◐)
- [x] `pnpm --filter template lint` (oxlint + oxfmt) — passes
- [ ] `pnpm --filter template start` (prefetch is production-only): scroll a product grid and open the nav menus → destinations prefetch (visible in the Network panel); clicking a card or menu item lands on real content with the correct title, no skeleton flash
- [ ] Confirm external menu links (absolute `http` URLs) still render as plain anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)