### PR TITLE
[template] PDP: precompute exact-signal product fields

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -94,6 +94,6 @@ The page emits two JSON-LD schemas:
 | `components/product-detail/product-media.tsx`          | Responsive image gallery (mobile carousel, desktop grid + lightbox)                            |
 | `components/product-detail/buy-buttons.tsx`            | Buy with Shop + add-to-cart client component                                                   |
 | `lib/product.ts`                                       | `parseSelectedOptions`, `buildOptionUrl`, default selection, color-image helpers               |
-| `lib/shopify/encoded-variants.ts`                      | Decodes `encodedVariantAvailability`/`Existence` into per-option availability + variant count   |
+| `lib/shopify/encoded-variants.ts`                      | Decodes `encodedVariantAvailability`/`Existence` into per-option availability                   |
 
 The rest of the PDP — option pickers, price display, lightbox, schema, and so on — lives in `components/product-detail/`. Browse the directory when you need them.

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -24,11 +24,9 @@ import {
   getSelectedColorImage,
   getSharedImages,
   hasColorImagePartitioning,
-  hasUniformPricing,
-  hasUniformStock,
   type SelectedOptions,
 } from "@/lib/product";
-import { countEncodedVariants, getAvailableOptionValues } from "@/lib/shopify/encoded-variants";
+import { getAvailableOptionValues } from "@/lib/shopify/encoded-variants";
 import type { ProductDetails, ProductVariant } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -55,7 +53,7 @@ export function ProductDetailSection({
           manufacturerName: product.manufacturerName,
           currencyCode: product.currencyCode,
           priceRange: product.priceRange,
-          offerCount: countEncodedVariants(product.encodedVariantExistence) || 1,
+          offerCount: product.variantsCount,
           availableForSale: product.availableForSale,
         }}
       />
@@ -164,9 +162,9 @@ async function ProductInfoArea({
   locale: Locale;
 }) {
   const { options, handle, title, featuredImage, descriptionHtml, availableForSale } = product;
-  const uniformPrice = hasUniformPricing(product.priceRange, product.compareAtPriceRange);
-  const uniformStock = hasUniformStock(product);
-  const singleVariant = countEncodedVariants(product.encodedVariantExistence) <= 1;
+  const uniformPrice = product.hasUniformPricing;
+  const uniformStock = product.allVariantsInStock;
+  const singleVariant = product.variantsCount === 1;
   const availableValues = getAvailableOptionValues(options, product.encodedVariantAvailability);
   const eagerSelection = singleVariant
     ? { selectedOptions: defaultSelectedOptions(product), selectedVariant: product.defaultVariant }

--- a/apps/template/lib/product.ts
+++ b/apps/template/lib/product.ts
@@ -98,31 +98,6 @@ export function getSelectedColorImage(
   );
 }
 
