### PR TITLE
fix(template): use cart mutation responses

### DIFF
--- a/apps/docs/content/docs/anatomy/cart.mdx
+++ b/apps/docs/content/docs/anatomy/cart.mdx
@@ -41,7 +41,7 @@ All cart mutations are defined in `lib/cart/action.ts` with `"use server"`:
 
 - `addToCartAction()` - adds line items and returns the updated cart
 - `updateCartQuantityAction()` - validates quantity (1–99) and updates the line
-- `removeFromCartAction()` - removes a line item and fetches the updated cart
+- `removeFromCartAction()` - removes a line item and returns the updated cart
 - `syncCartLocaleAction()` - updates buyer identity for locale and currency switching
 - `updateCartNoteAction()` - updates the cart note field
 - `buyNowAction()` - adds an item and returns the Shopify checkout URL
@@ -76,7 +76,7 @@ Below the items, a `RelatedProductsSection` shows product recommendations based 
 
 ## Shopify integration
 
-Cart operations in `lib/shopify/operations/cart.ts` use GraphQL mutations: `cartLinesAdd`, `cartLinesUpdate`, and `cartLinesRemove`. The cart ID is stored in a `shopify_cartId` HTTP-only cookie with a 7-day expiry. Every mutation calls `invalidateCartCache()` to ensure subsequent reads reflect the latest state.
+Cart operations in `lib/shopify/operations/cart.ts` use GraphQL mutations: `cartLinesAdd`, `cartLinesUpdate`, and `cartLinesRemove`. Each mutation returns the full cart through `CartFields`; the operation normalizes that response and the server action uses it directly without a follow-up `getCart()` query. The cart ID is stored in a `shopify_cartId` HTTP-only cookie with a 7-day expiry. Every mutation calls `invalidateCartCache()` to ensure subsequent reads reflect the latest state.
 
 The transform layer in `lib/shopify/transforms/cart.ts` converts Shopify's GraphQL response shape into a domain `Cart` type used throughout the application. This isolates the rest of the codebase from Shopify's API structure.
 

