### PR TITLE
feat(template): complementary products ("Pairs well with") on the PDP

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -77,6 +77,12 @@ These are product-level facts (which products a bundle contains / which bundles 
 
 A customized bundle parent (`requiresComponents` with no fixed `components`) disables the buy buttons with a "Choose bundle items" label, since the generic storefront can't configure it. The bundle relationship arrays stay server-side; `BuyButtons` receives only a `requiresBundleConfiguration` boolean.
 
+### Complementary products
+
+`complementary-products.tsx` renders the merchant-curated "Pairs well with" set below the bundle relationships — Shopify's [complementary products](/docs/shopify/pdp#complementary-products) from `productRecommendations(intent: COMPLEMENTARY)`. These are distinct from the algorithmic related products below the fold (`intent: RELATED`): complementary products are deliberately chosen add-ons, so they sit beside the buy section like bundle relationships rather than in the footer grid.
+
+Unlike bundle relationships (free on the cached default variant), complementary products need their own recommendation fetch, so the section **streams in behind a `Suspense` boundary** with a compact-list skeleton — the same pattern as the price and option pickers. It shows up to four products as thumbnail + title + price rows and collapses to nothing when none are configured.
+
 ## Related Products
 
 Below the product details, a `RelatedProductsSection` component fetches related products from Shopify's recommendation API. It renders inside a `Suspense` boundary with a skeleton grid fallback.

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -81,7 +81,7 @@ A customized bundle parent (`requiresComponents` with no fixed `components`) dis
 
 `complementary-products.tsx` renders the merchant-curated "Pairs well with" set below the bundle relationships — Shopify's [complementary products](/docs/shopify/pdp#complementary-products) from `productRecommendations(intent: COMPLEMENTARY)`. These are distinct from the algorithmic related products below the fold (`intent: RELATED`): complementary products are deliberately chosen add-ons, so they sit beside the buy section like bundle relationships rather than in the footer grid.
 
-Unlike bundle relationships (free on the cached default variant), complementary products need their own recommendation fetch, so the section **streams in behind a `Suspense` boundary** with a compact-list skeleton — the same pattern as the price and option pickers. It shows up to four products as thumbnail + title + price rows and collapses to nothing when none are configured.
+Like bundle relationships, the section renders **eagerly into the prerendered shell** rather than streaming. `getComplementaryProducts()` is a cached (`use cache: remote`) operation, so its result is baked into the static PPR/ISR document — there's no skeleton fallback and no layout shift on cached hits (a `Suspense` boundary would instead make it a streamed hole). It shows up to four products as thumbnail + title + price rows and renders nothing when none are configured.
 
 ## Related Products
 

--- a/apps/docs/content/docs/shopify/pdp.mdx
+++ b/apps/docs/content/docs/shopify/pdp.mdx
@@ -72,6 +72,12 @@ Products must be assigned to at least one collection to appear on collection lis
 
 Product recommendations on the PDP are powered by Shopify's recommendation API. No configuration is needed - Shopify generates recommendations automatically based on purchase history and product similarity.
 
+## Complementary products
+
+Beyond the automatic recommendations above, the PDP shows a merchant-curated **"Pairs well with"** list near the buy section, powered by the Storefront API's `productRecommendations(intent: COMPLEMENTARY)`.
+
+Unlike the `RELATED` recommendations Shopify generates automatically, complementary products are **configured by hand** in the free [Shopify Search & Discovery](https://apps.shopify.com/search-and-discovery) app — open a product's **Product recommendations** settings and add its complementary items. With none configured for a product, the section renders nothing.
+
 ## Bundles
 
 The template renders Shopify [product bundles](https://help.shopify.com/en/manual/products/bundles) from the Storefront API's variant-level relationships, fetched for the selected variant in `PurchasableProductVariantFields`:

--- a/apps/template/components/product-detail/complementary-products.tsx
+++ b/apps/template/components/product-detail/complementary-products.tsx
@@ -1,0 +1,75 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { ImagePlaceholder } from "@/components/ui/image-placeholder";
+import { Skeleton } from "@/components/ui/skeleton";
+import { getComplementaryProducts } from "@/lib/shopify/operations/products";
+import type { ProductCard } from "@/lib/types";
+import { formatPrice } from "@/lib/utils";
+
+const COMPLEMENTARY_LIMIT = 4;
+
+export function ComplementaryProductsSkeleton({ title }: { title: string }) {
+  return (
+    <div className="grid gap-2.5" data-slot="complementary-products">
+      <h2 className="font-medium text-foreground/70 text-sm">{title}</h2>
+      <ul className="grid gap-2.5">
+        {Array.from({ length: COMPLEMENTARY_LIMIT }, (_, index) => (
+          <li
+            key={index}
+            className="flex items-center gap-2.5 rounded-lg border border-border p-2.5"
+          >
+            <Skeleton className="size-12 shrink-0 rounded-md" />
+            <Skeleton className="h-4 flex-1" />
+            <Skeleton className="h-4 w-12 shrink-0" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export async function ComplementaryProducts({
+  handle,
+  locale,
+  title,
+}: {
+  handle: string;
+  locale: string;
+  title: string;
+}) {
+  const products = await getComplementaryProducts({ handle, locale });
+  if (products.length === 0) return null;
+
+  return (
+    <div className="grid gap-2.5" data-slot="complementary-products">
+      <h2 className="font-medium text-foreground/70 text-sm">{title}</h2>
+      <ul className="grid gap-2.5">
+        {products.slice(0, COMPLEMENTARY_LIMIT).map((product: ProductCard) => (
+          <li key={product.id}>
+            <Link
+              href={`/products/${product.handle}`}
+              className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-border p-2.5 transition-colors hover:border-foreground/30"
+            >
+              {product.featuredImage ? (
+                <Image
+                  src={product.featuredImage.url}
+                  alt={product.featuredImage.altText || product.title}
+                  width={48}
+                  height={48}
+                  className="size-12 rounded-md object-cover"
+                />
+              ) : (
+                <ImagePlaceholder className="size-12 shrink-0 rounded-md" />
+              )}
+              <span className="min-w-0 flex-1 truncate font-medium text-sm">{product.title}</span>
+              <span className="shrink-0 text-foreground/50 text-sm">
+                {formatPrice(Number(product.price.amount), product.price.currencyCode, locale)}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/template/components/product-detail/complementary-products.tsx
+++ b/apps/template/components/product-detail/complementary-products.tsx
@@ -2,32 +2,11 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
-import { Skeleton } from "@/components/ui/skeleton";
 import { getComplementaryProducts } from "@/lib/shopify/operations/products";
 import type { ProductCard } from "@/lib/types";
 import { formatPrice } from "@/lib/utils";
 
 const COMPLEMENTARY_LIMIT = 4;
-
-export function ComplementaryProductsSkeleton({ title }: { title: string }) {
-  return (
-    <div className="grid gap-2.5" data-slot="complementary-products">
-      <h2 className="font-medium text-foreground/70 text-sm">{title}</h2>
-      <ul className="grid gap-2.5">
-        {Array.from({ length: COMPLEMENTARY_LIMIT }, (_, index) => (
-          <li
-            key={index}
-            className="flex items-center gap-2.5 rounded-lg border border-border p-2.5"
-          >
-            <Skeleton className="size-12 shrink-0 rounded-md" />
-            <Skeleton className="h-4 flex-1" />
-            <Skeleton className="h-4 w-12 shrink-0" />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
 
 export async function ComplementaryProducts({
   handle,

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -3,10 +3,7 @@ import { Suspense } from "react";
 
 import { BundleComponents, BundleParents } from "@/components/product-detail/bundle-components";
 import { BuyButtons, type BuyButtonVariant } from "@/components/product-detail/buy-buttons";
-import {
-  ComplementaryProducts,
-  ComplementaryProductsSkeleton,
-} from "@/components/product-detail/complementary-products";
+import { ComplementaryProducts } from "@/components/product-detail/complementary-products";
 import {
   ProductInfoDescription,
   ProductInfoOptions,
@@ -250,9 +247,7 @@ async function ProductInfoArea({
 
       <BundleRelationships variant={product.defaultVariant} t={t} />
 
-      <Suspense fallback={<ComplementaryProductsSkeleton title={t("pairsWith")} />}>
-        <ComplementaryProducts handle={handle} locale={locale} title={t("pairsWith")} />
-      </Suspense>
+      <ComplementaryProducts handle={handle} locale={locale} title={t("pairsWith")} />
 
       <ProductInfoDescription descriptionHtml={descriptionHtml} />
     </div>

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -4,6 +4,10 @@ import { Suspense } from "react";
 import { BundleComponents, BundleParents } from "@/components/product-detail/bundle-components";
 import { BuyButtons, type BuyButtonVariant } from "@/components/product-detail/buy-buttons";
 import {
+  ComplementaryProducts,
+  ComplementaryProductsSkeleton,
+} from "@/components/product-detail/complementary-products";
+import {
   ProductInfoDescription,
   ProductInfoOptions,
 } from "@/components/product-detail/product-info";
@@ -245,6 +249,10 @@ async function ProductInfoArea({
       )}
 
       <BundleRelationships variant={product.defaultVariant} t={t} />
+
+      <Suspense fallback={<ComplementaryProductsSkeleton title={t("pairsWith")} />}>
+        <ComplementaryProducts handle={handle} locale={locale} title={t("pairsWith")} />
+      </Suspense>
 
       <ProductInfoDescription descriptionHtml={descriptionHtml} />
     </div>

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -294,6 +294,7 @@
     "noImage": "No image",
     "officialStore": "Official Store",
     "outOfStock": "Out of Stock",
+    "pairsWith": "Pairs well with",
     "quantity": "Quantity",
     "recommendations": "You May Also Like",
     "seeAllSpecs": "See all specs",

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -757,12 +757,48 @@ export async function getCollectionProducts(params: {
 
 const PRODUCT_RECOMMENDATIONS_QUERY = `
   ${PRODUCT_CARD_FRAGMENT}
-  query productRecommendations($productId: ID!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
-    productRecommendations(productId: $productId) {
+  query productRecommendations($productId: ID!, $intent: ProductRecommendationIntent, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    productRecommendations(productId: $productId, intent: $intent) {
       ...ProductCardFields
     }
   }
 `;
+
+// RELATED is Shopify's auto-generated "you may also like" set; COMPLEMENTARY is the
+// merchant-curated "pair it with" set configured in the Search & Discovery app.
+type RecommendationIntent = "COMPLEMENTARY" | "RELATED";
+
+async function fetchRecommendations({
+  handle,
+  intent,
+  locale,
+}: {
+  handle: string;
+  intent: RecommendationIntent;
+  locale: string;
+}): Promise<ProductCard[]> {
+  const country = getCountryCode(locale);
+  const language = getLanguageCode(locale);
+
+  const product = await getProduct({ handle, locale });
+  if (!product) {
+    return [];
+  }
+
+  const data = await shopifyFetch<{ productRecommendations: ShopifyProductCard[] }>({
+    operation: "productRecommendations",
+    query: PRODUCT_RECOMMENDATIONS_QUERY,
+    variables: { productId: product.id, intent, country, language },
+  });
+
+  if (!data.productRecommendations) {
+    return [];
+  }
+
+  tagProducts(data.productRecommendations);
+
+  return data.productRecommendations.map(transformShopifyProductCard);
+}
 
 export async function getProductRecommendations({
   handle,
@@ -775,27 +811,21 @@ export async function getProductRecommendations({
   cacheLife("max");
   cacheTag("products", `recommendations-${handle}`);
 
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
+  return fetchRecommendations({ handle, intent: "RELATED", locale });
+}
 
-  const product = await getProduct({ handle, locale });
-  if (!product) {
-    return [];
-  }
+export async function getComplementaryProducts({
+  handle,
+  locale = defaultLocale,
+}: {
+  handle: string;
+  locale?: string;
+}): Promise<ProductCard[]> {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("products", `complementary-${handle}`);
 
-  const data = await shopifyFetch<{ productRecommendations: ShopifyProductCard[] }>({
-    operation: "productRecommendations",
-    query: PRODUCT_RECOMMENDATIONS_QUERY,
-    variables: { productId: product.id, country, language },
-  });
-
-  if (!data.productRecommendations) {
-    return [];
-  }
-
-  tagProducts(data.productRecommendations);
-
-  return data.productRecommendations.map(transformShopifyProductCard);
+  return fetchRecommendations({ handle, intent: "COMPLEMENTARY", locale });
 }
 
 const GET_PRODUCTS_BY_HANDLES_QUERY = `

--- a/packages/plugin/template-rollout-log/2026-06-20-complementary-products.md
+++ b/packages/plugin/template-rollout-log/2026-06-20-complementary-products.md
@@ -1,0 +1,52 @@
+---
+title: Complementary products — merchant-curated "Pairs well with" on the PDP
+changeKey: complementary-products
+introducedOn: 2026-06-20
+changeType: feature
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/shopify/operations/products.ts
+  - apps/template/components/product-detail/complementary-products.tsx
+  - apps/template/components/product-detail/product-detail-section.tsx
+  - apps/template/lib/i18n/messages/en.json
+  - apps/docs/content/docs/anatomy/pages/pdp.mdx
+  - apps/docs/content/docs/shopify/pdp.mdx
+---
+
+## Summary
+
+The PDP now surfaces Shopify's merchant-curated [complementary products](https://help.shopify.com/en/manual/online-store/search-and-discovery/product-recommendations) — the "Pair it with" set — as a compact "Pairs well with" list in the product info column, beside the buy section.
+
+- A new `getComplementaryProducts()` operation calls the same `productRecommendations` query as related products but with `intent: COMPLEMENTARY`. `getProductRecommendations()` is unchanged in behavior — it now delegates to a shared `fetchRecommendations()` helper with the default `intent: RELATED`.
+- `complementary-products.tsx` renders up to four products as thumbnail + title + price rows, modeled on `bundle-components.tsx`. It streams in behind a `Suspense` boundary (its own recommendation fetch, unlike the cached-shell bundle relationships) and collapses to nothing when no complementary products are configured.
+- The list reuses the existing `ProductCard` domain type and `transformShopifyProductCard` — no new types.
+
+## Why it matters
+
+Complementary products are deliberately chosen add-ons (configured per product in the Search & Discovery app), not the algorithmic "you may also like" set. Presenting them next to the buy box — the way bundle relationships are presented — keeps that curation visible at the point of decision, instead of folding it into the recommendation grid below the product.
+
+## Apply when
+
+- The store uses the Shopify Search & Discovery app to curate complementary products and wants them shown on the PDP.
+- You already surface related products and want to distinguish merchant-curated add-ons from automatic recommendations.
+
+## Safe to skip when
+
+- The catalog has no complementary products configured (the section simply renders nothing, so adopting it is harmless but inert).
+- A custom PDP layout already owns the buy-section relationship area.
+
+## Adoption notes
+
+- Complementary products **require manual configuration** in the free [Search & Discovery](https://apps.shopify.com/search-and-discovery) app — there is no automatic fallback. `productRecommendations(intent: COMPLEMENTARY)` returns an empty list until a merchant sets them.
+- `intent` is a query argument (`ProductRecommendationIntent`), available on Storefront API 2024-04+; the template defaults to 2026-04.
+- A new `product.pairsWith` message ("Pairs well with") is added to `en.json`; add it to any other locale catalogs.
+- This change is PDP + data layer only. The shopping agent's `get-recommendations` tool still uses `RELATED`; wiring complementary products into the agent is a separate change.
+
+## Validation
+
+1. Configure complementary products for a product in the Search & Discovery app and open its PDP; confirm the "Pairs well with" list renders with thumbnails, titles, and prices, and links resolve.
+2. Open a product with no complementary products configured and confirm the section renders nothing (no empty heading).
+3. Confirm related products ("You may also like") still render unchanged below the product.
+4. Run `pnpm --filter template lint`, `pnpm --filter template build`, and `pnpm --filter docs build`.

--- a/packages/plugin/template-rollout-log/2026-06-20-complementary-products.md
+++ b/packages/plugin/template-rollout-log/2026-06-20-complementary-products.md
@@ -20,7 +20,7 @@ paths:
 The PDP now surfaces Shopify's merchant-curated [complementary products](https://help.shopify.com/en/manual/online-store/search-and-discovery/product-recommendations) — the "Pair it with" set — as a compact "Pairs well with" list in the product info column, beside the buy section.
 
 - A new `getComplementaryProducts()` operation calls the same `productRecommendations` query as related products but with `intent: COMPLEMENTARY`. `getProductRecommendations()` is unchanged in behavior — it now delegates to a shared `fetchRecommendations()` helper with the default `intent: RELATED`.
-- `complementary-products.tsx` renders up to four products as thumbnail + title + price rows, modeled on `bundle-components.tsx`. It streams in behind a `Suspense` boundary (its own recommendation fetch, unlike the cached-shell bundle relationships) and collapses to nothing when no complementary products are configured.
+- `complementary-products.tsx` renders up to four products as thumbnail + title + price rows, modeled on `bundle-components.tsx`. `getComplementaryProducts()` is a cached (`use cache: remote`) operation, so the section renders eagerly into the prerendered PPR/ISR document — no fallback and no layout shift on cached hits — and renders nothing when no complementary products are configured.
 - The list reuses the existing `ProductCard` domain type and `transformShopifyProductCard` — no new types.
 
 ## Why it matters


### PR DESCRIPTION
## Summary

Surfaces Shopify **Search & Discovery** *complementary products* — the merchant-curated "Pair it with" set — as a compact **"Pairs well with"** list in the PDP product info column, beside the buy section. This mirrors how bundle relationships are presented, because complementary products are a deliberate, explicit relationship rather than the algorithmic "you may also like" set already shown in the footer grid.

Verified against the live Storefront API `2026-04` schema: `productRecommendations(productId, intent: ProductRecommendationIntent)` where `COMPLEMENTARY` returns the manually-curated set and `RELATED` (the default) returns the auto-generated set.

## Changes

- **Data layer** (`lib/shopify/operations/products.ts`): added `intent` to the existing `productRecommendations` query and extracted a shared `fetchRecommendations()` helper. `getProductRecommendations()` is unchanged in behavior (delegates with `RELATED`); new `getComplementaryProducts()` delegates with `COMPLEMENTARY`. Reuses the `ProductCard` type — no new types.
- **Component** (`components/product-detail/complementary-products.tsx`, new): thumbnail + title + price rows modeled on `bundle-components.tsx`. Because `getComplementaryProducts()` is a cached (`use cache: remote`) operation, the section renders **eagerly into the prerendered PPR/ISR document** (no fallback, no layout shift on cached hits) and renders nothing when no complementary products are configured.
- **Wiring**: rendered eagerly in `ProductInfoArea` immediately after the bundle relationships — like the bundle relationships, not a streamed `Suspense` hole.
- **i18n**: `product.pairsWith` → "Pairs well with".
- **Docs**: PDP anatomy + Shopify config pages; new `template-rollout-log/2026-06-20-complementary-products.md`.

## Prerequisite

Complementary products are **configured by hand** in the free Search & Discovery app — there's no automatic fallback. The section renders nothing until a merchant sets them.

## Scope / follow-ups

- **PDP + data layer only.** The shopping agent's `get-recommendations` tool still uses `RELATED`; wiring complementary products into the agent is intentionally deferred.

## Verification

- `pnpm --filter template lint` ✅
- `pnpm --filter template build` ✅ (PDP stays partial-prerendered `◐`; the cached complementary section resolves into the static document rather than a dynamic hole)
- `pnpm --filter docs build` ✅
- Manual check pending against a store with complementary products configured (preview store `vpparel`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)