### PR TITLE
feat(template): product card + PDP gallery placeholder polish

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -47,7 +47,7 @@ The gallery is handled by a single `ProductMedia` component that adapts to scree
 
 Both layouts receive pre-filtered images as props from the server.
 
-When a product has no images or videos at all, `ProductMedia` renders a single `ImagePlaceholder` (`components/ui/image-placeholder.tsx`) sized to the gallery's `aspect-square` footprint — full-bleed on mobile, full-width within the media column on desktop — so the page keeps its two-column shape instead of collapsing.
+When a product has no images or videos at all, `ProductMedia` renders a single `ImagePlaceholder` (`components/ui/image-placeholder.tsx`) as if it were the gallery's only image — flowing through the same grid/carousel path as a real media item: one `aspect-square` cell in the desktop grid, a single full-bleed item in the mobile carousel. The placeholder has no lightbox trigger (there is nothing to enlarge), so the desktop grid skips the `Lightbox` wrapper entirely in this case. This keeps the gallery consistent with a one-image product instead of special-casing a full-width block.
 
 ### Color-based image filtering
 

--- a/apps/docs/content/docs/anatomy/product-card.mdx
+++ b/apps/docs/content/docs/anatomy/product-card.mdx
@@ -25,7 +25,7 @@ The badge label comes from the `product.featuredBadge` translation key, so it st
 
 ## Image fallback
 
-The card renders `product.featuredImage` with `next/image` (`fill`, `object-cover`). When a product has **no featured image**, the card does not show a broken image - the image box keeps its aspect-ratio footprint and renders the shared `ImagePlaceholder` (`components/ui/image-placeholder.tsx`): a white square centering a muted Lucide image icon sized relative to the box. This keeps grids visually aligned even for products that are missing imagery.
+The card renders `product.featuredImage` with `next/image` (`fill`, `object-cover`). When a product has **no featured image**, the card does not show a broken image - the image box keeps its aspect-ratio footprint and renders the shared `ImagePlaceholder` (`components/ui/image-placeholder.tsx`): a white square centering a Lucide image icon tinted with the skeleton color (`text-accent`) and sized relative to the box. This keeps grids visually aligned even for products that are missing imagery, and makes the empty state read as a settled version of the loading skeleton.
 
 When the product is unavailable, an out-of-stock overlay darkens the image and shows the localized out-of-stock label on top.
 
@@ -33,7 +33,7 @@ When the product is unavailable, an out-of-stock overlay darkens the image and s
 
 ## Skeleton
 
-`ProductCardSkeleton` mirrors the card's footprint - an aspect-ratio image block plus title and price bars - for use in Suspense fallbacks and during infinite-scroll loads.
+`ProductCardSkeleton` mirrors the card's footprint - an aspect-ratio image block (the same `ImagePlaceholder`, pulsing via `animate-pulse`) plus title and price bars - for use in Suspense fallbacks and during infinite-scroll loads. Because the loading block and the no-image fallback are the same element, the only visual difference between "still loading" and "no image" is the pulse.
 
 ## Recipes
 

