### PR TITLE
[template] PDP: select variants by options instead of variant id

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -24,7 +24,7 @@ Variants are selected via `searchParams`. Each option (color, size, etc.) render
 /products/classic-tee?color=Blue&size=XS
 ```
 
-The page receives `searchParams` as a promise. `parseSelectedOptions()` reads the option params (merged with the default variant's options for anything unset) into a `selectedOptions` record, and `getProductVariant({ handle, selectedOptions })` resolves the matching variant via Shopify's `selectedOrFirstAvailableVariant(selectedOptions:)` field. The result is threaded down as props with no client-side variant context or `useState`. This means:
+The page receives `searchParams` as a promise and derives two things from it. `parseSelectedOptions()` reads the option params (merged with the default variant's options for anything unset) into a `selectedOptions` record on a **fast promise** — it depends only on the URL, and drives the picker highlight and the color image so they resolve at `searchParams` speed. The **variant** (for price + add-to-cart) rides a separate promise: `getProductVariant({ handle, selectedOptions })` resolves it via Shopify's `selectedOrFirstAvailableVariant(selectedOptions:)` field. Keeping the picker off the network promise stops the selected option from snapping in late. Everything is threaded down as props with no client-side variant context or `useState`. This means:
 
 - Every variant selection is a navigation, giving you browser back/forward for free
 - URLs are shareable and human-readable - opening a link loads the exact variant
@@ -49,7 +49,7 @@ Both layouts receive pre-filtered images as props from the server.
 
 ### Color-based image filtering
 
-When a product's options carry representative images (each value's `firstSelectableVariant` image, exposed as `OptionValue.image`), the gallery leads with the selected variant's image. The shared media — product images that aren't a specific color's representative image, via `getSharedImages()` in `lib/product.ts` — renders immediately in the static shell, while the leading color slot streams behind a small Suspense fallback so changing the selection does not skeletonize the whole gallery. The slot resolves the selected variant from `getProductVariant` and renders its single image at the front.
+When the **color** option has multiple values with distinct representative images (each value's `firstSelectableVariant` image, exposed as `OptionValue.image`), the gallery leads with the selected color's image. The shared media — product images that aren't a specific color's representative image, via `getSharedImages()` in `lib/product.ts` — renders immediately in the static shell, while the leading color slot streams behind a small Suspense fallback so changing the selection does not skeletonize the whole gallery. The slot resolves from the fast options promise via `getSelectedColorImage()` (no variant query), so it streams at `searchParams` speed. Non-color axes like size or finish never trigger a streamed slot — those products keep a fully static gallery.
 
 If no option has representative images (one color, or no color option), all product images are shown.
 
@@ -93,7 +93,7 @@ The page emits two JSON-LD schemas:
 | `components/product-detail/product-detail-section.tsx` | Orchestrates media, options, pricing, and buy buttons with per-section Suspense; emits JSON-LD |
 | `components/product-detail/product-media.tsx`          | Responsive image gallery (mobile carousel, desktop grid + lightbox)                            |
 | `components/product-detail/buy-buttons.tsx`            | Buy with Shop + add-to-cart client component                                                   |
-| `lib/product.ts`                                       | `parseSelectedOptions`, `buildOptionUrl`, default selection, shared-image helpers              |
+| `lib/product.ts`                                       | `parseSelectedOptions`, `buildOptionUrl`, default selection, color-image helpers               |
 | `lib/shopify/encoded-variants.ts`                      | Decodes `encodedVariantAvailability`/`Existence` into per-option availability + variant count   |
 
 The rest of the PDP — option pickers, price display, lightbox, schema, and so on — lives in `components/product-detail/`. Browse the directory when you need them.

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -14,26 +14,26 @@ The PDP runs under Next.js 16 Cache Components, with a deliberate split between 
 
 Two structural choices keep that copy coherent, and both are load-bearing. The product promise is **not** threaded into a `<Suspense>` boundary, and the route does **not** set `prefetch = "allow-runtime"`. Either one re-renders the body at request time into a separate RSC flight that can drift from the frozen shell when the cached value changes — the symptom is a React hydration mismatch and product copy that appears to change on its own. Use plain `"use cache"` here rather than `"use cache: remote"`: `remote` resolves at request time, _outside_ the static shell, so it would not bake in. The shell refreshes when it regenerates on its `cacheLife` window or when a Shopify [webhook](/docs/anatomy/webhooks) calls `revalidateTag` — that governs freshness (how quickly edits surface), not coherence.
 
-The only dynamic input is the `?variant=` query parameter. Rather than block the whole page on that lookup, the route passes the `searchParams` promise — unawaited — down into `ProductDetailSection`. Anything that doesn't depend on the chosen variant (title, shared gallery images, uniformly-priced variants, the description) renders from the product resolved at the top of the page, baked into the static shell. Anything that does (the color-specific gallery slot, variant-specific price, option highlight, buy buttons) sits inside its own Suspense boundary so a `?variant=` change streams the affected slot without skeletonizing the rest of the page.
+The only dynamic input is the selected-options query (`?color=Blue&size=XS`). Rather than block the whole page on that lookup, the route passes the `searchParams` promise — unawaited — down into `ProductDetailSection`. Anything that doesn't depend on the chosen variant (title, shared gallery images, uniformly-priced variants, the description) renders from the product resolved at the top of the page, baked into the static shell. Anything that does (the color-specific gallery slot, variant-specific price, option highlight, buy buttons) sits inside its own Suspense boundary so an option change streams the affected slot without skeletonizing the rest of the page. The chosen variant itself is resolved by a second, per-selection Shopify query (`getProductVariant`) rather than from an inline variant list — so the cached shell stays small and the price/availability reflect the exact selection.
 
 ## Variant selection
 
-Variants are selected via `searchParams`. Each option (color, size, etc.) renders as a `<Link>` pointing to the same product with Shopify's `?variant` query parameter:
+Variants are selected via `searchParams`. Each option (color, size, etc.) renders as a `<Link>` pointing to the same product with one query parameter per option, keyed by the lowercased option name:
 
 ```
