### PR TITLE
feat(template): add llms.txt discovery index + serve /collections/all as Markdown

### DIFF
--- a/apps/docs/content/docs/anatomy/aeo-geo.mdx
+++ b/apps/docs/content/docs/anatomy/aeo-geo.mdx
@@ -18,6 +18,7 @@ The template ships with several built-in surfaces that contribute to AEO/GEO. Th
 | **Schema.org JSON-LD**           | Embeds structured `Product`, `BreadcrumbList`, and `Organization` data               | `components/product-detail/schema.tsx`, `components/schema/**` |
 | **Sitemap**                      | [Sitemap index + paged children](/docs/anatomy/sitemap) for products and collections | `app/sitemap.xml/route.ts`, `app/sitemap/[shard]/route.ts`     |
 | **Robots**                       | Declares crawl policy and blocks faceted (sort/filter) collection URLs               | `app/robots.ts`                                                |
+| **`llms.txt`**                   | Curated `/llms.txt` index of collections and discovery links for AI agents           | `app/llms.txt/route.ts`, `lib/markdown/llms.ts`                |
 | **OpenGraph & Twitter metadata** | Provides title, description, and image previews per route                            | `lib/seo.ts`, route-level `generateMetadata`                   |
 
 The rest of this page goes deep on content negotiation. The other surfaces are documented inline in the linked files.
@@ -87,3 +88,16 @@ The `Vary: Accept` header ensures CDNs cache markdown and HTML responses separat
 ### Multi-locale
 
 If you have enabled Shopify Markets, the rewrite fires before locale routing — no additional configuration is needed. Pass a `?locale=` query parameter to the markdown endpoint for locale-specific pricing and collection/search context.
