### PR TITLE
feat(template): show a price range on product cards when variants span one

### DIFF
--- a/apps/docs/content/docs/anatomy/product-card.mdx
+++ b/apps/docs/content/docs/anatomy/product-card.mdx
@@ -19,6 +19,10 @@ Used in the home featured grid, collection (PLP) and search grids, the related-p
 
 The badge label comes from the `product.featuredBadge` translation key, so it stays localized.
 
+## Price
+
+`ProductCard` carries both `price` (the lowest variant price) and `maxPrice` (the highest). When they differ — the product's variants span a price range — the card renders both bounds as a `min – max` range (_$48.00 – $96.00_); otherwise it shows the single price. Because per-variant discounts differ across a range, the compare-at strike-through and discount badge are suppressed when a range is shown; single-price products keep the strike-through and percent-off badge. The PDP, which has variant selection, instead resolves the exact selected variant's price rather than the range.
+
 ## Aspect ratio
 
 `ProductCardImage` accepts `aspectRatio` of `square` (default), `portrait`, or `landscape`, applied via `data-[aspect-ratio=...]` selectors. The skeleton honors the same prop so the placeholder matches the loaded card.

--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -139,6 +139,7 @@ function ClientProductCard({
             <ProductCardPrice
               amount={product.price.amount}
               currencyCode={product.price.currencyCode}
+              maxAmount={product.maxPrice.amount}
               compareAtAmount={product.compareAtPrice?.amount}
               compareAtCurrencyCode={product.compareAtPrice?.currencyCode}
               locale={locale}

--- a/apps/template/components/product-card/components.tsx
+++ b/apps/template/components/product-card/components.tsx
@@ -130,6 +130,8 @@ function ProductCardTitle({ className, children, ...props }: React.ComponentProp
 interface ProductCardPriceProps {
   amount: string;
   currencyCode: string;
+  /** Highest variant price; when it differs from amount the card renders a "min – max" range. */
+  maxAmount?: string;
   compareAtAmount?: string;
   compareAtCurrencyCode?: string;
   locale: string;
@@ -145,6 +147,7 @@ function getDiscountPercent(price: number, compareAtPrice: number | undefined): 
 function ProductCardPrice({
   amount,
   currencyCode,
+  maxAmount,
   compareAtAmount,
   compareAtCurrencyCode,
   locale,
@@ -153,17 +156,32 @@ function ProductCardPrice({
 }: ProductCardPriceProps) {
   const priceNum = parseFloat(amount);
   const compareAtNum = compareAtAmount ? parseFloat(compareAtAmount) : undefined;
-  const discountPercent = getDiscountPercent(priceNum, compareAtNum);
+  const isRange = maxAmount != null && maxAmount !== amount;
+  // A range's per-variant discounts differ, so a single compare-at would be misleading.
+  const discountPercent = isRange ? null : getDiscountPercent(priceNum, compareAtNum);
 
   return (
     <div data-slot="product-card-price" className={cn(className)}>
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-        <Price
-          amount={amount}
-          currencyCode={currencyCode}
-          locale={locale}
-          className="text-sm text-main-foreground"
-        />
+        <span className="inline-flex items-baseline gap-x-1 text-sm text-main-foreground">
+          <Price
+            amount={amount}
+            currencyCode={currencyCode}
+            locale={locale}
+            className="text-sm text-main-foreground"
+          />
+          {isRange && (
+            <>
+              <span>–</span>
+              <Price
+                amount={maxAmount}
+                currencyCode={currencyCode}
+                locale={locale}
+                className="text-sm text-main-foreground"
+              />
+            </>
+          )}
+        </span>
         {discountPercent && compareAtAmount && compareAtCurrencyCode && (
           <>
             <Price

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -62,6 +62,7 @@ export async function ProductCard({
             <ProductCardPrice
               amount={product.price.amount}
               currencyCode={product.price.currencyCode}
+              maxAmount={product.maxPrice.amount}
               compareAtAmount={product.compareAtPrice?.amount}
               compareAtCurrencyCode={product.compareAtPrice?.currencyCode}
               locale={locale}

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -426,6 +426,9 @@ export const PRODUCT_CARD_FRAGMENT = `#graphql
       minVariantPrice {
         ...MoneyFields
       }
+      maxVariantPrice {
+        ...MoneyFields
+      }
     }
     compareAtPriceRange {
       minVariantPrice {

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -156,6 +156,7 @@ export interface ShopifyProductCard {
   featuredImage: ShopifyImage | null;
   priceRange: {
     minVariantPrice: ShopifyMoney;
+    maxVariantPrice: ShopifyMoney;
   };
   compareAtPriceRange?: {
     minVariantPrice: ShopifyMoney;
@@ -403,6 +404,7 @@ export function transformShopifyProductCard(product: ShopifyProductCard): Produc
     title: product.title,
     featuredImage: transformImage(product.featuredImage),
     price: product.priceRange.minVariantPrice,
+    maxPrice: product.priceRange.maxVariantPrice,
     compareAtPrice: product.compareAtPriceRange?.minVariantPrice ?? undefined,
     vendor: product.vendor || undefined,
     availableForSale: product.availableForSale,
@@ -437,6 +439,7 @@ export function transformShopifyProductDetails(product: ShopifyProduct): Product
     title: product.title,
     featuredImage: transformImage(product.featuredImage),
     price: product.priceRange.minVariantPrice,
+    maxPrice: product.priceRange.maxVariantPrice,
     compareAtPrice: product.compareAtPriceRange?.minVariantPrice ?? undefined,
     vendor: product.vendor || undefined,
     availableForSale: product.availableForSale,

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -50,6 +50,9 @@ export interface ProductCard {
   featuredImage: Image | null;
   handle: string;
   id: string;
+  /** Highest variant price; equals price for single-price products, else the top of the range. */
+  maxPrice: Money;
+  /** Lowest variant price; the card shows a "min – max" range when maxPrice differs. */
   price: Money;
   title: string;
   vendor?: string;

--- a/packages/plugin/template-rollout-log/2026-06-21-product-card-price-range.md
+++ b/packages/plugin/template-rollout-log/2026-06-21-product-card-price-range.md
@@ -1,0 +1,53 @@
+---
+title: Product card — show a "min – max" price range when variants span one
+changeKey: product-card-price-range
+introducedOn: 2026-06-21
+changeType: enhancement
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/shopify/fragments.ts
+  - apps/template/lib/shopify/transforms/product.ts
+  - apps/template/lib/types.ts
+  - apps/template/components/product-card/components.tsx
+  - apps/template/components/product-card/product-card.tsx
+  - apps/template/components/collections/infinite-product-grid.tsx
+relatedSkills: []
+---
+
+## Summary
+
+Product cards now reflect a varying price instead of showing a bare minimum. When a product's variants span a price range (`priceRange.minVariantPrice ≠ maxVariantPrice`), the card renders both bounds as a `min – max` range — _$48.00 – $96.00_ — and suppresses the compare-at strike-through and discount badge (per-variant discounts differ across a range, so a single one would mislead). Single-price products are unchanged.
+
+Mechanics:
+
+- `ProductCardFields` (`fragments.ts`) now selects `priceRange.maxVariantPrice` alongside `minVariantPrice`; codegen regenerated.
+- `ShopifyProductCard.priceRange` gains `maxVariantPrice`; the `ProductCard` domain type gains `maxPrice: Money`, set from `priceRange.maxVariantPrice` in both `transformShopifyProductCard` and `transformShopifyProductDetails`.
+- `ProductCardPrice` takes an optional `maxAmount`; when it differs from `amount` the component renders `min – max` (en-dash separator, matching the filter range UI) and drops the discount UI.
+- The two card renderers (`product-card.tsx`, `infinite-product-grid.tsx`) pass `maxAmount={product.maxPrice.amount}`. No i18n string or label threading is needed — the range is pure product data.
+
+## Why it matters
+
+- Grids and sliders previously displayed only `minVariantPrice` with no signal that pricing varied, so a $48–$96 product read as a flat "$48.00". Showing both bounds sets correct price expectations before the click.
+- `maxPrice` lives on the base `ProductCard` type, so it is available wherever cards render (home, PLP, search, recommendations) without per-call-site plumbing.
+- The agent product card (`components/agent/registry.tsx`) is unaffected — it parses prices from strings and has no range data, so it keeps a single price.
+
+## Apply when
+
+- The storefront uses the template product cards largely as shipped and sells products with per-variant pricing (size/material tiers, etc.).
+
+## Safe to skip when
+
+- The catalog is effectively single-price per product (no variant price spread), so `maxPrice === price` everywhere and nothing changes.
+- You prefer the compact "From {min}" convention over an explicit range (drop `maxAmount`, gate on `price !== maxPrice`, and render a localized "From" label before the min).
+
+## Validation
+
+1. `pnpm --filter template codegen` (regenerates the fragment types), then `pnpm --filter template lint` and `pnpm --filter template build`.
+2. `pnpm --filter template start`: a product whose variants differ in price shows _$min – $max_ with no discount badge; a single-price product shows the plain price and keeps its strike-through/percent-off when on sale.
+3. `grep -n 'maxPrice' apps/template/lib/types.ts apps/template/lib/shopify/transforms/product.ts` → present on the type and set in both transforms.
+
+## See also
+
+- `anatomy/product-card` docs — the **Price** section documents the range behavior.


### PR DESCRIPTION
## Summary

Product cards previously rendered only `minVariantPrice`, so a product whose variants span **$48–$96** read as a flat **\$48.00** with no signal that pricing varied. This makes the card reflect the range by default.

When `priceRange.minVariantPrice ≠ maxVariantPrice`, the card now renders both bounds as a **min – max** range — _\$48.00 – \$96.00_ — and suppresses the compare-at strike-through + discount badge (per-variant discounts differ across a range, so a single one would mislead). **Single-price products are unchanged**, including their strike-through and percent-off badge when on sale.

## How

- **Fragment**: `ProductCardFields` now selects `priceRange.maxVariantPrice` alongside `minVariantPrice` (codegen regenerated; generated types are gitignored and rebuilt by the `build` step).
- **Domain type**: new `maxPrice: Money` on `ProductCard`, set from `priceRange.maxVariantPrice` in both `transformShopifyProductCard` and `transformShopifyProductDetails`.
- **Component**: `ProductCardPrice` takes an optional `maxAmount`; when it differs from `amount` it renders `min – max` (en-dash separator, matching the filter range UI) and drops the discount UI.
- **Plumbing**: the two card renderers (`product-card.tsx`, `infinite-product-grid.tsx`) pass `maxAmount={product.maxPrice.amount}`. Because `maxPrice` lives on the base `ProductCard` type, no i18n string or label threading is needed — the range is pure product data.
- The agent product card (`components/agent/registry.tsx`) is untouched — it parses prices from strings and has no range data, so it keeps a single price.

## Note

Earlier revisions of this PR used a compact **From {min}** prefix; switched to an explicit **min – max** range for code simplicity (no i18n key, no label threaded through the client `InfiniteProductGrid`). The rollout-log entry documents the "From" variant as the alternative.

## Docs & rollout

- Adds a **Price** section to `anatomy/product-card`.
- Adds `template-rollout-log/2026-06-21-product-card-price-range.md`.

## Validation

- `pnpm --filter template codegen` ✅
- `pnpm --filter template lint` ✅
- `pnpm --filter template build` ✅