-/products/classic-tee?variant=123456
+/products/classic-tee?color=Blue&size=XS
 ```
 
-The page receives `searchParams` as a promise, threads the variant ID through to `computeSelection()` on the server, and that function returns `{ selectedOptions, selectedVariant, colorImages }` in one pass — matching the numeric variant ID to the full variant object. The result is threaded down as props with no client-side variant context or `useState`. This means:
+The page receives `searchParams` as a promise. `parseSelectedOptions()` reads the option params (merged with the default variant's options for anything unset) into a `selectedOptions` record, and `getProductVariant({ handle, selectedOptions })` resolves the matching variant via Shopify's `selectedOrFirstAvailableVariant(selectedOptions:)` field. The result is threaded down as props with no client-side variant context or `useState`. This means:
 
 - Every variant selection is a navigation, giving you browser back/forward for free
-- URLs are shareable - opening a link loads the exact variant
+- URLs are shareable and human-readable - opening a link loads the exact variant
 - The page is fully server-rendered with zero layout shift
-- Variant links use `scroll={false}` to prevent the page from jumping to the top on selection
+- Option links use `scroll={false}` to prevent the page from jumping to the top on selection
 
-The `getVariantUrl()` helper in `lib/product.ts` computes the target URL for each option. When a user selects a new option value, it finds the matching variant (or falls back to the first variant with that option) and returns the URL with the correct `variant` query parameter.
+The `buildOptionUrl()` helper in `lib/product.ts` computes the target URL for each option — a pure merge of the current selection with the changed option, no variant lookup required. When no option params are present, the page skips the variant query and renders the cached default variant.
 
-Unavailable options render as inert `<span>` elements instead of links.
+Swatch availability comes from Shopify's `encodedVariantAvailability` field, decoded in `lib/shopify/encoded-variants.ts` into the set of in-stock values per option. Unavailable options render as inert `<span>` elements instead of links.
 
 Options with a single value render as a plain `Name: Value` label without a picker — there is no choice to surface, but the attribute is still useful information to the shopper (e.g. `Finish: Natural White Oak` on a one-variant product). Shopify's synthetic `Title: Default Title` option (emitted for products with no variant axes) is the only single-value option that is hidden entirely.
 
@@ -49,15 +49,11 @@ Both layouts receive pre-filtered images as props from the server.
 
 ### Color-based image filtering
 
-When a product has color variants, the gallery shows only images relevant to the selected color. Shared images render immediately, while the color-specific slot streams behind a small Suspense fallback so changing `?variant` does not skeletonize the whole gallery. The `getPartitionedImagesForSelectedColor()` function in `lib/product.ts`:
+When a product's options carry representative images (each value's `firstSelectableVariant` image, exposed as `OptionValue.image`), the gallery leads with the selected variant's image. The shared media — product images that aren't a specific color's representative image, via `getSharedImages()` in `lib/product.ts` — renders immediately in the static shell, while the leading color slot streams behind a small Suspense fallback so changing the selection does not skeletonize the whole gallery. The slot resolves the selected variant from `getProductVariant` and renders its single image at the front.
 
-1. Identifies the color option via swatch data or option name
-2. Collects variant images assigned to each color
-3. Excludes images belonging to other colors
-4. Preserves shared/unassigned images
-5. Moves the selected variant's image to the front
+If no option has representative images (one color, or no color option), all product images are shown.
 
-If a product has only one color or no color option, all images are shown.
+Because selection is option-driven, the gallery no longer filters out _every_ image belonging to other colors — that required the full inline variant list, which the PDP no longer fetches. It leads with the selected variant's image followed by the shared media instead.
 
 ## Buy section
 
@@ -93,10 +89,11 @@ The page emits two JSON-LD schemas:
 
 | File                                                   | Purpose                                                                                        |
 | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| `app/products/[handle]/page.tsx`                       | Route entry: metadata, awaits the product at the top (baked into the shell), streams variant selection |
+| `app/products/[handle]/page.tsx`                       | Route entry: metadata, awaits the product at the top (baked into the shell), streams the per-selection variant query |
 | `components/product-detail/product-detail-section.tsx` | Orchestrates media, options, pricing, and buy buttons with per-section Suspense; emits JSON-LD |
 | `components/product-detail/product-media.tsx`          | Responsive image gallery (mobile carousel, desktop grid + lightbox)                            |
 | `components/product-detail/buy-buttons.tsx`            | Buy with Shop + add-to-cart client component                                                   |
-| `lib/product.ts`                                       | `computeSelection`, variant resolution, URL generation, color-image partitioning               |
+| `lib/product.ts`                                       | `parseSelectedOptions`, `buildOptionUrl`, default selection, shared-image helpers              |
+| `lib/shopify/encoded-variants.ts`                      | Decodes `encodedVariantAvailability`/`Existence` into per-option availability + variant count   |
 
 The rest of the PDP — option pickers, price display, lightbox, schema, and so on — lives in `components/product-detail/`. Browse the directory when you need them.

--- a/apps/docs/content/docs/anatomy/product-card.mdx
+++ b/apps/docs/content/docs/anatomy/product-card.mdx
@@ -8,7 +8,7 @@ Used in the home featured grid, collection (PLP) and search grids, the related-p
 
 ## Composition
 
-`ProductCard` is a server component that wraps the product in a `Link` to `/products/[handle]` (appending `?variant=` when a default variant id is known). Each part — image container, image, content, title, price, optional badge — exposes a `data-slot` attribute (`product-card`, `product-card-image`, etc.) as a stable styling hook.
+`ProductCard` is a server component that wraps the product in a `Link` to `/products/[handle]` — the bare product URL, which renders the first-available (default) variant. Each part — image container, image, content, title, price, optional badge — exposes a `data-slot` attribute (`product-card`, `product-card-image`, etc.) as a stable styling hook.
 
 ## Variants
 

--- a/apps/docs/content/docs/reference/routes.mdx
+++ b/apps/docs/content/docs/reference/routes.mdx
@@ -9,7 +9,7 @@ type: reference
 | Route                   | File                                | Description                                                                                        |
 | ----------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `/`                     | `app/page.tsx`                      | Home page with hero, products grid, info section                                                   |
-| `/products/[handle]`    | `app/products/[handle]/page.tsx`    | Product detail page; `?variant=` selects a specific variant                                        |
+| `/products/[handle]`    | `app/products/[handle]/page.tsx`    | Product detail page; `?color=…&size=…` option params select a variant                              |
 | `/collections/[handle]` | `app/collections/[handle]/page.tsx` | Collection listing with filters, sort, pagination                                                  |
 | `/collections/all`      | `app/collections/[handle]/page.tsx` | Virtual "All Products" listing; synthesized since Shopify's Storefront API has no `all` collection |
 | `/search`               | `app/search/page.tsx`               | Search results (same grid as collections)                                                          |
@@ -27,8 +27,9 @@ type: reference
 
 ## Variant URLs
 
-Product variant selection uses Shopify's standard `variant` query parameter directly on the product route:
+Product variant selection uses one query parameter per option, keyed by the lowercased option name:
 
 | URL                                    | Purpose                                                   |
 | -------------------------------------- | --------------------------------------------------------- |
-| `/products/:handle?variant=:variantId` | Opens the product page with the matching variant selected |
+| `/products/:handle?color=Blue&size=XS` | Opens the product page with the matching variant selected |
+| `/products/:handle`                    | No options selected — renders the first available variant |

--- a/apps/docs/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/content/docs/reference/troubleshooting.mdx
@@ -19,9 +19,9 @@ The cart ID is stored in a `shopify_cartId` HTTP-only cookie with a 7-day expiry
 
 ## Variant selection not working
 
-Variant selection uses Shopify's standard `?variant=123` query parameter. If option links change the URL but the page does not update, check that `app/products/[handle]/page.tsx` reads `searchParams.variant` and passes it to the product detail components.
+Variant selection uses one option param per axis (`?color=Blue&size=XS`). If option links change the URL but the price/buy buttons do not update, check that `app/products/[handle]/page.tsx` parses the params with `parseSelectedOptions()` and resolves the variant with `getProductVariant()` inside the streamed `selectionPromise`.
 
-Also confirm variant links are generated with `getVariantUrl()` from `lib/product.ts`, which should return `/products/:handle?variant=:variantId` for variant-specific links.
+Also confirm option links are generated with `buildOptionUrl()` from `lib/product.ts` (a pure merge of the current selection with the changed option), and that swatch availability comes from `getAvailableOptionValues()` in `lib/shopify/encoded-variants.ts` — if every value shows as available, the product's `encodedVariantAvailability` may be missing from the query.
 
 ## Images not loading
 

--- a/apps/docs/content/docs/shopify/pdp.mdx
+++ b/apps/docs/content/docs/shopify/pdp.mdx
@@ -16,7 +16,7 @@ The PDP renders any product that has a handle (URL slug) in Shopify. At minimum,
 - At least one **variant** (even single-option products have a default variant)
 - A **featured image** and optionally up to 10 media items (images or videos)
 
-The template fetches up to 250 variants per product and 10 media items.
+The PDP shell fetches the product's options and Shopify's encoded variant-availability data (not the full variant list) plus up to 10 media items; the selected variant is resolved per request from its options. The AI agent and markdown routes still fetch the full variant list (up to 250) via `getProductWithVariants`.
 
 ## Metafields
 
@@ -79,4 +79,4 @@ Product recommendations on the PDP are powered by Shopify's recommendation API. 
 | `lib/shopify/fragments.ts`           | `PRODUCT_FRAGMENT` and `METAFIELD_FRAGMENT`                     |
 | `lib/shopify/transforms/product.ts`  | Metafield label mapping and product transform                   |
 | `lib/shopify/operations/products.ts` | Product fetch operations with caching                           |
-| `lib/product.ts`                     | Variant resolution, swatch detection, and option URL generation |
+| `lib/product.ts`                     | Option parsing, default selection, and option URL generation    |

--- a/apps/docs/content/docs/skills/enable-shopify-markets.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-markets.mdx
@@ -358,7 +358,7 @@ export function proxy(request: NextRequest) {
 }
 ```
 
-> **Note:** Product variant selection stays on Shopify's standard `?variant=` query parameter. The built-in content negotiation rewrite in `next.config.ts` handles markdown negotiation automatically — no proxy.ts changes needed.
+> **Note:** Product variant selection uses per-option query params (`?color=Blue&size=XS`), which are locale-agnostic and carry across locale-prefixed URLs unchanged. The built-in content negotiation rewrite in `next.config.ts` handles markdown negotiation automatically — no proxy.ts changes needed.
 
 ---
 
@@ -577,7 +577,7 @@ After completing all steps, verify the implementation:
    - Locale-prefixed URL works (e.g., `http://localhost:3000/de-DE/products/technest-smart-speaker-pro-jk0c`)
    - Product prices render in the correct currency for each locale
 3. **Locale selector**: Confirm the selector appears in the megamenu and switching locales changes the URL + cart currency
-4. **Variants**: Confirm product variant links preserve `?variant=` across locale-prefixed URLs
+4. **Variants**: Confirm product option params (`?color=…&size=…`) are preserved across locale-prefixed URLs
 5. **SEO**: Check that page metadata includes `hreflang` alternates for all enabled locales
 6. **Sitemap**: Visit `/sitemap.xml` and confirm per-locale entries
 

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -13,7 +13,7 @@ import { defaultLocale, type Locale } from "@/lib/i18n";
 import { withFallback } from "@/lib/shopify/errors";
 import { createCartWithoutCookie } from "@/lib/shopify/operations/cart";
 import { getCollection } from "@/lib/shopify/operations/collections";
