### PR TITLE
[template] Shopify bundles: PDP relationships, buy-button gating, and cart components

### DIFF
--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -74,7 +74,7 @@ The agent doesn't just return text - it renders rich UI components via json-rend
 
 - **AgentProductCard** - clickable card with image, title, price, compare-at price, and availability
 - **AgentProductGrid** - 2-column responsive grid wrapping multiple product cards
-- **AgentCartSummary** - full cart breakdown with line item thumbnails, subtotal, tax, total, and checkout button
+- **AgentCartSummary** - full cart breakdown with line item thumbnails, any bundle components, subtotal, total, and checkout button
 - **AgentCartConfirmation** - success card shown after adding an item to cart
 - **AgentVariantPicker** - display-only variant selector with option groups and availability status
 

--- a/apps/docs/content/docs/anatomy/cart.mdx
+++ b/apps/docs/content/docs/anatomy/cart.mdx
@@ -55,7 +55,13 @@ The overlay content in `overlay-content.tsx` composes three sections: an empty s
 
 ## Overlay items
 
-Each line item in `overlay-item.tsx` reads from `cartWithPending` to reflect optimistic state. It renders the product image, title, variant options (color, size, etc.), quantity controls (+/- buttons), a remove button, and the line total. Quantity changes and removals dispatch through the cart context, which handles debouncing and server action calls.
+Each line item in `overlay-item.tsx` reads from `cartWithPending` to reflect optimistic state. It renders the product image, title, variant options (color, size, etc.), any bundle components, quantity controls (+/- buttons), a remove button, and the line total. Quantity changes and removals dispatch through the cart context, which handles debouncing and server action calls. The controls honor Shopify's `canUpdateQuantity` and `canRemove` instructions rather than assuming every line is editable, so a fixed bundle's component lines can't be pulled out from under the parent.
+
+### Bundles and taxes
+
+The cart fragment reads both `CartLine` and `ComponentizableCartLine`, preserving each bundle parent's `lineComponents` as nested domain cart lines (`CartLine.components`). Fixed and transformed bundles therefore render as one parent line listing its included products. `addToCart()` also accepts Shopify's optional `CartLineInput.parent` relationship as a foundation for app-specific customized bundle flows.
+
+The fragment intentionally omits the deprecated cart tax and duty amounts (removed from the Storefront API in 2025-01). Shopify finalizes those at checkout, so summaries show a taxes-and-shipping-at-checkout note instead of a misleading pre-checkout figure.
 
 ## Cart page
 

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -64,6 +64,15 @@ The buy section includes stock status and two action buttons:
 
 A single `BuyButtons` component renders identically on both mobile and desktop. It receives the `selectedVariant` as a prop and is a client component for cart interactivity.
 
+### Bundles
+
+For the selected variant, `bundle-components.tsx` renders Shopify's [bundle relationships](/docs/shopify/pdp#bundles) below the buy buttons:
+
+- **Bundle includes** — a fixed bundle's component products, from the variant's `components` (`BundleComponents`).
+- **Available in bundles** — bundles containing the current product, collapsed to one link per bundle, from the variant's `groupedBy` (`BundleParents`).
+
+A customized bundle parent (`requiresComponents` with no fixed `components`) disables the buy buttons with a "Choose bundle items" label, since the generic storefront can't configure it. The bundle relationship arrays stay server-side; `BuyButtons` receives only a `requiresBundleConfiguration` boolean.
+
 ## Related Products
 
 Below the product details, a `RelatedProductsSection` component fetches related products from Shopify's recommendation API. It renders inside a `Suspense` boundary with a skeleton grid fallback.
@@ -87,13 +96,14 @@ The page emits two JSON-LD schemas:
 
 ## Key files
 
-| File                                                   | Purpose                                                                                        |
-| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| File                                                   | Purpose                                                                                                              |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
 | `app/products/[handle]/page.tsx`                       | Route entry: metadata, awaits the product at the top (baked into the shell), streams the per-selection variant query |
-| `components/product-detail/product-detail-section.tsx` | Orchestrates media, options, pricing, and buy buttons with per-section Suspense; emits JSON-LD |
-| `components/product-detail/product-media.tsx`          | Responsive image gallery (mobile carousel, desktop grid + lightbox)                            |
-| `components/product-detail/buy-buttons.tsx`            | Buy with Shop + add-to-cart client component                                                   |
-| `lib/product.ts`                                       | `parseSelectedOptions`, `buildOptionUrl`, default selection, color-image helpers               |
-| `lib/shopify/encoded-variants.ts`                      | Decodes `encodedVariantAvailability`/`Existence` into per-option availability                   |
+| `components/product-detail/product-detail-section.tsx` | Orchestrates media, options, pricing, and buy buttons with per-section Suspense; emits JSON-LD                       |
+| `components/product-detail/product-media.tsx`          | Responsive image gallery (mobile carousel, desktop grid + lightbox)                                                  |
+| `components/product-detail/buy-buttons.tsx`            | Buy with Shop + add-to-cart client component                                                                         |
+| `components/product-detail/bundle-components.tsx`      | Renders a bundle's contents and the bundles a product is part of                                                     |
+| `lib/product.ts`                                       | `parseSelectedOptions`, `buildOptionUrl`, default selection, color-image helpers                                     |
+| `lib/shopify/encoded-variants.ts`                      | Decodes `encodedVariantAvailability`/`Existence` into per-option availability                                        |
 
 The rest of the PDP — option pickers, price display, lightbox, schema, and so on — lives in `components/product-detail/`. Browse the directory when you need them.

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -66,10 +66,12 @@ A single `BuyButtons` component renders identically on both mobile and desktop. 
 
 ### Bundles
 
-For the selected variant, `bundle-components.tsx` renders Shopify's [bundle relationships](/docs/shopify/pdp#bundles) below the buy buttons:
+`bundle-components.tsx` renders Shopify's [bundle relationships](/docs/shopify/pdp#bundles) below the buy buttons:
 
-- **Bundle includes** — a fixed bundle's component products, from the variant's `components` (`BundleComponents`).
-- **Available in bundles** — bundles containing the current product, collapsed to one link per bundle, from the variant's `groupedBy` (`BundleParents`).
+- **Bundle includes** — a fixed bundle's component products, from `components` (`BundleComponents`).
+- **Available in bundles** — bundles containing the current product, collapsed to one link per bundle, from `groupedBy` (`BundleParents`).
+
+These are product-level facts (which products a bundle contains / which bundles a product belongs to), so they render **eagerly from the cached default variant in the static shell** rather than streaming in behind the variant query — no layout shift on load.
 
 A customized bundle parent (`requiresComponents` with no fixed `components`) disables the buy buttons with a "Choose bundle items" label, since the generic storefront can't configure it. The bundle relationship arrays stay server-side; `BuyButtons` receives only a `requiresBundleConfiguration` boolean.
 

--- a/apps/docs/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/content/docs/reference/troubleshooting.mdx
@@ -10,6 +10,12 @@ The most common cause is missing Storefront API permissions. In your Shopify adm
 
 Also check that your products are set to the **Online Store** and **Headless** sales channels in Shopify admin.
 
+## Bundles not appearing (404 on the storefront)
+
+A bundle that is **ACTIVE** in Shopify admin but 404s on the storefront is almost always missing from your **Headless** sales channel. The free Shopify Bundles app publishes a new bundle to the **Online Store** channel only, while the template's Storefront token reads from Headless — so `getProduct()` returns nothing and the route renders `notFound()`.
+
+Fix it in admin: open the bundle product → **Publishing** → add your Headless channel. Then, because product reads are cached with `cacheLife("max")`, redeploy (or fire a product webhook) so the cached "not found" clears. The bundle's component products must be on Headless too, or their relationships won't resolve.
+
 ## Cart not persisting across page loads
 
 The cart ID is stored in a `shopify_cartId` HTTP-only cookie with a 7-day expiry. Common causes:

