### PR TITLE
fix(template): gate next.config env asserts so create-next-app typegen succeeds

### DIFF
--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -1,28 +1,35 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
+import {
+  PHASE_DEVELOPMENT_SERVER,
+  PHASE_PRODUCTION_BUILD,
+  PHASE_PRODUCTION_SERVER,
+} from "next/constants";
 
-const missingShopify = ["SHOPIFY_STORE_DOMAIN", "SHOPIFY_STOREFRONT_ACCESS_TOKEN"].filter(
-  (key) => !process.env[key],
-);
-
-if (missingShopify.length > 0) {
-  throw new Error(
-    `Missing required Shopify environment variables: ${missingShopify.join(", ")}. See .env.example.`,
+function assertRequiredEnv() {
+  const missingShopify = ["SHOPIFY_STORE_DOMAIN", "SHOPIFY_STOREFRONT_ACCESS_TOKEN"].filter(
+    (key) => !process.env[key],
   );
-}
 
-if (process.env.NEXT_PUBLIC_ENABLE_AUTH === "1") {
-  const missing = [
-    "BETTER_AUTH_SECRET",
-    "SHOPIFY_CUSTOMER_CLIENT_ID",
-    "SHOPIFY_CUSTOMER_CLIENT_SECRET",
-  ].filter((key) => !process.env[key]);
-
-  if (missing.length > 0) {
+  if (missingShopify.length > 0) {
     throw new Error(
-      `NEXT_PUBLIC_ENABLE_AUTH=1 requires: ${missing.join(", ")}. ` +
-        `Set the missing variables or unset NEXT_PUBLIC_ENABLE_AUTH.`,
+      `Missing required Shopify environment variables: ${missingShopify.join(", ")}. See .env.example.`,
     );
+  }
+
+  if (process.env.NEXT_PUBLIC_ENABLE_AUTH === "1") {
+    const missing = [
+      "BETTER_AUTH_SECRET",
+      "SHOPIFY_CUSTOMER_CLIENT_ID",
+      "SHOPIFY_CUSTOMER_CLIENT_SECRET",
+    ].filter((key) => !process.env[key]);
+
+    if (missing.length > 0) {
+      throw new Error(
+        `NEXT_PUBLIC_ENABLE_AUTH=1 requires: ${missing.join(", ")}. ` +
+          `Set the missing variables or unset NEXT_PUBLIC_ENABLE_AUTH.`,
+      );
+    }
   }
 }
 
@@ -77,4 +84,19 @@ const withNextIntl = createNextIntlPlugin({
   requestConfig: "./lib/i18n/request.ts",
 });
 
-export default withNextIntl(nextConfig);
+const config = withNextIntl(nextConfig);
+
+export default function getConfig(phase: string): NextConfig {
+  // `next typegen` shares PHASE_PRODUCTION_BUILD but runs before any .env exists (create-next-app), so exclude it.
+  const isTypegen = process.argv.includes("typegen");
+  const isRuntime =
+    phase === PHASE_DEVELOPMENT_SERVER ||
+    phase === PHASE_PRODUCTION_BUILD ||
+    phase === PHASE_PRODUCTION_SERVER;
+
+  if (isRuntime && !isTypegen) {
+    assertRequiredEnv();
+  }
+
+  return config;
+}


### PR DESCRIPTION
## Problem

Cloning the template with `create-next-app` aborts during its post-clone `next typegen` step:

```
Unexpected error while generating route types. Original error:
Error: Missing required Shopify environment variables: SHOPIFY_STORE_DOMAIN, SHOPIFY_STOREFRONT_ACCESS_TOKEN. See .env.example.
    at Object.<anonymous> (next.config.compiled.js:22:11)
Error running typegen: Error: next typegen exited with code 1
```

The Shopify (and auth) env checks were a **top-level `throw` at module load**, so they fired on *any* process that imported `next.config.ts` — including the `next typegen` that `create-next-app` runs before a `.env` exists.

## Why phase gating alone isn't enough

`next typegen` loads the config under `PHASE_PRODUCTION_BUILD` — the **same phase as a real `next build`** (confirmed in `next/dist/cli/next-typegen.js`). So the discriminator also has to look at argv, mirroring how `next-intl` already guards its own throws.

## Fix

- Move the env assertions into `assertRequiredEnv()` (logic unchanged).
- Export the config as a **phase function** and only assert for a genuine dev/build/start (`PHASE_DEVELOPMENT_SERVER` / `PHASE_PRODUCTION_BUILD` / `PHASE_PRODUCTION_SERVER`), excluding `typegen` via `process.argv`.
- `withNextIntl(nextConfig)` is still evaluated once at module scope; next-intl already no-ops its throws outside dev/build.

Real `build`/`dev`/`start` still fail fast on missing env — only auxiliary commands (`typegen`, `info`) are exempt.

## Verification

- `next typegen` with no `.env.local` (fresh-clone simulation) → `✓ Types generated successfully`, exit 0.
- Gating truth table: `build`/`dev`/`start` → **validate**; `typegen`/`info` → **skip**.
- oxlint + oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)