### PR TITLE
fix(template): wire Geist Mono to the variable the theme reads

### DIFF
--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -23,7 +23,7 @@ const geistSans = Geist({
 });
 
 const geistMono = Geist_Mono({
-  variable: "--font-mono",
+  variable: "--font-geist-mono",
   subsets: ["latin"],
 });
 


### PR DESCRIPTION
## What

Register Geist Mono with `variable: "--font-geist-mono"` (was `"--font-mono"`) in `apps/template/app/layout.tsx`.

## Why

The mono font's CSS variable name didn't match what the theme reads:

- `layout.tsx` registered Geist Mono as `--font-mono`
- `globals.css` defines `--font-mono: var(--font-geist-mono)` — and `--font-geist-mono` was **never defined anywhere**

So the `font-mono` utility resolved to nothing and fell back to the browser's default monospace. Geist Mono was still downloaded (its `.variable` class sits on `<body>`) but never actually applied to any text.

Renaming the registration to `--font-geist-mono` mirrors the existing Geist Sans pattern and matches what `globals.css` already reads. No CSS changes required — `globals.css` is untouched.

## Test plan

- [ ] `font-mono` text (prices, metadata, etc.) now renders in Geist Mono rather than the system monospace.
- [ ] No visual regression in `font-sans` text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)