--- a/apps/docs/content/docs/shopify/pdp.mdx
+++ b/apps/docs/content/docs/shopify/pdp.mdx
@@ -72,11 +72,23 @@ Products must be assigned to at least one collection to appear on collection lis
 
 Product recommendations on the PDP are powered by Shopify's recommendation API. No configuration is needed - Shopify generates recommendations automatically based on purchase history and product similarity.
 
+## Bundles
+
+The template renders Shopify [product bundles](https://help.shopify.com/en/manual/products/bundles) from the Storefront API's variant-level relationships, fetched for the selected variant in `PurchasableProductVariantFields`:
+
+- `components` — the items in a **fixed bundle** (each component variant and its quantity).
+- `groupedBy` — up to 10 bundles that contain the current product (the reverse relationship).
+- `requiresComponents` — marks a **customized bundle** parent that can't be purchased without shopper-selected components.
+
+Fixed bundles (such as those created with the free **Shopify Bundles** app) render their contents and add to cart normally. A customized bundle whose parent sets `requiresComponents` but has no fixed `components` is disabled by the buy buttons until you build an app-specific component picker and send the component lines through `CartLineInput.parent`.
+
+> **Publish bundles to your Headless channel.** The Shopify Bundles app publishes a new bundle to the **Online Store** channel only, but the template reads from your **Headless** channel. A bundle that 404s on the storefront while showing fine in admin is almost always missing from Headless — add it under the product's **Publishing** section. See [Troubleshooting → Bundles not appearing](/docs/reference/troubleshooting).
+
 ## Key files
 
-| File                                 | Purpose                                                         |
-| ------------------------------------ | --------------------------------------------------------------- |
-| `lib/shopify/fragments.ts`           | `PRODUCT_FRAGMENT` and `METAFIELD_FRAGMENT`                     |
-| `lib/shopify/transforms/product.ts`  | Metafield label mapping and product transform                   |
-| `lib/shopify/operations/products.ts` | Product fetch operations with caching                           |
-| `lib/product.ts`                     | Option parsing, default selection, and option URL generation    |
+| File                                 | Purpose                                                      |
+| ------------------------------------ | ------------------------------------------------------------ |
+| `lib/shopify/fragments.ts`           | `PRODUCT_FRAGMENT` and `METAFIELD_FRAGMENT`                  |
+| `lib/shopify/transforms/product.ts`  | Metafield label mapping and product transform                |
+| `lib/shopify/operations/products.ts` | Product fetch operations with caching                        |
+| `lib/product.ts`                     | Option parsing, default selection, and option URL generation |

--- a/apps/template/components/agent/registry.tsx
+++ b/apps/template/components/agent/registry.tsx
@@ -80,7 +80,6 @@ export const { registry } = defineRegistry(catalog, {
       const locale = useLocale();
       const tCart = useTranslations("cart");
       const subtotal = parsePriceString(props.subtotal);
-      const tax = parsePriceString(props.tax);
       const total = parsePriceString(props.total);
 
       return (
@@ -119,6 +118,22 @@ export const { registry } = defineRegistry(catalog, {
                       <span className="text-muted-foreground text-xs">{item.options}</span>
                     )}
                     <span className="text-muted-foreground text-xs">Qty: {item.quantity}</span>
+                    {item.components?.length ? (
+                      <div className="mt-0.5 grid gap-0.5">
+                        <span className="font-medium text-muted-foreground text-xs">
+                          {tCart("bundleIncludes")}
+                        </span>
+                        {item.components.map((component) => (
+                          <span
+                            key={`${component.productTitle}-${component.variantTitle}`}
+                            className="text-muted-foreground text-xs"
+                          >
+                            {component.productTitle}
+                            {component.quantity > 1 ? ` ×${component.quantity}` : ""}
+                          </span>
+                        ))}
+                      </div>
+                    ) : null}
                   </div>
                   <Price
                     amount={itemPrice.amount}
@@ -139,14 +154,11 @@ export const { registry } = defineRegistry(catalog, {
                 locale={locale}
               />
             </div>
-            <div className="flex justify-between text-muted-foreground text-sm">
-              <span>Tax</span>
-              <Price amount={tax.amount} currencyCode={tax.currencyCode} locale={locale} />
-            </div>
             <div className="mt-1 flex justify-between border-t pt-1 font-medium text-sm">
               <span>Total</span>
               <Price amount={total.amount} currencyCode={total.currencyCode} locale={locale} />
             </div>
+            <p className="mt-1 text-muted-foreground text-xs">{tCart("taxesAndShippingNote")}</p>
           </div>
           <div className="border-t px-2.5 py-2">
             <a

--- a/apps/template/components/cart/context.tsx
+++ b/apps/template/components/cart/context.tsx
@@ -100,7 +100,6 @@ function computeCartWithPending(
       cost: {
         subtotalAmount: { amount: "0", currencyCode: "USD" },
         totalAmount: { amount: "0", currencyCode: "USD" },
-        totalTaxAmount: { amount: "0", currencyCode: "USD" },
       },
       lines: pendingLines,
       shippingCost: null,
@@ -255,6 +254,9 @@ export function CartProvider({
   ): CartLine => ({
     id: `optimistic-${variantId}`,
     quantity: qty,
+    canRemove: true,
+    canUpdateQuantity: true,
+    components: [],
     cost: {
       totalAmount: {
         amount: (parseFloat(info.price.amount) * qty).toString(),

--- a/apps/template/components/cart/overlay-item.tsx
+++ b/apps/template/components/cart/overlay-item.tsx
@@ -63,6 +63,23 @@ export function OverlayItem({ item, locale }: OverlayItemProps) {
               {item.merchandise.selectedOptions.map((option) => option.value).join(" / ")}
             </p>
           )}
+
+          {item.components.length > 0 && (
+            <div className="mt-2 grid gap-1">
+              <p className="text-xs font-medium text-muted-foreground">{t("bundleIncludes")}</p>
+              <ul className="grid gap-0.5">
+                {item.components.map((component) => (
+                  <li
+                    key={component.id}
+                    className="flex items-center gap-1.5 text-xs text-muted-foreground"
+                  >
+                    <span className="truncate">{component.merchandise.product.title}</span>
+                    {component.quantity > 1 ? <span>×{component.quantity}</span> : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
 
         <div className="flex items-center gap-1.5">
@@ -72,7 +89,7 @@ export function OverlayItem({ item, locale }: OverlayItemProps) {
             size="icon"
             className="size-7 rounded-full"
             onClick={() => updateItemOptimistic(item.id || "", quantity - 1)}
-            disabled={quantity === 1}
+            disabled={!item.canUpdateQuantity || quantity === 1}
             aria-label={t("decreaseQuantity")}
           >
             <MinusIcon className="size-3" />
@@ -88,7 +105,7 @@ export function OverlayItem({ item, locale }: OverlayItemProps) {
             size="icon"
             className="size-7 rounded-full"
             onClick={() => updateItemOptimistic(item.id || "", quantity + 1)}
-            disabled={quantity === 99}
+            disabled={!item.canUpdateQuantity || quantity === 99}
             aria-label={t("increaseQuantity")}
           >
             <PlusIcon className="size-3" />
@@ -100,6 +117,7 @@ export function OverlayItem({ item, locale }: OverlayItemProps) {
             size="icon"
             className="size-7 text-muted-foreground hover:text-foreground"
             onClick={() => updateItemOptimistic(item.id || "", 0)}
+            disabled={!item.canRemove}
             aria-label={t("removeItem")}
           >
             <Trash2Icon className="size-4" />

--- a/apps/template/components/product-detail/bundle-components.tsx
+++ b/apps/template/components/product-detail/bundle-components.tsx
@@ -3,6 +3,15 @@ import Link from "next/link";
 
 import type { ProductVariantComponent, ProductVariantReference } from "@/lib/types";
 
+interface BundleListItem {
+  href: string;
+  image: ProductVariantReference["image"];
+  key: string;
+  quantity?: number;
+  subtitle?: string;
+  title: string;
+}
+
 interface BundleComponentsProps {
   components: ProductVariantComponent[];
   title: string;
@@ -10,12 +19,17 @@ interface BundleComponentsProps {
 
 export function BundleComponents({ components, title }: BundleComponentsProps) {
   if (components.length === 0) return null;
-  return (
-    <BundleProductList
-      items={components.map(({ quantity, variant }) => ({ quantity, variant }))}
-      title={title}
-    />
+  const items = components.map(
+    ({ quantity, variant }): BundleListItem => ({
+      href: `/products/${variant.product.handle}`,
+      image: variant.image ?? variant.product.featuredImage,
+      key: variant.id,
+      quantity,
+      subtitle: variant.title,
+      title: variant.product.title,
+    }),
   );
+  return <BundleProductList items={items} title={title} />;
 }
 
 interface BundleParentsProps {
@@ -24,12 +38,26 @@ interface BundleParentsProps {
 }
 
 export function BundleParents({ title, variants }: BundleParentsProps) {
-  if (variants.length === 0) return null;
-  return <BundleProductList items={variants.map((variant) => ({ variant }))} title={title} />;
+  // A component variant is grouped into many bundle variant combinations that all
+  // belong to the same bundle product — collapse to one link per bundle product.
+  const byProduct = new Map<string, ProductVariantReference>();
+  for (const variant of variants) {
+    if (!byProduct.has(variant.product.handle)) byProduct.set(variant.product.handle, variant);
+  }
+  if (byProduct.size === 0) return null;
+  const items = [...byProduct.values()].map(
+    (variant): BundleListItem => ({
+      href: `/products/${variant.product.handle}`,
+      image: variant.product.featuredImage ?? variant.image,
+      key: variant.product.handle,
+      title: variant.product.title,
+    }),
+  );
+  return <BundleProductList items={items} title={title} />;
 }
 
 interface BundleProductListProps {
-  items: Array<{ quantity?: number; variant: ProductVariantReference }>;
+  items: BundleListItem[];
   title: string;
 }
 
@@ -38,36 +66,33 @@ function BundleProductList({ items, title }: BundleProductListProps) {
     <div className="grid gap-2.5" data-slot="bundle-components">
       <h2 className="font-medium text-foreground/70 text-sm">{title}</h2>
       <ul className="grid gap-2.5">
-        {items.map(({ quantity, variant }) => {
-          const image = variant.image ?? variant.product.featuredImage;
-          return (
-            <li key={variant.id}>
-              <Link
-                href={`/products/${variant.product.handle}`}
-                className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-border p-2.5 transition-colors hover:border-foreground/30"
-              >
-                {image ? (
-                  <Image
-                    src={image.url}
-                    alt={image.altText || variant.product.title}
-                    width={48}
-                    height={48}
-                    className="size-12 rounded-md object-cover"
-                  />
+        {items.map((item) => (
+          <li key={item.key}>
+            <Link
+              href={item.href}
+              className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-border p-2.5 transition-colors hover:border-foreground/30"
+            >
+              {item.image ? (
+                <Image
+                  src={item.image.url}
+                  alt={item.image.altText || item.title}
+                  width={48}
+                  height={48}
+                  className="size-12 rounded-md object-cover"
+                />
+              ) : null}
+              <span className="min-w-0 flex-1">
+                <span className="block truncate font-medium text-sm">{item.title}</span>
+                {item.subtitle ? (
+                  <span className="block truncate text-foreground/50 text-xs">{item.subtitle}</span>
                 ) : null}
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate font-medium text-sm">
-                    {variant.product.title}
-                  </span>
-                  <span className="block truncate text-foreground/50 text-xs">{variant.title}</span>
-                </span>
-                {quantity && quantity > 1 ? (
-                  <span className="text-foreground/50 text-sm">×{quantity}</span>
-                ) : null}
-              </Link>
-            </li>
-          );
-        })}
+              </span>
+              {item.quantity && item.quantity > 1 ? (
+                <span className="text-foreground/50 text-sm">×{item.quantity}</span>
+              ) : null}
+            </Link>
+          </li>
+        ))}
       </ul>
     </div>
   );

--- a/apps/template/components/product-detail/bundle-components.tsx
+++ b/apps/template/components/product-detail/bundle-components.tsx
@@ -8,7 +8,6 @@ interface BundleListItem {
   image: ProductVariantReference["image"];
   key: string;
   quantity?: number;
-  subtitle?: string;
   title: string;
 }
 
@@ -25,7 +24,6 @@ export function BundleComponents({ components, title }: BundleComponentsProps) {
       image: variant.image ?? variant.product.featuredImage,
       key: variant.id,
       quantity,
-      subtitle: variant.title,
       title: variant.product.title,
     }),
   );
@@ -81,12 +79,7 @@ function BundleProductList({ items, title }: BundleProductListProps) {
                   className="size-12 rounded-md object-cover"
                 />
               ) : null}
-              <span className="min-w-0 flex-1">
-                <span className="block truncate font-medium text-sm">{item.title}</span>
-                {item.subtitle ? (
-                  <span className="block truncate text-foreground/50 text-xs">{item.subtitle}</span>
-                ) : null}
-              </span>
+              <span className="min-w-0 flex-1 truncate font-medium text-sm">{item.title}</span>
               {item.quantity && item.quantity > 1 ? (
                 <span className="text-foreground/50 text-sm">×{item.quantity}</span>
               ) : null}

--- a/apps/template/components/product-detail/bundle-components.tsx
+++ b/apps/template/components/product-detail/bundle-components.tsx
@@ -1,25 +1,74 @@
-import type { ProductVariant } from "@/lib/types";
+import Image from "next/image";
+import Link from "next/link";
 
-// TEMP scaffold for slice B: dumps the selected variant's bundle relationships
-// so we can inspect the live shape before building real UI. Replace with the
-// fixed-bundle contents + "part of these bundles" components.
-export function BundleComponents({ variant }: { variant: ProductVariant }) {
+import type { ProductVariantComponent, ProductVariantReference } from "@/lib/types";
+
+interface BundleComponentsProps {
+  components: ProductVariantComponent[];
+  title: string;
+}
+
+export function BundleComponents({ components, title }: BundleComponentsProps) {
+  if (components.length === 0) return null;
   return (
-    <pre
-      data-slot="bundle-debug"
-      className="overflow-auto rounded-md border border-border bg-muted p-4 text-xs leading-relaxed"
-    >
-      {JSON.stringify(
-        {
-          variantId: variant.id,
-          variantTitle: variant.title,
-          requiresComponents: variant.requiresComponents,
-          components: variant.components,
-          bundleParents: variant.bundleParents,
-        },
-        null,
-        2,
-      )}
-    </pre>
+    <BundleProductList
+      items={components.map(({ quantity, variant }) => ({ quantity, variant }))}
+      title={title}
+    />
+  );
+}
+
+interface BundleParentsProps {
+  title: string;
+  variants: ProductVariantReference[];
+}
+
+export function BundleParents({ title, variants }: BundleParentsProps) {
+  if (variants.length === 0) return null;
+  return <BundleProductList items={variants.map((variant) => ({ variant }))} title={title} />;
+}
+
+interface BundleProductListProps {
+  items: Array<{ quantity?: number; variant: ProductVariantReference }>;
+  title: string;
+}
+
+function BundleProductList({ items, title }: BundleProductListProps) {
+  return (
+    <div className="grid gap-2.5" data-slot="bundle-components">
+      <h2 className="font-medium text-foreground/70 text-sm">{title}</h2>
+      <ul className="grid gap-2.5">
+        {items.map(({ quantity, variant }) => {
+          const image = variant.image ?? variant.product.featuredImage;
+          return (
+            <li key={variant.id}>
+              <Link
+                href={`/products/${variant.product.handle}`}
+                className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-border p-2.5 transition-colors hover:border-foreground/30"
+              >
+                {image ? (
+                  <Image
+                    src={image.url}
+                    alt={image.altText || variant.product.title}
+                    width={48}
+                    height={48}
+                    className="size-12 rounded-md object-cover"
+                  />
+                ) : null}
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-medium text-sm">
+                    {variant.product.title}
+                  </span>
+                  <span className="block truncate text-foreground/50 text-xs">{variant.title}</span>
+                </span>
+                {quantity && quantity > 1 ? (
+                  <span className="text-foreground/50 text-sm">×{quantity}</span>
+                ) : null}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 }

--- a/apps/template/components/product-detail/bundle-components.tsx
+++ b/apps/template/components/product-detail/bundle-components.tsx
@@ -1,0 +1,25 @@
+import type { ProductVariant } from "@/lib/types";
+
+// TEMP scaffold for slice B: dumps the selected variant's bundle relationships
+// so we can inspect the live shape before building real UI. Replace with the
+// fixed-bundle contents + "part of these bundles" components.
+export function BundleComponents({ variant }: { variant: ProductVariant }) {
+  return (
+    <pre
+      data-slot="bundle-debug"
+      className="overflow-auto rounded-md border border-border bg-muted p-4 text-xs leading-relaxed"
+    >
+      {JSON.stringify(
+        {
+          variantId: variant.id,
+          variantTitle: variant.title,
+          requiresComponents: variant.requiresComponents,
+          components: variant.components,
+          bundleParents: variant.bundleParents,
+        },
+        null,
+        2,
+      )}
+    </pre>
+  );
+}

--- a/apps/template/components/product-detail/buy-buttons.tsx
+++ b/apps/template/components/product-detail/buy-buttons.tsx
@@ -8,10 +8,23 @@ import { useCart } from "@/components/cart/context";
 import { Button } from "@/components/ui/button";
 import { buyNowAction } from "@/lib/cart/action";
 import { variantToOptimisticInfo } from "@/lib/product";
-import type { Image, ProductVariant } from "@/lib/types";
+import type { Image, Money, SelectedOption } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 import { ShopLogo } from "./shop-logo";
+
+// Client-facing projection of the selected variant — only the fields the buy
+// controls need. Bundle relationship arrays stay on the server; the gating they
+// imply is collapsed to the requiresBundleConfiguration boolean.
+export interface BuyButtonVariant {
+  availableForSale: boolean;
+  id: string;
+  image: Image | null;
+  price: Money;
+  requiresBundleConfiguration: boolean;
+  selectedOptions: SelectedOption[];
+  title: string;
+}
 
 export function BuyButtons({
   selectedVariant,
@@ -20,7 +33,7 @@ export function BuyButtons({
   featuredImage,
   availableForSale = true,
 }: {
-  selectedVariant: ProductVariant | undefined;
+  selectedVariant: BuyButtonVariant | undefined;
   title: string;
   handle: string;
   featuredImage: Image | null;
@@ -77,11 +90,13 @@ export function BuyButtons({
     return null;
   }
 
+  const requiresBundleConfiguration = selectedVariant.requiresBundleConfiguration;
   const isOutOfStock = !selectedVariant.availableForSale;
 
   const getButtonText = () => {
     if (pendingQuantity > 0) return t("addingQuantity", { quantity: String(pendingQuantity) });
     if (isAddingToCart) return t("addingToCart");
+    if (requiresBundleConfiguration) return t("bundleConfigurationRequired");
     if (isOutOfStock) return t("outOfStock");
     return t("addToCart");
   };
@@ -94,7 +109,7 @@ export function BuyButtons({
           "flex flex-1 items-center justify-center gap-1.5 rounded-lg h-12 bg-shop text-white transition-all hover:bg-shop/85 disabled:pointer-events-none disabled:opacity-50",
           !availableForSale && "invisible",
         )}
-        disabled={isOutOfStock || isBuyingNow}
+        disabled={isOutOfStock || isBuyingNow || requiresBundleConfiguration}
         onClick={handleBuyNow}
       >
         {isBuyingNow ? (
@@ -108,7 +123,7 @@ export function BuyButtons({
       </button>
       <Button
         type="button"
-        disabled={isOutOfStock}
+        disabled={isOutOfStock || requiresBundleConfiguration}
         onClick={handleAddToCart}
         className="flex-1 justify-center h-12"
       >

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -244,30 +244,29 @@ async function ProductInfoArea({
         </Suspense>
       )}
 
-      <Suspense fallback={null}>
-        <ResolvedBundleRelationships variantPromise={variantPromise} />
-      </Suspense>
+      <BundleRelationships variant={product.defaultVariant} t={t} />
 
       <ProductInfoDescription descriptionHtml={descriptionHtml} />
     </div>
   );
 }
 
-async function ResolvedBundleRelationships({
-  variantPromise,
+// Bundle relationships are product-level (which products a bundle contains / which
+// bundles a product belongs to), so they render eagerly from the cached default
+// variant in the static shell rather than streaming in behind the variant query.
+function BundleRelationships({
+  variant,
+  t,
 }: {
-  variantPromise: Promise<ProductVariant | undefined>;
+  variant: ProductVariant | undefined;
+  t: Awaited<ReturnType<typeof getTranslations<"product">>>;
 }) {
-  const selectedVariant = await variantPromise;
-  if (!selectedVariant) return null;
-  if (selectedVariant.components.length === 0 && selectedVariant.bundleParents.length === 0) {
-    return null;
-  }
-  const t = await getTranslations("product");
+  if (!variant) return null;
+  if (variant.components.length === 0 && variant.bundleParents.length === 0) return null;
   return (
     <div className="grid gap-5">
-      <BundleComponents components={selectedVariant.components} title={t("bundleIncludes")} />
-      <BundleParents variants={selectedVariant.bundleParents} title={t("availableInBundles")} />
+      <BundleComponents components={variant.components} title={t("bundleIncludes")} />
+      <BundleParents variants={variant.bundleParents} title={t("availableInBundles")} />
     </div>
   );
 }

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
-import { BundleComponents } from "@/components/product-detail/bundle-components";
+import { BundleComponents, BundleParents } from "@/components/product-detail/bundle-components";
 import { BuyButtons } from "@/components/product-detail/buy-buttons";
 import {
   ProductInfoDescription,
@@ -244,23 +244,32 @@ async function ProductInfoArea({
         </Suspense>
       )}
 
-      <ProductInfoDescription descriptionHtml={descriptionHtml} />
-
       <Suspense fallback={null}>
-        <ResolvedBundleComponents variantPromise={variantPromise} />
+        <ResolvedBundleRelationships variantPromise={variantPromise} />
       </Suspense>
+
+      <ProductInfoDescription descriptionHtml={descriptionHtml} />
     </div>
   );
 }
 
-async function ResolvedBundleComponents({
+async function ResolvedBundleRelationships({
   variantPromise,
 }: {
   variantPromise: Promise<ProductVariant | undefined>;
 }) {
   const selectedVariant = await variantPromise;
   if (!selectedVariant) return null;
-  return <BundleComponents variant={selectedVariant} />;
+  if (selectedVariant.components.length === 0 && selectedVariant.bundleParents.length === 0) {
+    return null;
+  }
+  const t = await getTranslations("product");
+  return (
+    <div className="grid gap-5">
+      <BundleComponents components={selectedVariant.components} title={t("bundleIncludes")} />
+      <BundleParents variants={selectedVariant.bundleParents} title={t("availableInBundles")} />
+    </div>
+  );
 }
 
 async function ResolvedProductPrice({

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -2,7 +2,7 @@ import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
 import { BundleComponents, BundleParents } from "@/components/product-detail/bundle-components";
-import { BuyButtons } from "@/components/product-detail/buy-buttons";
+import { BuyButtons, type BuyButtonVariant } from "@/components/product-detail/buy-buttons";
 import {
   ProductInfoDescription,
   ProductInfoOptions,
@@ -226,7 +226,7 @@ async function ProductInfoArea({
 
       {eagerSelection ? (
         <BuyButtons
-          selectedVariant={eagerSelection.selectedVariant}
+          selectedVariant={toBuyButtonVariant(eagerSelection.selectedVariant)}
           title={title}
           handle={handle}
           featuredImage={featuredImage}
@@ -316,6 +316,21 @@ async function ResolvedProductInfoOptions({
   );
 }
 
+// Bundle relationship arrays stay server-side; the client buy controls only need
+// the gating boolean (a customized bundle parent has no fixed components to ship).
+function toBuyButtonVariant(variant: ProductVariant | undefined): BuyButtonVariant | undefined {
+  if (!variant) return undefined;
+  return {
+    availableForSale: variant.availableForSale,
+    id: variant.id,
+    image: variant.image,
+    price: variant.price,
+    requiresBundleConfiguration: variant.requiresComponents && variant.components.length === 0,
+    selectedOptions: variant.selectedOptions,
+    title: variant.title,
+  };
+}
+
 async function ResolvedBuyButtons({
   title,
   handle,
@@ -332,7 +347,7 @@ async function ResolvedBuyButtons({
   const selectedVariant = await variantPromise;
   return (
     <BuyButtons
-      selectedVariant={selectedVariant}
+      selectedVariant={toBuyButtonVariant(selectedVariant)}
       title={title}
       handle={handle}
       featuredImage={featuredImage}

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
+import { BundleComponents } from "@/components/product-detail/bundle-components";
 import { BuyButtons } from "@/components/product-detail/buy-buttons";
 import {
   ProductInfoDescription,
@@ -244,8 +245,22 @@ async function ProductInfoArea({
       )}
 
       <ProductInfoDescription descriptionHtml={descriptionHtml} />
+
+      <Suspense fallback={null}>
+        <ResolvedBundleComponents variantPromise={variantPromise} />
+      </Suspense>
     </div>
   );
+}
+
+async function ResolvedBundleComponents({
+  variantPromise,
+}: {
+  variantPromise: Promise<ProductVariant | undefined>;
+}) {
+  const selectedVariant = await variantPromise;
+  if (!selectedVariant) return null;
+  return <BundleComponents variant={selectedVariant} />;
 }
 
 async function ResolvedProductPrice({

--- a/apps/template/lib/agent/index.ts
+++ b/apps/template/lib/agent/index.ts
@@ -40,17 +40,23 @@ export const catalog = defineCatalog(schema, {
             quantity: z.number(),
             totalPrice: z.string(),
             handle: z.string(),
+            components: z.array(
+              z.object({
+                productTitle: z.string(),
+                quantity: z.number(),
+                variantTitle: z.string(),
+              }),
+            ),
           }),
         ),
         subtotal: z.string(),
         total: z.string(),
-        tax: z.string(),
         totalQuantity: z.number(),
         checkoutUrl: z.string(),
       }),
       description:
         "A rich cart summary card showing line items with thumbnails, quantities, " +
-        "prices, cost breakdown (subtotal/tax/total), and a checkout button. " +
+        "prices, any bundle components, cost breakdown (subtotal/total), and a checkout button. " +
         "Use when getCart returns a non-empty cart.",
     },
 

--- a/apps/template/lib/agent/server.ts
+++ b/apps/template/lib/agent/server.ts
@@ -168,7 +168,7 @@ function createSystemPrompt(ctx: AgentContext) {
         "For a single product detail result, use one AgentProductCard without an AgentProductGrid wrapper.",
         "Pass price and compareAtPrice strings directly from tool results as props.",
         "Include conversational text before or after the product cards to provide context.",
-        "When getCart returns a non-empty cart (empty: false), ALWAYS render an AgentCartSummary with the cart data. Pass items (including image), subtotal, total, tax, totalQuantity, and checkoutUrl directly from the tool result.",
+        "When getCart returns a non-empty cart (empty: false), ALWAYS render an AgentCartSummary with the cart data. Pass items (including image and any bundle components), subtotal, total, totalQuantity, and checkoutUrl directly from the tool result.",
         "After a successful addToCart call, ALWAYS render an AgentCartConfirmation. Use product data from your context (prior search results, product details, or page context) to populate image, title, variant, and price props.",
         "When a user wants to add a product to cart but hasn't specified a variant, and the product has multiple variants, render an AgentVariantPicker with the product's variants from getProductDetails. Then ask the user which variant they'd like. Do NOT use AgentVariantPicker for single-variant products.",
       ],

--- a/apps/template/lib/agent/tools/add-to-cart.ts
+++ b/apps/template/lib/agent/tools/add-to-cart.ts
@@ -11,7 +11,8 @@ export function addToCartTool() {
 
 IMPORTANT: You must use the variant_id (e.g., "gid://shopify/ProductVariant/..."), NOT the product_id.
 When the user is on a product page, the available variant IDs are provided in the context.
-If there are multiple variants (sizes, colors), ask the user which one they want before calling this tool.`,
+If there are multiple variants (sizes, colors), ask the user which one they want before calling this tool.
+Do not add customized bundle parents that require components but have no fixed components.`,
     inputSchema: z.object({
       variant_id: z
         .string()

--- a/apps/template/lib/agent/tools/get-cart.ts
+++ b/apps/template/lib/agent/tools/get-cart.ts
@@ -54,6 +54,11 @@ Use this when the user asks "what's in my cart?", "how much is my order?", or wh
             totalPrice: `${line.cost.totalAmount.amount} ${line.cost.totalAmount.currencyCode}`,
             handle: line.merchandise.product.handle,
             merchandiseId: line.merchandise.id,
+            components: line.components.map((component) => ({
+              productTitle: component.merchandise.product.title,
+              quantity: component.quantity,
+              variantTitle: component.merchandise.title,
+            })),
           })),
           cart,
         };

--- a/apps/template/lib/agent/tools/get-cart.ts
+++ b/apps/template/lib/agent/tools/get-cart.ts
@@ -40,7 +40,6 @@ Use this when the user asks "what's in my cart?", "how much is my order?", or wh
           totalQuantity: cart.totalQuantity,
           subtotal: `${cart.cost.subtotalAmount.amount} ${cart.cost.subtotalAmount.currencyCode}`,
           total: `${cart.cost.totalAmount.amount} ${cart.cost.totalAmount.currencyCode}`,
-          tax: `${cart.cost.totalTaxAmount.amount} ${cart.cost.totalTaxAmount.currencyCode}`,
           note: cart.note,
           checkoutUrl: cart.checkoutUrl,
           items: cart.lines.map((line) => ({

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -65,6 +65,7 @@
     "adding": "Adding...",
     "addressPlaceholder": "Address will be added at checkout",
     "applyDiscount": "Apply",
+    "bundleIncludes": "Bundle includes",
     "cartItemsLabel": "Cart items",
     "cartTotalIs": "Cart total is",
     "checkout": "Checkout",

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -234,6 +234,7 @@
       "home": "Home",
       "toggleMenu": "Toggle menu"
     },
+    "bundleConfigurationRequired": "Choose bundle items",
     "bundleIncludes": "Bundle includes",
     "buyNow": "Buy now",
     "buyWithShop": "Buy with",

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -228,11 +228,13 @@
     "addingQuantity": "Adding {quantity}...",
     "addingToCart": "Adding to Cart...",
     "addToCart": "Add to Cart",
+    "availableInBundles": "Available in bundles",
     "brand": "Brand",
     "breadcrumb": {
       "home": "Home",
       "toggleMenu": "Toggle menu"
     },
+    "bundleIncludes": "Bundle includes",
     "buyNow": "Buy now",
     "buyWithShop": "Buy with",
     "color": "Color",

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -103,64 +103,124 @@ export const METAFIELD_FRAGMENT = `
   }
 `;
 
+// A bundle's component lines carry Shopify edit instructions (e.g. canRemove:false
+// so a shopper can't pull one product out of a fixed bundle); the parent bundle line
+// is a ComponentizableCartLine whose lineComponents are ordinary CartLines.
 export const CART_FRAGMENT = `
   ${IMAGE_FRAGMENT}
   ${MONEY_FRAGMENT}
+  fragment CartLineFields on CartLine {
+    id
+    quantity
+    instructions {
+      canRemove
+      canUpdateQuantity
+    }
+    cost {
+      totalAmount {
+        ...MoneyFields
+      }
+    }
+    discountAllocations {
+      __typename
+      discountedAmount {
+        ...MoneyFields
+      }
+      ... on CartCodeDiscountAllocation {
+        code
+      }
+      ... on CartAutomaticDiscountAllocation {
+        title
+      }
+      ... on CartCustomDiscountAllocation {
+        title
+      }
+    }
+    merchandise {
+      ... on ProductVariant {
+        id
+        title
+        selectedOptions {
+          name
+          value
+        }
+        image {
+          ...ImageFields
+        }
+        price {
+          ...MoneyFields
+        }
+        product {
+          id
+          title
+          handle
+          featuredImage {
+            ...ImageFields
+          }
+        }
+      }
+    }
+  }
+  fragment ComponentizableCartLineFields on ComponentizableCartLine {
+    id
+    quantity
+    cost {
+      totalAmount {
+        ...MoneyFields
+      }
+    }
+    discountAllocations {
+      __typename
+      discountedAmount {
+        ...MoneyFields
+      }
+      ... on CartCodeDiscountAllocation {
+        code
+      }
+      ... on CartAutomaticDiscountAllocation {
+        title
+      }
+      ... on CartCustomDiscountAllocation {
+        title
+      }
+    }
+    merchandise {
+      ... on ProductVariant {
+        id
+        title
+        selectedOptions {
+          name
+          value
+        }
+        image {
+          ...ImageFields
+        }
+        price {
+          ...MoneyFields
+        }
+        product {
+          id
+          title
+          handle
+          featuredImage {
+            ...ImageFields
+          }
+        }
+      }
+    }
+    lineComponents {
+      ...CartLineFields
+    }
+  }
   fragment CartFields on Cart {
     id
     checkoutUrl
     totalQuantity
     note
     lines(first: 50) {
-      edges {
-        node {
-          id
-          quantity
-          cost {
-            totalAmount {
-              ...MoneyFields
-            }
-          }
-          discountAllocations {
-            __typename
-            discountedAmount {
-              ...MoneyFields
-            }
-            ... on CartCodeDiscountAllocation {
-              code
-            }
-            ... on CartAutomaticDiscountAllocation {
-              title
-            }
-            ... on CartCustomDiscountAllocation {
-              title
-            }
-          }
-          merchandise {
-            ... on ProductVariant {
-              id
-              title
-              selectedOptions {
-                name
-                value
-              }
-              image {
-                ...ImageFields
-              }
-              price {
-                ...MoneyFields
-              }
-              product {
-                id
-                title
-                handle
-                featuredImage {
-                  ...ImageFields
-                }
-              }
-            }
-          }
-        }
+      nodes {
+        ...CartLineFields
+        ...ComponentizableCartLineFields
       }
     }
     cost {
@@ -168,9 +228,6 @@ export const CART_FRAGMENT = `
         ...MoneyFields
       }
       subtotalAmount {
-        ...MoneyFields
-      }
-      totalTaxAmount {
         ...MoneyFields
       }
     }

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -37,6 +37,52 @@ export const PRODUCT_VARIANT_FRAGMENT = `
   }
 `;
 
+// Lightweight variant reference for bundle relationships. Relies on the parent
+// to include IMAGE_FRAGMENT (matches PRODUCT_VARIANT_FRAGMENT).
+export const BUNDLE_COMPONENT_VARIANT_FRAGMENT = `
+  fragment BundleComponentVariantFields on ProductVariant {
+    id
+    title
+    image {
+      ...ImageFields
+    }
+    product {
+      id
+      title
+      handle
+      featuredImage {
+        ...ImageFields
+      }
+    }
+  }
+`;
+
+// The selected/purchasable variant: base fields plus Shopify bundle relationships.
+// Used only where one variant is resolved (the shell default + the suspended query),
+// never for the full matrix or cards. Relies on the parent to include IMAGE_FRAGMENT.
+export const PURCHASABLE_PRODUCT_VARIANT_FRAGMENT = `
+  ${PRODUCT_VARIANT_FRAGMENT}
+  ${BUNDLE_COMPONENT_VARIANT_FRAGMENT}
+  fragment PurchasableProductVariantFields on ProductVariant {
+    ...ProductVariantFields
+    requiresComponents
+    groupedBy(first: 10) {
+      nodes {
+        ...BundleComponentVariantFields
+      }
+    }
+    # 30 is Shopify's per-bundle component maximum, so this can never truncate
+    components(first: 30) {
+      nodes {
+        quantity
+        productVariant {
+          ...BundleComponentVariantFields
+        }
+      }
+    }
+  }
+`;
+
 export const TAXONOMY_CATEGORY_FRAGMENT = `
   fragment TaxonomyCategoryFields on TaxonomyCategory {
     id
@@ -189,7 +235,7 @@ export const COLLECTION_FIELDS_FRAGMENT = `
 
 export const PRODUCT_FRAGMENT = `
   ${IMAGE_FRAGMENT}
-  ${PRODUCT_VARIANT_FRAGMENT}
+  ${PURCHASABLE_PRODUCT_VARIANT_FRAGMENT}
   ${TAXONOMY_CATEGORY_FRAGMENT}
   fragment ProductFields on Product {
     id
@@ -249,7 +295,7 @@ export const PRODUCT_FRAGMENT = `
       count
     }
     selectedOrFirstAvailableVariant {
-      ...ProductVariantFields
+      ...PurchasableProductVariantFields
     }
     options {
       id

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -263,8 +263,20 @@ export async function createCart(locale: string = defaultLocale): Promise<CartMu
   return result;
 }
 
+// Shopify's CartLineInput. `parent` links a line to a bundle/add-on parent —
+// the foundation for app-specific customized bundle flows; the default PDP only
+// adds ordinary products and fixed bundle parents directly (no parent).
+export interface CartLineInput {
+  merchandiseId: string;
+  parent?: {
+    lineId?: string;
+    merchandiseId?: string;
+  };
+  quantity: number;
+}
+
 export async function addToCart(
-  lines: { merchandiseId: string; quantity: number }[],
+  lines: CartLineInput[],
   cartId?: string,
   locale: string = defaultLocale,
 ): Promise<CartMutationResult> {

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -16,8 +16,8 @@ import {
   IMAGE_FRAGMENT,
   PRODUCT_CARD_FRAGMENT,
   PRODUCT_FRAGMENT,
-  PRODUCT_VARIANT_FRAGMENT,
   PRODUCT_WITH_VARIANTS_FRAGMENT,
+  PURCHASABLE_PRODUCT_VARIANT_FRAGMENT,
 } from "../fragments";
 import { transformShopifyFilters } from "../transforms/filters";
 import {
@@ -88,11 +88,11 @@ export async function getProduct({
 
 const GET_PRODUCT_VARIANT_QUERY = `
   ${IMAGE_FRAGMENT}
-  ${PRODUCT_VARIANT_FRAGMENT}
+  ${PURCHASABLE_PRODUCT_VARIANT_FRAGMENT}
   query getProductVariant($handle: String!, $selectedOptions: [SelectedOptionInput!]!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     productByHandle(handle: $handle) {
       selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {
-        ...ProductVariantFields
+        ...PurchasableProductVariantFields
       }
     }
   }

--- a/apps/template/lib/shopify/transforms/cart.ts
+++ b/apps/template/lib/shopify/transforms/cart.ts
@@ -1,4 +1,3 @@
-import { flattenEdges, type ShopifyEdges } from "@/lib/shopify/utils";
 import type {
   AppliedGiftCard,
   Cart,
@@ -45,6 +44,14 @@ interface ShopifyCartLine {
   };
   discountAllocations: ShopifyDiscountAllocation[];
   id: string;
+  // Present on CartLine (and a bundle's nested component lines), absent on the
+  // ComponentizableCartLine parent — defaults to editable in the transform.
+  instructions?: {
+    canRemove: boolean;
+    canUpdateQuantity: boolean;
+  };
+  // Present only on a ComponentizableCartLine (the bundle parent's contents).
+  lineComponents?: ShopifyCartLine[];
   merchandise: {
     id: string;
     image?: ShopifyImage | null;
@@ -75,13 +82,12 @@ export interface ShopifyCart {
   cost: {
     subtotalAmount: ShopifyMoney;
     totalAmount: ShopifyMoney;
-    totalTaxAmount: ShopifyMoney | null;
   };
   deliveryGroups?: { nodes: ShopifyDeliveryGroup[] };
   discountAllocations: ShopifyDiscountAllocation[];
   discountCodes: Array<{ applicable: boolean; code: string }>;
   id: string;
-  lines: ShopifyEdges<ShopifyCartLine>;
+  lines: { nodes: ShopifyCartLine[] };
   note: string | null;
   totalQuantity: number;
 }
@@ -150,6 +156,9 @@ function transformCartLine(line: ShopifyCartLine): CartLine {
   return {
     id: line.id,
     quantity: line.quantity,
+    canRemove: line.instructions?.canRemove ?? true,
+    canUpdateQuantity: line.instructions?.canUpdateQuantity ?? true,
+    components: line.lineComponents?.map(transformCartLine) ?? [],
     cost: {
       totalAmount: line.cost.totalAmount,
     },
@@ -190,12 +199,8 @@ export function transformShopifyCart(cart: ShopifyCart): Cart {
     cost: {
       subtotalAmount: cart.cost.subtotalAmount,
       totalAmount: cart.cost.totalAmount,
-      totalTaxAmount: cart.cost.totalTaxAmount ?? {
-        amount: "0",
-        currencyCode: cart.cost.totalAmount.currencyCode,
-      },
     },
-    lines: flattenEdges(cart.lines).map(transformCartLine),
+    lines: cart.lines.nodes.map(transformCartLine),
     shippingCost: transformShippingCost(cart),
     discountCodes: transformDiscountCodes(cart.discountCodes),
     discountAllocations: transformDiscountAllocations(cart.discountAllocations),

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -9,6 +9,8 @@ import type {
   ProductDetails,
   ProductOption,
   ProductVariant,
+  ProductVariantComponent,
+  ProductVariantReference,
   Video,
 } from "@/lib/types";
 
@@ -24,6 +26,18 @@ interface ShopifyMoney {
   currencyCode: string;
 }
 
+interface ShopifyBundleComponentVariant {
+  id: string;
+  title: string;
+  image: ShopifyImage | null;
+  product: {
+    id: string;
+    title: string;
+    handle: string;
+    featuredImage: ShopifyImage | null;
+  };
+}
+
 export interface ShopifyVariant {
   id: string;
   title: string;
@@ -32,6 +46,12 @@ export interface ShopifyVariant {
   compareAtPrice: ShopifyMoney | null;
   selectedOptions: Array<{ name: string; value: string }>;
   image: ShopifyImage | null;
+  // Bundle relationships — present only on variants fetched via PurchasableProductVariantFields.
+  requiresComponents?: boolean;
+  groupedBy?: { nodes: ShopifyBundleComponentVariant[] };
+  components?: {
+    nodes: Array<{ quantity: number; productVariant: ShopifyBundleComponentVariant }>;
+  };
 }
 
 interface ShopifyOptionValueSwatch {
@@ -216,6 +236,32 @@ function transformCategory(category: ShopifyCategory | null | undefined): Catego
   };
 }
 
+function transformVariantReference(
+  variant: ShopifyBundleComponentVariant,
+): ProductVariantReference {
+  return {
+    id: variant.id,
+    image: transformImage(variant.image),
+    product: {
+      featuredImage: transformImage(variant.product.featuredImage),
+      handle: variant.product.handle,
+      id: variant.product.id,
+      title: variant.product.title,
+    },
+    title: variant.title,
+  };
+}
+
+function transformBundleComponent(component: {
+  quantity: number;
+  productVariant: ShopifyBundleComponentVariant;
+}): ProductVariantComponent {
+  return {
+    quantity: component.quantity,
+    variant: transformVariantReference(component.productVariant),
+  };
+}
+
 export function transformVariant(variant: ShopifyVariant): ProductVariant {
   return {
     id: variant.id,
@@ -225,6 +271,9 @@ export function transformVariant(variant: ShopifyVariant): ProductVariant {
     compareAtPrice: variant.compareAtPrice ?? undefined,
     selectedOptions: variant.selectedOptions,
     image: transformImage(variant.image),
+    bundleParents: variant.groupedBy?.nodes.map(transformVariantReference) ?? [],
+    components: variant.components?.nodes.map(transformBundleComponent) ?? [],
+    requiresComponents: variant.requiresComponents ?? false,
   };
 }
 

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -171,7 +171,6 @@ export interface Cart {
   cost: {
     subtotalAmount: Money;
     totalAmount: Money;
-    totalTaxAmount: Money;
   };
   discountAllocations: DiscountAllocation[];
   discountCodes: DiscountCode[];
@@ -183,6 +182,12 @@ export interface Cart {
 }
 
 export interface CartLine {
+  /** Shopify edit instruction — false for a fixed bundle's component lines. */
+  canRemove: boolean;
+  /** Shopify edit instruction — false for a fixed bundle's component lines. */
+  canUpdateQuantity: boolean;
+  /** Nested bundle component lines; empty for ordinary lines. */
+  components: CartLine[];
   cost: {
     totalAmount: Money;
   };

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -96,11 +96,36 @@ export interface ProductDetails extends ProductCard {
 
 export interface ProductVariant {
   availableForSale: boolean;
+  /** Bundle variants this variant is a component of (Shopify `groupedBy`); empty for non-components. */
+  bundleParents: ProductVariantReference[];
   compareAtPrice?: Money;
+  /** Fixed-bundle contents (Shopify `components`); empty unless this is a bundle variant. */
+  components: ProductVariantComponent[];
   id: string;
   image: Image | null;
   price: Money;
+  /** True when the variant cannot be purchased without components (bundle parent). */
+  requiresComponents: boolean;
   selectedOptions: SelectedOption[];
+  title: string;
+}
+
+/** A bundle component: a referenced variant and how many of it the bundle includes. */
+export interface ProductVariantComponent {
+  quantity: number;
+  variant: ProductVariantReference;
+}
+
+/** Lightweight variant pointer used by bundle relationships (no price/availability). */
+export interface ProductVariantReference {
+  id: string;
+  image: Image | null;
+  product: {
+    featuredImage: Image | null;
+    handle: string;
+    id: string;
+    title: string;
+  };
   title: string;
 }
 

--- a/packages/plugin/template-rollout-log/2026-06-19-shopify-bundles.md
+++ b/packages/plugin/template-rollout-log/2026-06-19-shopify-bundles.md
@@ -1,0 +1,75 @@
+---
+title: Shopify bundles — PDP relationships, buy-button gating, and cart components
+changeKey: shopify-bundles
+introducedOn: 2026-06-19
+changeType: feature
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/shopify/fragments.ts
+  - apps/template/lib/shopify/transforms/product.ts
+  - apps/template/lib/shopify/transforms/cart.ts
+  - apps/template/lib/shopify/operations/products.ts
+  - apps/template/lib/shopify/operations/cart.ts
+  - apps/template/lib/types.ts
+  - apps/template/components/product-detail/bundle-components.tsx
+  - apps/template/components/product-detail/product-detail-section.tsx
+  - apps/template/components/product-detail/buy-buttons.tsx
+  - apps/template/components/cart/overlay-item.tsx
+  - apps/template/components/cart/context.tsx
+  - apps/template/components/agent/registry.tsx
+  - apps/template/lib/agent/index.ts
+  - apps/template/lib/agent/server.ts
+  - apps/template/lib/agent/tools/get-cart.ts
+  - apps/template/lib/agent/tools/add-to-cart.ts
+  - apps/template/lib/i18n/messages/en.json
+  - apps/docs/content/docs/anatomy/pages/pdp.mdx
+  - apps/docs/content/docs/anatomy/cart.mdx
+  - apps/docs/content/docs/anatomy/agent.mdx
+  - apps/docs/content/docs/shopify/pdp.mdx
+  - apps/docs/content/docs/reference/troubleshooting.mdx
+---
+
+## Summary
+
+The template now models Shopify [product bundles](https://help.shopify.com/en/manual/products/bundles) across the PDP, cart, and shopping agent.
+
+- The selected/purchasable variant exposes Shopify's bundle relationships via a new `PurchasableProductVariantFields` fragment: `requiresComponents`, fixed-bundle `components`, and reverse `groupedBy`. These flow onto `ProductVariant` as `requiresComponents` / `components` / `bundleParents` (defaulted to `false` / `[]` by `transformVariant`, so non-bundle variants are unaffected). Bundle fields are fetched only for the resolved variant — never the full matrix or cards.
+- The PDP renders a fixed bundle's contents ("Bundle includes") and the bundles a product is part of ("Available in bundles", collapsed to one link per bundle) via `bundle-components.tsx`.
+- `BuyButtons` takes a `BuyButtonVariant` projection with a `requiresBundleConfiguration` boolean; a customized bundle parent (`requiresComponents` and no fixed `components`) disables the buy buttons with a "Choose bundle items" label. Bundle relationship arrays stay server-side.
+- The cart reads `ComponentizableCartLine.lineComponents` as nested `CartLine.components`, renders them under the parent line, and honors Shopify's `canRemove` / `canUpdateQuantity` edit instructions. `addToCart()` accepts Shopify's optional `CartLineInput.parent`.
+- The deprecated `Cart.cost.totalTaxAmount` is removed (Shopify dropped it in Storefront API 2025-01); taxes/duties are described as checkout-time values.
+- The shopping agent renders bundle components in cart summaries and is told not to add customized bundle parents that lack fixed components.
+
+## Why it matters
+
+Shopify's bundle model adds relationships at the product-variant and cart-line levels. Without preserving them, a storefront presents a bundle as an ordinary product, loses its component grouping in the cart, and can let a shopper "buy" a customized bundle parent that isn't actually purchasable.
+
+## Apply when
+
+- The catalog sells fixed bundles (e.g. via the Shopify Bundles app) or uses Cart Transform customized bundles.
+- The storefront should show what a bundle contains, surface the bundles a product belongs to, or block direct purchase of customized bundle parents.
+
+## Safe to skip when
+
+- The catalog has no bundles and won't add them.
+- A custom product/cart domain model already represents bundle relationships and this rollout would conflict with its ownership boundaries.
+
+## Adoption notes
+
+- `ProductVariant` gains `requiresComponents`, `components` (`ProductVariantComponent[]`), and `bundleParents` (`ProductVariantReference[]`). `CartLine` gains `components`, `canRemove`, and `canUpdateQuantity`.
+- `Cart.cost.totalTaxAmount` is removed. Update any summary that read it to a checkout-time note.
+- Pass only the fields client buy controls need (the `BuyButtonVariant` projection) — keep the bundle relationship arrays on the server.
+- Customized bundle selection remains app-specific: add a component picker and send component lines through `CartLineInput.parent` before enabling direct purchase for a `requiresComponents` variant with no fixed components.
+- **Publish bundles to the Headless channel.** The Shopify Bundles app publishes only to Online Store; the template reads from Headless. A bundle that 404s while ACTIVE in admin is almost always missing from Headless. Its component products must be on Headless too.
+
+## Validation
+
+1. Validate the product and cart operations against your Storefront API version (bundle fields require 2024-10+; the template defaults to 2026-04).
+2. Open a fixed bundle PDP and confirm its components render and it adds to cart.
+3. Open a component product and confirm the bundles returned by `groupedBy` render as one link each.
+4. Confirm a customized bundle parent without fixed components cannot be added (buy buttons disabled, "Choose bundle items").
+5. Add a bundle to the cart and confirm its components are grouped under the parent line and the edit controls honor Shopify's instructions.
+6. Ask the shopping agent to show the cart and confirm bundle components appear in the summary.
+7. Run `pnpm --filter template lint`, `pnpm --filter template build`, and `pnpm --filter docs build`.


### PR DESCRIPTION
**Draft** — porting Shopify bundle support from #350 onto the merged #349/#352 PDP foundation, one slice at a time. Each slice is its own commit; this PR stays in draft until the track is functionally complete (then I'll add the rollout-log entry + docs).

## Plan

- [x] **A — Bundle data model** (this commit)
- [x] **B — Bundle PDP UI** (`bundle-components.tsx`: fixed-bundle contents + "part of these bundles"; buy-button gating for customized bundles)
- [x] **C — Cart bundle awareness** (`ComponentizableCartLine.lineComponents`, grouped cart rendering, `addToCart` parent input)

## Slice A — data model (no UI yet)

Adds the Storefront bundle relationships to the **selected/purchasable** variant only:

- New `PurchasableProductVariantFields` fragment = `ProductVariantFields` + `requiresComponents` + `groupedBy(first:10)` + `components(first:30)`. Wired into the shell's `selectedOrFirstAvailableVariant` and the suspended `getProductVariant` query. The base variant fragment (cards, full 250-variant matrix) stays lean — bundle fields are expensive and only needed for the resolved variant.
- `ProductVariant` gains `requiresComponents`, `components` (`ProductVariantComponent`), `bundleParents` (`ProductVariantReference`). `transformVariant` defaults them to `false` / `[]`, so every variant stays valid regardless of which fragment fetched it.
- **Excludes** `productHandle` / cross-handle navigation — that's Combined Listings (slice G), which collides with #349's per-option URL contract.

## Verification

Fixture: **"Pale Yellow Bundle"** on vpparel — a fixed bundle (AtlasRange Jacket + EmberMode Hoodie) with its own 5×5 size matrix, every variant `requiresComponents: true`. Confirmed via Admin API; the Storefront field shapes (`components.nodes[].{quantity,productVariant}`, `groupedBy.nodes[]`) verified against Storefront 2026-04.

- `pnpm --filter template lint` ✓ (oxlint + oxfmt)
- `tsc --noEmit` ✓
- `pnpm --filter template build` ✓ — live Storefront schema accepts the new fields (no GraphQL errors), fragment composition is duplication-free, `/products/[handle]` stays Partial Prerender (◐).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

