### PR TITLE
fix(template): type ToolLoopAgent defaults with satisfies for AI SDK 7

### DIFF
--- a/apps/template/lib/agent/server.ts
+++ b/apps/template/lib/agent/server.ts
@@ -182,9 +182,9 @@ function getSystemPrompt() {
   return createSystemPrompt(ctx);
 }
 
-const defaults: ToolLoopAgentSettings = {
+const defaults = {
   model: "anthropic/claude-sonnet-4.6",
-};
+} satisfies Partial<ToolLoopAgentSettings>;
 
 const tools = {
   searchProducts: searchProductsTool(),


### PR DESCRIPTION
## Summary
Fixes the `template:build` type error introduced by the AI SDK 6 → 7 upgrade in `lib/agent/server.ts`.

AI SDK 7's `ToolLoopAgent` / `ToolLoopAgentSettings` gained a 4th generic, `OUTPUT extends Output = never`. The shared `defaults` object was annotated with the bare `ToolLoopAgentSettings`, which pins `OUTPUT = never`. Spreading `...defaults` into `new ToolLoopAgent({...})` then injects an `onStart?: …<never>` member, which conflicts with the `OUTPUT` the constructor infers from the literal — producing the `onStart`/`output` incompatibility build error.

## Change
```ts
// before
const defaults: ToolLoopAgentSettings = { model: "anthropic/claude-sonnet-4.6" };
// after
const defaults = { model: "anthropic/claude-sonnet-4.6" } satisfies Partial<ToolLoopAgentSettings>;
```
`satisfies` keeps `defaults`'s inferred type narrow (`{ model: string }`), so the spread only contributes `model` and the constructor infers its generics cleanly — still type-checked, no over-broad annotation polluting inference.

## Scope / verification
- This is the **only** v7 type break in the template. Tools (`tool({ inputSchema, execute })`), the chat route (`convertToModelMessages`, `safeValidateUIMessages`, `createUIMessageStream`, `agent.stream()`), and the client (`useChat`, `DefaultChatTransport`, `UIMessage`) already type-check under v7.
- `tsc --noEmit`: 0 errors. `oxfmt --check` and `oxlint` pass.

## Notes
- `apps/docs` remains on `ai@6` — not part of this upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)