### PR TITLE
feat(template): emit product OpenGraph tags on the PDP

### DIFF
--- a/apps/docs/content/docs/anatomy/aeo-geo.mdx
+++ b/apps/docs/content/docs/anatomy/aeo-geo.mdx
@@ -12,13 +12,13 @@ The template ships with several built-in surfaces that contribute to AEO/GEO. Th
 
 ## Surfaces in the template
 
-| Surface                          | What it does                                                                         | Key files                                                      |
-| -------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
-| **Content negotiation**          | Serves clean markdown to AI clients via `Accept: text/markdown`                      | `next.config.ts`, `app/md/**`, `lib/markdown/**`               |
-| **Schema.org JSON-LD**           | Embeds structured `Product`, `BreadcrumbList`, and `Organization` data               | `components/product-detail/schema.tsx`, `components/schema/**` |
-| **Sitemap**                      | [Sitemap index + paged children](/docs/anatomy/sitemap) for products and collections | `app/sitemap.xml/route.ts`, `app/sitemap/[shard]/route.ts`     |
-| **Robots**                       | Declares crawl policy and blocks faceted (sort/filter) collection URLs               | `app/robots.ts`                                                |
-| **OpenGraph & Twitter metadata** | Provides title, description, and image previews per route                            | `lib/seo.ts`, route-level `generateMetadata`                   |
+| Surface                          | What it does                                                                                           | Key files                                                                                |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| **Content negotiation**          | Serves clean markdown to AI clients via `Accept: text/markdown`                                        | `next.config.ts`, `app/md/**`, `lib/markdown/**`                                         |
+| **Schema.org JSON-LD**           | Embeds structured `Product`, `BreadcrumbList`, and `Organization` data                                 | `components/product-detail/schema.tsx`, `components/schema/**`                           |
+| **Sitemap**                      | [Sitemap index + paged children](/docs/anatomy/sitemap) for products and collections                   | `app/sitemap.xml/route.ts`, `app/sitemap/[shard]/route.ts`                               |
+| **Robots**                       | Declares crawl policy and blocks faceted (sort/filter) collection URLs                                 | `app/robots.ts`                                                                          |
+| **OpenGraph & Twitter metadata** | Per-route title/description/image previews, plus `product` OG tags (type, price, availability) on PDPs | `lib/seo.ts`, `components/product-detail/open-graph.tsx`, route-level `generateMetadata` |
 
 The rest of this page goes deep on content negotiation. The other surfaces are documented inline in the linked files.
 

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -51,7 +51,6 @@ async function buildProductMetadata(
       title: product.seo.title,
       description: product.seo.description,
       url: canonicalPath,
-      type: "website",
       images,
     }),
     twitter: {

--- a/apps/template/components/product-detail/open-graph.tsx
+++ b/apps/template/components/product-detail/open-graph.tsx
@@ -1,0 +1,29 @@
+import type { Money } from "@/lib/types";
+
+interface ProductOpenGraphProps {
+  availableForSale: boolean;
+  price: Money;
+}
+
+// Renders the OpenGraph "product" object tags as raw <meta property> elements
+// (React 19 hoists them to <head>). Next's Metadata API has no product OG variant,
+// and its `other` field emits name= rather than the property= that OG parsers need.
+// Both the product:* (Facebook) and og:price/availability (Pinterest, older parsers)
+// namespaces are emitted for broad compatibility. Priced off the "from" (min) price
+// to match the displayed price and the JSON-LD AggregateOffer lowPrice.
+export function ProductOpenGraph({ availableForSale, price }: ProductOpenGraphProps) {
+  return (
+    <>
+      <meta property="og:type" content="product" />
+      <meta property="og:price:amount" content={price.amount} />
+      <meta property="og:price:currency" content={price.currencyCode} />
+      <meta property="og:availability" content={availableForSale ? "instock" : "oos"} />
+      <meta property="product:price:amount" content={price.amount} />
+      <meta property="product:price:currency" content={price.currencyCode} />
+      <meta
+        property="product:availability"
+        content={availableForSale ? "in stock" : "out of stock"}
+      />
+    </>
+  );
+}

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import { BundleComponents, BundleParents } from "@/components/product-detail/bundle-components";
 import { BuyButtons, type BuyButtonVariant } from "@/components/product-detail/buy-buttons";
 import { ComplementaryProducts } from "@/components/product-detail/complementary-products";
+import { ProductOpenGraph } from "@/components/product-detail/open-graph";
 import {
   ProductInfoDescription,
   ProductInfoOptions,
@@ -58,6 +59,10 @@ export function ProductDetailSection({
           offerCount: product.variantsCount,
           availableForSale: product.availableForSale,
         }}
+      />
+      <ProductOpenGraph
+        availableForSale={product.availableForSale}
+        price={product.priceRange.minVariantPrice}
       />
       <BreadcrumbSchema
         items={[

--- a/apps/template/lib/seo.ts
+++ b/apps/template/lib/seo.ts
@@ -68,7 +68,7 @@ export function buildOpenGraph({
   title,
   description,
   url,
-  type = "website",
+  type,
   images = ["/og-default.png"],
 }: {
   title: string;
@@ -85,8 +85,10 @@ export function buildOpenGraph({
       }
   >;
 }): Metadata["openGraph"] {
+  // Omitting `type` emits no og:type, letting product pages own og:type=product
+  // via a dedicated meta block (Next only emits og:type when the key is present).
   return {
-    type,
+    ...(type ? { type } : {}),
     title,
     description,
     url,

--- a/packages/plugin/template-rollout-log/2026-06-20-pdp-product-opengraph-tags.md
+++ b/packages/plugin/template-rollout-log/2026-06-20-pdp-product-opengraph-tags.md
@@ -1,0 +1,62 @@
+---
+title: Product OpenGraph tags on the PDP
+changeKey: pdp-product-opengraph-tags
+introducedInVersion: 0.1.0
+introducedOn: 2026-06-20
+changeType: feature
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-detail/open-graph.tsx
+  - apps/template/components/product-detail/product-detail-section.tsx
+  - apps/template/app/products/[handle]/page.tsx
+  - apps/template/lib/seo.ts
+relatedSkills: []
+---
+
+## Summary
+
+Product detail pages now emit OpenGraph "product" object tags instead of a generic
+`og:type=website`.
+
+- `components/product-detail/open-graph.tsx` *(new)* — `ProductOpenGraph` server component
+  rendering raw `<meta property>` tags (React 19 hoists them to `<head>`):
+  `og:type=product`, `og:price:amount`, `og:price:currency`, `og:availability`, plus the
+  `product:price:amount` / `product:price:currency` / `product:availability` namespace.
+  Both namespaces are emitted because Facebook reads `product:*` while Pinterest Rich Pins
+  and older parsers read `og:price:*` / `og:availability`. Priced off the "from" (min)
+  variant price to match the displayed price and the JSON-LD `AggregateOffer` `lowPrice`.
+- `product-detail-section.tsx` — renders `<ProductOpenGraph>` beside `<ProductSchema>`.
+- `app/products/[handle]/page.tsx` — drops `type: "website"` from the PDP's `buildOpenGraph`
+  call so there is no duplicate/conflicting `og:type`.
+- `lib/seo.ts` — `buildOpenGraph`'s `type` is now optional and only emitted when provided.
+  Next only renders `og:type` when the key is present, so omitting it lets the component own
+  `og:type=product`. All other callers still pass `type: "website"` and are unchanged.
+
+The Metadata API has no product OG variant, and its `other` field emits `name=` rather than
+the `property=` that OG parsers require — hence the dedicated component.
+
+## Why it matters
+
+JSON-LD already covers structured-data agents, but social/link-unfurl surfaces (iMessage,
+Slack, Facebook) and Pinterest Rich Pins lean on OG `product` tags for price and
+availability. A generic `og:type=website` leaves those surfaces without a price or stock
+signal.
+
+## Apply when
+
+The storefront uses the template's `buildOpenGraph` helper and PDP structure (the default).
+
+## Safe to skip when
+
+The storefront has replaced the OG metadata pipeline, or intentionally suppresses price
+exposure in shared previews.
+
+## Validation
+
+1. `pnpm --filter template lint` passes.
+2. `curl <pdp-url>` shows exactly one `<meta property="og:type" content="product">`, plus
+   `og:price:amount` / `og:price:currency` / `og:availability` and the `product:*` triplet,
+   all with `property=`.
+3. Home, collection, and `/collections/all` still emit `<meta property="og:type" content="website">`.


### PR DESCRIPTION
## What

PDPs now emit a proper OpenGraph **product** object instead of a generic `og:type=website`, so social/link-unfurl surfaces and Pinterest Rich Pins get price and availability signals.

| Tag | Example |
|---|---|
| `og:type` | `product` |
| `og:price:amount` / `og:price:currency` | `523.0` / `USD` |
| `og:availability` | `instock` |
| `product:price:amount` / `product:price:currency` | `523.0` / `USD` |
| `product:availability` | `in stock` |

## Why
JSON-LD (`Product` + `AggregateOffer`) already covers structured-data agents, but iMessage/Slack/Facebook unfurls and Pinterest Rich Pins lean on OG `product` tags for price/stock. A generic `og:type=website` leaves those surfaces with no price or availability signal.

## How
- **`components/product-detail/open-graph.tsx`** *(new)* — `ProductOpenGraph` server component rendering the tags as raw `<meta property>` (React 19 hoists to `<head>`). Necessary because Next's Metadata API has no product OG variant, and its `other` field emits `name=`, not the `property=` OG parsers require.
- **`lib/seo.ts`** — `buildOpenGraph`'s `type` is now optional, emitted only when provided. Next gates `og:type` on the key being present (`if ('type' in og)`), so omitting it lets the component own `og:type=product` with no duplicate. All other callers still pass `type:"website"` and are unchanged.
- **`product-detail-section.tsx`** — renders `<ProductOpenGraph>` beside `<ProductSchema>`.
- **`app/products/[handle]/page.tsx`** — drops `type:"website"` from the PDP's `buildOpenGraph` call.
- Docs: `anatomy/aeo-geo.mdx` OG row notes product OG on PDPs. Rollout-log entry added.

## Decisions
- **Both namespaces** — `product:*` (Facebook) + `og:price:*`/`og:availability` (Pinterest Rich Pins, older parsers) — for max compatibility.
- **Priced off the min/"from" price** — matches the displayed price and JSON-LD `lowPrice`, and stays prerender-friendly (no per-variant `searchParams` dependency).

## Files
- `apps/template/components/product-detail/open-graph.tsx` *(new)*
- `apps/template/lib/seo.ts`
- `apps/template/components/product-detail/product-detail-section.tsx`
- `apps/template/app/products/[handle]/page.tsx`
- `apps/docs/content/docs/anatomy/aeo-geo.mdx`
- `packages/plugin/template-rollout-log/2026-06-20-pdp-product-opengraph-tags.md` *(new)*

## Verification
- `pnpm --filter template lint` (oxlint + oxfmt) passes; docs doc-path validator passes (71 paths).
- Runtime (dev server, furniture dev store):

  | Check | Result |
  |---|---|
  | PDP `og:type` | exactly one, `product` |
  | PDP price/availability tags | `product:*` + `og:price:*`/`og:availability` present, `property=` |
  | Home / collection / `/collections/all` `og:type` | still `website` (no regression) |

## Notes
- No dependency changes.
- Touches `aeo-geo.mdx`, which is also edited by #363 (llms.txt). If both merge, expect a trivial one-row conflict in the surfaces table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)