### PR TITLE
fix(template): bump collection price-range input text to 16px on mobile

### DIFF
--- a/apps/template/components/collections/filter-primitives.tsx
+++ b/apps/template/components/collections/filter-primitives.tsx
@@ -284,7 +284,7 @@ function FilterPriceRange({
       {...props}
     >
       <div className="flex flex-1 items-center rounded-lg bg-input px-2.5 h-8">
-        <span className="text-sm text-muted-foreground">{currencySymbol}</span>
+        <span className="text-base text-muted-foreground md:text-sm">{currencySymbol}</span>
         <Input
           type="number"
           step="0.01"
@@ -292,12 +292,12 @@ function FilterPriceRange({
           placeholder={fromPlaceholder}
           value={minValue}
           onChange={(e) => onMinChange?.(e.target.value)}
-          className="h-auto border-0 bg-transparent px-1 text-sm shadow-none outline-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+          className="h-auto border-0 bg-transparent px-1 shadow-none outline-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
         />
       </div>
       <span className="text-muted-foreground">–</span>
       <div className="flex flex-1 items-center rounded-lg bg-input px-2.5 h-8">
-        <span className="text-sm text-muted-foreground">{currencySymbol}</span>
+        <span className="text-base text-muted-foreground md:text-sm">{currencySymbol}</span>
         <Input
           type="number"
           step="0.01"
@@ -305,7 +305,7 @@ function FilterPriceRange({
           placeholder={toPlaceholder}
           value={maxValue}
           onChange={(e) => onMaxChange?.(e.target.value)}
-          className="h-auto border-0 bg-transparent px-1 text-sm shadow-none outline-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+          className="h-auto border-0 bg-transparent px-1 shadow-none outline-none focus-visible:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
         />
       </div>
       <button

--- a/packages/plugin/template-rollout-log/2026-06-22-filter-price-input-ios-zoom.md
+++ b/packages/plugin/template-rollout-log/2026-06-22-filter-price-input-ios-zoom.md
@@ -1,0 +1,43 @@
+---
+title: Collection filters — bump price-range input text to 16px on mobile (prevent iOS focus-zoom)
+changeKey: filter-price-input-ios-zoom
+introducedOn: 2026-06-22
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/collections/filter-primitives.tsx
+relatedSkills: []
+---
+
+## Summary
+
+`FilterPriceRange` (the from/to price inputs in the collection/search filters) rendered its `<input>`s at a flat `text-sm` (14px). The shared `Input` primitive already ships the shadcn anti-zoom pattern — `text-base md:text-sm` (16px on mobile, 14px on desktop) — but the local `text-sm` override flattened it back to 14px at every breakpoint.
+
+- Dropped the `text-sm` class from both price `<input>` overrides so they inherit the base `Input`'s `text-base md:text-sm`.
+- Matched the `$` currency-symbol `<span>`s to `text-base text-muted-foreground md:text-sm` so the prefix and the typed value read at one size per breakpoint.
+
+No element box sizes change — the `h-8` pill, `h-auto` input, and `px-1` padding are untouched. Only the font-size per breakpoint changes.
+
+## Why it matters
+
+- iOS Safari auto-zooms the viewport when a focused form control's font-size is **under 16px**. At 14px, tapping a price input zoomed the whole page and left it zoomed. 16px is the hard threshold — 15px still zooms — so 16px is the smallest text that avoids it.
+- On desktop (md+) the inputs stay at 14px, so the filter UI looks identical to before; the bump is mobile-only.
+
+## Apply when
+
+- The storefront uses the template's `FilterPriceRange` largely as shipped and serves a Shopify price-range facet on collection/search pages.
+
+## Safe to skip when
+
+- The price inputs were already restyled downstream to `text-base`/16px on mobile (or the price facet is disabled entirely).
+
+## Validation
+
+1. `pnpm --filter template lint`.
+2. On a collection with a price facet at a mobile width, the price `<input>` computes to `font-size: 16px` (`md:` ≥768px → 14px). Tapping it on a real iOS device no longer zooms the page.
+
+## See also
+
+- `components/ui/input.tsx` — the base `Input` whose `text-base md:text-sm` pattern these inputs now inherit.


### PR DESCRIPTION
## Problem

On iOS Safari, tapping a **price-range input** in the collection/search filters zoomed the whole page (and left it zoomed). iOS auto-zooms whenever a focused form control's font-size is **under 16px**.

The shared `Input` primitive already ships the standard shadcn anti-zoom pattern — `text-base md:text-sm` (16px on mobile, 14px on desktop) — but `FilterPriceRange` overrode it with a flat `text-sm` (14px at every breakpoint), defeating it.

> Note: 15px would still zoom — 16px is the hard iOS threshold, so it's the smallest text that avoids it.

## Fix

- Drop the `text-sm` override from both price `<input>`s so they inherit the base `Input`'s `text-base md:text-sm`.
- Match the `$` currency-prefix `<span>`s to `text-base … md:text-sm` so the symbol and the typed value read at one size per breakpoint.

Element box sizes are untouched — the `h-8` pill, `h-auto` input, and `px-1` padding are exactly as before. Only the per-breakpoint font-size changes (mobile-only bump; desktop is visually identical).

## Verification

- Ran the project's real `cn()`/tailwind-merge on the exact class strings: old → `text-sm` (14px) at all widths; new → `text-base` + `md:text-sm` (16px mobile / 14px desktop).
- Confirmed in a 390px-wide browser that the base `Input` pattern computes to 16px.
- `oxlint` clean.

Added a `template-rollout-log` entry (`changeType: fix`, `defaultAction: adopt`). No docs change needed — the PLP doc only describes the price filter at a feature level, not its styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)