### PR TITLE
feat(template): render opt-in product metafields as a PDP specifications list

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -83,6 +83,10 @@ A customized bundle parent (`requiresComponents` with no fixed `components`) dis
 
 Like bundle relationships, the section renders **eagerly into the prerendered shell** rather than streaming. Both recommendation surfaces — this set and the [related grid](#related-products) below the fold — come from a single cached (`use cache: remote`) `getProductRecommendationSets()` operation that fetches both intents in one aliased `productRecommendations` request and is tagged with both `complementary-{handle}` and `recommendations-{handle}`. Because both surfaces call it with the same arguments, they dedupe to **one** Shopify request; this section reads the `complementary` slice, baked into the static PPR/ISR document — there's no skeleton fallback and no layout shift on cached hits (a `Suspense` boundary would instead make it a streamed hole). It shows up to four products as thumbnail + title + price rows and renders nothing when none are configured.
 
+### Specifications
+
+`product-specs.tsx` renders configured product [metafields](/docs/shopify/pdp#metafields) as a label/value "Specifications" list below the description. The set is **opt-in**: `productMetafieldIdentifiers` in `lib/config.ts` is empty by default, so the product query is unchanged and the section renders nothing until a storefront lists the namespaces and keys it populates. Like bundle relationships, it renders eagerly from the cached product in the static shell. Values are formatted by metafield type (measurements, ratings, lists, booleans); reference (product/metaobject) types are skipped pending GID resolution.
+
 ## Related Products
 
 Below the product details, a `RelatedProductsSection` component renders Shopify's algorithmic "you might also like" set. It reads the `related` slice of the same cached `getProductRecommendationSets()` operation the [complementary set](#complementary-products) consumes — so the two surfaces share one Shopify request — and renders inside a `Suspense` boundary with a skeleton grid fallback.
@@ -113,6 +117,7 @@ The page emits two JSON-LD schemas:
 | `components/product-detail/product-media.tsx`          | Responsive image gallery (mobile carousel, desktop grid + lightbox)                                                  |
 | `components/product-detail/buy-buttons.tsx`            | Buy with Shop + add-to-cart client component                                                                         |
 | `components/product-detail/bundle-components.tsx`      | Renders a bundle's contents and the bundles a product is part of                                                     |
+| `components/product-detail/product-specs.tsx`         | Renders configured product metafields as a "Specifications" label/value list                                         |
 | `lib/product.ts`                                       | `parseSelectedOptions`, `buildOptionUrl`, default selection, color-image helpers                                     |
 | `lib/shopify/encoded-variants.ts`                      | Decodes `encodedVariantAvailability`/`Existence` into per-option availability                                        |
 

--- a/apps/docs/content/docs/shopify/pdp.mdx
+++ b/apps/docs/content/docs/shopify/pdp.mdx
@@ -20,23 +20,20 @@ The PDP shell fetches the product's options and Shopify's encoded variant-availa
 
 ## Metafields
 
-The template ships with **no metafield identifiers** in `PRODUCT_FRAGMENT`. Metafield namespaces and keys are shop-specific (Shopify's only standard product metafield namespaces are `descriptors`, `facts`, `reviews`, `shopify`, etc. — not generic spec namespaces like `custom` or `specs`), so the template doesn't presume any defaults.
+The template ships with **no metafields wired in** by default. Namespaces and keys are shop-specific (Shopify's only standard product metafield namespaces are `descriptors`, `facts`, `reviews`, `shopify`, etc. — not generic spec namespaces like `custom` or `specs`), so the template doesn't presume any defaults: an empty config means the product query is unchanged and nothing renders.
 
-To wire metafields into the PDP for your store:
+To surface metafields on the PDP for your store, list the ones you populate in `productMetafieldIdentifiers` in `lib/config.ts`:
 
-1. Add a `metafields(identifiers: [...])` field to `PRODUCT_FRAGMENT` in `lib/shopify/fragments.ts`, importing `${METAFIELD_FRAGMENT}` and selecting `...MetafieldFields` inside.
-2. Extend the `METAFIELD_LABELS` map in `lib/shopify/transforms/product.ts` with friendly labels for the keys you query.
-
-Example:
-
-```graphql
-metafields(identifiers: [
-  {namespace: "custom", key: "material"},
-  {namespace: "custom", key: "warranty"},
-]) {
-  ...MetafieldFields
-}
+```ts
+export const productMetafieldIdentifiers: Array<{ key: string; namespace: string }> = [
+  { namespace: "custom", key: "material" },
+  { namespace: "custom", key: "warranty" },
+];
 ```
+
+The product-detail query (`getProductByHandle` in `lib/shopify/operations/products.ts`) appends a `metafields(identifiers: [...])` selection built from that list, and `ProductSpecs` (`components/product-detail/product-specs.tsx`) renders them as a label/value "Specifications" list below the description. Optionally extend the `METAFIELD_LABELS` map in `lib/shopify/transforms/product.ts` with friendly labels for your keys — keys without an entry fall back to a humanized version of the key.
+
+Values are formatted by metafield type: text and number pass through, measurements (`dimension`/`weight`/`volume`) and `rating` are parsed from their JSON, `boolean` becomes Yes/No, and `list.*` types are joined. **Reference types** (product or metaobject references) are skipped — their value is a GID that needs a follow-up query to resolve.
 
 Define metafields in Shopify admin under **Settings → Custom data → Products → Add definition**.
 

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -16,6 +16,7 @@ import {
   ProductMediaSkeleton,
 } from "@/components/product-detail/product-media";
 import { ProductPrice } from "@/components/product-detail/product-price";
+import { ProductSpecs } from "@/components/product-detail/product-specs";
 import { ProductSchema } from "@/components/product-detail/schema";
 import { ShopLogo } from "@/components/product-detail/shop-logo";
 import { BreadcrumbSchema } from "@/components/schema/breadcrumb-schema";
@@ -255,6 +256,8 @@ async function ProductInfoArea({
       <ComplementaryProducts handle={handle} locale={locale} title={t("pairsWith")} />
 
       <ProductInfoDescription descriptionHtml={descriptionHtml} />
+
+      <ProductSpecs metafields={product.metafields ?? []} title={t("specifications")} />
     </div>
   );
 }

--- a/apps/template/components/product-detail/product-specs.tsx
+++ b/apps/template/components/product-detail/product-specs.tsx
@@ -1,0 +1,23 @@
+import type { Metafield } from "@/lib/types";
+
+interface ProductSpecsProps {
+  metafields: Metafield[];
+  title: string;
+}
+
+export function ProductSpecs({ metafields, title }: ProductSpecsProps) {
+  if (metafields.length === 0) return null;
+  return (
+    <div className="grid gap-2.5" data-slot="product-specs">
+      <h2 className="font-medium text-foreground/70 text-sm">{title}</h2>
+      <dl className="grid gap-2.5">
+        {metafields.map((metafield) => (
+          <div key={metafield.key} className="flex items-baseline justify-between gap-4">
+            <dt className="text-foreground/50 text-sm">{metafield.label}</dt>
+            <dd className="text-right font-medium text-sm">{metafield.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -37,6 +37,14 @@ export const agent = {
   enabled: process.env.NEXT_PUBLIC_ENABLE_AGENT === "1",
 } as const;
 
+// Product metafields to surface on the PDP, by namespace + key. Empty by default:
+// namespaces are shop-specific, so a storefront opts in to the ones it populates.
+// Friendly labels for each key live in METAFIELD_LABELS (lib/shopify/transforms/product.ts).
+export const productMetafieldIdentifiers: Array<{ key: string; namespace: string }> = [
+  // { namespace: "custom", key: "material" },
+  // { namespace: "reviews", key: "rating" },
+];
+
 export const navItems: MenuItem[] = [
   {
     id: "default-nav-shop",

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -301,6 +301,7 @@
     "selectVariant": "Please select a variant",
     "selectVariantLabel": "Select {name}: {value}",
     "sku": "SKU",
+    "specifications": "Specifications",
     "stockLeft": "({stock} left)",
     "swatchAlt": "{value} swatch",
     "unavailableVariantLabel": "{name}: {value} (unavailable)",

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -1,5 +1,6 @@
 import { cacheLife, cacheTag } from "next/cache";
 
+import { productMetafieldIdentifiers } from "@/lib/config";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import type {
   Filter,
@@ -14,6 +15,7 @@ import type {
 import { shopifyFetch } from "../fetch";
 import {
   IMAGE_FRAGMENT,
+  METAFIELD_FRAGMENT,
   PRODUCT_CARD_FRAGMENT,
   PRODUCT_FRAGMENT,
   PRODUCT_WITH_VARIANTS_FRAGMENT,
@@ -47,11 +49,21 @@ function tagProducts(products: Array<{ id: string }>): void {
   }
 }
 
+const productMetafieldsSelection = productMetafieldIdentifiers.length
+  ? `metafields(identifiers: [${productMetafieldIdentifiers
+      .map(({ key, namespace }) => `{ namespace: "${namespace}", key: "${key}" }`)
+      .join(", ")}]) {
+      ...MetafieldFields
+    }`
+  : "";
+
 const GET_PRODUCT_BY_HANDLE_QUERY = `
+  ${productMetafieldIdentifiers.length ? METAFIELD_FRAGMENT : ""}
   ${PRODUCT_FRAGMENT}
   query getProductByHandle($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     productByHandle(handle: $handle) {
       ...ProductFields
+      ${productMetafieldsSelection}
     }
   }
 `;

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -321,39 +321,59 @@ const METAFIELD_LABELS: Record<string, string> = {
   model_number: "Model Number",
 };
 
-// Shopify stores some metafield values as JSON (measurements, ratings, lists). Reference
-// types resolve to GIDs we can't render without extra queries, so they're skipped (null).
+// A single scalar metafield value, already parsed from its JSON envelope: an object
+// for measurement/money/rating types, a primitive otherwise.
+function formatScalarMetafield(type: string, value: unknown): string {
+  switch (type) {
+    case "boolean":
+      return value === true || value === "true" ? "Yes" : "No";
+    case "dimension":
+    case "volume":
+    case "weight": {
+      const v = value as { unit?: string; value?: number };
+      return v?.unit ? `${v.value} ${v.unit}` : String(v?.value ?? value);
+    }
+    case "money": {
+      const v = value as { amount?: string; currency_code?: string };
+      return v?.currency_code ? `${v.amount} ${v.currency_code}` : String(v?.amount ?? value);
+    }
+    case "rating": {
+      const v = value as { value?: number | string };
+      return String(v?.value ?? value);
+    }
+    default:
+      return String(value);
+  }
+}
+
+const STRUCTURED_METAFIELD_TYPES = new Set(["dimension", "money", "rating", "volume", "weight"]);
+
+// Shopify stores measurement/money/rating values as JSON, and list.* values as a JSON
+// array of those. Reference types resolve to GIDs we can't render without extra queries,
+// so they're skipped (null); every list element is formatted by its element type.
 function formatMetafieldValue(type: string, value: string): string | null {
   if (type.includes("_reference")) return null;
-  if (type === "boolean") return value === "true" ? "Yes" : "No";
-
-  if (type === "dimension" || type === "weight" || type === "volume") {
-    try {
-      const parsed = JSON.parse(value) as { unit?: string; value: number };
-      return parsed.unit ? `${parsed.value} ${parsed.unit}` : String(parsed.value);
-    } catch {
-      return value;
-    }
-  }
-
-  if (type === "rating") {
-    try {
-      return String((JSON.parse(value) as { value: number }).value);
-    } catch {
-      return value;
-    }
-  }
 
   if (type.startsWith("list.")) {
+    const itemType = type.slice("list.".length);
     try {
       const items = JSON.parse(value) as unknown[];
-      return Array.isArray(items) ? items.join(", ") : value;
+      if (!Array.isArray(items)) return value;
+      return items.map((item) => formatScalarMetafield(itemType, item)).join(", ");
     } catch {
       return value;
     }
   }
 
-  return value;
+  if (STRUCTURED_METAFIELD_TYPES.has(type)) {
+    try {
+      return formatScalarMetafield(type, JSON.parse(value));
+    } catch {
+      return value;
+    }
+  }
+
+  return formatScalarMetafield(type, value);
 }
 
 function transformMetafields(

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -321,6 +321,41 @@ const METAFIELD_LABELS: Record<string, string> = {
   model_number: "Model Number",
 };
 
+// Shopify stores some metafield values as JSON (measurements, ratings, lists). Reference
+// types resolve to GIDs we can't render without extra queries, so they're skipped (null).
+function formatMetafieldValue(type: string, value: string): string | null {
+  if (type.includes("_reference")) return null;
+  if (type === "boolean") return value === "true" ? "Yes" : "No";
+
+  if (type === "dimension" || type === "weight" || type === "volume") {
+    try {
+      const parsed = JSON.parse(value) as { unit?: string; value: number };
+      return parsed.unit ? `${parsed.value} ${parsed.unit}` : String(parsed.value);
+    } catch {
+      return value;
+    }
+  }
+
+  if (type === "rating") {
+    try {
+      return String((JSON.parse(value) as { value: number }).value);
+    } catch {
+      return value;
+    }
+  }
+
+  if (type.startsWith("list.")) {
+    try {
+      const items = JSON.parse(value) as unknown[];
+      return Array.isArray(items) ? items.join(", ") : value;
+    } catch {
+      return value;
+    }
+  }
+
+  return value;
+}
+
 function transformMetafields(
   metafields?: (ShopifyMetafield | null)[],
 ): Array<{ key: string; label: string; value: string }> {
@@ -328,11 +363,12 @@ function transformMetafields(
 
   return metafields
     .filter((mf): mf is ShopifyMetafield => mf !== null && mf.value !== "")
-    .map((mf) => ({
-      key: mf.key,
-      label: METAFIELD_LABELS[mf.key] || formatKey(mf.key),
-      value: mf.value,
-    }));
+    .map((mf) => {
+      const value = formatMetafieldValue(mf.type, mf.value);
+      if (value === null) return null;
+      return { key: mf.key, label: METAFIELD_LABELS[mf.key] || formatKey(mf.key), value };
+    })
+    .filter((mf): mf is { key: string; label: string; value: string } => mf !== null);
 }
 
 function formatKey(key: string): string {

--- a/packages/plugin/template-rollout-log/2026-06-20-pdp-metafields-specs.md
+++ b/packages/plugin/template-rollout-log/2026-06-20-pdp-metafields-specs.md
@@ -1,0 +1,53 @@
+---
+title: PDP specifications — opt-in product metafields rendered from config
+changeKey: pdp-metafields-specs
+introducedOn: 2026-06-20
+changeType: feature
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/config.ts
+  - apps/template/lib/shopify/operations/products.ts
+  - apps/template/lib/shopify/transforms/product.ts
+  - apps/template/components/product-detail/product-specs.tsx
+  - apps/template/components/product-detail/product-detail-section.tsx
+  - apps/template/lib/i18n/messages/en.json
+  - apps/docs/content/docs/shopify/pdp.mdx
+  - apps/docs/content/docs/anatomy/pages/pdp.mdx
+---
+
+## Summary
+
+The PDP can now render product metafields as a "Specifications" label/value list below the description — opt-in, with no hardcoded namespaces.
+
+- `lib/config.ts` gains `productMetafieldIdentifiers: Array<{ key: string; namespace: string }>`, **empty by default**.
+- `getProductByHandle` (`lib/shopify/operations/products.ts`) appends a `metafields(identifiers: [...])` selection built from that list — and includes `${METAFIELD_FRAGMENT}` — only when it is non-empty. An empty list leaves the query byte-for-byte unchanged (zero query weight).
+- `transformMetafields` now formats values by `type`: text/number pass through, measurements (`dimension`/`weight`/`volume`) and `rating` are parsed from their JSON, `boolean` → Yes/No, `list.*` joined. Reference types (`*_reference`) are skipped — their value is a GID that needs a follow-up query to resolve. The domain `Metafield` shape (`{ key, label, value }`) is unchanged, so the agent markdown builder benefits from the cleaner values too.
+- New `ProductSpecs` component (`components/product-detail/product-specs.tsx`) renders the list (returns nothing when empty) and is mounted in `product-detail-section.tsx` below the description. It renders eagerly from the cached product in the static shell, like bundle relationships.
+- New `product.specifications` message ("Specifications") in `en.json`.
+
+## Why it matters
+
+Metafields are the storage layer most first-party and third-party apps write into (size charts, ingredients, warranty/specs, reviews-app data). This adds the PDP UI consumer that was missing — `ProductDetails.metafields` previously surfaced only in the agent markdown — while honoring the prior decision to ship no default identifiers: wiring is now a config edit plus optional label entries, not a manual fragment edit.
+
+## Apply when
+
+- Your store populates product metafields you want shown on the PDP.
+
+## Safe to skip when
+
+- You don't use product metafields (the default empty config leaves the PDP and the product query unchanged).
+- A custom PDP already renders its own spec/detail section.
+
+## Adoption notes
+
+- Supersedes the adoption guidance in `2026-04-29-drop-default-metafield-identifiers.md`: instead of hand-editing `PRODUCT_FRAGMENT`, list identifiers in `productMetafieldIdentifiers` (`lib/config.ts`). The query injection and the renderer are now shipped.
+- Add friendly labels to `METAFIELD_LABELS` in `lib/shopify/transforms/product.ts`; keys without an entry fall back to a humanized key.
+- Reference / metaobject metafields are not yet resolved (skipped). Resolving them is a follow-up (add `reference`/`references` to `METAFIELD_FRAGMENT` + resolution logic).
+
+## Validation
+
+1. Set `productMetafieldIdentifiers` to a couple of keys your store populates, open a PDP, and confirm the "Specifications" list renders with friendly labels and type-formatted values.
+2. Confirm an empty config renders nothing and leaves the product query unchanged.
+3. Run `pnpm --filter template lint`, `pnpm --filter template build`, and `pnpm --filter docs build`.


### PR DESCRIPTION
## What

Adds the missing PDP UI consumer for product metafields. A storefront opts in by listing the metafields it populates, and they render as a "Specifications" label/value list below the description — **without** re-introducing the hardcoded shop-specific identifiers that [#2026-04-29 drop-default-metafield-identifiers](../blob/main/packages/plugin/template-rollout-log/2026-04-29-drop-default-metafield-identifiers.md) deliberately removed.

## How

- **`lib/config.ts`** — new `productMetafieldIdentifiers: Array<{ key: string; namespace: string }>`, **empty by default**.
- **`lib/shopify/operations/products.ts`** — `getProductByHandle` appends a `metafields(identifiers: […])` selection (and includes `METAFIELD_FRAGMENT`) built from that list, *only when it's non-empty*. Empty config ⇒ the product query is byte-for-byte unchanged (zero added weight).
- **`lib/shopify/transforms/product.ts`** — `transformMetafields` now formats values by `type`: text/number pass through, measurements (`dimension`/`weight`/`volume`) and `rating` parsed from JSON, `boolean` → Yes/No, `list.*` joined. **Reference types are skipped** — their value is a GID needing a follow-up query. The domain `Metafield` shape is unchanged, so the agent markdown builder gets the cleaner values for free.
- **`product-specs.tsx`** (new) — renders the list, returns `null` when empty; mounted below the description, eager in the static shell like bundle relationships.
- **i18n** — new `product.specifications` ("Specifications").

## Default behavior unchanged

With the empty default config, the product query is identical to before and the section renders nothing — so this is inert until a store opts in.

## Out of scope (follow-ups)

- Resolving metaobject / product-reference metafields (GID → content).
- Shipping a non-empty default identifier set (intentionally omitted to honor the prior breaking decision).

## Docs

- Rewrote the metafields wiring guide in `shopify/pdp.mdx` for the config-driven flow.
- Added a "Specifications" subsection + key-files row in `anatomy/pages/pdp.mdx`.
- Added `template-rollout-log/2026-06-20-pdp-metafields-specs.md` (supersedes the adoption guidance in the drop-default entry).

## Verification

- `tsc --noEmit`, `oxlint`, `oxfmt --check` all clean.
- `metafields(identifiers:)` query shape validated against the Storefront API 2026-04 schema.
- `en.d.json.ts` is gitignored / auto-generated from `en.json` by next-intl on build, so only `en.json` is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)