### PR TITLE
fix(template): scope Shopify webhook cache invalidation to per-item tags

### DIFF
--- a/apps/docs/content/docs/anatomy/webhooks.mdx
+++ b/apps/docs/content/docs/anatomy/webhooks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Webhooks
-description: Shopify webhook handler that invalidates Next.js cache tags so storefront content updates near-instantly when products, collections, inventory, or CMS metaobjects change.
+description: Shopify webhook handler that invalidates Next.js cache tags so storefront content updates near-instantly when products, collections, or CMS metaobjects change.
 type: guide
 ---
 
@@ -18,18 +18,22 @@ A single route handles every supported topic. Shopify sets the topic on each req
 
 ## Topics and cache tags
 
-| Webhook topic        | Tags invalidated                                                          |
-| -------------------- | ------------------------------------------------------------------------- |
-| `products/create`    | `products`, `collections`, `product-{handle}`, `recommendations-{handle}` |
-| `products/update`    | `products`, `collections`, `product-{handle}`, `recommendations-{handle}` |
-| `products/delete`    | `products`, `collections`, `product-{handle}`, `recommendations-{handle}` |
-| `collections/create` | `collections`, `products`, `menus`, `collection-{handle}`                 |
-| `collections/update` | `collections`, `products`, `menus`, `collection-{handle}`                 |
-| `collections/delete` | `collections`, `products`, `menus`                                        |
-| `inventory_levels/*` | `products`, `collections`                                                 |
-| `metaobjects/*`      | `cms:all` plus type-specific tags (see below)                             |
+| Webhook topic        | Tags invalidated                                                      |
+| -------------------- | -------------------------------------------------------------------- |
+| `products/create`    | `product-{handle}`, `product-{numericId}`, `recommendations-{handle}` |
+| `products/update`    | `product-{handle}`, `product-{numericId}`, `recommendations-{handle}` |
+| `products/delete`    | `product-{handle}`, `product-{numericId}`, `recommendations-{handle}` |
+| `collections/create` | `collection-{handle}`                                                |
+| `collections/update` | `collection-{handle}`                                                |
+| `collections/delete` | `collection-{handle}`                                                |
+| `metaobjects/*`      | `cms:all` plus type-specific tags (see below)                        |
 
-Product topics also try to derive a numeric product tag from `admin_graphql_api_id` so reads that cache by ID (not handle) are invalidated alongside handle-based reads.
+No branch ever invalidates the broad `products` or `collections` tags. Those tags wrap every list, search, and PDP read, so firing one on a single edit would bust the entire catalog cache. The handler relies on fine-grained tags instead, which is sufficient because the reads in `lib/shopify/operations/` stamp each aggregate cache entry with the granular tag of every item it contains — `tagProducts()` adds a `product-{numericId}` tag per product (on list/search/collection/recommendation reads), and `getCollections` adds a `collection-{handle}` tag per collection:
+
+- **Product topics** fire only per-product tags. Invalidating one product cascades to exactly the surfaces that display it. The numeric tag is derived from `admin_graphql_api_id` (falling back to the payload `id`) so reads that cache by ID are invalidated alongside the handle-based PDP reads.
+- **Collection topics** fire only the `collection-{handle}` tag. It busts that collection's PLP reads — `getCollection` (metadata) and `getCollectionProducts` (the product list, including membership and sort changes) — and, because `getCollections` stamps every collection it returns with that same tag, it also busts the all-collections list whenever an existing collection is edited or deleted. (A brand-new collection still won't appear in that list until cache expiry, since its tag wasn't present when the list was cached — the same limitation a newly created product has in cached catalog lists.) Product cards inside a collection list are independently covered by their own `product-{numericId}` tags via the product webhook. Navigation menus aren't busted here; menu titles and links are edited independently in Shopify Navigation, and there is no menu webhook topic.
+
+> **No `inventory_levels/*` branch.** The inventory webhook payload identifies an `inventory_item_id` and `location_id`, not a product — so it can't be scoped to a per-product tag without an extra lookup, and busting the catalog on every stock tick would destroy cache hit rates. The template intentionally omits this branch; availability propagates at cache expiry (or via any live, uncached reads you add). Registering the webhook anyway is harmless — it hits no branch and returns an empty `tagsInvalidated`.
 
 ### Metaobject tags
 