-/** When true, the price renders without waiting for searchParams to resolve the variant. */
-export function hasUniformPricing(
-  priceRange: ProductDetails["priceRange"],
-  compareAtPriceRange?: ProductDetails["compareAtPriceRange"],
-): boolean {
-  const { maxVariantPrice, minVariantPrice } = priceRange;
-  const priceUniform =
-    minVariantPrice.amount === maxVariantPrice.amount &&
-    minVariantPrice.currencyCode === maxVariantPrice.currencyCode;
-  if (!priceUniform) return false;
-  if (!compareAtPriceRange) return true;
-  return compareAtPriceRange.minVariantPrice.amount === compareAtPriceRange.maxVariantPrice.amount;
-}
-
-/**
- * True when every existing option combination is in stock, so buy-button labels
- * can render in the Suspense fallback without resolving the variant. Derived from
- * the encoded availability/existence tries (equal ⇒ nothing is sold out).
- */
-export function hasUniformStock(product: ProductDetails): boolean {
-  const { encodedVariantAvailability, encodedVariantExistence } = product;
-  if (!encodedVariantExistence) return true;
-  return encodedVariantAvailability === encodedVariantExistence;
-}
-
 export type OptimisticProductInfo = {
   variantTitle: string;
   productTitle: string;

--- a/apps/template/lib/shopify/encoded-variants.ts
+++ b/apps/template/lib/shopify/encoded-variants.ts
@@ -78,16 +78,6 @@ function v1Decoder(encoded: string): number[][] {
   return result;
 }
 
-/** Count of existing variants from an encoded existence trie (0 on missing/invalid). */
-export function countEncodedVariants(encoded: string | undefined): number {
-  if (!encoded) return 0;
-  try {
-    return decodeEncodedVariant(encoded).length;
-  } catch {
-    return 0;
-  }
-}
-
 // Maps decoded availability combinations to the set of in-stock value names per
 // option. Falls back to "all available" on missing data, decode failure, or the
 // empty result Shopify returns for synthetic single-option products (a known

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -245,6 +245,9 @@ export const PRODUCT_FRAGMENT = `
     }
     encodedVariantExistence
     encodedVariantAvailability
+    variantsCount {
+      count
+    }
     selectedOrFirstAvailableVariant {
       ...ProductVariantFields
     }

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -114,6 +114,7 @@ export interface ShopifyProduct {
   } | null;
   encodedVariantAvailability?: string | null;
   encodedVariantExistence?: string | null;
+  variantsCount: { count: number };
   selectedOrFirstAvailableVariant?: ShopifyVariant | null;
   variants?: ShopifyEdges<ShopifyVariant>;
   options: ShopifyOption[];
@@ -308,6 +309,16 @@ export function transformShopifyProductCard(product: ShopifyProductCard): Produc
   };
 }
 
+function hasUniformPriceRange(product: ShopifyProduct): boolean {
+  const { compareAtPriceRange, priceRange } = product;
+  if (priceRange.minVariantPrice.amount !== priceRange.maxVariantPrice.amount) return false;
+  if (priceRange.minVariantPrice.currencyCode !== priceRange.maxVariantPrice.currencyCode) {
+    return false;
+  }
+  if (!compareAtPriceRange) return true;
+  return compareAtPriceRange.minVariantPrice.amount === compareAtPriceRange.maxVariantPrice.amount;
+}
+
 export function transformShopifyProductDetails(product: ShopifyProduct): ProductDetails {
   const variants = product.variants
     ? flattenEdges(product.variants).map(transformVariant)
@@ -324,6 +335,11 @@ export function transformShopifyProductDetails(product: ShopifyProduct): Product
     compareAtPrice: product.compareAtPriceRange?.minVariantPrice ?? undefined,
     vendor: product.vendor || undefined,
     availableForSale: product.availableForSale,
+    allVariantsInStock:
+      !product.encodedVariantExistence ||
+      product.encodedVariantExistence === product.encodedVariantAvailability,
+    hasUniformPricing: hasUniformPriceRange(product),
+    variantsCount: product.variantsCount.count,
     defaultVariant,
     defaultVariantId: defaultVariant?.id,
     defaultVariantNumericId: defaultVariant

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -56,6 +56,8 @@ export interface ProductCard {
 }
 
 export interface ProductDetails extends ProductCard {
+  /** True when every existing variant is in stock (existence trie == availability trie). */
+  allVariantsInStock: boolean;
   category?: Category | null;
   categoryId?: string;
   collectionHandles: string[];
@@ -72,6 +74,8 @@ export interface ProductDetails extends ProductCard {
   encodedVariantAvailability?: string;
   /** Trie of option-value combinations that exist (Storefront 2024-10+). */
   encodedVariantExistence?: string;
+  /** True when min/max price (and compare-at) bounds match, so price renders without a variant. */
+  hasUniformPricing: boolean;
   images: Image[];
   manufacturerName: string;
   metafields?: Metafield[];
@@ -85,6 +89,8 @@ export interface ProductDetails extends ProductCard {
   updatedAt: string;
   /** Only populated by getProductWithVariants (agent + markdown); the PDP omits it. */
   variants?: ProductVariant[];
+  /** Exact variant count from Shopify; authoritative single-variant signal (=== 1). */
+  variantsCount: number;
   videos: Video[];
 }
 

--- a/packages/plugin/template-rollout-log/2026-06-19-pdp-exact-signal-product-fields.md
+++ b/packages/plugin/template-rollout-log/2026-06-19-pdp-exact-signal-product-fields.md
@@ -1,0 +1,73 @@
+---
+title: PDP exact-signal product fields (variantsCount, hasUniformPricing, allVariantsInStock)
+changeKey: pdp-exact-signal-product-fields
+introducedOn: 2026-06-19
+changeType: refactor
+defaultAction: adopt
+appliesTo:
+  - all
+supersedes:
+  - pdp-selected-options-variant-urls
+paths:
+  - apps/template/lib/shopify/fragments.ts
+  - apps/template/lib/shopify/transforms/product.ts
+  - apps/template/lib/types.ts
+  - apps/template/lib/product.ts
+  - apps/template/lib/shopify/encoded-variants.ts
+  - apps/template/components/product-detail/product-detail-section.tsx
+  - apps/docs/content/docs/anatomy/pages/pdp.mdx
+---
+
+## Summary
+
+`ProductDetails` now carries three precomputed, product-level signals instead of recomputing them
+in the PDP from helper functions:
+
+- `variantsCount` — the exact variant count, queried from Shopify's `variantsCount { count }`.
+- `hasUniformPricing` — `true` when the `priceRange` (and `compareAtPriceRange`) min/max bounds match,
+  so the price renders eagerly in the static shell without the suspended variant query.
+- `allVariantsInStock` — `true` when every existing variant is in stock (`encodedVariantExistence`
+  equals `encodedVariantAvailability`), so buy-button labels can resolve in the Suspense fallback.
+
+The values are computed once in `transformShopifyProductDetails` and read as fields by
+`product-detail-section.tsx`. The previous component-side helpers are removed:
+`hasUniformPricing` / `hasUniformStock` (`lib/product.ts`) and `countEncodedVariants`
+(`lib/shopify/encoded-variants.ts`). `decodeEncodedVariant` / `getAvailableOptionValues` are
+unchanged.
+
+## Why it matters
+
+Single-variant detection previously decoded the `encodedVariantExistence` trie and compared its
+length (`<= 1`). That trie is a proxy: Shopify returns an empty string for synthetic single-option
+products and omits it past certain variant counts, so the proxy mis-fires. `variantsCount === 1` is
+the authoritative single-variant signal, and `variantsCount` is also the correct value for JSON-LD
+`offerCount`. Modeling uniform-pricing and all-in-stock as fields keeps the derivation in one place
+(the transform) rather than duplicated across consumers.
+
+This supersedes the variant-count detail of [`pdp-selected-options-variant-urls`](./2026-06-18-pdp-selected-options-variant-urls.md):
+the encoded-existence trie no longer drives the variant count.
+
+## Apply when
+
+- The storefront reads the PDP shell from `getProduct` and renders price / buy buttons eagerly for
+  uniform-price or single-variant products.
+- The storefront derives single-variant status by decoding the encoded-existence trie.
+
+## Adoption notes
+
+- `Product.variantsCount { count }` is a Storefront API 2024-10+ field (the template defaults to
+  2026-04). It is added to `ProductFields`, so both `getProduct` (slim shell) and the
+  with-variants queries (agent / markdown) receive it.
+- Read the exact signals from `ProductDetails`: `variantsCount`, `hasUniformPricing`,
+  `allVariantsInStock`. Do not infer them from `ProductDetails.variants` (a representative set).
+- Behavior is unchanged: `allVariantsInStock` equals the old `hasUniformStock(product)` value, and
+  `hasUniformPricing` is the old helper's logic moved into the transform.
+
+## Validation
+
+1. `pnpm --filter template lint`, `pnpm --filter template build`.
+2. Confirm `/products/[handle]` still reports Partial Prerender.
+3. On a single-variant product, confirm price + buy buttons render eagerly (no suspended flash) and
+   JSON-LD `offerCount` equals the real variant count.
+4. On a multi-variant, varying-price product, confirm the price resolves through the suspended
+   variant query and swatch availability still reflects `encodedVariantAvailability`.


### PR DESCRIPTION
## What

Cherry-picks the **exact-signal product fields** slice of #350 onto #349's per-option PDP. Moves three product-level signals from component-side helper functions to precomputed `ProductDetails` fields, backed by Shopify's authoritative `variantsCount { count }`:

- **`variantsCount`** — exact variant count. Replaces decoding the `encodedVariantExistence` trie (`countEncodedVariants(...) <= 1`), which is a proxy that mis-fires on Shopify's empty single-option string and past certain variant counts. Now drives single-variant detection (`=== 1`) and JSON-LD `offerCount`.
- **`hasUniformPricing`** — min/max price (and compare-at) bounds match → price renders eagerly in the static shell.
- **`allVariantsInStock`** — `encodedVariantExistence === encodedVariantAvailability` → buy-button labels resolve in the Suspense fallback.

The values are computed once in `transformShopifyProductDetails`; `product-detail-section.tsx` reads them as fields. Removes the now-dead helpers `hasUniformPricing` / `hasUniformStock` (`lib/product.ts`) and `countEncodedVariants` (`encoded-variants.ts`).

## Behavior

No behavior change. `allVariantsInStock` equals the old `hasUniformStock(product)` value exactly, and `hasUniformPricing` is the old helper's logic (currency-code check included) moved into the transform. #350's reformulated buy-button gating (`allInStock`/`uniformStock` involving `availableForSale`) is intentionally **out of scope** — it belongs to #350's buy-button/bundles work, not this slice.

## Why `variantsCount` is required (not optional)

`getProduct` (PDP shell) uses plain `"use cache"` — per-instance, cold after deploy — so it refetches with the new fragment. The remote-cached `getProductById` caches the *transformed output*, not the raw `ShopifyProduct`, and the transform only runs on a fresh `shopifyFetch` whose query now includes `variantsCount`. So no code path feeds the transform a product without the field.

## Verification

- `pnpm --filter template lint` ✓ (oxlint + oxfmt)
- `tsc --noEmit` ✓
- `pnpm --filter template build` ✓ — static generation hit the live 2026-04 schema with `variantsCount { count }` (field valid), and `/products/[handle]` still reports **Partial Prerender** (◐).

Docs (`anatomy/pages/pdp.mdx`) and a `template-rollout-log` entry updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)