### PR TITLE
[template] Link: dynamic prefetch on hover instead of eager full prefetch

### DIFF
--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -119,7 +119,7 @@ function ClientProductCard({
     : `/products/${product.handle}`;
 
   return (
-    <Link href={href} prefetch={true}>
+    <Link href={href} unstable_dynamicOnHover>
       <ProductCardRoot>
         <ProductCardImageContainer>
           <ProductCardImage

--- a/apps/template/components/footer/index.tsx
+++ b/apps/template/components/footer/index.tsx
@@ -46,7 +46,7 @@ function MenuLink({ url, children, className }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className} prefetch={true}>
+    <Link href={url} className={className} unstable_dynamicOnHover>
       {children}
     </Link>
   );

--- a/apps/template/components/nav/mobile-menu.tsx
+++ b/apps/template/components/nav/mobile-menu.tsx
@@ -36,7 +36,7 @@ function MenuLink({ url, children, className, onClick }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className} onClick={onClick} prefetch={true}>
+    <Link href={url} className={className} onClick={onClick} unstable_dynamicOnHover>
       {children}
     </Link>
   );

--- a/apps/template/components/nav/quick-links.tsx
+++ b/apps/template/components/nav/quick-links.tsx
@@ -21,7 +21,7 @@ function MenuLink({ url, children, className }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className} prefetch={true}>
+    <Link href={url} className={className} unstable_dynamicOnHover>
       {children}
     </Link>
   );

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -46,7 +46,7 @@ export async function ProductCard({
           : `/products/${product.handle}`
       }
       className={className}
-      prefetch={true}
+      unstable_dynamicOnHover
     >
       <ProductCardRoot variant={variant}>
         {isFeatured && t && (

--- a/apps/template/global.ts
+++ b/apps/template/global.ts
@@ -7,3 +7,10 @@ declare module "next-intl" {
     Messages: typeof messages;
   }
 }
+
+// Supported by the app-router runtime + gated behind experimental.dynamicOnHover, but absent from next/link's public LinkProps. Remove when upstream types catch up.
+declare module "next/link" {
+  interface LinkProps<RouteInferType = any> {
+    unstable_dynamicOnHover?: boolean;
+  }
+}

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -29,6 +29,7 @@ if (process.env.NEXT_PUBLIC_ENABLE_AUTH === "1") {
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
+    dynamicOnHover: true,
     inlineCss: true,
     turbopackFileSystemCacheForDev: true,
   },

--- a/packages/plugin/template-rollout-log/2026-06-16-link-dynamic-on-hover-prefetch.md
+++ b/packages/plugin/template-rollout-log/2026-06-16-link-dynamic-on-hover-prefetch.md
@@ -1,0 +1,46 @@
+---
+title: Replace eager full Link prefetch with hover-upgraded dynamic prefetch (unstable_dynamicOnHover)
+changeKey: link-dynamic-on-hover-prefetch
+introducedOn: 2026-06-16
+changeType: feature
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/next.config.ts
+  - apps/template/components/collections/infinite-product-grid.tsx
+  - apps/template/components/footer/index.tsx
+  - apps/template/components/nav/mobile-menu.tsx
+  - apps/template/components/nav/quick-links.tsx
+  - apps/template/components/product-card/product-card.tsx
+---
+
+## Summary
+
+Every internal `<Link>` that previously set `prefetch={true}` (footer links, quick links, mobile menu, product cards, and the infinite product grid) now sets `unstable_dynamicOnHover` instead, and `next.config.ts` enables `experimental.dynamicOnHover: true`.
+
+`prefetch={true}` does a **full** prefetch (route + dynamic data) as soon as the link enters the viewport. On link-dense pages — PLP grids especially — that fans out into a large number of eager background requests, which Next.js 16 made more aggressive by default.
+
+`unstable_dynamicOnHover` keeps the cheap default viewport prefetch (the partial shell down to the nearest `loading` boundary, `FetchStrategy.PPR`) and **upgrades that link to a full dynamic prefetch only on hover/touchstart** (`FetchStrategy.Full`). The prop is gated behind the `experimental.dynamicOnHover` flag (exposed to the client as `process.env.__NEXT_DYNAMIC_ON_HOVER`); without the flag the prop is inert. Both are required.
+
+Verified against `next@16.3.0-canary.48`: prop typed at `node_modules/next/dist/client/app-dir/link.d.ts` (`unstable_dynamicOnHover?: boolean`); gate at `client/components/links.js` (`onNavigationIntent`); flag default `false` in `server/config-shared.js`. Landed upstream in vercel/next.js#77866.
+
+## Why it matters
+
+Cuts background data transfer on link-heavy pages without losing perceived navigation speed: the full payload is still warmed on hover/touch intent, before the click. This is the framework-native equivalent of the documented `HoverPrefetchLink` (`prefetch={active ? null : false}` toggled on `onMouseEnter`) recipe, without the per-link `useState` wrapper.
+
+## Apply when
+
+- You are on a Next.js version that ships the prop **and** the `experimental.dynamicOnHover` flag (16.3 canary line or later that retains it), and your storefront has link-dense surfaces (PLP grids, mega-nav, footer) where eager full prefetch is wasteful.
+
+## Safe to skip when
+
+- You are pinned to a Next.js version without the flag/prop — the prop is inert (or a type error) without `experimental.dynamicOnHover`. Because the API is `unstable_`, it can change or be removed between canaries; treat adoption as a conscious, revisitable choice rather than a default.
+- A given link must have its full payload ready even when the user navigates without hovering (e.g. keyboard-only or programmatic navigation). For those, keep `prefetch={true}`.
+
+## Validation
+
+1. `pnpm --filter template lint` and `pnpm --filter template build`.
+2. Build and run in production mode (`pnpm --filter template build && pnpm --filter template start`) — prefetch is production-only, so dev will not exercise it.
+3. With the Network panel open on a PLP, confirm links in the viewport issue a partial (not full) prefetch on load, and that hovering a product card issues the full route/data prefetch before click.
+4. Remove `experimental.dynamicOnHover` and confirm the prop goes inert (no hover-triggered full prefetch) — verifies the flag gate, not just the prop.


### PR DESCRIPTION
## Summary

Replaces eager full Link prefetch with Next's hover-upgraded dynamic prefetch on every internal `<Link>` that previously set `prefetch={true}`:

- `components/footer/index.tsx`, `components/nav/quick-links.tsx`, `components/nav/mobile-menu.tsx`, `components/product-card/product-card.tsx`, `components/collections/infinite-product-grid.tsx` — `prefetch={true}` → `unstable_dynamicOnHover`.
- `next.config.ts` — enable `experimental.dynamicOnHover: true` (required; the prop is gated behind `process.env.__NEXT_DYNAMIC_ON_HOVER` and is inert without it).
- `global.ts` — augment `next/link`'s `LinkProps` with `unstable_dynamicOnHover?: boolean`. The prop is supported by the app-router runtime but absent from `next/link`'s **public** types (`dist/client/link.d.ts`), so it doesn't typecheck otherwise. Remove when upstream types catch up.
- `packages/plugin/template-rollout-log/2026-06-16-link-dynamic-on-hover-prefetch.md` — rollout entry (`defaultAction: review`).

## Behavior change

`prefetch={true}` does a **full** prefetch (route + dynamic data) as soon as a link enters the viewport — aggressive on link-dense pages, more so under Next 16's defaults. `unstable_dynamicOnHover` keeps the cheap default viewport prefetch (partial shell to nearest `loading` boundary) and **upgrades to a full dynamic prefetch only on hover/touchstart**. Same staleness caveat as `prefetch={true}` (hover-fetched data may be slightly stale by click). Production-only.

Framework-native equivalent of the documented `HoverPrefetchLink` (`prefetch={active ? null : false}` + `onMouseEnter`) recipe, landed upstream in vercel/next.js#77866. Verified against `next@16.3.0-canary.48`.

## Notes / risks

- The API is `unstable_` and flag-gated — it can change or be removed between canaries. Hence `defaultAction: review` in the rollout log, not `adopt`.
- Links navigated without hover (keyboard-only, programmatic) now get only the partial prefetch up front. If any link must always have its full payload warmed, keep `prefetch={true}` there.

## Test plan

- [x] `pnpm --filter template lint`
- [x] `pnpm exec tsc --noEmit` (clean after the `LinkProps` augmentation)
- [ ] `pnpm --filter template build`
- [ ] Prod run (`build && start`): on a PLP, confirm viewport links issue a **partial** prefetch on load and hovering a product card issues the **full** route/data prefetch before click
- [ ] Remove `experimental.dynamicOnHover` and confirm the prop goes inert (verifies the flag gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)