### PR TITLE
[template] PDP: reserve price-fallback height to prevent CLS

### DIFF
--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -187,7 +187,8 @@ async function ProductInfoArea({
             locale={locale}
           />
         ) : (
-          <Suspense fallback={<div className="h-6" aria-hidden />}>
+          // h-7 matches the resolved price's text-xl line-height (1.75rem) — keep in sync to avoid CLS
+          <Suspense fallback={<div className="h-7" aria-hidden />}>
             <ResolvedProductPrice variantPromise={variantPromise} locale={locale} />
           </Suspense>
         )}


### PR DESCRIPTION
## What

On products whose variant prices differ, the PDP price renders from the suspended variant query (it can't be committed eagerly from the static shell). Its `Suspense` fallback reserved `h-6` (24px), but the resolved `ProductPrice` renders `Price` at `text-xl` whose line-height is `1.75rem` = **28px**. When the price resolved, the header grew 4px and pushed Color / Size / buy buttons / description down — a visible CLS on every cold load.

## Fix

Reserve `h-7` (28px) so the fallback matches the resolved price line exactly. Added a one-line note so the coupling (fallback height ↔ the price's `text-xl` line-height) doesn't silently drift again.

The uniform-price path was already shift-free (rendered eagerly in the static shell); this only affected products with varying prices (e.g. the apparel store).

Verified the discounted case too: `DiscountBadge` is `text-xs` + `py-0.5` (~20px), shorter than the 28px text line in an `items-center` row, so the row stays 28px with or without a sale badge — `h-7` covers both.

## Verification

- `pnpm --filter template lint` ✓ (oxlint + oxfmt --check)
- Repro: load a varying-price PDP (e.g. `/products/cadencewing-tee-womens-8ff7f2?color=Black&size=SM`) and confirm content below the title no longer drops when the price streams in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)