### PR TITLE
chore(template): remove experimental inlineCss from next.config

### DIFF
--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -35,9 +35,6 @@ function assertRequiredEnv() {
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
-  experimental: {
-    inlineCss: true,
-  },
   images: {
     deviceSizes: [1080, 1920],
     imageSizes: [],

--- a/packages/plugin/template-rollout-log/2026-07-02-remove-experimental-inline-css.md
+++ b/packages/plugin/template-rollout-log/2026-07-02-remove-experimental-inline-css.md
@@ -1,0 +1,32 @@
+---
+title: Remove experimental inlineCss from next.config
+changeKey: remove-experimental-inline-css
+introducedInVersion: 0.1.0
+introducedOn: 2026-07-02
+changeType: refactor
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/next.config.ts
+---
+
+## Summary
+
+Dropped the `experimental.inlineCss: true` flag from the template's `next.config.ts`. The `experimental` block held only that key, so the whole block is gone and the template now uses Next's default CSS delivery (external `<link>` stylesheets) instead of inlining CSS into the document `<style>`.
+
+## Why it matters
+
+`inlineCss` is an experimental Next flag whose behavior and tradeoffs can shift between releases. Inlining removes a render-blocking request but repeats CSS in every HTML payload (uncacheable across navigations) and grows the streamed document. Reverting to the default keeps the template on stable, well-understood CSS delivery and off an experimental knob.
+
+## Apply when
+
+Adopt this if your storefront tracks the template's default config and you want to stay off experimental Next flags, or you have seen duplicated/inlined CSS bloat in HTML responses.
+
+## Safe to skip when
+
+Skip if you deliberately enabled `experimental.inlineCss` for a measured first-paint win on your storefront and want to keep it. This is a conscious performance tradeoff, not a correctness fix.
+
+## Validation
+
+Run `pnpm build` in `apps/template` and confirm the build succeeds. Load a page and confirm CSS now arrives via `<link rel="stylesheet">` in the head rather than inlined `<style>` blocks.


### PR DESCRIPTION
## What

Removes the `experimental` block from the template's `next.config.ts`. It held only `inlineCss: true`, so the whole block is gone and the template reverts to Next's default CSS delivery (external `<link>` stylesheets) rather than inlining CSS into the document.

```diff
 const nextConfig: NextConfig = {
   cacheComponents: true,
-  experimental: {
-    inlineCss: true,
-  },
   images: {
```

## Why

`inlineCss` is an experimental Next flag with shifting behavior across releases. Inlining trades a render-blocking request for CSS duplicated in every (uncacheable) HTML payload. Reverting keeps the template on stable, well-understood CSS delivery and off an experimental knob. Downstream storefronts that deliberately want the inlining tradeoff can keep it.

## Notes

- No docs reference `inlineCss` (grepped `.ts/.tsx/.md/.mdx/.json`), so no docs update needed.
- Added a rollout-log entry (`packages/plugin/template-rollout-log/2026-07-02-remove-experimental-inline-css.md`) marked `defaultAction: review` since this is a conscious performance tradeoff, not a correctness fix.
- `oxlint next.config.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)