### PR TITLE
[template] drop prefetch={true} from product-card and nav Links

### DIFF
--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -119,7 +119,7 @@ function ClientProductCard({
     : `/products/${product.handle}`;
 
   return (
-    <Link href={href} prefetch={true}>
+    <Link href={href}>
       <ProductCardRoot>
         <ProductCardImageContainer>
           <ProductCardImage

--- a/apps/template/components/footer/index.tsx
+++ b/apps/template/components/footer/index.tsx
@@ -44,7 +44,7 @@ function MenuLink({ url, children, className }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className} prefetch={true}>
+    <Link href={url} className={className}>
       {children}
     </Link>
   );

--- a/apps/template/components/nav/mobile-menu.tsx
+++ b/apps/template/components/nav/mobile-menu.tsx
@@ -36,7 +36,7 @@ function MenuLink({ url, children, className, onClick }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className} onClick={onClick} prefetch={true}>
+    <Link href={url} className={className} onClick={onClick}>
       {children}
     </Link>
   );

--- a/apps/template/components/nav/quick-links.tsx
+++ b/apps/template/components/nav/quick-links.tsx
@@ -21,7 +21,7 @@ function MenuLink({ url, children, className }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className} prefetch={true}>
+    <Link href={url} className={className}>
       {children}
     </Link>
   );

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -46,7 +46,6 @@ export async function ProductCard({
           : `/products/${product.handle}`
       }
       className={className}
-      prefetch={true}
     >
       <ProductCardRoot variant={variant}>
         {isFeatured && t && (

--- a/packages/plugin/template-rollout-log/2026-06-14-drop-link-prefetch-true.md
+++ b/packages/plugin/template-rollout-log/2026-06-14-drop-link-prefetch-true.md
@@ -1,0 +1,38 @@
+---
+title: Drop prefetch={true} from product-card and nav <Link>s
+changeKey: drop-link-prefetch-true
+introducedOn: 2026-06-14
+changeType: refactor
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/components/footer/index.tsx
+  - apps/template/components/product-card/product-card.tsx
+  - apps/template/components/nav/mobile-menu.tsx
+  - apps/template/components/nav/quick-links.tsx
+  - apps/template/components/collections/infinite-product-grid.tsx
+---
+
+## Summary
+
+Removed `prefetch={true}` from the product-card and navigation `<Link>`s (footer, product card, mobile menu, quick links, infinite product grid). They now use Next's default `<Link>` prefetch (prefetch the static shell on viewport) instead of forcing a full-route prefetch.
+
+## Why it matters
+
+`prefetch={true}` prefetches the **full route** for every such link in the viewport — many product cards plus nav — which means a server render per link for routes that do request-time work (e.g. anything still on `prefetch = "allow-runtime"`). That was added to make client navigations skip the loading fallback.
+
+It's no longer needed for the PDP: now that the product body is rendered into the **static shell** (see [`pdp-product-body-in-static-shell`](./2026-06-14-pdp-product-body-in-static-shell.md)), the default prefetch already pulls the shell — including the title/description/gallery — so client navs land on a populated page without forcing the heavier full-route prefetch and its server-invocation cost.
+
+## Apply when
+
+- You want to cut prefetch server load / cost from grids and nav, and your detail routes render their above-the-fold body into the static shell (so default prefetch is enough).
+
+## Safe to skip when
+
+- Your linked routes defer their main content to request time and you specifically want full-route prefetch so client navs skip the fallback — keep `prefetch={true}` there.
+
+## Validation
+
+1. `pnpm --filter template lint`.
+2. Click through from a grid/nav into a PDP/collection and confirm the navigation still lands on populated content (the static shell), not a skeleton that lingers.


### PR DESCRIPTION
> 🥞 Stacked on #339 (base branch `shopify-reads-remote-cache`). GitHub will retarget this to `main` when #339 merges.

## What

Removes `prefetch={true}` from the product-card and navigation `<Link>`s (footer, product card, mobile menu, quick links, infinite product grid). They now use Next's default `<Link>` prefetch (static shell on viewport) instead of forcing a full-route prefetch.

## Why

`prefetch={true}` prefetches the **full route** for every card/nav target in the viewport — a server render per link for routes that do request-time work. With the PDP product body now rendered into the **static shell** (#339), the default prefetch already pulls a populated shell, so the heavier full-route prefetch isn't needed. Reverts the `prefetch={true}` added for full-content prefetch.

## Test plan

- [x] `pnpm --filter template lint`
- [ ] Click from a grid/nav into a PDP/collection — navigation lands on populated content (the static shell), not a lingering skeleton

🤖 Generated with [Claude Code](https://claude.com/claude-code)