### PR TITLE
[template] PDP: derive static price from price range, not variant prices

### DIFF
--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -148,7 +148,7 @@ async function ProductInfoArea({
 }) {
   const { variants, options, handle, title, featuredImage, descriptionHtml, availableForSale } =
     product;
-  const uniformPrice = hasUniformPricing(variants);
+  const uniformPrice = hasUniformPricing(product.priceRange, product.compareAtPriceRange);
   const uniformStock = hasUniformStock(variants);
   const singleVariant = variants.length === 1;
   const eagerSelection = singleVariant ? computeSelection(product, undefined) : null;
@@ -160,14 +160,12 @@ async function ProductInfoArea({
       <div data-slot="product-info-header">
         <h1 className="font-semibold text-foreground tracking-tight text-3xl">{title}</h1>
         {uniformPrice ? (
-          variants[0] && (
-            <ProductPrice
-              amount={variants[0].price.amount}
-              currencyCode={variants[0].price.currencyCode}
-              compareAtAmount={variants[0].compareAtPrice?.amount}
-              locale={locale}
-            />
-          )
+          <ProductPrice
+            amount={product.priceRange.minVariantPrice.amount}
+            currencyCode={product.priceRange.minVariantPrice.currencyCode}
+            compareAtAmount={product.compareAtPriceRange?.minVariantPrice.amount}
+            locale={locale}
+          />
         ) : (
           <Suspense fallback={<div className="h-6" aria-hidden />}>
             <ResolvedProductPrice selectionPromise={selectionPromise} locale={locale} />

--- a/apps/template/lib/product.ts
+++ b/apps/template/lib/product.ts
@@ -272,15 +272,17 @@ export function getPartitionedImagesForSelectedColor(
 }
 
 /** When true, the price renders without waiting for searchParams to resolve the variant. */
-export function hasUniformPricing(variants: ProductVariant[]): boolean {
-  if (variants.length <= 1) return true;
-  const first = variants[0];
-  return variants.every(
-    (v) =>
-      v.price.amount === first.price.amount &&
-      v.price.currencyCode === first.price.currencyCode &&
-      v.compareAtPrice?.amount === first.compareAtPrice?.amount,
-  );
+export function hasUniformPricing(
+  priceRange: ProductDetails["priceRange"],
+  compareAtPriceRange?: ProductDetails["compareAtPriceRange"],
+): boolean {
+  const { maxVariantPrice, minVariantPrice } = priceRange;
+  const priceUniform =
+    minVariantPrice.amount === maxVariantPrice.amount &&
+    minVariantPrice.currencyCode === maxVariantPrice.currencyCode;
+  if (!priceUniform) return false;
+  if (!compareAtPriceRange) return true;
+  return compareAtPriceRange.minVariantPrice.amount === compareAtPriceRange.maxVariantPrice.amount;
 }
 
 /** When true, buy-button labels can render in the Suspense fallback without variant resolution. */

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -331,6 +331,7 @@ export function transformShopifyProductDetails(product: ShopifyProduct): Product
     category: transformCategory(product.category),
     updatedAt: product.updatedAt,
     priceRange: product.priceRange,
+    compareAtPriceRange: product.compareAtPriceRange ?? undefined,
     currencyCode: product.priceRange.minVariantPrice.currencyCode,
     manufacturerName: product.vendor,
     categoryId: product.category?.id,

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -59,6 +59,10 @@ export interface ProductDetails extends ProductCard {
   category?: Category | null;
   categoryId?: string;
   collectionHandles: string[];
+  compareAtPriceRange?: {
+    maxVariantPrice: Money;
+    minVariantPrice: Money;
+  };
   currencyCode: string;
   description: string;
   descriptionHtml: string;

--- a/packages/plugin/template-rollout-log/2026-06-16-pdp-uniform-price-from-range.md
+++ b/packages/plugin/template-rollout-log/2026-06-16-pdp-uniform-price-from-range.md
@@ -1,0 +1,40 @@
+---
+title: Derive the PDP static price from the product price range, not variant prices
+changeKey: pdp-uniform-price-from-range
+introducedOn: 2026-06-16
+changeType: refactor
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-detail/product-detail-section.tsx
+  - apps/template/lib/product.ts
+  - apps/template/lib/shopify/transforms/product.ts
+  - apps/template/lib/types.ts
+---
+
+## Summary
+
+The PDP renders the price into the static shell (no Suspense, no `?variant=` wait) when every variant shares one price. That uniform-price path no longer reads the `variants` array. `hasUniformPricing()` now takes the product's `priceRange` (and optional `compareAtPriceRange`) and reports uniform when `minVariantPrice === maxVariantPrice`. The static `<ProductPrice>` renders from `product.priceRange.minVariantPrice` and `product.compareAtPriceRange?.minVariantPrice` instead of `variants[0].price` / `variants[0].compareAtPrice`.
+
+Supporting changes: `compareAtPriceRange` (min + max) is now surfaced on the `ProductDetails` domain type and mapped in `transformShopifyProductDetails`. Both `priceRange` and `compareAtPriceRange` were already requested in the product fragment — only the regular `priceRange` was being kept before. The non-uniform path (Suspense → resolved selected variant) is unchanged.
+
+## Why it matters
+
+Decouples the statically-rendered price from having the full variant set loaded. If a storefront moves to a model where variants are fetched lazily or partially (deferred variant loading, paginated variants, a lighter PDP query), `variants[0].price` and a variants `.every()` scan would be wrong or empty, whereas `priceRange` is a product-level field that is always complete. The visible price and strikethrough render identically to before for products fetched with the full variant set.
+
+## Apply when
+
+- Always, for PDP price rendering. It is a behavior-preserving refactor with no UI change for the current full-variant query.
+- Especially relevant before adopting any change that stops loading all variants up front.
+
+## Safe to skip when
+
+- You have diverged the PDP price rendering and no longer rely on `hasUniformPricing` or the static-shell price path.
+
+## Validation
+
+1. `pnpm --filter template lint` and `pnpm --filter template exec tsc --noEmit`.
+2. Single-price product (all variants same price): price renders in the static shell with no layout shift on load and no `?variant=` dependency.
+3. Multi-price product: price still streams in behind its Suspense fallback and updates as `?variant=` changes.
+4. On-sale uniform product: the compare-at strikethrough and discount badge still render; a product with no compare-at shows no strikethrough.


### PR DESCRIPTION
## Summary

On the PDP, the price is rendered into the **static shell** (no Suspense, no `?variant=` wait) when every variant shares one price. That uniform-price path was coupled to having the full `variants` array:

- `hasUniformPricing(variants)` scanned `variants.every(...)` to decide uniformity.
- The static `<ProductPrice>` read `variants[0].price` / `variants[0].compareAtPrice` directly.

Both are wrong (or empty) if variants aren't all loaded. This PR sources the static price from the **product-level price range** instead, which is always complete regardless of how many variants are fetched.

Changes:
- `hasUniformPricing()` now takes `priceRange` (+ optional `compareAtPriceRange`) and reports uniform when `minVariantPrice === maxVariantPrice` (and compare-at min === max).
- Static `<ProductPrice>` renders from `product.priceRange.minVariantPrice` and `product.compareAtPriceRange?.minVariantPrice`.
- `compareAtPriceRange` (min + max) is surfaced on the `ProductDetails` type and mapped in `transformShopifyProductDetails`. Both ranges were already requested in the product fragment; only `priceRange` was being kept.
- The non-uniform path (Suspense → resolved selected variant) is unchanged.
- Added a `template-rollout-log` entry.

Behavior is identical for products fetched with the full variant set. No visible UI change.

## Test plan

- [x] `pnpm --filter template lint`
- [x] `pnpm --filter template exec tsc --noEmit`
- [ ] Single-price product: price renders in the static shell, no CLS, no `?variant=` dependency
- [ ] Multi-price product: price still streams behind its Suspense fallback and updates on `?variant=` change
- [ ] On-sale uniform product: strikethrough + discount badge still render; no compare-at → no strikethrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)