--- a/apps/template/lib/agent/tools/update-cart-item.ts
+++ b/apps/template/lib/agent/tools/update-cart-item.ts
@@ -8,16 +8,15 @@ import { getAgentContext } from "../server";
 export function updateCartItemTool() {
   return tool({
     description: `Update the quantity of an item in the cart.
-IMPORTANT: You must call getCart first to get the lineId and merchandiseId of the item to update.
+IMPORTANT: You must call getCart first to get the lineId of the item to update.
 Use the lineId from getCart results, not the product or variant ID.`,
     inputSchema: z.object({
       lineId: z
         .string()
         .describe("The cart line item ID from getCart results (e.g. 'gid://shopify/CartLine/...')"),
-      merchandiseId: z.string().describe("The merchandise/variant ID from getCart results"),
       quantity: z.number().min(1).max(99).describe("New quantity for the item"),
     }),
-    execute: async ({ lineId, merchandiseId, quantity }) => {
+    execute: async ({ lineId, quantity }) => {
       const { cart: cartId } = getAgentContext();
 
       if (!cartId) {
@@ -28,10 +27,7 @@ Use the lineId from getCart results, not the product or variant ID.`,
       }
 
       try {
-        const { cart: updatedCart } = await updateCart(
-          [{ id: lineId, merchandiseId, quantity }],
-          cartId,
-        );
+        const { cart: updatedCart } = await updateCart([{ id: lineId, quantity }], cartId);
 
         return {
           success: true,

--- a/apps/template/lib/cart/action.ts
+++ b/apps/template/lib/cart/action.ts
@@ -36,12 +36,11 @@ export async function removeFromCartAction(itemId: string): Promise<CartActionRe
   }
 
   try {
-    const { warnings } = await removeFromCart([itemId]);
-    const updatedCart = await getCart();
+    const { cart, warnings } = await removeFromCart([itemId]);
 
     return {
       success: true,
-      cart: updatedCart,
+      cart,
       warnings,
     };
   } catch (error) {
@@ -72,34 +71,11 @@ export async function updateCartQuantityAction(
   }
 
   try {
-    const currentCart = await getCart();
-    if (!currentCart) {
-      return {
-        success: false,
-        error: "Cart not found",
-      };
-    }
-
-    const item = currentCart.lines.find((line) => line.id === itemId);
-    if (!item) {
-      return {
-        success: false,
-        error: "Item not found in cart",
-      };
-    }
-
-    const { warnings } = await updateCart([
-      {
-        id: itemId,
-        merchandiseId: item.merchandise.id,
-        quantity,
-      },
-    ]);
-    const updatedCart = await getCart();
+    const { cart, warnings } = await updateCart([{ id: itemId, quantity }]);
 
     return {
       success: true,
-      cart: updatedCart,
+      cart,
       warnings,
     };
   } catch (error) {
@@ -130,12 +106,11 @@ export async function addToCartAction(
   }
 
   try {
-    const { warnings } = await addToCart([{ merchandiseId, quantity }]);
-    const updatedCart = await getCart();
+    const { cart, warnings } = await addToCart([{ merchandiseId, quantity }]);
 
     return {
       success: true,
-      cart: updatedCart,
+      cart,
       warnings,
     };
   } catch (error) {

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -335,7 +335,7 @@ export async function addToCart(
 }
 
 export async function updateCart(
-  lines: { id: string; merchandiseId: string; quantity: number }[],
+  lines: { id: string; quantity: number }[],
   cartIdOverride?: string,
 ): Promise<CartMutationResult> {
   const cartId = cartIdOverride || (await getCartIdFromCookie());
@@ -346,7 +346,7 @@ export async function updateCart(
   }>(CART_LINES_UPDATE_MUTATION, {
     variables: {
       cartId,
-      lines: lines.map((line) => ({ id: line.id, quantity: line.quantity })),
+      lines,
     },
   });
   assertStorefrontOk(response, "cartLinesUpdate");

--- a/packages/plugin/template-rollout-log/2026-06-25-cart-mutations-use-response.md
+++ b/packages/plugin/template-rollout-log/2026-06-25-cart-mutations-use-response.md
@@ -1,0 +1,39 @@
+---
+title: Cart mutations — use normalized mutation response
+changeKey: cart-mutations-use-response
+introducedOn: 2026-06-25
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/cart/action.ts
+  - apps/template/lib/shopify/operations/cart.ts
+  - apps/template/lib/agent/tools/update-cart-item.ts
+  - apps/docs/content/docs/anatomy/cart.mdx
+---
+
+## Summary
+
+Add, update, and remove server actions now use the normalized cart returned by their Shopify GraphQL mutation instead of issuing a follow-up `getCart()` query. Quantity updates also stop reading the cart before the mutation: `CartLineUpdateInput` only needs the cart line ID and quantity, so `updateCart()` and the shopping agent's update tool no longer accept an unused merchandise ID.
+
+## Why it matters
+
+- Add and remove actions use one Shopify request instead of two.
+- Quantity updates use one Shopify request instead of three.
+- The UI receives the same normalized `Cart` shape directly from the authoritative mutation response.
+
+## Apply when
+
+- Cart actions call `getCart()` after `addToCart()`, `updateCart()`, or `removeFromCart()`.
+- Quantity updates read the current cart only to recover a merchandise ID before calling `cartLinesUpdate`.
+
+## Safe to skip when
+
+- Custom mutation documents do not select the full cart fields required by the storefront.
+- A custom pre-mutation read performs business validation beyond recovering the line's merchandise ID.
+
+## Validation
+
+1. Run `pnpm --filter template lint` and `pnpm --filter template build`.
+2. Add, update, and remove a cart line; confirm each action returns the updated cart and issues only its mutation request to Shopify.


### PR DESCRIPTION
## What changed

- return the normalized cart from add, update, and remove mutations directly to server-action callers
- remove the pre-mutation cart read and unused merchandise ID from quantity updates
- align the shopping agent tool, cart documentation, and downstream rollout guidance

## Why

The GraphQL mutations already select the complete `CartFields` fragment and normalize the returned cart. The server actions discarded that cart and fetched it again; quantity updates also fetched before mutating solely to recover a merchandise ID that was never sent to Shopify.

This reduces add and remove from two Shopify requests to one, and quantity updates from three requests to one.

## Validation

- `pnpm --filter template lint`
- `pnpm --filter template build`
- `pnpm --filter docs lint`