--- a/apps/template/components/product-card/components.tsx
+++ b/apps/template/components/product-card/components.tsx
@@ -119,7 +119,7 @@ function ProductCardTitle({ className, children, ...props }: React.ComponentProp
   return (
     <h3
       data-slot="product-card-title"
-      className={cn("text-sm font-semibold text-main-foreground line-clamp-2", className)}
+      className={cn("text-sm font-semibold text-main-foreground line-clamp-1", className)}
       {...props}
     >
       {children}
@@ -196,9 +196,8 @@ function ProductCardSkeleton({
         data-aspect-ratio={aspectRatio}
         className={cn("animate-pulse", aspectRatioClasses)}
       />
-      <div className="py-2.5 h-18 box-content grid gap-2">
+      <div className="py-2.5 h-12 box-content grid gap-2">
         <div className="h-4 w-full bg-accent animate-pulse" />
-        <div className="h-4 w-3/4 bg-accent animate-pulse" />
         <div className="h-4 w-12 bg-accent animate-pulse" />
       </div>
     </div>

--- a/apps/template/components/product-card/components.tsx
+++ b/apps/template/components/product-card/components.tsx
@@ -192,9 +192,9 @@ function ProductCardSkeleton({
       data-slot="product-card-skeleton"
       className={cn("flex flex-col overflow-hidden", className)}
     >
-      <div
+      <ImagePlaceholder
         data-aspect-ratio={aspectRatio}
-        className={cn("bg-accent animate-pulse", aspectRatioClasses)}
+        className={cn("animate-pulse", aspectRatioClasses)}
       />
       <div className="py-2.5 h-18 box-content grid gap-2">
         <div className="h-4 w-full bg-accent animate-pulse" />

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -6,7 +6,6 @@ import { useEffect, useRef, useState } from "react";
 
 import { AutoPlayVideo } from "@/components/ui/auto-play-video";
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
-import { Skeleton } from "@/components/ui/skeleton";
 import type { Image as ImageType, Video } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -314,18 +313,18 @@ export function ColorImageCarouselItems({ images, title }: { images: ImageType[]
 }
 
 export function ProductMediaSkeleton({ className }: { className?: string }) {
-  const tile = "w-full rounded-none aspect-square";
+  const tile = "aspect-square w-full animate-pulse";
   return (
     <div className={className}>
       <div className="grid gap-5 lg:hidden -mx-5">
-        <Skeleton className={tile} />
+        <ImagePlaceholder className={tile} />
         <div className="h-1.5" />
       </div>
       <div className="hidden lg:grid grid-cols-2 gap-2.5">
-        <Skeleton className={tile} />
-        <Skeleton className={tile} />
-        <Skeleton className={tile} />
-        <Skeleton className={tile} />
+        <ImagePlaceholder className={tile} />
+        <ImagePlaceholder className={tile} />
+        <ImagePlaceholder className={tile} />
+        <ImagePlaceholder className={tile} />
       </div>
     </div>
   );

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -11,10 +11,15 @@ import { cn } from "@/lib/utils";
 
 import { Lightbox, LightboxTrigger } from "./lightbox";
 
-type MediaItem = { type: "video"; video: Video } | { type: "image"; image: ImageType };
+type MediaItem =
+  | { type: "image"; image: ImageType }
+  | { type: "placeholder" }
+  | { type: "video"; video: Video };
 
 function mediaKey(item: MediaItem) {
-  return item.type === "video" ? item.video.url : item.image.url;
+  if (item.type === "image") return item.image.url;
+  if (item.type === "video") return item.video.url;
+  return "placeholder";
 }
 
 function MediaImage({
@@ -160,6 +165,8 @@ function Carousel({
             >
               {item.type === "video" ? (
                 <MediaVideo item={item} sizes="100vw" priority={priority || eager} />
+              ) : item.type === "placeholder" ? (
+                <ImagePlaceholder className="size-full" />
               ) : (
                 <MediaImage
                   item={item}
@@ -217,6 +224,8 @@ function GridItem({
           sizes="(min-width: 1024px) 25vw, 50vw"
           priority={priority || eager}
         />
+      ) : item.type === "placeholder" ? (
+        <ImagePlaceholder className="size-full" />
       ) : (
         <LightboxTrigger item={item}>
           <MediaImage
@@ -238,33 +247,35 @@ function Grid({
   mediaItems,
   title,
   hasColorSlot,
+  interactive = true,
   children,
 }: {
   mediaItems: MediaItem[];
   title: string;
   hasColorSlot: boolean;
+  interactive?: boolean;
   children?: React.ReactNode;
 }) {
-  return (
-    <Lightbox label={title}>
-      <div className="grid grid-cols-2 gap-2.5">
-        {children}
-        {mediaItems.map((item, idx) => {
-          const priority = !hasColorSlot && idx === 0;
-          return (
-            <GridItem
-              key={mediaKey(item)}
-              item={item}
-              title={title}
-              idx={idx}
-              priority={priority}
-              eager
-            />
-          );
-        })}
-      </div>
-    </Lightbox>
+  const grid = (
+    <div className="grid grid-cols-2 gap-2.5">
+      {children}
+      {mediaItems.map((item, idx) => {
+        const priority = !hasColorSlot && idx === 0;
+        return (
+          <GridItem
+            key={mediaKey(item)}
+            item={item}
+            title={title}
+            idx={idx}
+            priority={priority}
+            eager
+          />
+        );
+      })}
+    </div>
   );
+
+  return interactive ? <Lightbox label={title}>{grid}</Lightbox> : grid;
 }
 
 /**
@@ -352,25 +363,24 @@ export function ProductMedia({
     ...otherImages.map((image): MediaItem => ({ type: "image", image })),
   ];
 
-  if (sharedMediaItems.length === 0 && !desktopSlot && !mobileSlot) {
-    return (
-      <div className={className}>
-        <ImagePlaceholder className="aspect-square -mx-5 w-[calc(100%+2.5rem)] lg:mx-0 lg:w-full" />
-      </div>
-    );
-  }
-
   const hasColorSlot = !!mobileSlot || !!desktopSlot;
+  const isEmpty = sharedMediaItems.length === 0 && !hasColorSlot;
+  const mediaItems: MediaItem[] = isEmpty ? [{ type: "placeholder" }] : sharedMediaItems;
 
   return (
     <div className={className}>
       <div className="lg:hidden">
-        <Carousel mediaItems={sharedMediaItems} title={title} hasColorSlot={hasColorSlot}>
+        <Carousel mediaItems={mediaItems} title={title} hasColorSlot={hasColorSlot}>
           {mobileSlot}
         </Carousel>
       </div>
       <div className="hidden lg:block">
-        <Grid mediaItems={sharedMediaItems} title={title} hasColorSlot={hasColorSlot}>
+        <Grid
+          mediaItems={mediaItems}
+          title={title}
+          hasColorSlot={hasColorSlot}
+          interactive={!isEmpty}
+        >
           {desktopSlot}
         </Grid>
       </div>

--- a/apps/template/components/ui/image-placeholder.tsx
+++ b/apps/template/components/ui/image-placeholder.tsx
@@ -17,7 +17,7 @@ function ImagePlaceholder({ className, iconClassName, ...props }: ImagePlacehold
       <ImageIcon
         aria-hidden
         strokeWidth={1.5}
-        className={cn("h-auto w-1/3 max-w-[10rem] text-muted-foreground/40", iconClassName)}
+        className={cn("h-auto w-1/3 max-w-[10rem] text-accent", iconClassName)}
       />
     </div>
   );

--- a/packages/plugin/template-rollout-log/2026-06-20-image-placeholder-skeleton-unify.md
+++ b/packages/plugin/template-rollout-log/2026-06-20-image-placeholder-skeleton-unify.md
@@ -1,0 +1,50 @@
+---
+title: Unify the no-image placeholder and loading skeletons on ImagePlaceholder
+changeKey: image-placeholder-skeleton-unify
+introducedOn: 2026-06-20
+changeType: enhancement
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/ui/image-placeholder.tsx
+  - apps/template/components/product-card/components.tsx
+  - apps/template/components/product-detail/product-media.tsx
+  - apps/docs/content/docs/anatomy/product-card.mdx
+---
+
+## Summary
+
+The no-image placeholder and the image-area loading skeletons now render the same element, so the empty state reads as a settled version of the loading state.
+
+- `ImagePlaceholder` (`components/ui/image-placeholder.tsx`) tints its Lucide `ImageIcon` with the skeleton color: `text-muted-foreground/40` → `text-accent` (`--accent`, `#efefef`). The icon now matches the fill color of the shared `Skeleton`.
+- `ProductCardSkeleton` (`product-card/components.tsx`) replaces its solid `bg-accent animate-pulse` image block with `<ImagePlaceholder className="animate-pulse …" />` carrying the same `data-aspect-ratio` footprint.
+- `ProductMediaSkeleton` (`product-detail/product-media.tsx`) replaces its `<Skeleton>` gallery tiles with `<ImagePlaceholder className="aspect-square w-full animate-pulse" />`. The now-unused `Skeleton` import is dropped from that file.
+
+The net effect: a loading product card/gallery and a no-image product card/gallery render the identical white box with a faint accent image icon — the only difference is the loading variant pulses via `animate-pulse`.
+
+## Why it matters
+
+- Loading and empty states were two different visuals (a solid accent block vs. a white box with a muted dark icon). Unifying them removes the visual "jump" between a skeleton and a product that turns out to have no image, and gives both states a single source of truth.
+- The icon color is keyed to `--accent` (the same token the skeletons use, see `skeleton-fallback-color`), so retuning skeleton color retunes the placeholder icon with it.
+
+## Apply when
+
+- The storefront still uses `ImagePlaceholder`, `ProductCardSkeleton`, and `ProductMediaSkeleton` largely as shipped (see `no-image-placeholder` and `product-card-aspect-ratio-and-skeleton`).
+
+## Safe to skip when
+
+- The storefront has customized the placeholder icon color or replaced the image skeletons with a bespoke loading treatment.
+
+## Validation
+
+1. `pnpm --filter template dev`.
+2. Trigger product-grid and PDP loading states (infinite scroll, navigation) and confirm the image areas pulse as a white box with a faint accent image icon rather than a solid accent block.
+3. Open a product with no featured image and no gallery media; confirm the card and PDP show the same box, static (no pulse).
+4. `pnpm --filter template lint` and `pnpm --filter docs build` clean.
+
+## See also
+
+- `no-image-placeholder` (2026-06-19) — introduced the shared `ImagePlaceholder`.
+- `skeleton-fallback-color` (2026-06-09) — unified skeletons on `--accent` (`#efefef`).
+- `product-card-aspect-ratio-and-skeleton` (2026-04-30) — the aspect-ratio-aware card skeleton.

--- a/packages/plugin/template-rollout-log/2026-06-20-pdp-empty-gallery-single-item.md
+++ b/packages/plugin/template-rollout-log/2026-06-20-pdp-empty-gallery-single-item.md
@@ -1,0 +1,51 @@
+---
+title: PDP empty gallery renders the placeholder as a single non-zoomable grid item
+changeKey: pdp-empty-gallery-single-item
+introducedOn: 2026-06-20
+changeType: enhancement
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-detail/product-media.tsx
+  - apps/docs/content/docs/anatomy/pages/pdp.mdx
+---
+
+## Summary
+
+When a product has no images or videos, the PDP gallery now renders the placeholder as if it were the gallery's only image, instead of a bespoke full-bleed block.
+
+- `ProductMedia` no longer early-returns a special full-width `ImagePlaceholder` (`aspect-square -mx-5 w-[calc(100%+2.5rem)] lg:mx-0 lg:w-full`). Instead it synthesizes a single `{ type: "placeholder" }` media item and routes it through the same `Carousel` (mobile) and `Grid` (desktop) paths as real media.
+- A new `placeholder` variant on the internal `MediaItem` union is rendered as `<ImagePlaceholder className="size-full" />` inside the standard `aspect-square` item wrapper — so it occupies one `aspect-square` cell in the desktop 2-column grid and one full-bleed item in the mobile carousel, exactly like a one-image product.
+- The placeholder renders **without** a `LightboxTrigger`, and `Grid` gained an `interactive` prop so the empty case skips the `Lightbox` wrapper entirely (there is nothing to enlarge). Mobile already hides the single dot indicator (`itemCount <= 1`).
+
+## Why it matters
+
+- The empty gallery previously used a one-off full-width layout that diverged from how a real single-image product renders. Reusing the grid/carousel path means a zero-image product and a one-image product share the same structure, and the placeholder inherits the gallery's sizing/snap behavior for free.
+- Gating the `Lightbox` wrapper on `interactive` keeps the "no image" state free of a dead zoom affordance.
+
+## Apply when
+
+- The storefront catalog can contain products with no gallery media, and you want the empty PDP gallery to match the one-image layout rather than a full-width block.
+
+## Safe to skip when
+
+- The storefront has customized `ProductMedia` (e.g. a bespoke empty-gallery treatment) or relies on the previous full-width placeholder footprint.
+
+## Adoption notes
+
+- The change is internal to `ProductMedia`; its public props (`otherImages`, `videos`, `title`, `className`, `desktopSlot`, `mobileSlot`) are unchanged.
+- On desktop the placeholder is now a half-width grid cell (one of two columns), not full-width. This is the intended "acts like one image" look; storefronts wanting a full-width empty state should override `ProductMedia`.
+
+## Validation
+
+1. Open a product with no images or videos on the PDP.
+2. Desktop: confirm a single `aspect-square` placeholder cell sits in the 2-column grid with no zoom cursor and no lightbox on click.
+3. Mobile: confirm a single full-bleed placeholder with no dot indicator.
+4. `pnpm --filter template lint`, `pnpm --filter template exec tsc --noEmit`, and `pnpm --filter docs build` clean.
+
+## See also
+
+- `image-placeholder-skeleton-unify` (2026-06-20) — the placeholder/skeleton visual unification this builds on.
+- `no-image-placeholder` (2026-06-19) — introduced the shared `ImagePlaceholder` and the PDP full-bleed empty state this replaces.
+- `pdp-aspect-ratio-and-oos-slideshow` (2026-05-04) — the gallery's grid/carousel structure.

--- a/packages/plugin/template-rollout-log/2026-06-20-product-card-title-single-line.md
+++ b/packages/plugin/template-rollout-log/2026-06-20-product-card-title-single-line.md
@@ -1,0 +1,41 @@
+---
+title: Product card title clamps to one line
+changeKey: product-card-title-single-line
+introducedOn: 2026-06-20
+changeType: enhancement
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-card/components.tsx
+---
+
+## Summary
+
+`ProductCardTitle` clamps to a single line instead of two (`line-clamp-2` → `line-clamp-1`), and `ProductCardSkeleton` drops its second title bar to match.
+
+- `ProductCardTitle`: `line-clamp-2` → `line-clamp-1`. Long titles now truncate after one line with an ellipsis.
+- `ProductCardSkeleton`: removed the second title bar and shrank the reserved content height from `h-18` to `h-12` so the skeleton footprint still matches a loaded card (one title line + price).
+
+## Why it matters
+
+- Tightens vertical rhythm in product grids and sliders: cards reserve less title space, so rows are shorter and more uniform regardless of title length.
+- The skeleton height is kept in lockstep with the title-line count to avoid layout shift between the Suspense fallback / infinite-scroll placeholder and the loaded card.
+
+## Apply when
+
+- The storefront uses `ProductCardTitle` / `ProductCardSkeleton` as shipped and wants the tighter one-line title.
+
+## Safe to skip when
+
+- Product titles are long and benefit from two lines of context in the grid, or the card has been restyled with its own title treatment.
+
+## Adoption notes
+
+- If you keep two-line titles, leave `line-clamp-2` and the skeleton's `h-18` + second title bar in place — the two must move together to avoid layout shift.
+
+## Validation
+
+1. Open a product grid (home, collection, search) with a long-titled product and confirm the title truncates after one line.
+2. Confirm the loading skeleton reserves the same height as the loaded card (no visible jump on hydration / infinite scroll).
+3. `pnpm --filter template lint` clean.


### PR DESCRIPTION
Three related refinements to product-card and PDP image/placeholder rendering.

## 1. Unify the no-image placeholder and loading skeletons

- `ImagePlaceholder` icon now uses the skeleton color — `text-muted-foreground/40` → `text-accent` (`#efefef`, the shared `Skeleton` fill).
- `ProductCardSkeleton`: solid `bg-accent` image block → `<ImagePlaceholder className="animate-pulse …" />`.
- `ProductMediaSkeleton`: `<Skeleton>` tiles → `<ImagePlaceholder … animate-pulse>` (dropped the now-unused `Skeleton` import).

Loading and no-image states now render the same white box with a faint accent image icon; the only difference is the pulse.

## 2. Empty PDP gallery renders as a single non-zoomable grid item

- `ProductMedia` no longer early-returns a bespoke full-bleed placeholder. It synthesizes a single `{ type: "placeholder" }` media item and routes it through the same `Carousel` (mobile) / `Grid` (desktop) path as real media.
- The placeholder renders **without** a `LightboxTrigger`, and `Grid` gained an `interactive` prop so the empty case skips the `Lightbox` wrapper entirely.
- Result: a zero-image product renders like a one-image product — one `aspect-square` cell in the desktop grid (half-width), one full-bleed mobile carousel item — with no zoom affordance.

## 3. Product card title clamps to one line

- `ProductCardTitle`: `line-clamp-2` → `line-clamp-1`.
- `ProductCardSkeleton`: dropped the second title bar and shrank reserved content height `h-18` → `h-12` so the skeleton footprint still matches a loaded card.

## Note

- The desktop empty-gallery placeholder is now **half-width** (one of two grid columns), not full-width — the intended "acts like one image in the grid" look.
- The loading skeleton is intentionally **more subtle** (faint accent icon pulsing vs. a solid accent block).

## Housekeeping

- Docs updated: `anatomy/product-card.mdx`, `anatomy/pages/pdp.mdx`.
- Rollout-log entries: `image-placeholder-skeleton-unify`, `pdp-empty-gallery-single-item`, `product-card-title-single-line`.

## Validation

- `pnpm --filter template lint` (oxlint + oxfmt) and `tsc --noEmit` clean.
- No dependency or skill changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)