### PR TITLE
[template] experiment: supermax cacheLife (all timings infinite) — cache durability test

### DIFF
--- a/apps/template/lib/shopify/operations/collections.ts
+++ b/apps/template/lib/shopify/operations/collections.ts
@@ -46,7 +46,7 @@ export async function getCollections({
   locale = defaultLocale,
 }: { limit?: number; locale?: string } = {}): Promise<Collection[]> {
   "use cache";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("collections");
 
   const country = getCountryCode(locale);
@@ -70,7 +70,7 @@ export async function getCollection({
   locale?: string;
 }): Promise<Collection | undefined> {
   "use cache";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("collections", `collection-${handle}`);
 
   const country = getCountryCode(locale);

--- a/apps/template/lib/shopify/operations/menu.ts
+++ b/apps/template/lib/shopify/operations/menu.ts
@@ -41,7 +41,7 @@ const GET_MENU_QUERY = `
 
 export async function getMenu({ handle }: { handle: string }): Promise<Menu | null> {
   "use cache";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("menus");
 
   const data = await shopifyFetch<ShopifyMenuResponse>({

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -48,7 +48,7 @@ export async function getProduct({
   locale?: string;
 }): Promise<ProductDetails | undefined> {
   "use cache";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("products", `product-${handle}`);
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
@@ -391,7 +391,7 @@ export async function getCatalogProducts(
   params: CatalogProductsParams,
 ): Promise<CatalogProductsResult> {
   "use cache";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("products");
 
   return fetchCatalogProducts(params);
@@ -401,7 +401,7 @@ export async function getFilteredCatalogProducts(
   params: FilteredCatalogProductsParams,
 ): Promise<CatalogProductsResult> {
   "use cache: remote";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("products");
 
   return fetchCatalogProducts(params);
@@ -415,7 +415,7 @@ export async function getSearchFacets(params: {
   query?: string;
 }): Promise<{ filters: Filter[]; priceRange?: PriceRange; total: number }> {
   "use cache: remote";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("products");
 
   const { activeFilters = {}, collection, filters = [], locale = defaultLocale, query } = params;
@@ -465,7 +465,7 @@ export async function searchIndexProducts(params: {
   sortKey?: string;
 }): Promise<{ pageInfo: PageInfo; products: ProductCard[]; total: number }> {
   "use cache: remote";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("products");
 
   const {
@@ -588,7 +588,7 @@ export async function getCollectionProducts(params: {
   products: ProductCard[];
 }> {
   "use cache: remote";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("products", "collections", `collection-${params.collection}`);
 
   const {
@@ -673,7 +673,7 @@ export async function getProductRecommendations({
   locale?: string;
 }): Promise<ProductCard[]> {
   "use cache";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("products", `recommendations-${handle}`);
 
   const country = getCountryCode(locale);
@@ -749,7 +749,7 @@ export async function getProductById({
   locale?: string;
 }): Promise<ProductDetails | undefined> {
   "use cache";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("products");
 
   const country = getCountryCode(locale);
@@ -782,7 +782,7 @@ export async function getProductsByIds({
   locale?: string;
 }): Promise<ProductCard[]> {
   "use cache";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("products");
 
   if (ids.length === 0) {
@@ -815,7 +815,7 @@ export async function getProductsByHandles({
   locale?: string;
 }): Promise<ProductCard[]> {
   "use cache";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag("products");
 
   if (handles.length === 0) {

--- a/apps/template/lib/shopify/operations/sitemap.ts
+++ b/apps/template/lib/shopify/operations/sitemap.ts
@@ -39,7 +39,7 @@ function cacheTagFor(type: ShopifySitemapType): string {
 
 export async function getShopifySitemapPagesCount(type: ShopifySitemapType): Promise<number> {
   "use cache";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag(cacheTagFor(type));
 
   const data = await shopifyFetch<{ sitemap: { pagesCount: { count: number } } }>({
@@ -56,7 +56,7 @@ export async function getShopifySitemapPage(
   page: number,
 ): Promise<{ hasNextPage: boolean; items: SitemapResource[] }> {
   "use cache";
-  cacheLife("max");
+  cacheLife("supermax");
   cacheTag(cacheTagFor(type));
 
   const data = await shopifyFetch<{

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -28,6 +28,14 @@ if (process.env.NEXT_PUBLIC_ENABLE_AUTH === "1") {
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
+  // Experiment: all three timings set to Next's INFINITE_CACHE sentinel (0xfffffffe) to test cache durability.
+  cacheLife: {
+    supermax: {
+      expire: 0xfffffffe,
+      revalidate: 0xfffffffe,
+      stale: 0xfffffffe,
+    },
+  },
   experimental: {
     inlineCss: true,
     turbopackFileSystemCacheForDev: true,


### PR DESCRIPTION
## What

Adds a `supermax` `cacheLife` profile to `apps/template/next.config.ts` with **all three timings set to Next's `INFINITE_CACHE` sentinel** (`0xfffffffe`):

```ts
cacheLife: {
  supermax: { expire: 0xfffffffe, revalidate: 0xfffffffe, stale: 0xfffffffe },
}
```

…and swaps every `cacheLife("max")` (15 call sites across `products.ts`, `collections.ts`, `sitemap.ts`, `menu.ts`) to `cacheLife("supermax")`. The `"use cache"` / `"use cache: remote"` directives are **unchanged** — only the timings move.

`max` caps `expire` at 365 days; `supermax` removes the time ceiling entirely, so nothing should ever revalidate or expire on a timer.

## Why — this is a diagnostic, not a feature

We're chasing: *"a PDP takes a Shopify edit, and a few minutes later the new value is live"* — with **no webhooks configured**, so `revalidateTag` never fires.

If the cache were durable, `supermax` would mean a product edit **never** appears (until a redeploy). So this isolates the question:

- **PDP still updates within minutes** → the cache is **not durable**; plain `use cache` entries live in per-instance Fluid Compute memory and die when the instance recycles. Confirms the real fix is `use cache: remote` for request-time reads (the PDP resolves `getProduct` inside a Suspense boundary, outside the static shell).
- **PDP stops updating (stays frozen until redeploy)** → timings were the lever after all, and the earlier churn came from the `max` profile's `stale`/`expire`, not instance recycling.

## How to observe (on the preview deploy)

1. Note a product's current value (price/title) on its PDP via the preview URL.
2. Edit that product in Shopify admin.
3. **Hard-refresh / `curl`** the PDP repeatedly over ~10–15 min (bypass the client router cache — `stale` is now infinite, so soft navigations won't reflect changes regardless).
4. Don't redeploy during the window (a redeploy resets all caches and invalidates the test).

Expected result, given the diagnosis: it still flips within minutes → not durable.

## Not for merge

Throwaway experiment. No `template-rollout-log` entry or docs update on purpose — downstream storefronts should not adopt this. The real follow-up (if confirmed) is moving PDP-path reads to `use cache: remote`, with either Shopify webhooks (keep `max`) or a time-based profile for freshness.