### PR TITLE
fix(template): fetch home products grid from the same search path as /collections/all

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/home.mdx
+++ b/apps/docs/content/docs/anatomy/pages/home.mdx
@@ -22,7 +22,7 @@ On mobile, the subheadline and CTA text are hidden to keep the banner compact.
 
 ## Products grid
 
-A responsive grid showing the top 8 products fetched via `getCatalogProducts()`. The grid uses the `ProductsGrid` component with a section title and a link to the full catalog. Each item is a [product card](/docs/anatomy/product-card) with:
+A responsive grid showing the top 8 products fetched via `searchIndexProducts()`. The grid uses the `ProductsGrid` component with a section title and a link to the full catalog. Each item is a [product card](/docs/anatomy/product-card) with:
 
 - Featured image, with a muted image-icon placeholder when the product has no image
 - Out-of-stock overlay when unavailable
@@ -32,7 +32,7 @@ The grid is responsive: 2 columns on mobile, 3 on tablet, 4 on desktop. A `Produ
 
 ## Data fetching
 
-Products are fetched server-side with `getCatalogProducts({ limit: 8, locale })`, which pulls the top products across the entire catalog (best-selling order) rather than a curated collection. The result is cached with `cacheLife("max")` and product-level cache tags for granular revalidation. The section heading and its "view all" link are set by the `title` and `collectionUrl` props on the `ProductsGrid` call in `app/page.tsx`, which point at `/collections/all` by default.
+Products are fetched server-side with `searchIndexProducts({ limit: 8, locale })` — the same relevance-ranked Storefront `search` path (wildcard `*` query) that backs `/collections/all`, so the home grid shows exactly the first 8 products a shopper sees on that page rather than a separate best-selling list or a curated collection. The result is cached with `cacheLife("max")` and product-level cache tags for granular revalidation. The section heading and its "view all" link are set by the `title` and `collectionUrl` props on the `ProductsGrid` call in `app/page.tsx`, which point at `/collections/all` by default.
 
 ## Key files
 

--- a/apps/template/components/product/products-grid.tsx
+++ b/apps/template/components/product/products-grid.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 
 import { ProductCard, ProductCardSkeleton } from "@/components/product-card/product-card";
 import type { Locale } from "@/lib/i18n";
-import { getCatalogProducts } from "@/lib/shopify/operations/products";
+import { searchIndexProducts } from "@/lib/shopify/operations/products";
 import { cn } from "@/lib/utils";
 
 interface ProductsGridSkeletonProps {
@@ -61,7 +61,8 @@ async function ProductsGridContent({
   locale: Locale;
   outOfStockText: string;
 }) {
-  const { products } = await getCatalogProducts({ limit, locale });
+  // Use the search index (not the products connection) so these match the first items on /collections/all.
+  const { products } = await searchIndexProducts({ limit, locale });
 
   if (products.length === 0) return null;
 

--- a/packages/plugin/template-rollout-log/2026-06-23-home-grid-matches-collections-all.md
+++ b/packages/plugin/template-rollout-log/2026-06-23-home-grid-matches-collections-all.md
@@ -1,0 +1,42 @@
+---
+title: Home products grid reads the same search-index path as /collections/all
+changeKey: home-grid-matches-collections-all
+introducedOn: 2026-06-23
+changeType: refactor
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product/products-grid.tsx
+  - apps/docs/content/docs/anatomy/pages/home.mdx
+---
+
+## Summary
+
+The home page featured-products grid now fetches with `searchIndexProducts({ limit, locale })` instead of `getCatalogProducts({ limit, locale })`, so its first 8 products match the first products shown on `/collections/all`.
+
+- `components/product/products-grid.tsx` (`ProductsGridContent`) swaps the import and call from `getCatalogProducts` to `searchIndexProducts`.
+- Both are `"use cache: remote"` + `cacheLife("max")` + `cacheTag("products")` wrappers, so caching/revalidation behavior is unchanged.
+- `getCatalogProducts` is left in place (still used by `app/products/[handle]/page.tsx`).
+
+## Why it matters
+
+The two surfaces previously used different Storefront APIs and different effective sorts:
+
+- Home grid → `getCatalogProducts` → the `products` connection. Its default sort is `RELEVANCE`, but with no query string `fetchCatalogProducts` falls back to `BEST_SELLING`, so the home grid was best-selling ordered.
+- `/collections/all` → `getAllProductsResultsData` → `fetchSearchIndexProducts` → the `search` field with `query: "*"`, default sort `RELEVANCE` (the wildcard query keeps it from falling back).
+
+So the home grid's "top 8" did not correspond to the first 8 cards on `/collections/all`. Routing the home grid through `searchIndexProducts` (same `search` field, same `*` query, same `RELEVANCE` default) makes the home grid a true preview of that page.
+
+## Apply when
+
+- You want the home featured grid to be a consistent preview of `/collections/all` (e.g. the "view all" link should land on the same products the shopper just saw).
+
+## Safe to skip when
+
+- You deliberately want the home grid to surface best-selling products rather than the catalog's relevance ordering, or you curate the home grid from a specific collection.
+
+## Validation
+
+1. `pnpm --filter template lint`, `pnpm --filter template build`, `pnpm --filter docs build`.
+2. With the dev server running, compare the first 8 product handles on `/` against the first 8 on `/collections/all` — they should match in the same order.


### PR DESCRIPTION
## What

The home page featured-products grid now fetches via `searchIndexProducts({ limit, locale })` instead of `getCatalogProducts({ limit, locale })`, so its first 8 products match the first products on `/collections/all`.

## Why

The two surfaces were using different Shopify APIs and different effective sorts, so the home grid was never a true preview of `/collections/all`:

| | Home grid (before) | `/collections/all` |
|---|---|---|
| Fetch fn | `getCatalogProducts` | `fetchSearchIndexProducts` |
| Storefront field | `products` connection | `search` (`query: "*"`, `types: PRODUCT`) |
| Effective sort | `RELEVANCE` → falls back to **`BEST_SELLING`** (no query) | **`RELEVANCE`** (wildcard query, no fallback) |

Routing the home grid through `searchIndexProducts` (same `search` field, same `*` query, same `RELEVANCE` default, no filters) makes the home grid show exactly the first 8 cards a shopper then sees on `/collections/all`.

Both `getCatalogProducts` and `searchIndexProducts` are `"use cache: remote"` + `cacheLife("max")` + `cacheTag("products")` wrappers, so caching/revalidation behavior is unchanged. `getCatalogProducts` is left in place (still used by `app/products/[handle]/page.tsx`).

## Changes

- `apps/template/components/product/products-grid.tsx` — `ProductsGridContent` swaps `getCatalogProducts` → `searchIndexProducts`.
- `apps/docs/content/docs/anatomy/pages/home.mdx` — data-fetching section was documented as best-selling order; corrected to describe the shared search-index path.
- `packages/plugin/template-rollout-log/2026-06-23-home-grid-matches-collections-all.md` — rollout entry (`defaultAction: review`; downstream stores may deliberately prefer best-selling on the home grid).

## Note

With `RELEVANCE` + a `*` wildcard query Shopify's ordering isn't perfectly stable over time (same property behind the earlier `uncached-browse-pagination` fix). The home grid and `/collections/all` always match because they issue the identical query, but the absolute "top 8" can shift as the catalog changes — expected for a relevance-ranked browse.

## Validation

- `pnpm --filter template lint` ✅
- `tsc --noEmit` ✅ (exit 0, 0 errors)
- Manual: first 8 product handles on `/` match the first 8 on `/collections/all` in the same order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)