### PR TITLE
fix(template): three downstream-sourced fixes (filters, lightbox, nav)

### DIFF
--- a/apps/template/components/nav/index.tsx
+++ b/apps/template/components/nav/index.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Suspense } from "react";
 
+import { Container } from "@/components/ui/container";
 import { isAuthEnabled } from "@/lib/auth";
 import { navItems, siteConfig } from "@/lib/config";
 
@@ -18,7 +19,7 @@ export async function Nav({ locale }: { locale: string }) {
       className="sticky top-0 z-30 w-full bg-background pt-[env(safe-area-inset-top,0px)] transition-shadow duration-250"
       id="nav-outer"
     >
-      <div className="mx-auto flex h-16 items-center gap-2.5 md:gap-5 px-5 lg:px-10">
+      <Container className="flex h-16 items-center gap-2.5 md:gap-5">
         <MobileMenu items={items} />
 
         <Link className="flex items-center shrink-0" href="/">
@@ -38,7 +39,7 @@ export async function Nav({ locale }: { locale: string }) {
             <CartIcon />
           </Suspense>
         </div>
-      </div>
+      </Container>
     </nav>
   );
 }

--- a/apps/template/components/product-detail/lightbox.tsx
+++ b/apps/template/components/product-detail/lightbox.tsx
@@ -79,7 +79,11 @@ export function Lightbox({ label, children }: { label: string; children: ReactNo
 export function LightboxTrigger({ item, children }: { item: MediaItem; children: ReactNode }) {
   const open = useContext(LightboxContext);
   return (
-    <button type="button" onClick={() => open?.(item)} className="h-full w-full cursor-zoom-in">
+    <button
+      type="button"
+      onClick={() => open?.(item)}
+      className="relative h-full w-full cursor-zoom-in"
+    >
       {children}
     </button>
   );

--- a/apps/template/lib/shopify/transforms/filters.ts
+++ b/apps/template/lib/shopify/transforms/filters.ts
@@ -143,6 +143,15 @@ function extractPriceRange(priceFilter: ShopifyFilter): PriceRange {
   return { min: 0, max: 1000 };
 }
 
+function isFilterValueSelected(
+  activeFilters: Record<string, string | string[] | undefined>,
+  paramKey: string,
+  value: string,
+): boolean {
+  const current = activeFilters[paramKey];
+  return Array.isArray(current) ? current.includes(value) : current === value;
+}
+
 export function transformShopifyFilters(
   shopifyFilters: ShopifyFilter[],
   options: TransformFiltersOptions = {},
@@ -162,16 +171,23 @@ export function transformShopifyFilters(
     filters = filters
       .map((filter) => ({
         ...filter,
-        values: filter.values.filter((value) => {
-          const currentValue = activeFilters[filter.paramKey];
-          const isSelected = Array.isArray(currentValue)
-            ? currentValue.includes(value.value)
-            : currentValue === value.value;
-          return value.count > 0 || isSelected;
-        }),
+        values: filter.values.filter(
+          (value) =>
+            value.count > 0 || isFilterValueSelected(activeFilters, filter.paramKey, value.value),
+        ),
       }))
       .filter((filter) => filter.values.length > 0);
   }
+
+  // Drop facet groups that resolve to a single choice — unless that lone value is
+  // active, so a selected filter never silently vanishes from the UI.
+  filters = filters.filter(
+    (filter) =>
+      filter.values.length > 1 ||
+      filter.values.some((value) =>
+        isFilterValueSelected(activeFilters, filter.paramKey, value.value),
+      ),
+  );
 
   return {
     filters,

--- a/packages/plugin/template-rollout-log/2026-06-29-nav-row-content-max-width.md
+++ b/packages/plugin/template-rollout-log/2026-06-29-nav-row-content-max-width.md
@@ -1,0 +1,37 @@
+---
+title: Cap the nav row to the content max-width via the shared Container
+changeKey: nav-row-content-max-width
+introducedOn: 2026-06-29
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/nav/index.tsx
+---
+
+## Summary
+
+The nav's inner row hand-rolled `mx-auto … px-5 lg:px-10` but set no max-width, so on viewports wider than the content cap (`max-w-[96rem]`) the nav items ran to the screen edges while page content and the announcement bar stayed centered. Wrapped the inner row in the shared `Container` primitive (`mx-auto w-full max-w-[96rem] px-5 lg:px-10`) instead, keeping the outer `<nav>` full-bleed so its background still spans the viewport.
+
+## Why it matters
+
+Every other top-level section (page `Container`, announcement bar) is capped at `max-w-[96rem]` and centered. The uncapped nav drifted out of alignment with that column on large/ultrawide displays — the logo and cart icon sat hard against the viewport edges instead of lining up with the page content below. Using `Container` ties the nav to the same token, so a future change to the content cap moves the nav with it.
+
+## Why via Container, not a literal max-width
+
+`Container` is the single source of truth for the content column (`mx-auto w-full max-w-[96rem] px-5 lg:px-10`). Re-using it keeps the nav from re-declaring the cap and padding by hand, which is exactly the drift that caused the bug.
+
+## Apply when
+
+- The storefront still uses the template nav whose inner row applies `mx-auto`/padding without a max-width.
+
+## Safe to skip when
+
+- The nav was rewritten (e.g. centered-logo + mega menu) with its own width strategy, or the storefront intentionally wants a full-bleed nav row.
+
+## Validation
+
+1. `pnpm --filter template lint` and `pnpm --filter template exec tsc --noEmit`.
+2. At a >1536px viewport, the nav's left/right content edges line up exactly with a page `Container` and the announcement bar.
+3. The nav background still spans the full viewport width (only the content is constrained).

--- a/packages/plugin/template-rollout-log/2026-06-29-pdp-lightbox-trigger-relative.md
+++ b/packages/plugin/template-rollout-log/2026-06-29-pdp-lightbox-trigger-relative.md
@@ -1,0 +1,32 @@
+---
+title: PDP lightbox trigger — make the button a positioning context for its fill image
+changeKey: pdp-lightbox-trigger-relative
+introducedOn: 2026-06-29
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/components/product-detail/lightbox.tsx
+---
+
+## Summary
+
+`LightboxTrigger` wraps a `fill` `next/image` in a `<button>` but the button lacked `relative`. Added `relative` to its className (`relative h-full w-full cursor-zoom-in`).
+
+## Why it matters
+
+A `fill` image is `position: absolute` and resolves against its nearest positioned ancestor. Without `relative` on the button, the image (and any absolutely-positioned affordance a downstream adds inside the trigger — e.g. a zoom icon) positions against an outer ancestor instead of the button itself. In the shipped template the grid cell happens to be `relative` and the same size as the button, so the image still fills correctly — but the button is the element that *should* own that context. This makes the trigger self-contained so a zoom badge or overlay can be dropped in without breaking on fill-image layouts.
+
+## Apply when
+
+- The storefront still uses `components/product-detail/lightbox.tsx` with `LightboxTrigger` wrapping a `fill` image.
+
+## Safe to skip when
+
+- The trigger has been replaced, or already wraps a non-fill (intrinsic-size) image in its own positioned container.
+
+## Validation
+
+1. `pnpm --filter template lint` and `pnpm --filter template exec tsc --noEmit`.
+2. On a desktop PDP, the gallery images still fill their grid cells and open the lightbox on click; an absolutely-positioned child of the trigger now anchors to the image bounds.

--- a/packages/plugin/template-rollout-log/2026-06-29-plp-drop-single-value-filter-groups.md
+++ b/packages/plugin/template-rollout-log/2026-06-29-plp-drop-single-value-filter-groups.md
@@ -1,0 +1,38 @@
+---
+title: Drop facet groups that resolve to a single value (filter transform)
+changeKey: plp-drop-single-value-filter-groups
+introducedOn: 2026-06-29
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - apps/template/lib/shopify/transforms/filters.ts
+---
+
+## Summary
+
+`transformShopifyFilters` pruned zero-count *values* but still emitted facet *groups* that ended up with a single value. A one-option group offers no real choice — it renders as dead UI in the filter sidebar.
+
+Two edits in `lib/shopify/transforms/filters.ts`:
+
+1. Extracted the selection check into a small `isFilterValueSelected(activeFilters, paramKey, value)` helper, and reused it inside the existing zero-count value-pruning step (it previously inlined the same `Array.isArray(...) ? includes : ===` logic).
+2. Added a final group-level filter after value pruning that drops any group with `values.length <= 1` **unless** its lone value is currently selected, so an active filter never silently disappears.
+
+## Why it matters
+
+Shopify returns facets like vendor/type/availability whose value list, after hiding zero-count entries for the current result set, often collapses to one. Rendering that group is pure clutter — the shopper can't narrow anything with it. Dropping it tidies the sidebar while the selected-value guard keeps active filters (and their clear-badge) visible even when they're the only remaining value in their group.
+
+## Apply when
+
+- The storefront uses `transformShopifyFilters` to build its collection/search facet UI (both `getCollectionProducts` and search pass `activeFilters`).
+
+## Safe to skip when
+
+- The storefront renders filters from a different transform, or deliberately wants to show single-value groups (e.g. to display the only available vendor as a static label).
+
+## Validation
+
+1. `pnpm --filter template lint` and `pnpm --filter template exec tsc --noEmit`.
+2. Open a collection where a facet resolves to one value — that group no longer renders.
+3. Select that lone value via URL param (e.g. `?filter.p.vendor=Acme`) — the group stays visible and its active badge is shown.


### PR DESCRIPTION
Three fixes surfaced while building a storefront on top of this template. Each is committed separately, with a matching `template-rollout-log` entry so downstream storefronts can reason about adopting them individually.

## Fixes

### 1. Drop single-value facet groups (`lib/shopify/transforms/filters.ts`)
A facet group whose value list collapses to one option offers no real choice — it rendered as dead UI in the filter sidebar. `transformShopifyFilters` now drops any group with ≤1 value after value-pruning, **unless** its lone value is currently selected (so an active filter never silently vanishes). Extracted the selection check into an `isFilterValueSelected()` helper and reused it in the existing zero-count pruning step.

### 2. Lightbox trigger positioning context (`components/product-detail/lightbox.tsx`)
`LightboxTrigger` wraps a `fill` `next/image` but the button lacked `relative`, so the absolutely-positioned image (and any overlay a downstream drops inside the trigger, e.g. a zoom badge) resolved against an outer ancestor instead of the button. Added `relative`.

### 3. Cap nav row to content max-width (`components/nav/index.tsx`)
The nav's inner row applied `mx-auto` + padding but no max-width, so on viewports wider than the content cap (`max-w-[96rem]`) the nav items ran to the screen edges while page content and the announcement bar stayed centered. Wrapped the inner row in the shared `Container` primitive; the outer `<nav>` stays full-bleed so its background still spans the viewport.

## Not included: PDP image `sizes` (a 4th proposed fix)
The downstream notes also proposed widening PDP gallery `sizes` from `100vw`. **Skipped — the bug doesn't exist in this template.** Here `ProductMedia` splits desktop (`Grid`, `hidden lg:block`) from mobile (`Carousel`, `lg:hidden`):
- The desktop `GridItem` already ships `sizes="(min-width: 1024px) 25vw, 50vw"`.
- The only `100vw` values are on the mobile-only carousel, where images render edge-to-edge and `100vw` is correct.

The literal change would only add a `25vw` branch that never triggers (carousel is `lg:hidden`).

## Validation
- `pnpm --filter template format` / `lint` (oxlint + oxfmt --check) — pass
- `pnpm --filter template exec tsc --noEmit` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)