### PR TITLE
[template] No-image placeholder for product cards and PDP gallery

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/home.mdx
+++ b/apps/docs/content/docs/anatomy/pages/home.mdx
@@ -24,7 +24,7 @@ On mobile, the subheadline and CTA text are hidden to keep the banner compact.
 
 A responsive grid showing the top 8 products fetched via `getCatalogProducts()`. The grid uses the `ProductsGrid` component with a section title and a link to the full catalog. Each item is a [product card](/docs/anatomy/product-card) with:
 
-- Featured image, with a muted title-text fallback when the product has no image
+- Featured image, with a muted image-icon placeholder when the product has no image
 - Out-of-stock overlay when unavailable
 - Title and price (with compare-at price for discounts)
 

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -47,6 +47,8 @@ The gallery is handled by a single `ProductMedia` component that adapts to scree
 
 Both layouts receive pre-filtered images as props from the server.
 
+When a product has no images or videos at all, `ProductMedia` renders a single `ImagePlaceholder` (`components/ui/image-placeholder.tsx`) sized to the gallery's `aspect-square` footprint — full-bleed on mobile, full-width within the media column on desktop — so the page keeps its two-column shape instead of collapsing.
+
 ### Color-based image filtering
 
 When the **color** option has multiple values with distinct representative images (each value's `firstSelectableVariant` image, exposed as `OptionValue.image`), the gallery leads with the selected color's image. The shared media — product images that aren't a specific color's representative image, via `getSharedImages()` in `lib/product.ts` — renders immediately in the static shell, while the leading color slot streams behind a small Suspense fallback so changing the selection does not skeletonize the whole gallery. The slot resolves from the fast options promise via `getSelectedColorImage()` (no variant query), so it streams at `searchParams` speed. Non-color axes like size or finish never trigger a streamed slot — those products keep a fully static gallery.

--- a/apps/docs/content/docs/anatomy/product-card.mdx
+++ b/apps/docs/content/docs/anatomy/product-card.mdx
@@ -25,7 +25,7 @@ The badge label comes from the `product.featuredBadge` translation key, so it st
 
 ## Image fallback
 
-The card renders `product.featuredImage` with `next/image` (`fill`, `object-cover`). When a product has **no featured image**, the card does not show a broken image - the image box keeps its aspect-ratio footprint (with a `bg-muted` background) and renders the product title centered as muted placeholder text. This keeps grids visually aligned even for products that are missing imagery.
+The card renders `product.featuredImage` with `next/image` (`fill`, `object-cover`). When a product has **no featured image**, the card does not show a broken image - the image box keeps its aspect-ratio footprint and renders the shared `ImagePlaceholder` (`components/ui/image-placeholder.tsx`): a white square centering a muted Lucide image icon sized relative to the box. This keeps grids visually aligned even for products that are missing imagery.
 
 When the product is unavailable, an out-of-stock overlay darkens the image and shows the localized out-of-stock label on top.
 

--- a/apps/template/components/agent/registry.tsx
+++ b/apps/template/components/agent/registry.tsx
@@ -46,7 +46,6 @@ export const { registry } = defineRegistry(catalog, {
                 alt={props.title}
                 outOfStock={!props.available}
                 outOfStockText={t("outOfStock")}
-                fallbackTitle={props.title}
                 sizes="(max-width: 640px) 45vw, 180px"
               />
               <ProductCardContent>

--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -128,7 +128,6 @@ function ClientProductCard({
             sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, (max-width: 1280px) 25vw, 20vw"
             outOfStock={!product.availableForSale}
             outOfStockText={outOfStockText}
-            fallbackTitle={product.title}
           />
           <ProductCardContent>
             <ProductCardTitle>{product.title}</ProductCardTitle>

--- a/apps/template/components/product-card/components.tsx
+++ b/apps/template/components/product-card/components.tsx
@@ -3,6 +3,7 @@ import type * as React from "react";
 
 import { DiscountBadge } from "@/components/product/discount-badge";
 import { Price } from "@/components/product/price";
+import { ImagePlaceholder } from "@/components/ui/image-placeholder";
 import { cn } from "@/lib/utils";
 
 interface ProductCardProps extends React.ComponentProps<"article"> {
@@ -67,7 +68,6 @@ interface ProductCardImageProps {
   sizes?: string;
   outOfStock?: boolean;
   outOfStockText?: string;
-  fallbackTitle?: string;
   aspectRatio?: ProductCardAspectRatio;
   className?: string;
 }
@@ -78,7 +78,6 @@ function ProductCardImage({
   sizes = "(max-width: 640px) 50vw, (max-width: 1024px) 33vw, (max-width: 1280px) 25vw, 20vw",
   outOfStock = false,
   outOfStockText,
-  fallbackTitle,
   aspectRatio = "square",
   className,
 }: ProductCardImageProps) {
@@ -91,9 +90,7 @@ function ProductCardImage({
       {src ? (
         <Image src={src} alt={alt} fill className="object-cover" sizes={sizes} />
       ) : (
-        <div className="w-full h-full flex items-center justify-center bg-muted text-muted-foreground font-medium text-xl p-2 text-center">
-          {fallbackTitle}
-        </div>
+        <ImagePlaceholder className="size-full" />
       )}
       {outOfStock && (
         <div className="absolute inset-0 bg-black/60 flex items-center justify-center">

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -55,7 +55,6 @@ export async function ProductCard({
             sizes={sizes}
             outOfStock={!product.availableForSale}
             outOfStockText={outOfStockText}
-            fallbackTitle={product.title}
             aspectRatio={aspectRatio}
           />
           <ProductCardContent>

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 
 import { AutoPlayVideo } from "@/components/ui/auto-play-video";
+import { ImagePlaceholder } from "@/components/ui/image-placeholder";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Image as ImageType, Video } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -352,7 +353,13 @@ export function ProductMedia({
     ...otherImages.map((image): MediaItem => ({ type: "image", image })),
   ];
 
-  if (sharedMediaItems.length === 0 && !desktopSlot && !mobileSlot) return null;
+  if (sharedMediaItems.length === 0 && !desktopSlot && !mobileSlot) {
+    return (
+      <div className={className}>
+        <ImagePlaceholder className="aspect-square -mx-5 w-[calc(100%+2.5rem)] lg:mx-0 lg:w-full" />
+      </div>
+    );
+  }
 
   const hasColorSlot = !!mobileSlot || !!desktopSlot;
 

--- a/apps/template/components/ui/image-placeholder.tsx
+++ b/apps/template/components/ui/image-placeholder.tsx
@@ -1,0 +1,26 @@
+import { ImageIcon } from "lucide-react";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+interface ImagePlaceholderProps extends React.ComponentProps<"div"> {
+  iconClassName?: string;
+}
+
+function ImagePlaceholder({ className, iconClassName, ...props }: ImagePlaceholderProps) {
+  return (
+    <div
+      data-slot="image-placeholder"
+      className={cn("flex items-center justify-center bg-white", className)}
+      {...props}
+    >
+      <ImageIcon
+        aria-hidden
+        strokeWidth={1.5}
+        className={cn("h-auto w-1/3 max-w-[10rem] text-muted-foreground/40", iconClassName)}
+      />
+    </div>
+  );
+}
+
+export { ImagePlaceholder };

--- a/packages/plugin/template-rollout-log/2026-06-19-no-image-placeholder.md
+++ b/packages/plugin/template-rollout-log/2026-06-19-no-image-placeholder.md
@@ -1,0 +1,52 @@
+---
+title: No-image placeholder — shared ImagePlaceholder for cards and the PDP gallery
+changeKey: no-image-placeholder
+introducedOn: 2026-06-19
+changeType: feature
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/components/ui/image-placeholder.tsx
+  - apps/template/components/product-card/components.tsx
+  - apps/template/components/product-card/product-card.tsx
+  - apps/template/components/collections/infinite-product-grid.tsx
+  - apps/template/components/agent/registry.tsx
+  - apps/template/components/product-detail/product-media.tsx
+  - apps/docs/content/docs/anatomy/product-card.mdx
+  - apps/docs/content/docs/anatomy/pages/home.mdx
+  - apps/docs/content/docs/anatomy/pages/pdp.mdx
+---
+
+## Summary
+
+Products with no imagery now render a consistent placeholder instead of ad-hoc text or an empty layout.
+
+- New shared primitive `ImagePlaceholder` (`components/ui/image-placeholder.tsx`): a white square that centers a muted Lucide `ImageIcon`. The icon is sized relative to the box (`w-1/3`, capped at `10rem`), so the same component reads correctly at card scale and at PDP-gallery scale.
+- `ProductCardImage` renders `ImagePlaceholder` (filling the aspect-ratio box) when `featuredImage` is missing, replacing the previous `bg-muted` box that showed the product title as placeholder text. The now-unused `fallbackTitle` prop is removed from `ProductCardImage` and its call sites.
+- `ProductMedia` no longer returns `null` when a product has no images or videos. It renders a single `ImagePlaceholder` at the gallery's `aspect-square` footprint — full-bleed on mobile (`-mx-5`), full-width within the media column on desktop — so the PDP keeps its two-column shape.
+
+## Why it matters
+
+A missing image previously produced two different, weaker outcomes: cards fell back to centered title text (visually noisy, duplicated the title shown below), and the PDP gallery rendered nothing, collapsing the two-column layout and leaving the buy column floating. A single placeholder primitive makes the empty state intentional and keeps grids and the PDP layout aligned.
+
+## Apply when
+
+- The storefront's catalog can contain products without a featured image or gallery media (common during merchandising, draft products, or partial imports).
+- You want a uniform empty-image treatment shared across cards and the PDP.
+
+## Safe to skip when
+
+- Every product is guaranteed to have imagery, or a custom empty-state treatment is already in place.
+
+## Adoption notes
+
+- `ImagePlaceholder` lives in `components/ui/` and takes primitive props only (`className`, `iconClassName`, plus native `div` props) — no domain types. The caller owns sizing: cards pass `size-full`; the PDP passes the `aspect-square` breakout classes.
+- `ProductCardImage` no longer accepts `fallbackTitle`. Remove that prop from any local call sites.
+- The icon is decorative (`aria-hidden`); the accessible product name still comes from the card title / PDP `<h1>`, so no new strings are introduced.
+
+## Validation
+
+1. Open a product with no featured image in a grid (home, collection, search) and confirm the card shows the white square with the centered image icon, with the title and price still below.
+2. Open a product with no gallery media on the PDP and confirm a single square placeholder fills the media column (full-bleed on mobile) and the buy column stays in place.
+3. Run `pnpm --filter template lint`, `pnpm --filter template build`, and `pnpm --filter docs build`.


### PR DESCRIPTION
## Summary

Products with no imagery now render a consistent placeholder instead of ad-hoc text or an empty layout.

- **New shared primitive** `ImagePlaceholder` (`components/ui/image-placeholder.tsx`): a white square centering a muted Lucide `ImageIcon`. The icon is sized relative to the box (`w-1/3`, capped at `10rem`), so the same component reads correctly at card scale and at PDP-gallery scale. Primitive props only — no domain types, safe in both server and client trees.
- **Product card**: `ProductCardImage` renders the placeholder (filling the aspect-ratio box) when `featuredImage` is missing, replacing the previous `bg-muted` box that echoed the product title as placeholder text (the title already renders below the image). The now-unused `fallbackTitle` prop is removed from `ProductCardImage` and its three call sites.
- **PDP gallery**: `ProductMedia` no longer returns `null` when a product has no images or videos. It renders a single placeholder at the gallery's `aspect-square` footprint — full-bleed on mobile (`-mx-5`), full-width within the media column on desktop — so the PDP keeps its two-column shape instead of collapsing.

## Docs & rollout

- Updated `anatomy/product-card.mdx`, `anatomy/pages/home.mdx`, and `anatomy/pages/pdp.mdx` to describe the new behavior.
- Added `packages/plugin/template-rollout-log/2026-06-19-no-image-placeholder.md`.

## Test plan

- [ ] Product with no featured image in a grid (home / collection / search): card shows the white square with the centered image icon; title and price still below.
- [ ] Product with no gallery media on the PDP: a single square placeholder fills the media column (full-bleed on mobile) and the buy column stays in place.
- [x] `pnpm --filter template lint`
- [x] `tsc --noEmit` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)