### PR TITLE
fix(template): use title case for bundle and upsell headings

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -70,8 +70,8 @@ A single `BuyButtons` component renders identically on both mobile and desktop. 
 
 `bundle-components.tsx` renders Shopify's [bundle relationships](/docs/shopify/pdp#bundles) below the buy buttons:
 
-- **Bundle includes** — a fixed bundle's component products, from `components` (`BundleComponents`).
-- **Available in bundles** — bundles containing the current product, collapsed to one link per bundle, from `groupedBy` (`BundleParents`).
+- **Bundle Includes** — a fixed bundle's component products, from `components` (`BundleComponents`).
+- **Available in Bundles** — bundles containing the current product, collapsed to one link per bundle, from `groupedBy` (`BundleParents`).
 
 These are product-level facts (which products a bundle contains / which bundles a product belongs to), so they render **eagerly from the cached default variant in the static shell** rather than streaming in behind the variant query — no layout shift on load.
 
@@ -79,7 +79,7 @@ A customized bundle parent (`requiresComponents` with no fixed `components`) dis
 
 ### Complementary products
 
-`complementary-products.tsx` renders the merchant-curated "Pairs well with" set below the bundle relationships — Shopify's [complementary products](/docs/shopify/pdp#complementary-products) from `productRecommendations(intent: COMPLEMENTARY)`. These are distinct from the algorithmic related products below the fold (`intent: RELATED`): complementary products are deliberately chosen add-ons, so they sit beside the buy section like bundle relationships rather than in the footer grid.
+`complementary-products.tsx` renders the merchant-curated "Pairs Well With" set below the bundle relationships — Shopify's [complementary products](/docs/shopify/pdp#complementary-products) from `productRecommendations(intent: COMPLEMENTARY)`. These are distinct from the algorithmic related products below the fold (`intent: RELATED`): complementary products are deliberately chosen add-ons, so they sit beside the buy section like bundle relationships rather than in the footer grid.
 
 Like bundle relationships, the section renders **eagerly into the prerendered shell** rather than streaming. Both recommendation surfaces — this set and the [related grid](#related-products) below the fold — come from a single cached (`use cache: remote`) `getProductRecommendationSets()` operation that fetches both intents in one aliased `productRecommendations` request and is tagged with both `complementary-{handle}` and `recommendations-{handle}`. Because both surfaces call it with the same arguments, they dedupe to **one** Shopify request; this section reads the `complementary` slice, baked into the static PPR/ISR document — there's no skeleton fallback and no layout shift on cached hits (a `Suspense` boundary would instead make it a streamed hole). It shows up to four products as thumbnail + title + price rows and renders nothing when none are configured.
 

--- a/apps/docs/content/docs/shopify/pdp.mdx
+++ b/apps/docs/content/docs/shopify/pdp.mdx
@@ -71,7 +71,7 @@ Product recommendations on the PDP are powered by Shopify's recommendation API. 
 
 ## Complementary products
 
-Beyond the automatic recommendations above, the PDP shows a merchant-curated **"Pairs well with"** list near the buy section, powered by the Storefront API's `productRecommendations(intent: COMPLEMENTARY)`.
+Beyond the automatic recommendations above, the PDP shows a merchant-curated **"Pairs Well With"** list near the buy section, powered by the Storefront API's `productRecommendations(intent: COMPLEMENTARY)`.
 
 Unlike the `RELATED` recommendations Shopify generates automatically, complementary products are **configured by hand** in the free [Shopify Search & Discovery](https://apps.shopify.com/search-and-discovery) app — open a product's **Product recommendations** settings and add its complementary items. With none configured for a product, the section renders nothing.
 

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -65,7 +65,7 @@
     "adding": "Adding...",
     "addressPlaceholder": "Address will be added at checkout",
     "applyDiscount": "Apply",
-    "bundleIncludes": "Bundle includes",
+    "bundleIncludes": "Bundle Includes",
     "cartItemsLabel": "Cart items",
     "cartTotalIs": "Cart total is",
     "checkout": "Checkout",
@@ -116,7 +116,7 @@
     "updatingCart": "Updating cart...",
     "upsell": {
       "description": "Complete your order with these complementary products",
-      "title": "You might also like"
+      "title": "You Might Also Like"
     },
     "viewFullCart": "View full cart",
     "warningsTitle": "Your cart was updated"
@@ -229,14 +229,14 @@
     "addingQuantity": "Adding {quantity}...",
     "addingToCart": "Adding to Cart...",
     "addToCart": "Add to Cart",
-    "availableInBundles": "Available in bundles",
+    "availableInBundles": "Available in Bundles",
     "brand": "Brand",
     "breadcrumb": {
       "home": "Home",
       "toggleMenu": "Toggle menu"
     },
     "bundleConfigurationRequired": "Choose bundle items",
-    "bundleIncludes": "Bundle includes",
+    "bundleIncludes": "Bundle Includes",
     "buyNow": "Buy now",
     "buyWithShop": "Buy with",
     "color": "Color",
@@ -294,7 +294,7 @@
     "noImage": "No image",
     "officialStore": "Official Store",
     "outOfStock": "Out of Stock",
-    "pairsWith": "Pairs well with",
+    "pairsWith": "Pairs Well With",
     "quantity": "Quantity",
     "recommendations": "You May Also Like",
     "seeAllSpecs": "See all specs",


### PR DESCRIPTION
## Problem

The bundle and complementary ("upsell") section headings render in **sentence case**, while every other PDP/cart section heading is **title case** (`Product Details`, `Care Instructions`, `Shipping & Returns`, `You May Also Like`, `Specifications`). The inconsistency is visible on the PDP, where `Pairs well with` sits right next to `Specifications` and `You May Also Like`.

## Change

Make the headings uniform title case in `en.json`:

| Key | Before | After |
| --- | --- | --- |
| `product.bundleIncludes` / `cart.bundleIncludes` | Bundle includes | **Bundle Includes** |
| `product.availableInBundles` | Available in bundles | **Available in Bundles** |
| `product.pairsWith` | Pairs well with | **Pairs Well With** |
| `cart.upsell.title` | You might also like | **You Might Also Like** |

Casing follows the existing convention (lowercase short prepositions like `in`; capitalize the last word, so `With` stays capped).

`cart.upsell.*` isn't rendered by any component yet, but it's title-cased alongside the rest to keep the catalog uniform.

## Docs

The PDP docs quote these headings verbatim, so `anatomy/pages/pdp.mdx` and `shopify/pdp.mdx` are updated to match.

## Notes

- Only `en.json` is tracked; `en.d.json.ts` is gitignored and regenerated from it (verified the regen produces the new values).
- Keys unchanged, so i18n alphabetization is preserved. JSON valid, oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)