-import { getProduct } from "@/lib/shopify/operations/products";
+import { getProductWithVariants } from "@/lib/shopify/operations/products";
 
 function parseReferer(referer: string | null): {
   locale: Locale;
@@ -48,7 +48,7 @@ async function resolvePageContext(
 
   if (pageType === "products" && segments.length >= 2) {
     const handle = segments[1];
-    const product = await withFallback(getProduct({ handle, locale }), undefined);
+    const product = await withFallback(getProductWithVariants({ handle, locale }), undefined);
     if (product) return { type: "product", product };
   }
 

--- a/apps/template/app/md/products/[handle]/route.ts
+++ b/apps/template/app/md/products/[handle]/route.ts
@@ -1,6 +1,6 @@
 import { defaultLocale, resolveLocale } from "@/lib/i18n";
 import { productToMarkdown } from "@/lib/markdown/product";
-import { getProduct } from "@/lib/shopify/operations/products";
+import { getProductWithVariants } from "@/lib/shopify/operations/products";
 
 export async function GET(request: Request, { params }: { params: Promise<{ handle: string }> }) {
   const { handle } = await params;
@@ -8,7 +8,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ hand
   const locale = resolveLocale(url.searchParams.get("locale") || defaultLocale);
 
   try {
-    const product = await getProduct({ handle, locale });
+    const product = await getProductWithVariants({ handle, locale });
 
     if (!product) {
       return new Response(

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -7,9 +7,19 @@ import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
 import { getLocale } from "@/lib/params";
-import { computeSelection } from "@/lib/product";
+import {
+  defaultSelectedOptions,
+  parseSelectedOptions,
+  type ProductSelection,
+  type SelectedOptions,
+  toSelectedOptionList,
+} from "@/lib/product";
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
-import { getCatalogProducts, getProduct } from "@/lib/shopify/operations/products";
+import {
+  getCatalogProducts,
+  getProduct,
+  getProductVariant,
+} from "@/lib/shopify/operations/products";
 
 const PLACEHOLDER_HANDLE = "__placeholder__";
 
@@ -84,10 +94,22 @@ export default async function ProductPage({
   if (!product) notFound();
 
   // Keep searchParams unawaited so only the variant-dependent UI streams; the
-  // product body resolves here and renders into the static shell.
-  const selectionPromise = searchParams.then((sp) =>
-    computeSelection(product, sp?.variant as string | undefined),
-  );
+  // product body resolves here and renders into the static shell. The selected
+  // variant is a per-selection Shopify query — skipped when no option params are
+  // present (the cached default variant already covers that case).
+  const selectionPromise: Promise<ProductSelection> = searchParams.then(async (sp) => {
+    const fromUrl = parseSelectedOptions(product.options, sp ?? {});
+    const selectedOptions: SelectedOptions = { ...defaultSelectedOptions(product), ...fromUrl };
+    const selectedVariant =
+      Object.keys(fromUrl).length === 0
+        ? product.defaultVariant
+        : await getProductVariant({
+            handle,
+            locale,
+            selectedOptions: toSelectedOptionList(selectedOptions),
+          });
+    return { selectedOptions, selectedVariant };
+  });
 
   return (
     <Page className="pt-0">

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -10,7 +10,6 @@ import { getLocale } from "@/lib/params";
 import {
   defaultSelectedOptions,
   parseSelectedOptions,
-  type ProductSelection,
   type SelectedOptions,
   toSelectedOptionList,
 } from "@/lib/product";
@@ -20,6 +19,7 @@ import {
   getProduct,
   getProductVariant,
 } from "@/lib/shopify/operations/products";
+import type { ProductVariant } from "@/lib/types";
 
 const PLACEHOLDER_HANDLE = "__placeholder__";
 
@@ -93,22 +93,23 @@ export default async function ProductPage({
   const product = await getProduct({ handle, locale });
   if (!product) notFound();
 
-  // Keep searchParams unawaited so only the variant-dependent UI streams; the
-  // product body resolves here and renders into the static shell. The selected
-  // variant is a per-selection Shopify query — skipped when no option params are
-  // present (the cached default variant already covers that case).
-  const selectionPromise: Promise<ProductSelection> = searchParams.then(async (sp) => {
+  // Keep searchParams unawaited so only the variant-dependent UI streams. The
+  // picker highlight and color image depend only on searchParams (fast), so they
+  // ride a separate promise from the per-selection variant query (the network
+  // round-trip that price + add-to-cart need) — otherwise the picker would wait
+  // on the network and the selected option would visibly snap in after load.
+  const selectedOptionsPromise: Promise<SelectedOptions> = searchParams.then((sp) => ({
+    ...defaultSelectedOptions(product),
+    ...parseSelectedOptions(product.options, sp ?? {}),
+  }));
+  const variantPromise: Promise<ProductVariant | undefined> = searchParams.then(async (sp) => {
     const fromUrl = parseSelectedOptions(product.options, sp ?? {});
-    const selectedOptions: SelectedOptions = { ...defaultSelectedOptions(product), ...fromUrl };
-    const selectedVariant =
-      Object.keys(fromUrl).length === 0
-        ? product.defaultVariant
-        : await getProductVariant({
-            handle,
-            locale,
-            selectedOptions: toSelectedOptionList(selectedOptions),
-          });
-    return { selectedOptions, selectedVariant };
+    if (Object.keys(fromUrl).length === 0) return product.defaultVariant;
+    return getProductVariant({
+      handle,
+      locale,
+      selectedOptions: toSelectedOptionList({ ...defaultSelectedOptions(product), ...fromUrl }),
+    });
   });
 
   return (
@@ -117,7 +118,8 @@ export default async function ProductPage({
         <Sections>
           <ProductDetailSection
             product={product}
-            selectionPromise={selectionPromise}
+            selectedOptionsPromise={selectedOptionsPromise}
+            variantPromise={variantPromise}
             locale={locale}
           />
           <RelatedProductsSection handle={handle} locale={locale} />

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -39,15 +39,7 @@ export async function ProductCard({
   const t = isFeatured ? await getTranslations("product") : null;
 
   return (
-    <Link
-      href={
-        product.defaultVariantNumericId
-          ? `/products/${product.handle}?variant=${product.defaultVariantNumericId}`
-          : `/products/${product.handle}`
-      }
-      className={className}
-      prefetch={true}
-    >
+    <Link href={`/products/${product.handle}`} className={className} prefetch={true}>
       <ProductCardRoot variant={variant}>
         {isFeatured && t && (
           <ProductCardBadge>

--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -3,8 +3,8 @@ import Image from "next/image";
 import Link from "next/link";
 import type * as React from "react";
 
-import { type SelectedOptions, getVariantUrl } from "@/lib/product";
-import type { ProductOption, ProductVariant } from "@/lib/types";
+import { buildOptionUrl, type SelectedOptions } from "@/lib/product";
+import type { ProductOption } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 export type ProductTranslator = Awaited<ReturnType<typeof getTranslations<"product">>>;
@@ -12,7 +12,7 @@ export type ProductTranslator = Awaited<ReturnType<typeof getTranslations<"produ
 interface ColorPickerProps extends React.ComponentProps<"div"> {
   option: ProductOption;
   selectedValue: string;
-  variants: ProductVariant[];
+  available: Set<string> | undefined;
   handle: string;
   selectedOptions: SelectedOptions;
   t: ProductTranslator;
@@ -22,7 +22,7 @@ interface ColorPickerProps extends React.ComponentProps<"div"> {
 export function ColorPicker({
   option,
   selectedValue,
-  variants,
+  available,
   handle,
   selectedOptions,
   t,
@@ -39,19 +39,11 @@ export function ColorPicker({
         {option.values.map((value) => {
           const isSelected = selectedValue === value.name;
 
-          const isAvailable = variants.some(
-            (v) =>
-              v.availableForSale &&
-              v.selectedOptions.some((opt) => opt.name === option.name && opt.value === value.name),
-          );
+          const isAvailable = !available || available.has(value.name);
 
-          const variantImage = variants.find((v) =>
-            v.selectedOptions.some((opt) => opt.name === option.name && opt.value === value.name),
-          )?.image?.url;
+          const imageUrl = hideImages ? undefined : value.swatch?.image || value.image;
 
-          const imageUrl = hideImages ? undefined : value.swatch?.image || variantImage;
-
-          const href = getVariantUrl(handle, variants, selectedOptions, option.name, value.name);
+          const href = buildOptionUrl(handle, selectedOptions, option.name, value.name);
 
           const swatch = (
             <div

--- a/apps/template/components/product-detail/option-picker.tsx
+++ b/apps/template/components/product-detail/option-picker.tsx
@@ -1,14 +1,14 @@
 import Link from "next/link";
 import type * as React from "react";
 
-import { type SelectedOptions, getVariantUrl } from "@/lib/product";
-import type { ProductOption, ProductVariant } from "@/lib/types";
+import { buildOptionUrl, type SelectedOptions } from "@/lib/product";
+import type { ProductOption } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 interface OptionPickerProps extends React.ComponentProps<"div"> {
   option: ProductOption;
   selectedValue: string;
-  variants: ProductVariant[];
+  available: Set<string> | undefined;
   handle: string;
   selectedOptions: SelectedOptions;
 }
@@ -16,7 +16,7 @@ interface OptionPickerProps extends React.ComponentProps<"div"> {
 export function OptionPicker({
   option,
   selectedValue,
-  variants,
+  available,
   handle,
   selectedOptions,
   className,
@@ -29,13 +29,9 @@ export function OptionPicker({
         {option.values.map((value) => {
           const isSelected = selectedValue === value.name;
 
-          const isAvailable = variants.some(
-            (v) =>
-              v.availableForSale &&
-              v.selectedOptions.some((opt) => opt.name === option.name && opt.value === value.name),
-          );
+          const isAvailable = !available || available.has(value.name);
 
-          const href = getVariantUrl(handle, variants, selectedOptions, option.name, value.name);
+          const href = buildOptionUrl(handle, selectedOptions, option.name, value.name);
 
           const classes = cn(
             "grid px-5 py-2 text-center text-sm rounded-lg transition-all",

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -21,23 +21,26 @@ import { siteConfig } from "@/lib/config";
 import type { Locale } from "@/lib/i18n";
 import {
   defaultSelectedOptions,
+  getSelectedColorImage,
   getSharedImages,
   hasColorImagePartitioning,
   hasUniformPricing,
   hasUniformStock,
-  type ProductSelection,
+  type SelectedOptions,
 } from "@/lib/product";
 import { countEncodedVariants, getAvailableOptionValues } from "@/lib/shopify/encoded-variants";
-import type { ProductDetails } from "@/lib/types";
+import type { ProductDetails, ProductVariant } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 export function ProductDetailSection({
   product,
-  selectionPromise,
+  selectedOptionsPromise,
+  variantPromise,
   locale,
 }: {
   product: ProductDetails;
-  selectionPromise: Promise<ProductSelection>;
+  selectedOptionsPromise: Promise<SelectedOptions>;
+  variantPromise: Promise<ProductVariant | undefined>;
   locale: Locale;
 }) {
   return (
@@ -63,8 +66,13 @@ export function ProductDetailSection({
         ]}
       />
       <div className="grid gap-10 lg:grid-cols-10 lg:items-start lg:gap-5">
-        <ProductMediaArea product={product} selectionPromise={selectionPromise} />
-        <ProductInfoArea product={product} selectionPromise={selectionPromise} locale={locale} />
+        <ProductMediaArea product={product} selectedOptionsPromise={selectedOptionsPromise} />
+        <ProductInfoArea
+          product={product}
+          selectedOptionsPromise={selectedOptionsPromise}
+          variantPromise={variantPromise}
+          locale={locale}
+        />
       </div>
     </>
   );
@@ -72,10 +80,10 @@ export function ProductDetailSection({
 
 function ProductMediaArea({
   product,
-  selectionPromise,
+  selectedOptionsPromise,
 }: {
   product: ProductDetails;
-  selectionPromise: Promise<ProductSelection>;
+  selectedOptionsPromise: Promise<SelectedOptions>;
 }) {
   if (!hasColorImagePartitioning(product.options)) {
     return (
@@ -96,7 +104,10 @@ function ProductMediaArea({
       className="lg:col-span-6"
       desktopSlot={
         <Suspense fallback={<Skeleton className="w-full rounded-none aspect-square" />}>
-          <ResolvedColorImageGrid title={product.title} selectionPromise={selectionPromise} />
+          <ResolvedColorImageGrid
+            product={product}
+            selectedOptionsPromise={selectedOptionsPromise}
+          />
         </Suspense>
       }
       mobileSlot={
@@ -107,7 +118,10 @@ function ProductMediaArea({
             </div>
           }
         >
-          <ResolvedColorImageCarousel title={product.title} selectionPromise={selectionPromise} />
+          <ResolvedColorImageCarousel
+            product={product}
+            selectedOptionsPromise={selectedOptionsPromise}
+          />
         </Suspense>
       }
     />
@@ -115,36 +129,38 @@ function ProductMediaArea({
 }
 
 async function ResolvedColorImageGrid({
-  title,
-  selectionPromise,
+  product,
+  selectedOptionsPromise,
 }: {
-  title: string;
-  selectionPromise: Promise<ProductSelection>;
+  product: ProductDetails;
+  selectedOptionsPromise: Promise<SelectedOptions>;
 }) {
-  const { selectedVariant } = await selectionPromise;
-  if (!selectedVariant?.image) return null;
-  return <ColorImageGrid images={[selectedVariant.image]} title={title} />;
+  const image = getSelectedColorImage(product, await selectedOptionsPromise);
+  if (!image) return null;
+  return <ColorImageGrid images={[image]} title={product.title} />;
 }
 
 async function ResolvedColorImageCarousel({
-  title,
-  selectionPromise,
+  product,
+  selectedOptionsPromise,
 }: {
-  title: string;
-  selectionPromise: Promise<ProductSelection>;
+  product: ProductDetails;
+  selectedOptionsPromise: Promise<SelectedOptions>;
 }) {
-  const { selectedVariant } = await selectionPromise;
-  if (!selectedVariant?.image) return null;
-  return <ColorImageCarouselItems images={[selectedVariant.image]} title={title} />;
+  const image = getSelectedColorImage(product, await selectedOptionsPromise);
+  if (!image) return null;
+  return <ColorImageCarouselItems images={[image]} title={product.title} />;
 }
 
 async function ProductInfoArea({
   product,
-  selectionPromise,
+  selectedOptionsPromise,
+  variantPromise,
   locale,
 }: {
   product: ProductDetails;
-  selectionPromise: Promise<ProductSelection>;
+  selectedOptionsPromise: Promise<SelectedOptions>;
+  variantPromise: Promise<ProductVariant | undefined>;
   locale: Locale;
 }) {
   const { options, handle, title, featuredImage, descriptionHtml, availableForSale } = product;
@@ -172,7 +188,7 @@ async function ProductInfoArea({
           />
         ) : (
           <Suspense fallback={<div className="h-6" aria-hidden />}>
-            <ResolvedProductPrice selectionPromise={selectionPromise} locale={locale} />
+            <ResolvedProductPrice variantPromise={variantPromise} locale={locale} />
           </Suspense>
         )}
       </div>
@@ -202,7 +218,7 @@ async function ProductInfoArea({
             availableValues={availableValues}
             options={options}
             handle={handle}
-            selectionPromise={selectionPromise}
+            selectedOptionsPromise={selectedOptionsPromise}
             t={t}
           />
         </Suspense>
@@ -223,7 +239,7 @@ async function ProductInfoArea({
             handle={handle}
             featuredImage={featuredImage}
             availableForSale={availableForSale}
-            selectionPromise={selectionPromise}
+            variantPromise={variantPromise}
           />
         </Suspense>
       )}
@@ -234,13 +250,13 @@ async function ProductInfoArea({
 }
 
 async function ResolvedProductPrice({
-  selectionPromise,
+  variantPromise,
   locale,
 }: {
-  selectionPromise: Promise<ProductSelection>;
+  variantPromise: Promise<ProductVariant | undefined>;
   locale: Locale;
 }) {
-  const { selectedVariant } = await selectionPromise;
+  const selectedVariant = await variantPromise;
   if (!selectedVariant) return null;
   return (
     <ProductPrice
@@ -256,16 +272,16 @@ async function ResolvedProductInfoOptions({
   availableValues,
   options,
   handle,
-  selectionPromise,
+  selectedOptionsPromise,
   t,
 }: {
   availableValues: Map<string, Set<string>>;
   options: ProductDetails["options"];
   handle: string;
-  selectionPromise: Promise<ProductSelection>;
+  selectedOptionsPromise: Promise<SelectedOptions>;
   t: Awaited<ReturnType<typeof getTranslations<"product">>>;
 }) {
-  const { selectedOptions } = await selectionPromise;
+  const selectedOptions = await selectedOptionsPromise;
   return (
     <ProductInfoOptions
       availableValues={availableValues}
@@ -282,15 +298,15 @@ async function ResolvedBuyButtons({
   handle,
   featuredImage,
   availableForSale,
-  selectionPromise,
+  variantPromise,
 }: {
   title: string;
   handle: string;
   featuredImage: ProductDetails["featuredImage"];
   availableForSale: boolean;
-  selectionPromise: Promise<ProductSelection>;
+  variantPromise: Promise<ProductVariant | undefined>;
 }) {
-  const { selectedVariant } = await selectionPromise;
+  const selectedVariant = await variantPromise;
   return (
     <BuyButtons
       selectedVariant={selectedVariant}

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -207,7 +207,7 @@ async function ProductInfoArea({
             <ProductInfoOptions
               availableValues={availableValues}
               options={options}
-              selectedOptions={defaultSelectedOptions(product)}
+              selectedOptions={{}}
               handle={handle}
               t={t}
               hideImages

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -20,13 +20,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { siteConfig } from "@/lib/config";
 import type { Locale } from "@/lib/i18n";
 import {
-  computeSelection,
+  defaultSelectedOptions,
   getSharedImages,
   hasColorImagePartitioning,
   hasUniformPricing,
   hasUniformStock,
   type ProductSelection,
 } from "@/lib/product";
+import { countEncodedVariants, getAvailableOptionValues } from "@/lib/shopify/encoded-variants";
 import type { ProductDetails } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -51,7 +52,7 @@ export function ProductDetailSection({
           manufacturerName: product.manufacturerName,
           currencyCode: product.currencyCode,
           priceRange: product.priceRange,
-          variants: product.variants,
+          offerCount: countEncodedVariants(product.encodedVariantExistence) || 1,
           availableForSale: product.availableForSale,
         }}
       />
@@ -76,7 +77,7 @@ function ProductMediaArea({
   product: ProductDetails;
   selectionPromise: Promise<ProductSelection>;
 }) {
-  if (!hasColorImagePartitioning(product.options, product.variants)) {
+  if (!hasColorImagePartitioning(product.options)) {
     return (
       <ProductMedia
         otherImages={product.images}
@@ -89,7 +90,7 @@ function ProductMediaArea({
 
   return (
     <ProductMedia
-      otherImages={getSharedImages(product.images, product.options, product.variants)}
+      otherImages={getSharedImages(product.images, product.options)}
       videos={product.videos}
       title={product.title}
       className="lg:col-span-6"
@@ -120,9 +121,9 @@ async function ResolvedColorImageGrid({
   title: string;
   selectionPromise: Promise<ProductSelection>;
 }) {
-  const { colorImages } = await selectionPromise;
-  if (colorImages.length === 0) return null;
-  return <ColorImageGrid images={colorImages} title={title} />;
+  const { selectedVariant } = await selectionPromise;
+  if (!selectedVariant?.image) return null;
+  return <ColorImageGrid images={[selectedVariant.image]} title={title} />;
 }
 
 async function ResolvedColorImageCarousel({
@@ -132,9 +133,9 @@ async function ResolvedColorImageCarousel({
   title: string;
   selectionPromise: Promise<ProductSelection>;
 }) {
-  const { colorImages } = await selectionPromise;
-  if (colorImages.length === 0) return null;
-  return <ColorImageCarouselItems images={colorImages} title={title} />;
+  const { selectedVariant } = await selectionPromise;
+  if (!selectedVariant?.image) return null;
+  return <ColorImageCarouselItems images={[selectedVariant.image]} title={title} />;
 }
 
 async function ProductInfoArea({
@@ -146,15 +147,17 @@ async function ProductInfoArea({
   selectionPromise: Promise<ProductSelection>;
   locale: Locale;
 }) {
-  const { variants, options, handle, title, featuredImage, descriptionHtml, availableForSale } =
-    product;
+  const { options, handle, title, featuredImage, descriptionHtml, availableForSale } = product;
   const uniformPrice = hasUniformPricing(product.priceRange, product.compareAtPriceRange);
-  const uniformStock = hasUniformStock(variants);
-  const singleVariant = variants.length === 1;
-  const eagerSelection = singleVariant ? computeSelection(product, undefined) : null;
+  const uniformStock = hasUniformStock(product);
+  const singleVariant = countEncodedVariants(product.encodedVariantExistence) <= 1;
+  const availableValues = getAvailableOptionValues(options, product.encodedVariantAvailability);
+  const eagerSelection = singleVariant
+    ? { selectedOptions: defaultSelectedOptions(product), selectedVariant: product.defaultVariant }
+    : null;
   const t = await getTranslations("product");
   const buyFallbackT = uniformStock && !singleVariant ? t : null;
-  const allInStock = variants[0]?.availableForSale ?? true;
+  const allInStock = product.defaultVariant?.availableForSale ?? availableForSale;
 
   return (
     <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
@@ -176,7 +179,7 @@ async function ProductInfoArea({
 
       {eagerSelection ? (
         <ProductInfoOptions
-          variants={variants}
+          availableValues={availableValues}
           options={options}
           selectedOptions={eagerSelection.selectedOptions}
           handle={handle}
@@ -186,9 +189,9 @@ async function ProductInfoArea({
         <Suspense
           fallback={
             <ProductInfoOptions
-              variants={variants}
+              availableValues={availableValues}
               options={options}
-              selectedOptions={{}}
+              selectedOptions={defaultSelectedOptions(product)}
               handle={handle}
               t={t}
               hideImages
@@ -196,7 +199,7 @@ async function ProductInfoArea({
           }
         >
           <ResolvedProductInfoOptions
-            variants={variants}
+            availableValues={availableValues}
             options={options}
             handle={handle}
             selectionPromise={selectionPromise}
@@ -250,13 +253,13 @@ async function ResolvedProductPrice({
 }
 
 async function ResolvedProductInfoOptions({
-  variants,
+  availableValues,
   options,
   handle,
   selectionPromise,
   t,
 }: {
-  variants: ProductDetails["variants"];
+  availableValues: Map<string, Set<string>>;
   options: ProductDetails["options"];
   handle: string;
   selectionPromise: Promise<ProductSelection>;
@@ -265,7 +268,7 @@ async function ResolvedProductInfoOptions({
   const { selectedOptions } = await selectionPromise;
   return (
     <ProductInfoOptions
-      variants={variants}
+      availableValues={availableValues}
       options={options}
       selectedOptions={selectedOptions}
       handle={handle}

--- a/apps/template/components/product-detail/product-info.tsx
+++ b/apps/template/components/product-detail/product-info.tsx
@@ -39,7 +39,7 @@ function ProductInfoHeader({
 }
 
 interface ProductInfoOptionsProps extends React.ComponentProps<"div"> {
-  variants: ProductVariant[];
+  availableValues: Map<string, Set<string>>;
   options: ProductOption[];
   selectedOptions: SelectedOptions;
   handle: string;
@@ -48,7 +48,7 @@ interface ProductInfoOptionsProps extends React.ComponentProps<"div"> {
 }
 
 function ProductInfoOptions({
-  variants,
+  availableValues,
   options,
   selectedOptions,
   handle,
@@ -87,7 +87,7 @@ function ProductInfoOptions({
             key={colorOption.id}
             option={colorOption}
             selectedValue={selectedOptions[colorOption.name] ?? ""}
-            variants={variants}
+            available={availableValues.get(colorOption.name)}
             handle={handle}
             selectedOptions={selectedOptions}
             t={t}
@@ -100,7 +100,7 @@ function ProductInfoOptions({
             key={option.id}
             option={option}
             selectedValue={selectedOptions[option.name] ?? ""}
-            variants={variants}
+            available={availableValues.get(option.name)}
             handle={handle}
             selectedOptions={selectedOptions}
           />

--- a/apps/template/components/product-detail/schema.tsx
+++ b/apps/template/components/product-detail/schema.tsx
@@ -1,5 +1,5 @@
 import { siteConfig } from "@/lib/config";
-import type { Image, Money, ProductVariant } from "@/lib/types";
+import type { Image, Money } from "@/lib/types";
 
 interface ProductSchemaData {
   id: string;
@@ -13,7 +13,7 @@ interface ProductSchemaData {
     minVariantPrice: Money;
     maxVariantPrice: Money;
   };
-  variants: ProductVariant[];
+  offerCount: number;
   availableForSale: boolean;
 }
 
@@ -37,7 +37,7 @@ function generateProductSchema(product: ProductSchemaData) {
       priceCurrency: product.currencyCode,
       lowPrice: product.priceRange.minVariantPrice.amount,
       highPrice: product.priceRange.maxVariantPrice.amount,
-      offerCount: product.variants.length,
+      offerCount: product.offerCount,
       availability: product.availableForSale
         ? "https://schema.org/InStock"
         : "https://schema.org/OutOfStock",

--- a/apps/template/lib/agent/server.ts
+++ b/apps/template/lib/agent/server.ts
@@ -105,7 +105,7 @@ function createSystemPrompt(ctx: AgentContext) {
     `;
   } else if (page?.type === "product") {
     const { product } = page;
-    const variantInfo = product.variants
+    const variantInfo = (product.variants ?? [])
       .map((v) => {
         const options = v.selectedOptions.map((o) => `${o.name}: ${o.value}`).join(", ");
         const stock = v.availableForSale ? "in stock" : "out of stock";

--- a/apps/template/lib/agent/tools/add-to-cart.ts
+++ b/apps/template/lib/agent/tools/add-to-cart.ts
@@ -41,7 +41,7 @@ If there are multiple variants (sizes, colors), ask the user which one they want
         let productInfo = "";
         if (page?.type === "product") {
           const { product } = page;
-          const variant = product.variants.find((v) => v.id === variant_id);
+          const variant = product.variants?.find((v) => v.id === variant_id);
           if (variant) {
             productInfo = ` (${product.title} - ${variant.title})`;
           }

--- a/apps/template/lib/agent/tools/get-product-details.ts
+++ b/apps/template/lib/agent/tools/get-product-details.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 
-import { getProduct } from "@/lib/shopify/operations/products";
+import { getProductWithVariants } from "@/lib/shopify/operations/products";
 
 import { getAgentContext } from "../server";
 
@@ -20,7 +20,7 @@ You can get handles from search results or the current page context.`,
       const { user } = getAgentContext();
 
       try {
-        const product = await getProduct({ handle, locale: user.locale });
+        const product = await getProductWithVariants({ handle, locale: user.locale });
 
         if (!product) {
           return {
@@ -43,7 +43,7 @@ You can get handles from search results or the current page context.`,
             vendor: product.vendor,
             tags: product.tags,
             images: product.images.map((img) => img.url),
-            variants: product.variants.map((v) => ({
+            variants: (product.variants ?? []).map((v) => ({
               id: v.id,
               title: v.title,
               available: v.availableForSale,

--- a/apps/template/lib/markdown/product.ts
+++ b/apps/template/lib/markdown/product.ts
@@ -65,7 +65,7 @@ export function productToMarkdown(product: ProductDetails, locale: string): stri
     sections.push("");
   }
 
-  if (product.variants.length > 0) {
+  if (product.variants && product.variants.length > 0) {
     sections.push("## Variants");
     sections.push("");
 

--- a/apps/template/lib/product.ts
+++ b/apps/template/lib/product.ts
@@ -1,4 +1,3 @@
-import { getNumericShopifyId } from "@/lib/shopify/utils";
 import type {
   Image,
   Money,
@@ -13,262 +12,75 @@ export type SelectedOptions = Record<string, string>;
 export interface ProductSelection {
   selectedOptions: SelectedOptions;
   selectedVariant: ProductVariant | undefined;
-  colorImages: Image[];
 }
 
-export function computeSelection(
-  product: ProductDetails,
-  variantId: string | undefined,
-): ProductSelection {
-  const { images, options, variants } = product;
-  const selectedOptions = computeInitialSelectedOptions(variants, variantId);
-  const selectedVariant = resolveSelectedVariant(variants, selectedOptions);
-  const colorImages = hasColorImagePartitioning(options, variants)
-    ? getPartitionedImagesForSelectedColor(images, options, variants, selectedOptions).colorImages
-    : [];
-  return { selectedOptions, selectedVariant, colorImages };
-}
-
-/** Called server-side so the initial HTML matches hydrated state (zero CLS). */
-export function computeInitialSelectedOptions(
-  variants: ProductVariant[],
-  initialVariantId?: string,
+/** Selected options from `?color=Blue&size=XS` params, keyed by canonical option name. */
+export function parseSelectedOptions(
+  options: ProductOption[],
+  searchParams: Record<string, string | string[] | undefined>,
 ): SelectedOptions {
-  if (initialVariantId) {
-    const matchedVariant = variants.find((v) => {
-      const numericId = getNumericShopifyId(v.id);
-      return numericId === initialVariantId;
-    });
-    if (matchedVariant) {
-      const opts: SelectedOptions = {};
-      for (const opt of matchedVariant.selectedOptions) {
-        opts[opt.name] = opt.value;
-      }
-      return opts;
-    }
+  const selected: SelectedOptions = {};
+  for (const option of options) {
+    const raw = searchParams[option.name.toLowerCase()];
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    if (value === undefined) continue;
+    const match = option.values.find((v) => v.name.toLowerCase() === value.toLowerCase());
+    selected[option.name] = match?.name ?? value;
   }
-  return getInitialSelectedOptions(variants);
+  return selected;
 }
 
-export function getInitialSelectedOptions(variants: ProductVariant[]): SelectedOptions {
-  const initial: SelectedOptions = {};
-  for (const option of variants[0]?.selectedOptions ?? []) {
-    initial[option.name] = option.value;
+/** The default variant's options — the selection shown when no params are present. */
+export function defaultSelectedOptions(product: ProductDetails): SelectedOptions {
+  const selected: SelectedOptions = {};
+  for (const option of product.defaultVariant?.selectedOptions ??
+    product.defaultVariantSelectedOptions ??
+    []) {
+    selected[option.name] = option.value;
   }
-  return initial;
+  return selected;
 }
 
-export function resolveSelectedVariant(
-  variants: ProductVariant[],
-  selectedOptions: SelectedOptions,
-) {
-  if (Object.keys(selectedOptions).length === 0) {
-    return variants[0];
-  }
-
-  return (
-    variants.find((variant) =>
-      variant.selectedOptions.every((option) => selectedOptions[option.name] === option.value),
-    ) ?? variants[0]
-  );
+export function toSelectedOptionList(selectedOptions: SelectedOptions): SelectedOption[] {
+  return Object.entries(selectedOptions).map(([name, value]) => ({ name, value }));
 }
 
-export function getVariantUrl(
+/** Option-based PDP URL, e.g. `/products/handle?color=Blue&size=XS`. */
+export function buildOptionUrl(
   handle: string,
-  variants: ProductVariant[],
   currentOptions: SelectedOptions,
   optionName: string,
   optionValue: string,
 ): string {
-  const newOptions = { ...currentOptions, [optionName]: optionValue };
-
-  let variant = variants.find((v) =>
-    v.selectedOptions.every((opt) => newOptions[opt.name] === opt.value),
+  const next = { ...currentOptions, [optionName]: optionValue };
+  const parts = Object.entries(next).map(
+    ([name, value]) => `${encodeURIComponent(name.toLowerCase())}=${encodeURIComponent(value)}`,
   );
-
-  if (!variant) {
-    variant = variants.find((v) =>
-      v.selectedOptions.some((opt) => opt.name === optionName && opt.value === optionValue),
-    );
-  }
-
-  const numericId = variant ? getNumericShopifyId(variant.id) : null;
-  if (numericId) {
-    return `/products/${handle}?variant=${numericId}`;
-  }
-
-  return `/products/${handle}`;
+  return parts.length > 0 ? `/products/${handle}?${parts.join("&")}` : `/products/${handle}`;
 }
 
-/**
- * Falls back to all product images when no color option exists, only one color
- * is available, or no variant images are assigned.
- */
-export function getImagesForSelectedColor(
-  images: Image[],
-  options: ProductOption[],
-  variants: ProductVariant[],
-  selectedOptions: SelectedOptions,
-): Image[] {
-  // Find the color option using swatch data (locale-agnostic) first, then
-  // fall back to the English name for stores without swatches configured.
-  const colorOption = options.find(
-    (opt) =>
-      opt.values.some((v) => v.swatch?.color || v.swatch?.image) ||
-      opt.name.toLowerCase().includes("color"),
-  );
-
-  if (!colorOption) return images;
-
-  const selectedColor = selectedOptions[colorOption.name];
-  if (!selectedColor) return images;
-
-  // Only one color means all images belong to it
-  if (colorOption.values.length <= 1) return images;
-
-  const colorToImageUrls = new Map<string, Set<string>>();
-  for (const variant of variants) {
-    if (!variant.image) continue;
-    const colorOpt = variant.selectedOptions.find((opt) => opt.name === colorOption.name);
-    if (!colorOpt) continue;
-
-    let urls = colorToImageUrls.get(colorOpt.value);
-    if (!urls) {
-      urls = new Set<string>();
-      colorToImageUrls.set(colorOpt.value, urls);
-    }
-    urls.add(variant.image.url);
-  }
-
-  if (colorToImageUrls.size === 0) return images;
-
-  const otherColorImageUrls = new Set<string>();
-  for (const [color, urls] of colorToImageUrls) {
-    if (color !== selectedColor) {
-      for (const url of urls) {
-        otherColorImageUrls.add(url);
-      }
+/** Representative variant images (one per option value, from firstSelectableVariant). */
+function colorImageUrls(options: ProductOption[]): Set<string> {
+  const urls = new Set<string>();
+  for (const option of options) {
+    for (const value of option.values) {
+      if (value.image) urls.add(value.image);
     }
   }
-
-  // Images shared with the selected color must not be excluded.
-  const selectedColorUrls = colorToImageUrls.get(selectedColor);
-  if (selectedColorUrls) {
-    for (const url of selectedColorUrls) {
-      otherColorImageUrls.delete(url);
-    }
-  }
-
-  const filtered = images.filter((img) => !otherColorImageUrls.has(img.url));
-
-  if (filtered.length === 0) return images;
-
-  const colorImages: typeof filtered = [];
-  const sharedImages: typeof filtered = [];
-
-  for (const img of filtered) {
-    if (selectedColorUrls?.has(img.url)) {
-      colorImages.push(img);
-    } else {
-      sharedImages.push(img);
-    }
-  }
-
-  const selectedVariant = resolveSelectedVariant(variants, selectedOptions);
-  const variantImageUrl = selectedVariant?.image?.url;
-
-  if (variantImageUrl) {
-    const variantIdx = colorImages.findIndex((img) => img.url === variantImageUrl);
-    if (variantIdx > 0) {
-      const [variantImage] = colorImages.splice(variantIdx, 1);
-      colorImages.unshift(variantImage);
-    }
-  }
-
-  return [...colorImages, ...sharedImages];
+  return urls;
 }
 
-export function getPartitionedImagesForSelectedColor(
-  images: Image[],
-  options: ProductOption[],
-  variants: ProductVariant[],
-  selectedOptions: SelectedOptions,
-): { colorImages: Image[]; otherImages: Image[] } {
-  // Find the color option using swatch data (locale-agnostic) first, then
-  // fall back to the English name for stores without swatches configured.
-  const colorOption = options.find(
-    (opt) =>
-      opt.values.some((v) => v.swatch?.color || v.swatch?.image) ||
-      opt.name.toLowerCase().includes("color"),
-  );
+/** True when the gallery should lead with a color-specific (selected-variant) image. */
+export function hasColorImagePartitioning(options: ProductOption[]): boolean {
+  return options.some((option) => option.values.filter((value) => value.image).length > 1);
+}
 
-  if (!colorOption) return { colorImages: [], otherImages: images };
-
-  const selectedColor = selectedOptions[colorOption.name];
-  if (!selectedColor) return { colorImages: [], otherImages: images };
-
-  if (colorOption.values.length <= 1) return { colorImages: images, otherImages: [] };
-
-  const colorToImageUrls = new Map<string, Set<string>>();
-  for (const variant of variants) {
-    if (!variant.image) continue;
-    const colorOpt = variant.selectedOptions.find((opt) => opt.name === colorOption.name);
-    if (!colorOpt) continue;
-
-    let urls = colorToImageUrls.get(colorOpt.value);
-    if (!urls) {
-      urls = new Set<string>();
-      colorToImageUrls.set(colorOpt.value, urls);
-    }
-    urls.add(variant.image.url);
-  }
-
-  if (colorToImageUrls.size === 0) return { colorImages: [], otherImages: images };
-
-  const otherColorImageUrls = new Set<string>();
-  for (const [color, urls] of colorToImageUrls) {
-    if (color !== selectedColor) {
-      for (const url of urls) {
-        otherColorImageUrls.add(url);
-      }
-    }
-  }
-
-  // Images shared with the selected color must not be excluded.
-  const selectedColorUrls = colorToImageUrls.get(selectedColor);
-  if (selectedColorUrls) {
-    for (const url of selectedColorUrls) {
-      otherColorImageUrls.delete(url);
-    }
-  }
-
-  const filtered = images.filter((img) => !otherColorImageUrls.has(img.url));
-
-  if (filtered.length === 0) return { colorImages: [], otherImages: images };
-
-  const colorImages: Image[] = [];
-  const otherImages: Image[] = [];
-
-  for (const img of filtered) {
-    if (selectedColorUrls?.has(img.url)) {
-      colorImages.push(img);
-    } else {
-      otherImages.push(img);
-    }
-  }
-
-  const selectedVariant = resolveSelectedVariant(variants, selectedOptions);
-  const variantImageUrl = selectedVariant?.image?.url;
-
-  if (variantImageUrl) {
-    const variantIdx = colorImages.findIndex((img) => img.url === variantImageUrl);
-    if (variantIdx > 0) {
-      const [variantImage] = colorImages.splice(variantIdx, 1);
-      colorImages.unshift(variantImage);
-    }
-  }
-
-  return { colorImages, otherImages };
+/** Product images that aren't a specific color's representative image. */
+export function getSharedImages(images: Image[], options: ProductOption[]): Image[] {
+  const colorUrls = colorImageUrls(options);
+  if (colorUrls.size === 0) return images;
+  const shared = images.filter((image) => !colorUrls.has(image.url));
+  return shared.length > 0 ? shared : images;
 }
 
 /** When true, the price renders without waiting for searchParams to resolve the variant. */
@@ -285,57 +97,15 @@ export function hasUniformPricing(
   return compareAtPriceRange.minVariantPrice.amount === compareAtPriceRange.maxVariantPrice.amount;
 }
 
-/** When true, buy-button labels can render in the Suspense fallback without variant resolution. */
-export function hasUniformStock(variants: ProductVariant[]): boolean {
-  if (variants.length <= 1) return true;
-  const first = variants[0];
-  return variants.every((v) => v.availableForSale === first.availableForSale);
-}
-
-/** True when the gallery depends on selected color (i.e. on searchParams). */
-export function hasColorImagePartitioning(
-  options: ProductOption[],
-  variants: ProductVariant[],
-): boolean {
-  const colorOption = options.find(
-    (opt) =>
-      opt.values.some((v) => v.swatch?.color || v.swatch?.image) ||
-      opt.name.toLowerCase().includes("color"),
-  );
-
-  if (!colorOption || colorOption.values.length <= 1) return false;
-
-  return variants.some(
-    (v) => v.image && v.selectedOptions.some((opt) => opt.name === colorOption.name),
-  );
-}
-
-/** Images not assigned to any color variant — can render without waiting for searchParams. */
-export function getSharedImages(
-  images: Image[],
-  options: ProductOption[],
-  variants: ProductVariant[],
-): Image[] {
-  const colorOption = options.find(
-    (opt) =>
-      opt.values.some((v) => v.swatch?.color || v.swatch?.image) ||
-      opt.name.toLowerCase().includes("color"),
-  );
-
-  if (!colorOption || colorOption.values.length <= 1) return images;
-
-  const allColorImageUrls = new Set<string>();
-  for (const variant of variants) {
-    if (!variant.image) continue;
-    const colorOpt = variant.selectedOptions.find((opt) => opt.name === colorOption.name);
-    if (colorOpt) {
-      allColorImageUrls.add(variant.image.url);
-    }
-  }
-
-  if (allColorImageUrls.size === 0) return images;
-
-  return images.filter((img) => !allColorImageUrls.has(img.url));
+/**
+ * True when every existing option combination is in stock, so buy-button labels
+ * can render in the Suspense fallback without resolving the variant. Derived from
+ * the encoded availability/existence tries (equal ⇒ nothing is sold out).
+ */
+export function hasUniformStock(product: ProductDetails): boolean {
+  const { encodedVariantAvailability, encodedVariantExistence } = product;
+  if (!encodedVariantExistence) return true;
+  return encodedVariantAvailability === encodedVariantExistence;
 }
 
 export type OptimisticProductInfo = {

--- a/apps/template/lib/product.ts
+++ b/apps/template/lib/product.ts
@@ -1,18 +1,6 @@
-import type {
-  Image,
-  Money,
-  ProductDetails,
-  ProductOption,
-  ProductVariant,
-  SelectedOption,
-} from "@/lib/types";
+import type { Image, Money, ProductDetails, ProductOption, SelectedOption } from "@/lib/types";
 
 export type SelectedOptions = Record<string, string>;
-
-export interface ProductSelection {
-  selectedOptions: SelectedOptions;
-  selectedVariant: ProductVariant | undefined;
-}
 
 /** Selected options from `?color=Blue&size=XS` params, keyed by canonical option name. */
 export function parseSelectedOptions(
@@ -59,28 +47,55 @@ export function buildOptionUrl(
   return parts.length > 0 ? `/products/${handle}?${parts.join("&")}` : `/products/${handle}`;
 }
 
-/** Representative variant images (one per option value, from firstSelectableVariant). */
-function colorImageUrls(options: ProductOption[]): Set<string> {
-  const urls = new Set<string>();
-  for (const option of options) {
-    for (const value of option.values) {
-      if (value.image) urls.add(value.image);
-    }
-  }
-  return urls;
+/** The color option, detected by swatch data or name — the only axis that partitions the gallery. */
+function findColorOption(options: ProductOption[]): ProductOption | undefined {
+  return options.find(
+    (option) =>
+      option.values.some((value) => value.swatch?.color || value.swatch?.image) ||
+      option.name.toLowerCase().includes("color"),
+  );
 }
 
-/** True when the gallery should lead with a color-specific (selected-variant) image. */
+/**
+ * True only when the color axis has multiple values with distinct representative
+ * images — so the gallery should lead with the selected color's image. Other
+ * multi-value axes (size, etc.) share imagery and must not trigger a streamed slot.
+ */
 export function hasColorImagePartitioning(options: ProductOption[]): boolean {
-  return options.some((option) => option.values.filter((value) => value.image).length > 1);
+  const color = findColorOption(options);
+  if (!color || color.values.length <= 1) return false;
+  return color.values.filter((value) => value.image).length > 1;
 }
 
 /** Product images that aren't a specific color's representative image. */
 export function getSharedImages(images: Image[], options: ProductOption[]): Image[] {
-  const colorUrls = colorImageUrls(options);
+  const color = findColorOption(options);
+  if (!color) return images;
+  const colorUrls = new Set(
+    color.values.map((value) => value.image).filter((url): url is string => Boolean(url)),
+  );
   if (colorUrls.size === 0) return images;
   const shared = images.filter((image) => !colorUrls.has(image.url));
   return shared.length > 0 ? shared : images;
+}
+
+/** The selected color's representative image, resolved from options alone (no variant query). */
+export function getSelectedColorImage(
+  product: ProductDetails,
+  selectedOptions: SelectedOptions,
+): Image | undefined {
+  const color = findColorOption(product.options);
+  if (!color) return undefined;
+  const value = color.values.find((v) => v.name === selectedOptions[color.name]);
+  if (!value?.image) return undefined;
+  return (
+    product.images.find((image) => image.url === value.image) ?? {
+      url: value.image,
+      altText: product.title,
+      width: 0,
+      height: 0,
+    }
+  );
 }
 
 /** When true, the price renders without waiting for searchParams to resolve the variant. */

--- a/apps/template/lib/shopify/encoded-variants.ts
+++ b/apps/template/lib/shopify/encoded-variants.ts
@@ -1,0 +1,127 @@
+import type { ProductOption } from "@/lib/types";
+
+// Decoder for Shopify's encodedVariantExistence / encodedVariantAvailability trie
+// strings (Storefront API 2024-10+). Control chars: ":" descends an option level,
+// "," ends a repeated prefix (consecutive commas pop multiple levels), " " marks a
+// gap between non-contiguous sibling values, "-" a contiguous range of values.
+export function decodeEncodedVariant(encoded: string): number[][] {
+  if (!encoded) return [];
+  if (!encoded.startsWith("v1_")) throw new Error("Unsupported option value encoding");
+  return v1Decoder(encoded.replace(/^v1_/, ""));
+}
+
+function v1Decoder(encoded: string): number[][] {
+  const result: number[][] = [];
+  const combination: number[] = [];
+  let depth = 0;
+  let rangeStart: number | null = null;
+  let prevControl = "";
+  let lastIndex = 0;
+
+  const pushRange = (end: number) => {
+    for (let v = rangeStart as number; v <= end; v++) {
+      combination[depth] = v;
+      result.push(combination.slice(0, depth + 1));
+    }
+    rangeStart = null;
+  };
+
+  const tokenizer = /[ :,-]/g;
+  let match = tokenizer.exec(encoded);
+  while (match !== null) {
+    const control = match[0];
+    const value =
+      match.index > lastIndex
+        ? Number.parseInt(encoded.slice(lastIndex, match.index), 10) || 0
+        : null;
+
+    if (control === "-") {
+      rangeStart = value ?? 0;
+    } else if (control === ":") {
+      if (value !== null) combination[depth] = value;
+      depth++;
+    } else if (control === " ") {
+      if (rangeStart !== null) {
+        pushRange(value ?? rangeStart);
+      } else if (value !== null) {
+        combination[depth] = value;
+        result.push(combination.slice(0, depth + 1));
+      }
+    } else {
+      // ","
+      if (rangeStart !== null) {
+        pushRange(value ?? rangeStart);
+      } else if (prevControl !== ",") {
+        if (value !== null) combination[depth] = value;
+        result.push(combination.slice(0, depth + 1));
+      }
+      depth = Math.max(0, depth - 1);
+      combination.length = depth;
+    }
+
+    prevControl = control;
+    lastIndex = tokenizer.lastIndex;
+    match = tokenizer.exec(encoded);
+  }
+
+  const trailing = encoded.slice(lastIndex);
+  if (/\d/.test(trailing)) {
+    const value = Number.parseInt(trailing, 10) || 0;
+    if (rangeStart !== null) {
+      pushRange(value);
+    } else {
+      combination[depth] = value;
+      result.push(combination.slice(0, depth + 1));
+    }
+  }
+
+  return result;
+}
+
+/** Count of existing variants from an encoded existence trie (0 on missing/invalid). */
+export function countEncodedVariants(encoded: string | undefined): number {
+  if (!encoded) return 0;
+  try {
+    return decodeEncodedVariant(encoded).length;
+  } catch {
+    return 0;
+  }
+}
+
+// Maps decoded availability combinations to the set of in-stock value names per
+// option. Falls back to "all available" on missing data, decode failure, or the
+// empty result Shopify returns for synthetic single-option products (a known
+// upstream quirk) — the authoritative per-variant availability still gates the
+// add-to-cart button via the suspended variant query.
+export function getAvailableOptionValues(
+  options: ProductOption[],
+  encodedAvailability: string | undefined,
+): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+  const allAvailable = () => {
+    for (const option of options) {
+      map.set(option.name, new Set(option.values.map((v) => v.name)));
+    }
+    return map;
+  };
+
+  if (!encodedAvailability) return allAvailable();
+
+  let combinations: number[][];
+  try {
+    combinations = decodeEncodedVariant(encodedAvailability);
+  } catch {
+    return allAvailable();
+  }
+  if (combinations.length === 0) return allAvailable();
+
+  for (const option of options) map.set(option.name, new Set());
+  for (const combination of combinations) {
+    for (let i = 0; i < combination.length; i++) {
+      const option = options[i];
+      const valueName = option?.values[combination[i]]?.name;
+      if (valueName) map.get(option.name)?.add(valueName);
+    }
+  }
+  return map;
+}

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -243,12 +243,10 @@ export const PRODUCT_FRAGMENT = `
         ...MoneyFields
       }
     }
-    variants(first: 250) {
-      edges {
-        node {
-          ...ProductVariantFields
-        }
-      }
+    encodedVariantExistence
+    encodedVariantAvailability
+    selectedOrFirstAvailableVariant {
+      ...ProductVariantFields
     }
     options {
       id
@@ -265,6 +263,11 @@ export const PRODUCT_FRAGMENT = `
             }
           }
         }
+        firstSelectableVariant {
+          image {
+            ...ImageFields
+          }
+        }
       }
     }
     seo {
@@ -278,6 +281,23 @@ export const PRODUCT_FRAGMENT = `
       edges {
         node {
           handle
+        }
+      }
+    }
+  }
+`;
+
+// Extends the slim shell with the full variant matrix. Used by the AI agent and
+// markdown routes, which enumerate variants; the PDP uses the slim ProductFields
+// plus a per-selection variant query instead.
+export const PRODUCT_WITH_VARIANTS_FRAGMENT = `
+  ${PRODUCT_FRAGMENT}
+  fragment ProductWithVariantsFields on Product {
+    ...ProductFields
+    variants(first: 250) {
+      edges {
+        node {
+          ...ProductVariantFields
         }
       }
     }

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -1,16 +1,32 @@
 import { cacheLife, cacheTag } from "next/cache";
 
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
-import type { Filter, PageInfo, PriceRange, ProductCard, ProductDetails } from "@/lib/types";
+import type {
+  Filter,
+  PageInfo,
+  PriceRange,
+  ProductCard,
+  ProductDetails,
+  ProductVariant,
+  SelectedOption,
+} from "@/lib/types";
 
 import { shopifyFetch } from "../fetch";
-import { PRODUCT_CARD_FRAGMENT, PRODUCT_FRAGMENT } from "../fragments";
+import {
+  IMAGE_FRAGMENT,
+  PRODUCT_CARD_FRAGMENT,
+  PRODUCT_FRAGMENT,
+  PRODUCT_VARIANT_FRAGMENT,
+  PRODUCT_WITH_VARIANTS_FRAGMENT,
+} from "../fragments";
 import { transformShopifyFilters } from "../transforms/filters";
 import {
   type ShopifyProduct,
   type ShopifyProductCard,
+  type ShopifyVariant,
   transformShopifyProductCard,
   transformShopifyProductDetails,
+  transformVariant,
 } from "../transforms/product";
 import type { ProductFilter, ShopifyFilter } from "../types/filters";
 import { getNumericShopifyId } from "../utils";
@@ -58,6 +74,89 @@ export async function getProduct({
   }>({
     operation: "getProductByHandle",
     query: GET_PRODUCT_BY_HANDLE_QUERY,
+    variables: { handle, country, language },
+  });
+
+  if (!data.productByHandle) {
+    return undefined;
+  }
+
+  tagProducts([data.productByHandle]);
+
+  return transformShopifyProductDetails(data.productByHandle);
+}
+
+const GET_PRODUCT_VARIANT_QUERY = `
+  ${IMAGE_FRAGMENT}
+  ${PRODUCT_VARIANT_FRAGMENT}
+  query getProductVariant($handle: String!, $selectedOptions: [SelectedOptionInput!]!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    productByHandle(handle: $handle) {
+      selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {
+        ...ProductVariantFields
+      }
+    }
+  }
+`;
+
+// Resolves the active variant from selected options (the suspended PDP query).
+// Empty selectedOptions returns the first available variant — matches the
+// no-params / partial-selection fallback the PDP relies on.
+export async function getProductVariant({
+  handle,
+  locale = defaultLocale,
+  selectedOptions,
+}: {
+  handle: string;
+  locale?: string;
+  selectedOptions: SelectedOption[];
+}): Promise<ProductVariant | undefined> {
+  "use cache";
+  cacheLife("max");
+  cacheTag("products", `product-${handle}`);
+  const country = getCountryCode(locale);
+  const language = getLanguageCode(locale);
+
+  const data = await shopifyFetch<{
+    productByHandle: { selectedOrFirstAvailableVariant: ShopifyVariant | null } | null;
+  }>({
+    operation: "getProductVariant",
+    query: GET_PRODUCT_VARIANT_QUERY,
+    variables: { handle, selectedOptions, country, language },
+  });
+
+  const variant = data.productByHandle?.selectedOrFirstAvailableVariant;
+  return variant ? transformVariant(variant) : undefined;
+}
+
+const GET_PRODUCT_WITH_VARIANTS_QUERY = `
+  ${PRODUCT_WITH_VARIANTS_FRAGMENT}
+  query getProductWithVariants($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    productByHandle(handle: $handle) {
+      ...ProductWithVariantsFields
+    }
+  }
+`;
+
+// Slim shell + full variant matrix; for the AI agent and markdown routes that
+// enumerate variants. The PDP uses getProduct + getProductVariant instead.
+export async function getProductWithVariants({
+  handle,
+  locale = defaultLocale,
+}: {
+  handle: string;
+  locale?: string;
+}): Promise<ProductDetails | undefined> {
+  "use cache";
+  cacheLife("max");
+  cacheTag("products", `product-${handle}`);
+  const country = getCountryCode(locale);
+  const language = getLanguageCode(locale);
+
+  const data = await shopifyFetch<{
+    productByHandle: ShopifyProduct;
+  }>({
+    operation: "getProductWithVariants",
+    query: GET_PRODUCT_WITH_VARIANTS_QUERY,
     variables: { handle, country, language },
   });
 
@@ -713,11 +812,11 @@ const GET_PRODUCTS_BY_HANDLES_QUERY = `
 `;
 
 const GET_PRODUCT_BY_ID_QUERY = `
-  ${PRODUCT_FRAGMENT}
+  ${PRODUCT_WITH_VARIANTS_FRAGMENT}
   query getProductById($id: ID!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     node(id: $id) {
       ... on Product {
-        ...ProductFields
+        ...ProductWithVariantsFields
       }
     }
   }

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -24,7 +24,7 @@ interface ShopifyMoney {
   currencyCode: string;
 }
 
-interface ShopifyVariant {
+export interface ShopifyVariant {
   id: string;
   title: string;
   availableForSale: boolean;
@@ -43,6 +43,7 @@ interface ShopifyOptionValue {
   id: string;
   name: string;
   swatch: ShopifyOptionValueSwatch | null;
+  firstSelectableVariant?: { image: ShopifyImage | null } | null;
 }
 
 interface ShopifyOption {
@@ -111,7 +112,10 @@ export interface ShopifyProduct {
     minVariantPrice: ShopifyMoney;
     maxVariantPrice: ShopifyMoney;
   } | null;
-  variants: ShopifyEdges<ShopifyVariant>;
+  encodedVariantAvailability?: string | null;
+  encodedVariantExistence?: string | null;
+  selectedOrFirstAvailableVariant?: ShopifyVariant | null;
+  variants?: ShopifyEdges<ShopifyVariant>;
   options: ShopifyOption[];
   seo: {
     title: string | null;
@@ -211,7 +215,7 @@ function transformCategory(category: ShopifyCategory | null | undefined): Catego
   };
 }
 
-function transformVariant(variant: ShopifyVariant): ProductVariant {
+export function transformVariant(variant: ShopifyVariant): ProductVariant {
   return {
     id: variant.id,
     title: variant.title,
@@ -234,9 +238,11 @@ function transformSwatch(swatch: ShopifyOptionValueSwatch | null): OptionValueSw
 
 function transformOption(option: ShopifyOption): ProductOption {
   const swatchLookup = new Map<string, OptionValueSwatch | undefined>();
+  const imageLookup = new Map<string, string | undefined>();
   if (option.optionValues) {
     for (const ov of option.optionValues) {
       swatchLookup.set(ov.name, transformSwatch(ov.swatch));
+      imageLookup.set(ov.name, ov.firstSelectableVariant?.image?.url);
     }
   }
 
@@ -246,6 +252,7 @@ function transformOption(option: ShopifyOption): ProductOption {
     values: option.values.map(
       (value): OptionValue => ({
         id: value,
+        image: imageLookup.get(value),
         name: value,
         swatch: swatchLookup.get(value),
       }),
@@ -302,8 +309,12 @@ export function transformShopifyProductCard(product: ShopifyProductCard): Produc
 }
 
 export function transformShopifyProductDetails(product: ShopifyProduct): ProductDetails {
-  const variants = flattenEdges(product.variants).map(transformVariant);
-  const defaultVariant = variants.find((v) => v.availableForSale);
+  const variants = product.variants
+    ? flattenEdges(product.variants).map(transformVariant)
+    : undefined;
+  const defaultVariant = product.selectedOrFirstAvailableVariant
+    ? transformVariant(product.selectedOrFirstAvailableVariant)
+    : (variants?.find((v) => v.availableForSale) ?? variants?.[0]);
   return {
     id: product.id,
     handle: product.handle,
@@ -313,6 +324,7 @@ export function transformShopifyProductDetails(product: ShopifyProduct): Product
     compareAtPrice: product.compareAtPriceRange?.minVariantPrice ?? undefined,
     vendor: product.vendor || undefined,
     availableForSale: product.availableForSale,
+    defaultVariant,
     defaultVariantId: defaultVariant?.id,
     defaultVariantNumericId: defaultVariant
       ? (getNumericShopifyId(defaultVariant.id) ?? undefined)
@@ -320,6 +332,8 @@ export function transformShopifyProductDetails(product: ShopifyProduct): Product
     defaultVariantSelectedOptions: defaultVariant?.selectedOptions ?? [],
     description: product.description,
     descriptionHtml: product.descriptionHtml,
+    encodedVariantAvailability: product.encodedVariantAvailability ?? undefined,
+    encodedVariantExistence: product.encodedVariantExistence ?? undefined,
     ...extractMediaFromProduct(product),
     variants,
     options: product.options.map(transformOption),

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -64,8 +64,14 @@ export interface ProductDetails extends ProductCard {
     minVariantPrice: Money;
   };
   currencyCode: string;
+  /** Selected-or-first-available variant; powers the eager/no-params render. */
+  defaultVariant?: ProductVariant;
   description: string;
   descriptionHtml: string;
+  /** Trie of option-value combinations with an available variant (Storefront 2024-10+). */
+  encodedVariantAvailability?: string;
+  /** Trie of option-value combinations that exist (Storefront 2024-10+). */
+  encodedVariantExistence?: string;
   images: Image[];
   manufacturerName: string;
   metafields?: Metafield[];
@@ -77,7 +83,8 @@ export interface ProductDetails extends ProductCard {
   seo: SEO;
   tags: string[];
   updatedAt: string;
-  variants: ProductVariant[];
+  /** Only populated by getProductWithVariants (agent + markdown); the PDP omits it. */
+  variants?: ProductVariant[];
   videos: Video[];
 }
 
@@ -104,6 +111,8 @@ export interface OptionValueSwatch {
 
 export interface OptionValue {
   id: string;
+  /** Representative variant image for this value (first selectable variant). */
+  image?: string;
   name: string;
   swatch?: OptionValueSwatch;
 }

--- a/packages/plugin/template-rollout-log/2026-06-18-pdp-selected-options-variant-urls.md
+++ b/packages/plugin/template-rollout-log/2026-06-18-pdp-selected-options-variant-urls.md
@@ -44,11 +44,19 @@ carries:
 - `options.optionValues.firstSelectableVariant.image` — a representative image per option value,
   threaded onto `OptionValue.image` for swatches and the color gallery.
 
-Price and add-to-cart depend on `getProductVariant({ handle, selectedOptions })`, which calls
+The page derives two promises from `searchParams`. A **fast** `selectedOptionsPromise` (URL only)
+drives the picker highlight and the color image, so they resolve at `searchParams` speed. A
+separate `variantPromise` resolves the variant for price + add-to-cart via
+`getProductVariant({ handle, selectedOptions })`, which calls
 `selectedOrFirstAvailableVariant(selectedOptions:, ignoreUnknownOptions: true,
 caseInsensitiveMatch: true)`. It is `use cache` + `cacheTag("products", \`product-${handle}\`)`,
 so each option combination is cached and invalidates with the product. When no option params are
-present, the page skips the round-trip and uses the cached default variant.
+present, the page skips the round-trip and uses the cached default variant. Keeping the picker off
+the network promise is what prevents the selected option from snapping in after load.
+
+Gallery partitioning is restricted to the **color** axis (multiple values with distinct
+representative images); the leading color image comes from `getSelectedColorImage()` on the fast
+options promise — no variant query. Non-color axes (size, finish) keep a fully static gallery.
 
 Consumers that genuinely enumerate the full matrix — the AI agent page context
 (`app/api/chat/route.ts`), `getProductDetails`, and the markdown route — now call the new

--- a/packages/plugin/template-rollout-log/2026-06-18-pdp-selected-options-variant-urls.md
+++ b/packages/plugin/template-rollout-log/2026-06-18-pdp-selected-options-variant-urls.md
@@ -1,0 +1,100 @@
+---
+title: PDP variant selection via selected-options URLs and a suspended variant query
+changeKey: pdp-selected-options-variant-urls
+introducedOn: 2026-06-18
+changeType: refactor
+defaultAction: adopt
+appliesTo:
+  - all
+supersedes:
+  - shopify-variant-query-param
+  - pdp-variants-first-250
+  - pdp-color-gallery-fallback
+paths:
+  - apps/template/lib/shopify/encoded-variants.ts
+  - apps/template/lib/shopify/fragments.ts
+  - apps/template/lib/shopify/operations/products.ts
+  - apps/template/lib/shopify/transforms/product.ts
+  - apps/template/lib/product.ts
+  - apps/template/lib/types.ts
+  - apps/template/app/products/[handle]/page.tsx
+  - apps/template/components/product-detail/product-detail-section.tsx
+  - apps/template/components/product-detail/product-info.tsx
+  - apps/template/components/product-detail/color-picker.tsx
+  - apps/template/components/product-detail/option-picker.tsx
+  - apps/template/components/product-detail/schema.tsx
+  - apps/template/app/md/products/[handle]/route.ts
+  - apps/template/app/api/chat/route.ts
+  - apps/template/lib/agent/tools/get-product-details.ts
+---
+
+## Summary
+
+The PDP now selects variants by option (`/products/handle?color=Blue&size=XS`) instead of
+`?variant=<numericId>`, and resolves the active variant with a **suspended Shopify query** keyed
+on the selected options rather than a client-side scan of an inline variant list.
+
+The cached product shell (`getProduct`) no longer fetches `variants(first: 250)`. Instead it
+carries:
+
+- `encodedVariantExistence` / `encodedVariantAvailability` (Storefront 2024-10 tries) — decoded
+  in `lib/shopify/encoded-variants.ts` to drive swatch availability and the variant count.
+- `selectedOrFirstAvailableVariant` — the default variant for the no-params / single-variant
+  eager render.
+- `options.optionValues.firstSelectableVariant.image` — a representative image per option value,
+  threaded onto `OptionValue.image` for swatches and the color gallery.
+
+Price and add-to-cart depend on `getProductVariant({ handle, selectedOptions })`, which calls
+`selectedOrFirstAvailableVariant(selectedOptions:, ignoreUnknownOptions: true,
+caseInsensitiveMatch: true)`. It is `use cache` + `cacheTag("products", \`product-${handle}\`)`,
+so each option combination is cached and invalidates with the product. When no option params are
+present, the page skips the round-trip and uses the cached default variant.
+
+Consumers that genuinely enumerate the full matrix — the AI agent page context
+(`app/api/chat/route.ts`), `getProductDetails`, and the markdown route — now call the new
+`getProductWithVariants` (slim shell + `variants(first: 250)`). `ProductDetails.variants` is now
+optional; only `getProductWithVariants` / `getProductById` populate it.
+
+## Why it matters
+
+- **Shareable, human-readable URLs.** `?color=Blue&size=XS` is meaningful and SEO-friendly; it no
+  longer leaks opaque numeric variant IDs.
+- **Correct contextual variant data.** The displayed price/availability and the add-to-cart
+  merchandise ID come from a live, locale-`@inContext` query for the exact selection, decoupled
+  from the long-lived cached shell — the right foundation for Shopify Markets pricing.
+- **Smaller cached payload.** The PDP shell stops shipping up to 250 variants; availability is a
+  compact encoded string.
+
+## Apply when
+
+- The storefront still ships the default `/products/[handle]` PDP, option pickers, and Shopify
+  Storefront API >= 2024-10 (for the encoded availability fields).
+
+## Safe to skip when
+
+- The storefront pins a Storefront API version older than 2024-10 (no `encodedVariant*` fields).
+- The storefront needs per-color galleries that show *every* image for a color. This change leads
+  the gallery with the selected variant's single image plus the shared media; multi-image-per-color
+  partitioning required the full variant list and is intentionally dropped.
+- The storefront already replaced the PDP data layer with its own variant resolution.
+
+## Tradeoff
+
+Swatch availability comes from `encodedVariantAvailability` rather than per-variant stock in an
+inline list. The decoder guards the known upstream quirk (synthetic single-option products) by
+treating all values as available; the authoritative per-variant availability still gates the
+add-to-cart button via the suspended query. The color gallery loses per-color multi-image
+filtering (see above).
+
+## Validation
+
+1. `pnpm --filter template build` succeeds; the PDP prerenders as Partial Prerender (◐).
+2. On a multi-variant product: selecting a swatch updates the URL to `?color=…&size=…`; price and
+   add-to-cart restream; the resolved variant adds the correct merchandise ID; out-of-stock /
+   nonexistent combinations are greyed.
+3. Deep-linking a full `?color=&size=` URL renders the matching variant with no layout shift; a
+   partial URL falls back via `selectedOrFirstAvailableVariant`.
+4. A single-variant product renders price + buy buttons eagerly (no suspended query).
+5. `curl -H "Accept: text/markdown" /products/<handle>` still includes the Variants table, and the
+   AI agent can still list variants and add the current product to the cart (both via
+   `getProductWithVariants`).


### PR DESCRIPTION
## What

Moves the PDP from `?variant=<numericId>` to per-option URLs (`/products/handle?color=Blue&size=XS`) and resolves the active variant with a **suspended Shopify query** keyed on the selected options, instead of scanning an inline 250-variant list.

## Why

- **Shareable, human-readable URLs** — no opaque numeric variant IDs.
- **Correct contextual variant data** — the displayed price/availability and add-to-cart merchandise ID come from a live, locale-`@inContext` query for the exact selection, decoupled from the long-lived cached shell (the right foundation for Shopify Markets pricing).
- **Smaller cached payload** — the PDP shell stops shipping up to 250 variants; availability is a compact encoded string.

## How

- **Slim shell** — `getProduct` drops `variants(first:250)` and instead carries `encodedVariantExistence`/`encodedVariantAvailability`, `selectedOrFirstAvailableVariant` (default/eager variant), and a representative image per option value (`firstSelectableVariant.image`).
- **Suspended variant query** — new `getProductVariant({handle, selectedOptions})` calls `selectedOrFirstAvailableVariant(selectedOptions:, ignoreUnknownOptions:true, caseInsensitiveMatch:true)`, cached per combination under the product tag. The no-params case skips the round-trip and uses the cached default.
- **Availability decoder** — new `lib/shopify/encoded-variants.ts` decodes Shopify's encoded-variant trie (validated against the documented example), with a guard for the known single-default-option upstream quirk.
- **Optional `variants`** — `ProductDetails.variants` is now optional; the AI agent page context, `getProductDetails`, and the markdown route use the new `getProductWithVariants` (slim shell + full matrix). Product cards link to the bare product URL.

## Tradeoff

The color gallery leads with the selected variant's image plus the shared media instead of filtering out *every* other-color image — that filtering required the inline variant list, which the PDP no longer fetches.

## Verification

- `pnpm build` ✓ (24/24 static pages; PDP prerenders as Partial Prerender), `pnpm lint` + format ✓.
- Live dev (jtwics-2): option links render `?finish=Smoked%20Ash`; deep-link resolves the variant and renders its price; markdown route still emits the Variants table; homepage cards use bare URLs with zero `?variant=` leakage; no runtime errors.

> [!NOTE]
> The dev store only has single-axis ("Finish") products, so the multi-axis color+size matrix and out-of-stock swatch greying weren't exercised locally — best validated against the apparel preview store (vpparel). No unit test is committed (the template has no test runner); the decoder was validated with a throwaway script + live data.

Docs (anatomy/PDP, shopify/PDP, routes, troubleshooting, markets, product-card) and a `template-rollout-log` entry are updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)