+
+## llms.txt
+
+`/llms.txt` is a curated, machine-readable index of the storefront — an [emerging convention](https://llmstxt.org) that is to AI agents what `robots.txt` is to crawlers. It links to the search entry point, the collection catalog, and the sitemap/robots discovery surfaces, and tells agents that those pages also serve clean Markdown under `Accept: text/markdown` (the content negotiation above).
+
+The route is dynamic: collections are pulled live from Shopify and capped so the file stays a concise index rather than an exhaustive dump — the full URL set lives in the [sitemap](/docs/anatomy/sitemap). Because the links honor content negotiation, the virtual `/collections/all` catalog page is served as Markdown too, not just HTML.
+
+### Key files
+
+| File                    | Purpose                                                      |
+| ----------------------- | ------------------------------------------------------------ |
+| `app/llms.txt/route.ts` | Route handler; fetches collections and serves `text/plain`   |
+| `lib/markdown/llms.ts`  | `llmsTxt()` generator that builds the index from the catalog |

--- a/apps/template/app/llms.txt/route.ts
+++ b/apps/template/app/llms.txt/route.ts
@@ -1,0 +1,16 @@
+import { defaultLocale, resolveLocale } from "@/lib/i18n";
+import { llmsTxt } from "@/lib/markdown/llms";
+import { getCollections } from "@/lib/shopify/operations/collections";
+
+export async function GET(request: Request): Promise<Response> {
+  const locale = resolveLocale(new URL(request.url).searchParams.get("locale") || defaultLocale);
+
+  const collections = await getCollections({ limit: 50, locale }).catch(() => []);
+
+  return new Response(llmsTxt({ collections, locale }), {
+    headers: {
+      "Cache-Control": "public, max-age=86400, stale-while-revalidate=604800",
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/apps/template/app/md/collections/[handle]/route.ts
+++ b/apps/template/app/md/collections/[handle]/route.ts
@@ -1,3 +1,9 @@
+import {
+  ALL_PRODUCTS_HANDLE,
+  getAllProductsCollection,
+  getAllProductsResultsData,
+  getCollectionSearchState,
+} from "@/lib/collections/server";
 import { defaultLocale, resolveLocale } from "@/lib/i18n";
 import { collectionToMarkdown } from "@/lib/markdown/collection";
 import { getCollection } from "@/lib/shopify/operations/collections";
@@ -20,13 +26,39 @@ export async function GET(request: Request, { params }: { params: Promise<{ hand
   const { handle } = await params;
   const url = new URL(request.url);
   const locale = resolveLocale(url.searchParams.get("locale") || defaultLocale);
-  const sort = url.searchParams.get("sort") ?? undefined;
-  const cursor = url.searchParams.get("cursor") ?? undefined;
   const searchParams = searchParamsToRecord(url.searchParams);
-  const activeFilters = parseFiltersFromSearchParams(searchParams);
-  const shopifyFilters = buildProductFiltersFromParams(activeFilters);
 
   try {
+    // /collections/all is a virtual route with no Shopify equivalent; mirror the HTML
+    // page's data path so the same URL is legible to markdown-negotiating agents.
+    if (handle === ALL_PRODUCTS_HANDLE) {
+      const searchStatePromise = getCollectionSearchState(Promise.resolve(searchParams));
+      const [collection, data] = await Promise.all([
+        getAllProductsCollection(),
+        getAllProductsResultsData({ locale, searchStatePromise }),
+      ]);
+
+      const markdown = collectionToMarkdown({
+        collection,
+        products: data.result.products,
+        filters: data.result.filters,
+        priceRange: data.result.priceRange,
+        activeFilters: data.activeFilters,
+        pageInfo: data.result.pageInfo,
+        locale,
+        sort: data.sort,
+      });
+
+      return new Response(markdown, {
+        headers: markdownHeaders("public, max-age=86400, stale-while-revalidate=604800"),
+      });
+    }
+
+    const sort = url.searchParams.get("sort") ?? undefined;
+    const cursor = url.searchParams.get("cursor") ?? undefined;
+    const activeFilters = parseFiltersFromSearchParams(searchParams);
+    const shopifyFilters = buildProductFiltersFromParams(activeFilters);
+
     const [collection, result] = await Promise.all([
       getCollection({ handle, locale }),
       getCollectionProducts({

--- a/apps/template/lib/markdown/llms.ts
+++ b/apps/template/lib/markdown/llms.ts
@@ -1,0 +1,56 @@
+import { siteConfig } from "@/lib/config";
+import type { Collection } from "@/lib/types";
+
+import { escapeMarkdown } from "./utils";
+
+function summarize(text: string, max = 200): string {
+  const line = text.replace(/\s+/g, " ").trim();
+  return line.length > max ? `${line.slice(0, max - 1).trimEnd()}…` : line;
+}
+
+export function llmsTxt({
+  collections,
+  locale,
+}: {
+  collections: Collection[];
+  locale: string;
+}): string {
+  const { name, url } = siteConfig;
+  const sections: string[] = [];
+
+  sections.push(`# ${escapeMarkdown(name)}`);
+  sections.push("");
+  sections.push(
+    `> Online store. Product, collection, and search pages additionally serve clean Markdown when fetched with an \`Accept: text/markdown\` header — use it to read structured catalog data instead of HTML.`,
+  );
+  sections.push("");
+
+  sections.push("## Browse");
+  sections.push("");
+  sections.push(`- [All products](${url}/collections/all): The full product catalog.`);
+  sections.push(`- [Search](${url}/search): Full-text product search; append \`?q=<query>\`.`);
+  sections.push("");
+
+  if (collections.length > 0) {
+    sections.push("## Collections");
+    sections.push("");
+    for (const collection of collections) {
+      const link = `[${escapeMarkdown(collection.title)}](${url}${collection.path})`;
+      const description = summarize(collection.description);
+      sections.push(description ? `- ${link}: ${escapeMarkdown(description)}` : `- ${link}`);
+    }
+    sections.push("");
+  }
+
+  sections.push("## Discovery");
+  sections.push("");
+  sections.push(`- [Sitemap](${url}/sitemap.xml): Complete index of product and collection URLs.`);
+  sections.push(`- [Robots](${url}/robots.txt): Crawl policy.`);
+  sections.push("");
+
+  sections.push("---");
+  sections.push("");
+  sections.push(`*Locale: ${locale}*`);
+
+  return sections.join("\n");
+}

--- a/packages/plugin/template-rollout-log/2026-06-20-collections-all-markdown-negotiation.md
+++ b/packages/plugin/template-rollout-log/2026-06-20-collections-all-markdown-negotiation.md
@@ -1,0 +1,51 @@
+---
+title: Serve /collections/all as Markdown under content negotiation
+changeKey: collections-all-markdown-negotiation
+introducedInVersion: 0.1.0
+introducedOn: 2026-06-20
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/app/md/collections/[handle]/route.ts
+relatedSkills: []
+---
+
+## Summary
+
+Fixes a content-negotiation gap on the virtual `/collections/all` route. The page served
+`200` as HTML but `404` under `Accept: text/markdown`, because the Markdown route did a
+literal `getCollection({ handle: "all" })` — and `all` has no Shopify Storefront API
+equivalent (see `collections-all-virtual-route`).
+
+`app/md/collections/[handle]/route.ts` now special-cases `ALL_PRODUCTS_HANDLE`, routing it
+through the same `lib/collections/server.ts` helpers the HTML page uses
+(`getAllProductsCollection()` + `getAllProductsResultsData()`). Real collection handles are
+unchanged. The Shopify data layer stays unaware of the virtual handle.
+
+## Why it matters
+
+`/collections/all` is the nav's "Shop" target and the home hero CTA — the storefront's
+primary catalog entry point. Before this fix it was invisible to markdown-negotiating
+agents even though the HTML page worked, undercutting the AEO/GEO content-negotiation
+contract for the single most important browse URL. It is also linked from `/llms.txt`.
+
+## Apply when
+
+The storefront has the virtual `/collections/all` route (`collections-all-virtual-route`)
+and the `/md/**` content-negotiation routes (the template default).
+
+## Safe to skip when
+
+The storefront removed the virtual `/collections/all` route, or does not expose the
+`Accept: text/markdown` content-negotiation layer.
+
+## Validation
+
+1. `pnpm --filter template lint` passes.
+2. `curl -I -H "Accept: text/markdown" http://localhost:3000/collections/all` returns `200`
+   with `Content-Type: text/markdown` (previously `404`).
+3. The body is a Markdown collection document titled `# Products` with the catalog grid.
+4. `curl -H "Accept: text/markdown" http://localhost:3000/collections/<real-handle>` still
+   renders normally.

--- a/packages/plugin/template-rollout-log/2026-06-20-llms-txt-discovery-index.md
+++ b/packages/plugin/template-rollout-log/2026-06-20-llms-txt-discovery-index.md
@@ -1,0 +1,58 @@
+---
+title: llms.txt discovery index for AI agents
+changeKey: llms-txt-discovery-index
+introducedInVersion: 0.1.0
+introducedOn: 2026-06-20
+changeType: feature
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/app/llms.txt/route.ts
+  - apps/template/lib/markdown/llms.ts
+relatedSkills: []
+---
+
+## Summary
+
+Adds a `/llms.txt` route — a curated, machine-readable index of the storefront for AI
+agents, following the [llmstxt.org](https://llmstxt.org) convention.
+
+- `app/llms.txt/route.ts` — `GET` handler serving `text/plain` (`max-age=86400`,
+  `stale-while-revalidate=604800`). Fetches up to 50 collections live from Shopify and
+  degrades to an index-without-collections if the catalog query fails.
+- `lib/markdown/llms.ts` — `llmsTxt({ collections, locale })` generator, same
+  `sections: string[]` + `escapeMarkdown()` house style as the other `lib/markdown/`
+  converters.
+
+The file emits an H1 (site name), a summary blockquote pointing agents at the
+`Accept: text/markdown` content negotiation, then `Browse` (all-products + search),
+`Collections` (live catalog, capped), and `Discovery` (sitemap + robots) sections.
+
+## Why it matters
+
+`llms.txt` is becoming the canonical entry point AI agents and answer engines look for —
+the agent-facing analog of `robots.txt`. It complements the existing AEO/GEO surfaces
+(content negotiation, JSON-LD, sitemap) by giving agents a single curated map of the
+catalog instead of forcing them to crawl. Pairs with the `/md/**` content-negotiation
+routes the index links to.
+
+## Apply when
+
+The storefront wants to be discoverable to AI shopping agents and answer engines (the
+template default). No configuration required; it reads `siteConfig` and live collections.
+
+## Safe to skip when
+
+The storefront intentionally blocks AI agents, or replaces the catalog browse model such
+that a flat collection list is not a useful index (e.g. a single-product store).
+
+## Validation
+
+1. `pnpm --filter template lint` passes.
+2. `curl http://localhost:3000/llms.txt` returns `200`, `Content-Type: text/plain`, with
+   `# <Site Name>`, a `> ` summary line, and `## Browse` / `## Collections` / `## Discovery`
+   sections.
+3. Every link under `## Collections` resolves; fetching one with `Accept: text/markdown`
+   returns Markdown (see the companion `collections-all-markdown-negotiation` entry for the
+   `/collections/all` link specifically).


### PR DESCRIPTION
## What

Two related agent-discoverability changes for the storefront template.

### 1. `/llms.txt` discovery index (feature)
A new `app/llms.txt/route.ts` serving a curated, machine-readable index of the storefront for AI agents, following the [llmstxt.org](https://llmstxt.org) convention — the agent-facing analog of `robots.txt`. It emits the site name, a summary blockquote pointing agents at the `Accept: text/markdown` content negotiation, then `Browse` / `Collections` (live, capped to 50) / `Discovery` (sitemap + robots) sections. Generator lives in `lib/markdown/llms.ts`, matching the house style of the other `lib/markdown/` converters.

### 2. `/collections/all` Markdown 404 → 200 (fix)
`/collections/all` is the nav's "Shop" target and the home hero CTA, but it returned `200` as HTML and **`404` under `Accept: text/markdown`** — the markdown route did a literal `getCollection({handle:"all"})`, and `all` is a virtual route with no Storefront API equivalent. The md route now special-cases `ALL_PRODUCTS_HANDLE` through the same `lib/collections/server.ts` helpers the HTML page uses, so the storefront's primary catalog URL is legible to markdown-negotiating agents (and to the `/llms.txt` link).

## Why
Surfaces the storefront to AI shopping agents / answer engines. `llms.txt` gives agents a single curated entry point; the `/collections/all` fix closes a hole in the existing content-negotiation contract for the single most important browse URL.

## Files
- `apps/template/app/llms.txt/route.ts` *(new)* — route handler, `text/plain`, graceful degrade
- `apps/template/lib/markdown/llms.ts` *(new)* — `llmsTxt()` generator
- `apps/template/app/md/collections/[handle]/route.ts` — `all` branch via virtual-collection helpers
- `apps/docs/content/docs/anatomy/aeo-geo.mdx` — documents the `llms.txt` surface
- `packages/plugin/template-rollout-log/2026-06-20-llms-txt-discovery-index.md` *(new)*
- `packages/plugin/template-rollout-log/2026-06-20-collections-all-markdown-negotiation.md` *(new)*

## Verification
- `pnpm --filter template lint` (oxlint + oxfmt) passes; docs doc-path validator passes (71 paths).
- Runtime (dev server, furniture dev store):

  | Check | Result |
  |---|---|
  | `/collections/all` + `Accept: text/markdown` | `200 text/markdown`, `# Products`, 40 products (was `404`) |
  | `/collections/all` HTML | `200` (unchanged) |
  | `/collections/<real-handle>` md | `200` (unchanged) |
  | `/llms.txt` | `200 text/plain`, well-formed index |

## Notes
- No dependency changes.
- Caveat for later: on md routes `?locale=` drives pricing/results, but `getAllProductsCollection()`'s title comes via next-intl, which `request.ts` hardwires to `defaultLocale`. Identical in the single-locale default; only relevant once Shopify Markets is enabled (which rewires `request.ts` anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)