@@ -50,11 +54,11 @@ When a request arrives, the handler runs in this order:
 1. Reads the raw body as text — required for stable HMAC verification
 2. If `SHOPIFY_WEBHOOK_SECRET` is set, computes the HMAC-SHA256 of the body and compares it to `x-shopify-hmac-sha256` using `crypto.timingSafeEqual`. Mismatch returns `401`.
 3. Reads `x-shopify-topic`. Missing topic returns `400`.
-4. Dispatches on the topic prefix (`products/`, `collections/`, `inventory_levels/`, `metaobjects/`) and builds a tag list from the payload
+4. Dispatches on the topic prefix (`products/`, `collections/`, `metaobjects/`) and builds a tag list from the payload
 5. Calls `revalidateTag()` for each affected tag
 6. Returns `{ success, topic, tagsInvalidated }` for log inspection
 
-Payload parsing is wrapped in `try`/`catch`. If Shopify ever sends a body the handler can't parse, the generic tags still fire — coarse invalidation is better than none.
+Payload parsing is wrapped in `try`/`catch`. Metaobject topics seed the generic `cms:all` tag before parsing, so it still fires on a parse failure. Product and collection topics carry no generic tag to fall back on — without a parseable identifier (`handle`/`admin_graphql_api_id`) there's nothing to scope the invalidation to, so the handler logs and invalidates nothing rather than busting the whole catalog. Real Shopify webhooks always carry a parseable payload, so this only matters for malformed test posts.
 
 > **Security note:** When `SHOPIFY_WEBHOOK_SECRET` is unset the handler skips signature verification. That's convenient in development but unsafe in production — always set the secret in deployed environments.
 
@@ -66,7 +70,7 @@ Payload parsing is wrapped in `try`/`catch`. If Shopify ever sends a body the ha
 4. Create a webhook for each topic in the table above
 5. Copy the webhook signing secret and set it as `SHOPIFY_WEBHOOK_SECRET` in your environment
 
-You can register only the topics you care about. Skipping `inventory_levels/*`, for example, just means inventory edits propagate at cache expiry instead of immediately.
+You can register only the topics you care about. Skipping `collections/*`, for example, just means collection edits propagate at cache expiry instead of immediately. The handler has no `inventory_levels/*` branch (see the note above), so there's no need to register that topic.
 
 ## Environment variables
 
@@ -90,8 +94,10 @@ In development (no secret set) you should see a JSON response listing the invali
 
 ```
 [Shopify Webhook] Received: products/update
-[Shopify Webhook] Invalidated tags: products, collections, product-speaker, recommendations-speaker
+[Shopify Webhook] Invalidated tags: product-speaker, recommendations-speaker
 ```
+
+(A real Shopify payload also carries `admin_graphql_api_id`, adding a `product-{numericId}` tag; the handcrafted `curl` body above only has a `handle`.)
 
 For a real Shopify-signed request, use the **Send test notification** button on each webhook in Shopify Admin and watch your function logs.
 

--- a/apps/docs/content/docs/shopify/index.mdx
+++ b/apps/docs/content/docs/shopify/index.mdx
@@ -50,16 +50,17 @@ The handler verifies the HMAC signature using the `SHOPIFY_WEBHOOK_SECRET` envir
 
 ### Supported topics
 
-| Webhook topic        | Cache tags invalidated                                                    |
-| -------------------- | ------------------------------------------------------------------------- |
-| `products/create`    | `products`, `collections`, `product-{handle}`, `recommendations-{handle}` |
-| `products/update`    | `products`, `collections`, `product-{handle}`, `recommendations-{handle}` |
-| `products/delete`    | `products`, `collections`, `product-{handle}`, `recommendations-{handle}` |
-| `collections/create` | `collections`, `products`, `menus`, `collection-{handle}`                 |
-| `collections/update` | `collections`, `products`, `menus`, `collection-{handle}`                 |
-| `collections/delete` | `collections`, `products`, `menus`                                        |
-| `inventory_levels/*` | `products`, `collections`                                                 |
-| `metaobjects/*`      | `cms:all` + type-specific tags (if using Shopify CMS)                     |
+| Webhook topic        | Cache tags invalidated                                                |
+| -------------------- | -------------------------------------------------------------------- |
+| `products/create`    | `product-{handle}`, `product-{numericId}`, `recommendations-{handle}` |
+| `products/update`    | `product-{handle}`, `product-{numericId}`, `recommendations-{handle}` |
+| `products/delete`    | `product-{handle}`, `product-{numericId}`, `recommendations-{handle}` |
+| `collections/create` | `collection-{handle}`                                                |
+| `collections/update` | `collection-{handle}`                                                |
+| `collections/delete` | `collection-{handle}`                                                |
+| `metaobjects/*`      | `cms:all` + type-specific tags (if using Shopify CMS)                |
+
+The handler never invalidates the broad `products` or `collections` tags — fine-grained per-product (`product-{numericId}`, stamped on every list and collection read via `tagProducts()`) and per-collection (`collection-{handle}`, stamped on every collection read including the all-collections list) tags cover changes, so a single edit doesn't flush the whole catalog cache. There is intentionally no `inventory_levels/*` branch. See [Webhooks](/docs/anatomy/webhooks) for the full rationale.
 
 ### Setting up webhooks
 

