### PR TITLE
[template] test: default to fr-CA market to verify French Shopify content

### DIFF
--- a/apps/template/lib/i18n/index.ts
+++ b/apps/template/lib/i18n/index.ts
@@ -1,11 +1,11 @@
-export const locales = ["en-US"] as const;
+export const locales = ["en-CA", "en-US", "fr-CA"] as const;
 
 export type Locale = (typeof locales)[number];
 
 // Deployment-level locale mode. By default the storefront runs in single-locale
 // mode, but additional locales can be enabled here when the app is ready.
-export const defaultLocale: Locale = "en-US";
-export const enabledLocales: readonly Locale[] = [defaultLocale];
+export const defaultLocale: Locale = "fr-CA";
+export const enabledLocales: readonly Locale[] = ["en-CA", "en-US", "fr-CA"];
 export const localeSwitchingEnabled = enabledLocales.length > 1;
 
 export function isLocale(value: string): value is Locale {
@@ -26,7 +26,9 @@ export function resolveLocale(value: string | null | undefined): Locale {
 }
 
 const localeCurrency: Record<Locale, { currency: string; symbol: string }> = {
+  "en-CA": { currency: "CAD", symbol: "$" },
   "en-US": { currency: "USD", symbol: "$" },
+  "fr-CA": { currency: "CAD", symbol: "$" },
 };
 
 export type LocaleData = {

--- a/apps/template/lib/i18n/request.ts
+++ b/apps/template/lib/i18n/request.ts
@@ -3,8 +3,12 @@ import { getRequestConfig } from "next-intl/server";
 import { defaultLocale, resolveLocale } from ".";
 import type enMessages from "./messages/en.json";
 
+// en-CA and fr-CA reuse the English UI catalog; only Shopify product content
+// is localized (via @inContext) while testing the fr-CA market.
 const messageLoaders = {
+  "en-CA": () => import("./messages/en.json"),
   "en-US": () => import("./messages/en.json"),
+  "fr-CA": () => import("./messages/en.json"),
 } as const;
 
 export default getRequestConfig(async () => {


### PR DESCRIPTION
## Summary

Draft for **testing the French (fr-CA) market** end-to-end against the live Shopify store. Config-only change:

- `lib/i18n/index.ts`: enable `en-CA`, `en-US`, `fr-CA`; flip `defaultLocale` → `fr-CA`; add CAD currency entries for the two CA locales.
- `lib/i18n/request.ts`: add message loaders for `en-CA`/`fr-CA` (both reuse `en.json`).

The Shopify operations already scope every query with `@inContext(country, language)`, so flipping the default locale makes `fr-CA` resolve to `country: CA, language: FR` and pull French product content. **UI chrome stays English** (en-CA/fr-CA reuse `en.json`) — only Shopify-sourced content (titles/descriptions/prices) is localized.

## Verification

Queried the live Storefront API (`@inContext(country: CA, language: FR)` vs `EN`) across a 50-product sample:

- **48 / 50 products** return genuinely French titles/descriptions (e.g. Arceau Lounge Chair → _"Abandonnez-vous au silence. Le fauteuil lounge Arceau…"_).
- **2 products** (Ravello sectional, Meridian coffee table) have no French translation in Shopify and fall back to English — expected Shopify behavior; resolved by adding the translations in Shopify admin, not in code.
- `tsc --noEmit` clean; `oxfmt --check` / `oxlint` clean.

## Not for merge as-is

The template's committed default should remain `en-US`. This branch exists to preview the fr-CA market; revert the default (or gate behind real Markets URL routing via `/vercel-shop:enable-shopify-markets`) before shipping.

## Test plan

- [ ] `pnpm dev`, load a PDP for a translated product (e.g. `/products/vellura-interiors-arceau-lounge-chair-srenit-collection-1f4z`) and confirm the description renders in French.
- [ ] Confirm prices render in CAD.
- [ ] Spot-check an untranslated product falls back to English gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)