### PR TITLE
feat(template): add dev:portless command, remove dev:https

### DIFF
--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -75,6 +75,27 @@ bun dev
 
 Your store is now running at [localhost:3000](http://localhost:3000).
 
+### Run over HTTPS at a custom domain (optional)
+
+Some flows behave differently over plain `http://localhost` - Shopify customer-account and OAuth callbacks and `Secure` cookies expect a real HTTPS origin. The template ships a `dev:portless` script that runs the dev server behind [portless](https://portless.sh), a local reverse proxy that serves the app over trusted HTTPS at `https://shop.localhost` with no port in the URL.
+
+Install portless globally (requires Node 24+):
+
+```bash
+npm install -g portless
+```
+
+Then start the dev server through it, using the run command for your package manager:
+
+```bash
+pnpm dev:portless
+npm run dev:portless
+yarn dev:portless
+bun dev:portless
+```
+
+Your store is now running at [shop.localhost](https://shop.localhost). The first run asks for `sudo` once to bind port 443 and trusts a local certificate authority; later runs are silent. To serve a different subdomain, change the `shop` argument in the `dev:portless` script.
+
 ## Next steps
 
 <Cards>

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -7,7 +7,7 @@
     "codegen": "graphql-codegen",
     "codegen:watch": "graphql-codegen --watch",
     "dev": "graphql-codegen || true && next dev",
-    "dev:https": "graphql-codegen || true && next dev --experimental-https",
+    "dev:portless": "graphql-codegen || true && portless shop next dev",
     "format": "oxfmt",
     "lint": "oxlint . && oxfmt --check",
     "start": "next start"

--- a/packages/plugin/template-rollout-log/2026-07-01-dev-portless-command.md
+++ b/packages/plugin/template-rollout-log/2026-07-01-dev-portless-command.md
@@ -1,0 +1,47 @@
+---
+title: Add a dev:portless script for HTTPS local dev at shop.localhost
+changeKey: dev-portless-command
+introducedOn: 2026-07-01
+changeType: enhancement
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/package.json
+---
+
+## Summary
+
+Added a `dev:portless` script that runs the Next dev server behind [portless](https://portless.sh), a local reverse proxy that serves the app over HTTPS/HTTP2 at a `*.localhost` domain with a trusted local CA. The script mirrors `dev` (`graphql-codegen || true && …`) and wraps `next dev` with `portless shop`, where `shop` is the app name that becomes the subdomain. The store runs at a clean **`https://shop.localhost`** (no port).
+
+portless is intentionally **not** a project dependency — the script resolves against a globally installed `portless` (`npm install -g portless`, Node ≥24). This keeps a machine-level dev tool out of the storefront's dependency tree and lockfile. The install-and-run steps are documented in the getting-started docs (`apps/docs/content/docs/getting-started/index.mdx`, "Run over HTTPS at a custom domain").
+
+The proxy listens on the default HTTPS port 443 deliberately: a portless URL is only port-free when the proxy owns 443, since browsers omit the port only when it matches the scheme default. No `next.config.ts` change is needed — Next 16 already allows `**.localhost` cross-origin dev requests by default (matched on hostname), so the `shop` subdomain is permitted out of the box.
+
+The previous `dev:https` script (`next dev --experimental-https`) was removed in the same change: portless supersedes it, giving trusted certs and a stable hostname instead of a self-signed cert on `https://localhost:3000`.
+
+## Why it matters
+
+Some workflows need a real HTTPS origin locally — Shopify OAuth/Customer Account callbacks, `Secure` cookies, better-auth trusted origins, and OG/absolute-URL testing all behave differently over `http://localhost:3000`. portless gives a stable, trusted `https://shop.localhost` without `next dev --experimental-https`'s self-signed-cert friction, and a memorable hostname across restarts (no shifting ports).
+
+## Note: port 443 needs one-time elevation
+
+portless runs a single shared proxy daemon for all `*.localhost` apps. Binding 443 requires elevation, so the first start prompts for `sudo` once; the daemon then stays up and later `dev:portless` runs just attach to it — no repeated prompts. To avoid the prompt entirely, run `portless service install` once to start the proxy on 443 at OS startup. The daemon persists its port in `~/.portless/proxy.port`; if it was ever started on a non-default port, `portless proxy stop` clears that file so the next start falls back to 443.
+
+## Apply when
+
+- The storefront wants a trusted, port-free HTTPS local origin, especially when exercising auth callbacks or secure-cookie flows.
+
+## Adopt with changes
+
+- Rename `shop` in the script to the store's own name (e.g. `acme` → `https://acme.localhost`), or drop the name arg and let portless infer it from `package.json`.
+
+## Safe to skip when
+
+- The storefront is happy with plain `pnpm dev` (HTTP), or standardizes on a different local-proxy tool. The script is inert without a global `portless` on the PATH, so leaving it in place is harmless even if unused. If the storefront still relies on `dev:https`, keep it rather than adopting the removal.
+
+## Validation
+
+1. `npm install -g portless`, then `pnpm dev:portless` from the storefront, then open `https://shop.localhost` — page loads over HTTPS with no port in the URL and no cross-origin dev-asset warnings in the terminal, and HMR reconnects on edit.
+2. First run prompts once for `sudo` (bind 443) and once to trust the local CA (`portless trust`); subsequent runs are silent.
+3. `pnpm --filter template lint` and a production `build` are unaffected.


### PR DESCRIPTION
## What

Replaces the template's `dev:https` script with `dev:portless`, which runs the Next dev server behind [portless](https://portless.sh) — a local reverse proxy that serves the storefront over trusted HTTPS at **`https://shop.localhost`** (no port in the URL).

```diff
- "dev:https":     "graphql-codegen || true && next dev --experimental-https",
+ "dev:portless":  "graphql-codegen || true && portless shop next dev",
```

## Why

Some flows behave differently over plain `http://localhost:3000` — Shopify Customer Account / OAuth callbacks, `Secure` cookies, and better-auth trusted origins all expect a real HTTPS origin. portless gives a stable, trusted `https://shop.localhost` without `next dev --experimental-https`'s self-signed-cert friction, and a memorable hostname across restarts. It supersedes `dev:https`, so that script is removed.

## Notes

- **portless is intentionally not a dependency.** The script resolves against a global install (`npm i -g portless`, Node ≥24), keeping a machine-level dev tool out of the storefront's dependency tree and lockfile. As a result there's no `pnpm-lock.yaml` change.
- **No `next.config.ts` change needed.** Next 16 already allows `**.localhost` cross-origin dev requests by default (matched on hostname), so `shop.localhost` on port 443 works out of the box.
- **Port 443 is deliberate** — a portless URL is only port-free when the proxy owns the scheme-default port. First run prompts once for `sudo` to bind 443 and to trust a local CA; later runs are silent (`portless service install` avoids the prompt entirely).

## Docs

Documented the setup in the getting-started guide (Step 4 → "Run over HTTPS at a custom domain") and added a `template-rollout-log` entry so downstream storefronts can reason about adopting the command and the `dev:https` removal.

## Test plan

- [ ] `npm i -g portless` then `pnpm dev:portless` from `apps/template` → opens `https://shop.localhost` over trusted HTTPS, HMR reconnects on edit
- [x] `pnpm --filter template lint` (oxlint + oxfmt) passes
- [x] `pnpm --filter docs lint` (oxlint + oxfmt + doc paths) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)