### PR TITLE
fix(template): uncache browse-grid pagination to stop boundary duplicates

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/plp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/plp.mdx
@@ -14,7 +14,9 @@ The collection PLP splits, like the [PDP](/docs/anatomy/pages/pdp), between what
 
 Two structural choices keep that copy coherent. The resolved collection is **not** threaded into a `<Suspense>` boundary, and the route does **not** set `prefetch = "allow-runtime"`. Either one re-renders the header at request time into a separate RSC flight that can drift from the frozen shell when the cached value changes — a React hydration mismatch and copy that appears to change on its own. Use plain `"use cache"` here rather than `"use cache: remote"`: `remote` resolves at request time, _outside_ the static shell, so it would not bake in. The shell refreshes when it regenerates on its `cacheLife` window or when a Shopify [webhook](/docs/anatomy/webhooks) calls `revalidateTag`.
 
-The dynamic inputs are the filter, sort, and cursor `searchParams`. Rather than block the whole page on them, the route passes the `searchParams` promise — unawaited — into the results data. The header renders from the collection resolved at the top; the toolbar's result count, filter sidebar, sort select, and the product grid each sit inside their own Suspense boundary so changing a filter or sort streams the affected slot without skeletonizing the header. `getCollectionProducts` and the facet reads stay `"use cache: remote"` — they key on the request-time filter/sort/cursor inputs and are served from the shared Runtime Cache, not the per-route shell.
+The dynamic inputs are the filter, sort, and cursor `searchParams`. Rather than block the whole page on them, the route passes the `searchParams` promise — unawaited — into the results data. The header renders from the collection resolved at the top; the toolbar's result count, filter sidebar, sort select, and the product grid each sit inside their own Suspense boundary so changing a filter or sort streams the affected slot without skeletonizing the header.
+
+The product-grid read is deliberately **uncached** — `fetchCollectionProducts` (and `fetchSearchIndexProducts` for `/collections/all` and `/search`) calls Shopify live on every request, inside its Suspense boundary. Caching it was the source of a duplicate-at-the-page-boundary bug: the first page and each cursor page were stored as independent `cacheLife("max")` snapshots taken at different times, so a first page's `endCursor` could be resolved against a later, drifted ordering and re-emit the boundary product as a duplicate. Reading every page live keeps the cursor handoff consistent within a scroll session. The facet reads (`getSearchFacets`) and the collection header stay cached; on `/collections/[handle]` the facet counts ride along inside the same live product query, while `/collections/all` and `/search` keep them in the separately-cached `getSearchFacets` read. The cached wrappers `getCollectionProducts` / `searchIndexProducts` remain for non-paginated consumers (the `/md` routes and agent tools).
 
 The `/search` route is different: its body is fully request-driven (the query lives entirely in `searchParams`), so there is no cacheable collection body to bake into a shell, and it does not follow this await-at-top pattern.
 
@@ -56,9 +58,9 @@ Sort changes use `useTransition` for non-blocking navigation.
 
 ## Infinite scroll
 
-Products load progressively using an `InfiniteProductGrid` component backed by `IntersectionObserver`. When the user scrolls near the bottom, a server action fetches the next page using Shopify's cursor-based pagination (`endCursor`). A loading indicator appears while the next batch loads.
+Products load progressively using an `InfiniteProductGrid` component backed by `IntersectionObserver`. When the user scrolls near the bottom, a server action fetches the next page using Shopify's cursor-based pagination (`endCursor`). That load-more read is uncached, like the initial grid (see [Rendering strategy](#rendering-strategy)), so consecutive pages come from consistent snapshots. A loading indicator appears while the next batch loads.
 
-The cursor resets automatically when filters or sort change. Each batch renders [product cards](/docs/anatomy/product-card) inline using the same card primitives as the initial grid.
+The cursor resets automatically when filters or sort change. Each batch renders [product cards](/docs/anatomy/product-card) inline using the same card primitives as the initial grid. As a final safeguard against a ranking shift mid-scroll, the grid tracks already-rendered product ids and skips any duplicate a live cursor page might surface.
 
 ## Toolbar
 

