### PR TITLE
[template] Use ImagePlaceholder for bundle list thumbnails

### DIFF
--- a/apps/template/components/product-detail/bundle-components.tsx
+++ b/apps/template/components/product-detail/bundle-components.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 
+import { ImagePlaceholder } from "@/components/ui/image-placeholder";
 import type { ProductVariantComponent, ProductVariantReference } from "@/lib/types";
 
 interface BundleListItem {
@@ -78,7 +79,9 @@ function BundleProductList({ items, title }: BundleProductListProps) {
                   height={48}
                   className="size-12 rounded-md object-cover"
                 />
-              ) : null}
+              ) : (
+                <ImagePlaceholder className="size-12 shrink-0 rounded-md" />
+              )}
               <span className="min-w-0 flex-1 truncate font-medium text-sm">{item.title}</span>
               {item.quantity && item.quantity > 1 ? (
                 <span className="text-foreground/50 text-sm">×{item.quantity}</span>

--- a/packages/plugin/template-rollout-log/2026-06-19-no-image-placeholder.md
+++ b/packages/plugin/template-rollout-log/2026-06-19-no-image-placeholder.md
@@ -12,6 +12,7 @@ paths:
   - apps/template/components/product-card/product-card.tsx
   - apps/template/components/collections/infinite-product-grid.tsx
   - apps/template/components/agent/registry.tsx
+  - apps/template/components/product-detail/bundle-components.tsx
   - apps/template/components/product-detail/product-media.tsx
   - apps/docs/content/docs/anatomy/product-card.mdx
   - apps/docs/content/docs/anatomy/pages/home.mdx
@@ -25,6 +26,7 @@ Products with no imagery now render a consistent placeholder instead of ad-hoc t
 - New shared primitive `ImagePlaceholder` (`components/ui/image-placeholder.tsx`): a white square that centers a muted Lucide `ImageIcon`. The icon is sized relative to the box (`w-1/3`, capped at `10rem`), so the same component reads correctly at card scale and at PDP-gallery scale.
 - `ProductCardImage` renders `ImagePlaceholder` (filling the aspect-ratio box) when `featuredImage` is missing, replacing the previous `bg-muted` box that showed the product title as placeholder text. The now-unused `fallbackTitle` prop is removed from `ProductCardImage` and its call sites.
 - `ProductMedia` no longer returns `null` when a product has no images or videos. It renders a single `ImagePlaceholder` at the gallery's `aspect-square` footprint — full-bleed on mobile (`-mx-5`), full-width within the media column on desktop — so the PDP keeps its two-column shape.
+- The PDP bundle lists ("Bundle includes" / "Available in bundles", `bundle-components.tsx`) render a `size-12` `ImagePlaceholder` for a component or parent with no image instead of dropping the thumbnail, so rows stay aligned.
 
 ## Why it matters
 


### PR DESCRIPTION
## Summary

Follow-on to #354. The PDP bundle lists ("Bundle includes" / "Available in bundles", `bundle-components.tsx`) previously **dropped the 48px thumbnail entirely** when a component or parent product had no image, leaving the row's text flush-left and misaligned with rows that do have images.

They now render the shared `ImagePlaceholder` at the same `size-12` footprint, so rows stay aligned. The relative `w-1/3` icon lands at ~16px inside the 48px box — proportional to the larger card/PDP placeholders.

The other bundle surfaces — the cart line bundle list (`overlay-item.tsx`, reused by the cart page) and the agent cart summary — render bundle components as **text only**, so they need no placeholder.

## Docs & rollout

- Extended the existing `2026-06-19-no-image-placeholder.md` rollout-log entry (added the `bundle-components.tsx` path and a bullet) rather than fragmenting one feature across two entries.
- No docs correction: the bundle thumbnail's empty state isn't separately documented.

## Test plan

- [ ] PDP for a bundle whose component (or a bundle it belongs to) has no image: the row shows the `size-12` placeholder square with the centered icon, aligned with imaged rows.
- [x] `pnpm --filter template lint`
- [x] `tsc --noEmit` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)