### PR TITLE
refactor(template): drop forced prefetch={true} from product cards and menu links

### DIFF
--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -124,7 +124,7 @@ function ClientProductCard({
     : `/products/${product.handle}`;
 
   return (
-    <Link href={href} prefetch={true}>
+    <Link href={href}>
       <ProductCardRoot>
         <ProductCardImageContainer>
           <ProductCardImage

--- a/apps/template/components/footer/index.tsx
+++ b/apps/template/components/footer/index.tsx
@@ -46,7 +46,7 @@ function MenuLink({ url, children, className }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className} prefetch={true}>
+    <Link href={url} className={className}>
       {children}
     </Link>
   );

--- a/apps/template/components/nav/mobile-menu.tsx
+++ b/apps/template/components/nav/mobile-menu.tsx
@@ -36,7 +36,7 @@ function MenuLink({ url, children, className, onClick }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className} onClick={onClick} prefetch={true}>
+    <Link href={url} className={className} onClick={onClick}>
       {children}
     </Link>
   );

--- a/apps/template/components/nav/quick-links.tsx
+++ b/apps/template/components/nav/quick-links.tsx
@@ -21,7 +21,7 @@ function MenuLink({ url, children, className }: MenuLinkProps) {
     );
   }
   return (
-    <Link href={url} className={className} prefetch={true}>
+    <Link href={url} className={className}>
       {children}
     </Link>
   );

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -39,7 +39,7 @@ export async function ProductCard({
   const t = isFeatured ? await getTranslations("product") : null;
 
   return (
-    <Link href={`/products/${product.handle}`} className={className} prefetch={true}>
+    <Link href={`/products/${product.handle}`} className={className}>
       <ProductCardRoot variant={variant}>
         {isFeatured && t && (
           <ProductCardBadge>

--- a/packages/plugin/template-rollout-log/2026-06-21-drop-link-prefetch-true.md
+++ b/packages/plugin/template-rollout-log/2026-06-21-drop-link-prefetch-true.md
@@ -1,0 +1,53 @@
+---
+title: Product cards and menu links — drop forced full-content prefetch (prefetch={true})
+changeKey: drop-link-prefetch-true
+introducedOn: 2026-06-21
+changeType: refactor
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-card/product-card.tsx
+  - apps/template/components/collections/infinite-product-grid.tsx
+  - apps/template/components/nav/mobile-menu.tsx
+  - apps/template/components/nav/quick-links.tsx
+  - apps/template/components/footer/index.tsx
+relatedSkills: []
+---
+
+## Summary
+
+Remove the `prefetch={true}` prop from the `<Link>` in the two product-card components and the three menu-link wrappers, reverting them to the default `prefetch: 'auto'`:
+
+- `product-card/product-card.tsx` — the server `ProductCard` wrapping link to `/products/[handle]`.
+- `collections/infinite-product-grid.tsx` — the `ClientProductCard` link used in the infinite-scroll collection grid.
+- `nav/quick-links.tsx`, `nav/mobile-menu.tsx`, `footer/index.tsx` — the internal-URL branch of each `MenuLink` wrapper (the external `http` branch is a plain `<a>` and was never affected).
+
+This backs out `prefetch-product-cards-and-menu-links` (2026-06-10). No config or type changes are involved — only the five `prefetch={true}` attributes are deleted.
+
+## Why it matters
+
+- With `partialPrefetching: true` on globally (`next.config.ts`), the default `prefetch: 'auto'` carries only the per-route App Shell into in-viewport links instead of the destination's full runtime content. On link-dense pages (product grids, nav menus) that is far less background prefetch traffic.
+- `prefetch={true}` issued one runtime prefetch per in-viewport link. Each was a cheap `cacheLife("max")` cache hit, but a dense grid could fan out dozens of them on scroll. Dropping the prop trades the instant full-content landing for the cheaper shell-only default; the runtime content fills in on a post-click round-trip.
+- The PDP and collection routes still export `prefetch = "allow-runtime"`, so they remain *able* to serve a runtime prefetch — this change only stops the links from *requesting* full content eagerly.
+
+## Apply when
+
+- The storefront wants to minimize runtime-prefetch volume on high-fanout product grids and Shopify-menu-driven nav.
+- The product cards and menu wrappers are largely as shipped (still carry `prefetch={true}` from the earlier rollout).
+
+## Safe to skip when
+
+- The storefront deliberately opted into eager full-content prefetch for instant client navigations and is comfortable with the extra prefetch traffic.
+- You instead prefer the on-intent middle ground (`unstable_dynamicOnHover`): cheap shell prefetch in viewport, full dynamic prefetch on hover/touch. That requires augmenting `LinkProps` in `global.ts` and enabling `experimental.dynamicOnHover` in `next.config.ts`.
+
+## Validation
+
+1. `pnpm --filter template lint` and `pnpm --filter template build`.
+2. `grep -rn 'prefetch=' apps/template/components/{product-card,collections,nav,footer}` → no matches.
+3. `pnpm --filter template start` (production): scrolling a product grid no longer fires one runtime prefetch per in-viewport card in the Network panel; clicking still navigates correctly (now via a post-click round-trip for the runtime content).
+
+## See also
+
+- `prefetch-product-cards-and-menu-links` (2026-06-10) — added the `prefetch={true}` this entry removes.
+- `pdp-allow-runtime-prefetch` (2026-06-10) — the PDP `prefetch = "allow-runtime"` route config, which stays in place.


### PR DESCRIPTION
## Summary

Removes `prefetch={true}` from the five `<Link>` sites added in #331, reverting them to the default `prefetch: 'auto'`:

- `product-card/product-card.tsx` — server `ProductCard` link to `/products/[handle]`
- `collections/infinite-product-grid.tsx` — `ClientProductCard` link in the infinite-scroll grid
- `nav/quick-links.tsx`, `nav/mobile-menu.tsx`, `footer/index.tsx` — the internal-URL branch of each `MenuLink` (external `http` links are plain `<a>` and untouched)

Under `partialPrefetching: true`, the default `auto` carries only the per-route App Shell into in-viewport links instead of issuing one full runtime prefetch each. On link-dense product grids and nav menus that is far less background prefetch traffic; the runtime content fills in on a post-click round-trip. The PDP/collection routes still export `prefetch = "allow-runtime"`, so they remain able to *serve* a runtime prefetch — this only stops the links from eagerly *requesting* full content.

Plain attribute removal — no config or type changes. (The alternative on-intent middle ground, `unstable_dynamicOnHover`, is noted in the rollout-log entry as a documented option but intentionally not taken here.)

## Rollout log

Backs out `prefetch-product-cards-and-menu-links` (2026-06-10); adds `2026-06-21-drop-link-prefetch-true.md` documenting the reversal for downstream storefronts.

## Validation

- `pnpm --filter template lint` ✅
- `pnpm --filter template build` ✅
- `grep -rn 'prefetch=' apps/template/components/{product-card,collections,nav,footer}` → no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)