--- a/apps/template/app/api/webhooks/shopify/route.ts
+++ b/apps/template/app/api/webhooks/shopify/route.ts
@@ -42,9 +42,11 @@ export async function POST(request: Request) {
   const tagsInvalidated: string[] = [];
 
   if (topic.startsWith("products/")) {
-    const productTags = ["products", "collections"];
+    // Per-product tags only — never the broad "products" tag. tagProducts() stamps every
+    // list/search/collection/recommendation entry with the contained products' product-<id>
+    // tag, so busting one product cascades to every surface showing it without nuking the catalog.
+    const productTags: string[] = [];
 
-    // Pull handle/id from the payload for targeted invalidation.
     try {
       const payload = JSON.parse(body);
       if (payload.handle) {
@@ -60,7 +62,7 @@ export async function POST(request: Request) {
         productTags.push(`product-${payload.id}`);
       }
     } catch {
-      // Parse failure: fall through and invalidate the generic tags.
+      console.error("[Shopify Webhook] Could not parse products payload; no tags invalidated");
     }
 
     for (const tag of productTags) {
@@ -70,7 +72,9 @@ export async function POST(request: Request) {
   }
 
   if (topic.startsWith("collections/")) {
-    const collectionTags = ["collections", "products", "menus"];
+    // Per-collection tag only — busts the collection's PLP (getCollection + getCollectionProducts).
+    // The all-collections list (getCollections) feeds only llms.txt and the agent tool; it refreshes at expiry.
+    const collectionTags: string[] = [];
 
     try {
       const payload = JSON.parse(body);
@@ -78,19 +82,10 @@ export async function POST(request: Request) {
         collectionTags.push(`collection-${payload.handle}`);
       }
     } catch {
-      // Parse failure: fall through and invalidate the generic tags.
+      console.error("[Shopify Webhook] Could not parse collections payload; no tags invalidated");
     }
 
     for (const tag of collectionTags) {
-      revalidateTag(tag, "max");
-      tagsInvalidated.push(tag);
-    }
-  }
-
-  if (topic.startsWith("inventory_levels/")) {
-    const inventoryTags = ["products", "collections"];
-
-    for (const tag of inventoryTags) {
       revalidateTag(tag, "max");
       tagsInvalidated.push(tag);
     }

--- a/apps/template/lib/shopify/operations/collections.ts
+++ b/apps/template/lib/shopify/operations/collections.ts
@@ -20,6 +20,12 @@ type CollectionResponse = {
   collection: ShopifyCollection | null;
 };
 
+function tagCollections(collections: Array<{ handle: string }>): void {
+  for (const collection of collections) {
+    cacheTag(`collection-${collection.handle}`);
+  }
+}
+
 const GET_COLLECTIONS_QUERY = `#graphql
   ${COLLECTION_FIELDS_FRAGMENT}
   query getCollections($first: Int!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
@@ -60,6 +66,7 @@ export async function getCollections({
   const { data } = response;
 
   const rawCollections = data.collections.edges.map((edge) => edge.node);
+  tagCollections(rawCollections);
   return transformShopifyCollections(rawCollections);
 }
 

--- a/packages/plugin/template-rollout-log/2026-06-23-product-webhook-per-product-invalidation.md
+++ b/packages/plugin/template-rollout-log/2026-06-23-product-webhook-per-product-invalidation.md
@@ -1,0 +1,56 @@
+---
+title: Stop the Shopify webhook from whole-catalog invalidation (scoped products + collections, drop inventory_levels)
+changeKey: webhook-targeted-invalidation
+introducedOn: 2026-06-23
+changeType: fix
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/app/api/webhooks/shopify/route.ts
+  - apps/template/lib/shopify/operations/collections.ts
+  - apps/docs/content/docs/anatomy/webhooks.mdx
+  - apps/docs/content/docs/shopify/index.mdx
+---
+
+## Summary
+
+The Shopify webhook handler used to invalidate the broad `products` tag on nearly every branch. That tag wraps **every** list, search, and PDP read, so almost any Shopify edit flushed the entire catalog cache. This change makes the handler invalidate only fine-grained, scoped tags:
+
+- **`products/*`** — now fires only `product-{handle}`, `product-{numericId}` (from `admin_graphql_api_id`, falling back to payload `id`), and `recommendations-{handle}`. No more `products`/`collections`.
+- **`collections/*`** — now fires only `collection-{handle}`. The broad `products`, broad `collections`, and `menus` tags are all dropped.
+- **`inventory_levels/*`** — branch removed entirely.
+
+`metaobjects/*` is unchanged.
+
+## Why it matters
+
+Fine-grained invalidation is **sufficient** by design: the reads in `lib/shopify/operations/products.ts` call the `tagProducts()` helper, which stamps every list/search/collection/recommendation cache entry with the `product-{numericId}` tag of each product it contains. So busting one product's numeric tag cascades to exactly the cached surfaces that display it, and collection reads are covered by `collections` + `collection-{handle}`. The broad `products` tag was pure over-invalidation — every product or collection edit threw away the whole catalog's cached reads and forced cold refetches across the store.
+
+- **Products:** the webhook's handle/numeric tags line up exactly with the operations layer — `product-{handle}` matches `getProduct`/`getProductVariant`/`getProductWithVariants`, and `product-{numericId}` matches the `tagProducts()` stamps on list reads (the webhook uses the same `getNumericShopifyId()` extraction).
+- **Collections:** `collection-{handle}` is stamped on `getCollection` (PLP metadata), `getCollectionProducts` (`cacheTag("products", "collections", collection-{handle})`), and — new in this change — every entry of the all-collections list via a `tagCollections()` helper in `getCollections` (mirroring `tagProducts`). So one `collection-{handle}` bust now covers the collection's PLP **and** the all-collections list whenever an existing collection is edited or deleted; the broad `collections` tag is redundant. (A brand-new collection still won't appear in the cached list until expiry, since its tag wasn't present when the list was cached — the same limitation a newly created product has in cached catalog lists.) Product cards within a collection list are independently covered by their own `product-{numericId}` tags via the product webhook. `menus` is dropped because it never belonged: menu titles/links are edited independently in Shopify Navigation, there's no menu webhook topic, so that cache already relied on expiry.
+- **Inventory:** the `inventory_levels/*` payload identifies an `inventory_item_id`/`location_id`, not a product, so it can't be scoped to a per-product tag without an extra lookup — and firing the broad `products` tag on every stock tick is the worst case for cache hit rates. The branch is removed; availability now propagates at cache expiry (or via any live, uncached reads). Registering the topic anyway is harmless (it hits no branch and returns an empty `tagsInvalidated`).
+
+## Apply when
+
+- You run the shipped webhook handler and want Shopify edits to invalidate only the affected surfaces instead of cold-flushing the entire catalog cache on every change.
+
+## Safe to skip when
+
+- You customized the webhook branches, or you deliberately rely on whole-catalog invalidation (e.g. you added catalog-wide cached reads that are **not** stamped per-product via `tagProducts()`, or you have a real-time inventory requirement that the prior whole-catalog inventory bust was satisfying).
+
+## Adoption notes
+
+- If you added new cached reads that surface product data, confirm they go through `tagProducts()` (or otherwise carry a `product-{numericId}` / `collection-{handle}` tag) — otherwise an edit will no longer bust them now that the broad `products` safety net is gone.
+- Inventory: if you need near-instant stock/availability updates, either keep availability on a live (uncached) read path, or re-add a scoped inventory branch that resolves `inventory_item_id` → product and fires that product's tags.
+- Parse-failure behavior for the products branch: with no generic tag to seed, an unparseable products payload now logs and invalidates nothing rather than busting the catalog. Real Shopify product webhooks always carry a parseable `id`/`admin_graphql_api_id`.
+- All-collections list: `getCollections` now stamps a `collection-{handle}` tag per entry (`tagCollections`), so collection **edits and deletes** bust it via the same per-collection tag the webhook fires — no broad `collections` tag needed. The only residual gap is collection **creation**: a brand-new collection isn't in the cached list, so its `collection-{handle}` tag isn't on that entry and it won't appear until cache expiry. This is acceptable for the stock consumers (`app/llms.txt`, the `list-collections` agent tool, build-time `generateStaticParams`); if you need instant create-visibility on a customer-facing collection index, put that read on a live/uncached path.
+- Collection deletes: invalidation keys off `payload.handle`. Shopify `collections/delete` payloads sometimes carry only a numeric `id`; collection reads are tagged by handle (no numeric collection tag exists), so a handle-less delete invalidates nothing and the deleted collection's PLP lingers until expiry. Add a numeric-`id`→handle resolution (or a numeric collection tag) if instant delete propagation matters.
+
+## Validation
+
+1. `pnpm --filter template lint`, `pnpm --filter docs build`.
+2. `curl -X POST http://localhost:3000/api/webhooks/shopify -H "x-shopify-topic: products/update" -d '{"handle":"speaker","admin_graphql_api_id":"gid://shopify/Product/123"}'` → `tagsInvalidated` is `["product-speaker","recommendations-speaker","product-123"]` (no `products`/`collections`).
+3. `curl -X POST http://localhost:3000/api/webhooks/shopify -H "x-shopify-topic: collections/update" -d '{"handle":"sale"}'` → `tagsInvalidated` is `["collection-sale"]` (no `products`, no `collections`, no `menus`).
+4. `curl -X POST http://localhost:3000/api/webhooks/shopify -H "x-shopify-topic: inventory_levels/update" -d '{}'` → `tagsInvalidated` is `[]`.
+5. Edit a single product, then a single collection, in Shopify Admin and confirm only the affected surfaces refresh while unrelated cached reads stay warm.


### PR DESCRIPTION
## What

The Shopify webhook handler (`app/api/webhooks/shopify/route.ts`) used to fire the broad `products`/`collections` cache tags on nearly every topic. Those tags wrap **every** list, search, and PDP read, so a single edit in Shopify Admin flushed the entire catalog cache. This PR scopes each branch to the minimum granular tags.

| Topic | Before | After |
| --- | --- | --- |
| `products/*` | `products`, `collections`, `product-{handle}`, `recommendations-{handle}` | `product-{handle}`, `product-{numericId}`, `recommendations-{handle}` |
| `collections/*` | `collections`, `products`, `menus`, `collection-{handle}` | `collection-{handle}` |
| `inventory_levels/*` | `products`, `collections` | _(branch removed)_ |
| `metaobjects/*` | unchanged | unchanged |

## Why it's safe

Granular invalidation is sufficient because the reads in `lib/shopify/operations/` stamp each aggregate cache entry with the granular tag of every item it contains:

- **Products** — `tagProducts()` stamps every list/search/collection/recommendation entry with each contained product's `product-{numericId}` tag, so one bust cascades to exactly the surfaces that display it.
- **Collections** — `getCollections` now stamps a `collection-{handle}` tag per entry (new `tagCollections()` helper, mirroring `tagProducts()`), so edits/deletes to existing collections still bust the all-collections list without the broad tag.

## Deliberate trade-offs (see rollout-log entry for full detail)

- **No `inventory_levels/*` branch.** The payload identifies an `inventory_item_id`/`location_id`, not a product, so it can't be scoped without an extra lookup — and busting the catalog on every stock tick wrecks hit rates. Availability propagates at cache expiry (or via live reads).
- **`menus` dropped from collections.** Menus are edited independently in Shopify Navigation and there's no menu webhook topic, so that cache already relied on expiry.
- **New collection creation** still lags the all-collections list until expiry (its tag wasn't present when the list was cached) — same inherent limitation a newly created product has in cached catalog lists. There is currently no customer-facing all-collections page consuming `getCollections` (only `llms.txt`, build-time `generateStaticParams`, and the agent tool), so this is not user-visible today.

## Docs

Updated `anatomy/webhooks.mdx` and `shopify/index.mdx` tag tables + rationale, and added a `template-rollout-log` entry so downstream storefronts can reason about adopting the change.

## Validation

- `pnpm --filter template lint` ✅
- `pnpm --filter docs build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)