--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -41,6 +41,8 @@ export function InfiniteProductGrid<TParams>({
   const [isLoading, setIsLoading] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const loadingRef = useRef(false);
+  // Live cursor pages can re-emit a boundary product if the ranking shifts mid-scroll; skip ids already shown.
+  const seenIdsRef = useRef<Set<string>>(new Set(initialProducts.map((product) => product.id)));
 
   // Reset when initial data changes (filter/sort navigation)
   useEffect(() => {
@@ -48,6 +50,7 @@ export function InfiniteProductGrid<TParams>({
     setPageInfo(initialPageInfo);
     setIsLoading(false);
     loadingRef.current = false;
+    seenIdsRef.current = new Set(initialProducts.map((product) => product.id));
   }, [initialProducts, initialPageInfo]);
 
   const handleLoadMore = useCallback(async () => {
@@ -57,7 +60,9 @@ export function InfiniteProductGrid<TParams>({
 
     try {
       const result = await loadMore({ ...loadMoreParams, cursor: pageInfo.endCursor });
-      setAdditionalProducts((prev) => [...prev, ...result.products]);
+      const fresh = result.products.filter((product) => !seenIdsRef.current.has(product.id));
+      for (const product of fresh) seenIdsRef.current.add(product.id);
+      setAdditionalProducts((prev) => [...prev, ...fresh]);
       setPageInfo(result.pageInfo);
     } finally {
       setIsLoading(false);

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -12,8 +12,8 @@ import type { Locale } from "@/lib/i18n";
 import { loadMoreSearchProducts } from "@/lib/search/action";
 import {
   buildProductFiltersFromParams,
+  fetchSearchIndexProducts,
   getSearchFacets,
-  searchIndexProducts,
 } from "@/lib/shopify/operations/products";
 import type { ProductFilter } from "@/lib/shopify/types/filters";
 import type { Filter, PageInfo, PriceRange, ProductCard as ProductCardType } from "@/lib/types";
@@ -46,7 +46,7 @@ export async function getSearchResultsData({
 }): Promise<SearchResultsData> {
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
   const [results, facets] = await Promise.all([
-    searchIndexProducts({
+    fetchSearchIndexProducts({
       query,
       collection,
       sortKey: sort,

--- a/apps/template/lib/collections/action.ts
+++ b/apps/template/lib/collections/action.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getCollectionProducts } from "@/lib/shopify/operations/products";
+import { fetchCollectionProducts } from "@/lib/shopify/operations/products";
 import type { ProductFilter } from "@/lib/shopify/types/filters";
 import type { PageInfo, ProductCard } from "@/lib/types";
 
@@ -11,7 +11,7 @@ export async function loadMoreCollectionProducts(params: {
   filters?: ProductFilter[];
   locale: string;
 }): Promise<{ products: ProductCard[]; pageInfo: PageInfo }> {
-  const result = await getCollectionProducts({
+  const result = await fetchCollectionProducts({
     collection: params.collection,
     cursor: params.cursor,
     sortKey: params.sortKey,

--- a/apps/template/lib/collections/server.ts
+++ b/apps/template/lib/collections/server.ts
@@ -3,9 +3,9 @@ import { getTranslations } from "next-intl/server";
 import type { Locale } from "@/lib/i18n";
 import {
   buildProductFiltersFromParams,
-  getCollectionProducts,
+  fetchCollectionProducts,
+  fetchSearchIndexProducts,
   getSearchFacets,
-  searchIndexProducts,
 } from "@/lib/shopify/operations/products";
 import type { ProductFilter } from "@/lib/shopify/types/filters";
 import type { Collection, Filter, PriceRange } from "@/lib/types";
@@ -27,7 +27,7 @@ export interface CollectionResultsData {
   collection: string;
   sort?: string;
   filters: ProductFilter[];
-  result: Awaited<ReturnType<typeof getCollectionProducts>>;
+  result: Awaited<ReturnType<typeof fetchCollectionProducts>>;
   transformedFilters: { filters: Filter[]; priceRange?: PriceRange };
 }
 
@@ -53,7 +53,7 @@ export async function getCollectionResultsData({
 }): Promise<CollectionResultsData> {
   const { activeFilters, sort } = await searchStatePromise;
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
-  const result = await getCollectionProducts({
+  const result = await fetchCollectionProducts({
     activeFilters,
     collection: handle,
     sortKey: sort,
@@ -75,7 +75,7 @@ export async function getCollectionResultsData({
 export function getExactCollectionResultCount({
   result,
 }: {
-  result: Awaited<ReturnType<typeof getCollectionProducts>>;
+  result: Awaited<ReturnType<typeof fetchCollectionProducts>>;
 }): number | undefined {
   if (result.pageInfo.hasNextPage) {
     return undefined;
@@ -113,7 +113,7 @@ export async function getAllProductsResultsData({
   const { activeFilters, sort } = await searchStatePromise;
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
   const [products, facets] = await Promise.all([
-    searchIndexProducts({
+    fetchSearchIndexProducts({
       sortKey: sort,
       limit: RESULTS_PER_PAGE,
       filters: shopifyFilters,

--- a/apps/template/lib/search/action.ts
+++ b/apps/template/lib/search/action.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { searchIndexProducts } from "@/lib/shopify/operations/products";
+import { fetchSearchIndexProducts } from "@/lib/shopify/operations/products";
 import { predictiveSearch } from "@/lib/shopify/operations/search";
 import type { ProductFilter } from "@/lib/shopify/types/filters";
 import type { PageInfo, PredictiveSearchResult, ProductCard } from "@/lib/types";
@@ -26,7 +26,7 @@ export async function loadMoreSearchProducts(params: {
   locale: string;
 }): Promise<{ products: ProductCard[]; pageInfo: PageInfo }> {
   // Storefront `search` cursor is anchored to the original `first`; using a different page size returns count=0.
-  const result = await searchIndexProducts({
+  const result = await fetchSearchIndexProducts({
     query: params.query,
     collection: params.collection,
     cursor: params.cursor,

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -551,10 +551,13 @@ export async function getSearchFacets(params: {
   };
 }
 
-// Relevance-ranked search via the Storefront `search` field. Accepts the full ProductFilter set
-// (variant options, metafields, etc.) — the products(...) query string in getCatalogProducts
-// silently drops variantOption/productMetafield, so /search uses this path even for no-query browse.
-export async function searchIndexProducts(params: {
+type SearchIndexProductsResult = {
+  pageInfo: PageInfo;
+  products: ProductCard[];
+  total: number;
+};
+
+type SearchIndexProductsParams = {
   collection?: string;
   cursor?: string;
   filters?: ProductFilter[];
@@ -562,11 +565,14 @@ export async function searchIndexProducts(params: {
   locale?: string;
   query?: string;
   sortKey?: string;
-}): Promise<{ pageInfo: PageInfo; products: ProductCard[]; total: number }> {
-  "use cache: remote";
-  cacheLife("max");
-  cacheTag("products");
+};
 
+// Relevance-ranked search via the Storefront `search` field. Accepts the full ProductFilter set
+// (variant options, metafields, etc.) — the products(...) query string in getCatalogProducts
+// silently drops variantOption/productMetafield, so /search uses this path even for no-query browse.
+export async function fetchSearchIndexProducts(
+  params: SearchIndexProductsParams,
+): Promise<SearchIndexProductsResult> {
   const {
     collection,
     cursor,
@@ -612,13 +618,23 @@ export async function searchIndexProducts(params: {
     .map((edge) => edge.node)
     .filter((node): node is ShopifyProductCard => node !== null);
 
-  tagProducts(shopifyProducts);
-
   return {
     pageInfo: data.search.pageInfo,
     products: shopifyProducts.map(transformShopifyProductCard),
     total: data.search.totalCount,
   };
+}
+
+export async function searchIndexProducts(
+  params: SearchIndexProductsParams,
+): Promise<SearchIndexProductsResult> {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("products");
+
+  const result = await fetchSearchIndexProducts(params);
+  tagProducts(result.products);
+  return result;
 }
 
 const COLLECTION_PRODUCTS_QUERY = `
@@ -672,7 +688,14 @@ const COLLECTION_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolea
   COLLECTION_DEFAULT: { sortKey: "COLLECTION_DEFAULT", reverse: false },
 };
 
-export async function getCollectionProducts(params: {
+type CollectionProductsResult = {
+  filters: Filter[];
+  pageInfo: PageInfo;
+  priceRange?: PriceRange;
+  products: ProductCard[];
+};
+
+type CollectionProductsParams = {
   activeFilters?: ActiveFilters;
   collection: string;
   cursor?: string;
@@ -680,16 +703,11 @@ export async function getCollectionProducts(params: {
   limit?: number;
   locale?: string;
   sortKey?: string;
-}): Promise<{
-  filters: Filter[];
-  pageInfo: PageInfo;
-  priceRange?: PriceRange;
-  products: ProductCard[];
-}> {
-  "use cache: remote";
-  cacheLife("max");
-  cacheTag("products", "collections", `collection-${params.collection}`);
+};
 
+export async function fetchCollectionProducts(
+  params: CollectionProductsParams,
+): Promise<CollectionProductsResult> {
   const {
     activeFilters = {},
     collection,
@@ -742,8 +760,6 @@ export async function getCollectionProducts(params: {
 
   const shopifyProducts = data.collection.products.edges.map((edge) => edge.node);
 
-  tagProducts(shopifyProducts);
-
   const products = shopifyProducts.map(transformShopifyProductCard);
   const transformed = transformShopifyFilters(data.collection.products.filters, { activeFilters });
 
@@ -753,6 +769,18 @@ export async function getCollectionProducts(params: {
     priceRange: transformed.priceRange,
     products,
   };
+}
+
+export async function getCollectionProducts(
+  params: CollectionProductsParams,
+): Promise<CollectionProductsResult> {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("products", "collections", `collection-${params.collection}`);
+
+  const result = await fetchCollectionProducts(params);
+  tagProducts(result.products);
+  return result;
 }
 
 const PRODUCT_RECOMMENDATIONS_QUERY = `

--- a/packages/plugin/template-rollout-log/2026-06-20-uncached-browse-pagination.md
+++ b/packages/plugin/template-rollout-log/2026-06-20-uncached-browse-pagination.md
@@ -1,0 +1,55 @@
+---
+title: Uncache browse-grid pagination to fix boundary duplicates
+changeKey: uncached-browse-pagination
+introducedOn: 2026-06-20
+changeType: fix
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/shopify/operations/products.ts
+  - apps/template/lib/collections/server.ts
+  - apps/template/lib/collections/action.ts
+  - apps/template/lib/search/action.ts
+  - apps/template/components/search/results.tsx
+  - apps/template/components/collections/infinite-product-grid.tsx
+  - apps/docs/content/docs/anatomy/pages/plp.mdx
+---
+
+## Summary
+
+The browse/search product grid now reads its ordered product list **live** (uncached) instead of from the shared Runtime Cache, fixing a product that duplicated at the infinite-scroll page boundary.
+
+- The two cursor-paginated operations in `lib/shopify/operations/products.ts` are split into an uncached inner fetch plus a thin cached wrapper, mirroring the existing `fetchCatalogProducts` / `getCatalogProducts` pattern:
+  - `fetchCollectionProducts` (uncached) + `getCollectionProducts` (`"use cache: remote"` wrapper).
+  - `fetchSearchIndexProducts` (uncached) + `searchIndexProducts` (`"use cache: remote"` wrapper).
+- The browse/search surfaces call the uncached inner fetches: `getCollectionResultsData` and `getAllProductsResultsData` (`lib/collections/server.ts`), `getSearchResultsData` (`components/search/results.tsx`), and both load-more actions (`loadMoreCollectionProducts`, `loadMoreSearchProducts`).
+- Facet aggregation (`getSearchFacets`) and the collection header (`getCollection`) stay cached. On `/collections/[handle]` the facet counts ride along inside the same now-live product query; `/collections/all` and `/search` keep facets in the separately-cached `getSearchFacets` read.
+- The cached wrappers remain for the non-paginated consumers that still want caching: the `/md` content routes and the agent tools (`browse-collection`, `search-products`).
+- `InfiniteProductGrid` gains a client-side dedup guard: a `seen` Set of product ids (seeded from the initial page, reset on filter/sort navigation) filters out any product a live cursor page re-emits.
+
+## Why it matters
+
+With both the first page and every load-more page cached under `"use cache: remote"` + `cacheLife("max")`, the two pages were independent snapshots taken at different times. The first page's cached `endCursor` was computed against one ordering; the page-2 fetch resolved that cursor against a different cached ordering. Because the Storefront `search` field's default sort is not perfectly stable, a drift between the two long-lived snapshots made the `after` cursor re-emit the boundary item. This reproduced live on `template.vercel.shop/collections/all`: page 1 ended with a product that page 2 then repeated as its first card (81 cards rendered, 80 unique). `shopifyFetch` sets no fetch-level caching, so under `cacheComponents` the `"use cache"` directive was the only thing caching these reads — dropping it from the paginated path makes consecutive pages come from consistent, near-simultaneous snapshots.
+
+## Apply when
+
+- Your storefront uses the template's infinite-scroll PLP/search grid and your catalog ordering can change (restocks, best-selling re-ranking, publishes) while shoppers browse.
+- You have seen — or want to preempt — duplicate or skipped products across the page boundary.
+
+## Safe to skip when
+
+- Your catalog ordering is effectively static, or you have replaced the infinite-scroll grid with offset/page-number pagination.
+- You depend on the product-grid read being cached for cost/latency reasons and accept the occasional boundary duplicate (in that case, you can still adopt just the `InfiniteProductGrid` dedup guard, which masks the visible duplicate without changing caching).
+
+## Adoption notes
+
+- The change relies on the grid already streaming inside a `<Suspense>` boundary that transitively `await`s `searchParams` — that is what keeps the route's PPR shape intact when the read goes live (the shell still prerenders; only the grid streams from a live call). If your fork awaits the results data at the top of the page instead, make it dynamic (Suspense + `searchParams`, or `connection()`) before uncaching, or the build will reject uncached I/O outside a dynamic scope.
+- Cost trade-off: every grid render now issues a live Storefront `collectionProducts` / `searchProducts` call. Facets and the header remain cached, so the additional load is one product query per render.
+- The dedup guard keys on `product.id`; it suppresses duplicates but cannot recover a product that a ranking shift skips entirely — uncaching is what minimizes skips.
+
+## Validation
+
+1. Run `pnpm --filter template lint`, `pnpm --filter template build` (the build is the gate that confirms the now-live grid reads are accepted inside their Suspense boundaries under `cacheComponents`), and `pnpm --filter docs build`.
+2. With the dev server running, scroll `/collections/all` past the first page and confirm the rendered product handles contain no duplicate at the page boundary (total === unique). Repeat on a `/collections/[handle]` page and `/search?q=...`.
+3. With `DEBUG_SHOPIFY=true`, confirm a `collectionProducts` / `searchProducts` call fires on each grid render while `searchFacets` and the collection header are served from cache on repeat loads.


### PR DESCRIPTION
## Problem

The infinite-scroll grid on `/collections/[handle]`, `/collections/all`, and `/search` renders a **duplicate product at the page-1↔page-2 boundary**. Reproduced live on `template.vercel.shop/collections/all`: page 1 ended with `crestshield-tee-womens-e4fe12` and page 2 began with the same product — **81 cards rendered, 80 unique**.


## Root cause

Both the first page and every load-more page read products under `"use cache: remote"` + `cacheLife("max")`, keyed (in part) by the `cursor`. Page 1 and page 2 are therefore **two independently-cached snapshots taken at different times**. The cached first page's `endCursor` was computed against one ordering; the page-2 fetch resolved that cursor against a *different* cached ordering. The Storefront `search` field's default sort isn't perfectly stable, so when the ordering drifts between the two long-lived snapshots, the `after` cursor re-emits the boundary item. `shopifyFetch` sets no fetch-level caching, so under `cacheComponents` the `"use cache"` directive was the *only* thing caching these reads.

## Change

Make the **ordered product-list reads live (uncached)** for the browse/search grid so consecutive pages come from near-simultaneous snapshots, while keeping the expensive/stable reads cached.

- **Split the two cursor-paginated ops** into an uncached inner fetch + a thin cached wrapper (mirrors the existing `fetchCatalogProducts` / `getCatalogProducts` pattern):
  - `fetchCollectionProducts` (uncached) + `getCollectionProducts` (`"use cache: remote"` wrapper)
  - `fetchSearchIndexProducts` (uncached) + `searchIndexProducts` (`"use cache: remote"` wrapper)
- **Browse/search surfaces and both load-more actions** call the uncached inner fetches (`getCollectionResultsData`, `getAllProductsResultsData`, `getSearchResultsData`, `loadMoreCollectionProducts`, `loadMoreSearchProducts`).
- **Facets (`getSearchFacets`) and the collection header (`getCollection`) stay cached.** On `/collections/[handle]` the facet counts ride along inside the same now-live product query; the cached wrappers remain for the non-paginated consumers (`/md` routes, agent tools).
- **`tagProducts()` moved into the cached wrappers** — `cacheTag()` is only valid inside a `use cache` scope, so the uncached path must not tag.
- **Client-side dedup guard** in `InfiniteProductGrid` (a `seen` Set of product ids) as a final safeguard against a ranking shift mid-scroll.
- **Docs** (`plp.mdx`) updated and a **template-rollout-log** entry added.

The browse pages already stream the grid inside a `<Suspense>` boundary that transitively `await`s `searchParams`, so swapping a cached read for a live one keeps the same PPR shape — the shell still prerenders, only the grid streams (now from a live call).

## Verification

- `pnpm --filter template build` ✅ — `/collections/[handle]`, `/collections/all`, `/search` stay **Partial Prerender** (no "uncached I/O outside Suspense / `connection()`" error).
- `pnpm --filter docs build` ✅ · `pnpm --filter template lint` ✅
- Live scroll of `/collections/all` on a local dev server: was 81 cards / 80 unique → now **65 cards / 65 unique, 0 duplicates**. `/search?q=oak` and `/collections/frontpage` load clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
