### PR TITLE
feat(plugin): consolidate upgrade flow into update-shop skill

### DIFF
--- a/apps/docs/content/docs/getting-started/extending-with-agents.mdx
+++ b/apps/docs/content/docs/getting-started/extending-with-agents.mdx
@@ -37,7 +37,7 @@ npx plugins add vercel/vercel-plugin --scope project --yes
 npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 ```
 
-For upgrade work, the `vercel-shop` plugin also carries a template rollout log so agents can reason about change-level updates instead of guessing from a single scaffold version. New scaffolds record bootstrap metadata so agents can compare rollout entries against when a project was created.
+For upgrade work, use the [`update-shop` skill](/docs/skills/update-shop). The `vercel-shop` plugin carries a template rollout log so agents can reason about change-level updates instead of guessing from a single scaffold version. New scaffolds record bootstrap metadata so agents can compare rollout entries against when a project was created.
 
 To initialize a storefront from an agent, use the `init-vercel-shop` skill and provide an explicit target directory. The skill delegates filesystem changes to `create-vercel-shop`, verifies the generated project, and can use Shopify CLI to connect an existing store or fall back to the Headless channel.
 

--- a/apps/docs/content/docs/skills/index.mdx
+++ b/apps/docs/content/docs/skills/index.mdx
@@ -12,6 +12,9 @@ Skills are agent-ready guides that transform your storefront. Run them with Clau
   <Card title="Build with Vercel Shop" href="/docs/skills/build-shop">
     Build or adapt Shopify storefronts with source-backed Vercel Shop patterns.
   </Card>
+  <Card title="Update Vercel Shop" href="/docs/skills/update-shop">
+    Audit drift and roll newer template changes into an existing storefront.
+  </Card>
   <Card title="Shopify GraphQL Integration" href="/docs/skills/shopify-graphql-reference">
     Apply Vercel Shop conventions after Shopify AI Toolkit validates an operation.
   </Card>

--- a/apps/docs/content/docs/skills/meta.json
+++ b/apps/docs/content/docs/skills/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "build-shop",
+    "update-shop",
     "shopify-graphql-reference",
     "enable-analytics",
     "enable-i18n",

--- a/apps/docs/content/docs/skills/update-shop.mdx
+++ b/apps/docs/content/docs/skills/update-shop.mdx
@@ -1,0 +1,108 @@
+---
+title: Update Vercel Shop
+description: Audit drift, plan a change-level upgrade, and apply newer template updates to an existing storefront.
+type: guide
+---
+
+## How to use
+
+```bash
+/vercel-shop:update-shop
+```
+
+The skill audits how far a storefront has drifted from the current template, plans an upgrade from the template rollout log entry by entry, and — when asked to apply — carries selected changes into the project with per-entry validation, recording decisions so future runs stay incremental.
+
+<div className="pb-6" />
+
+{/* BEGIN SKILL CONTENT: update-shop */}
+
+# Update Vercel Shop
+
+Bring an existing Vercel Shop project up to date with the template by reasoning about individual rollout entries, never by diffing against a template version. Downstream storefronts often adopt only part of the template, so every decision must be validated against the current codebase.
+
+## Pick a mode
+
+Infer the mode from the user's request:
+
+- **Audit** — report how far the project has drifted. Read-only; stop after the audit phase.
+- **Plan** — produce a change-level upgrade plan. Read-only; stop after the plan phase.
+- **Apply** — plan, confirm the selection with the user, then apply and validate. Use this when the user asks to "update" or "upgrade" the shop.
+
+## Read these inputs
+
+1. `.vercel-shop/bootstrap.json` in the project root — original `templateVersion` and `scaffoldedAt`
+2. `.vercel-shop/rollout-state.json` in the project root — decisions recorded by earlier runs of this skill (may not exist)
+3. `template-version.json` from this plugin
+4. Every markdown entry in `template-rollout-log/` from this plugin except `README.md`
+5. `AGENTS.md` and `.claude/settings.json` in the project if present
+6. The current project structure and any files named by matching rollout entries
+
+If `.vercel-shop/bootstrap.json` is missing, say the project predates plugin bootstrap metadata and continue with a best-effort heuristic audit.
+
+## Phase 1 — audit
+
+Compare the scaffold metadata against the current recommended template version and check for structural drift:
+
+- missing `.vercel-shop/bootstrap.json`
+- missing `AGENTS.md`
+- missing project-scoped plugin config in `.claude/settings.json`
+- legacy local skill files such as `.agents/skills/` or a legacy `.claude/skills` symlink
+- obvious divergence from the expected Vercel Shop structure such as missing `lib/shopify/` or `components/`
+
+Report the original scaffold version, the scaffold timestamp, the current recommended template version, and a short note on overall drift. If the scaffold version matches the current version, say so explicitly. In audit mode, stop here.
+
+## Phase 2 — plan
+
+Build the candidate list from the rollout log:
+
+1. If bootstrap metadata includes `scaffoldedAt`, treat entries with a newer `introducedOn` as the primary candidates. Versions are only hints.
+2. Add older entries that still look applicable from the current project state.
+3. Drop entries that `.vercel-shop/rollout-state.json` already records as adopted, skipped, or not applicable — unless the user asks to revisit them.
+
+For each remaining entry, decide one of:
+
+- **Adopt now** — clearly applicable and mechanical enough to apply confidently
+- **Review manually** — applicable but touches heavily customized code
+- **Already present** — the project has the change (adopted independently or scaffolded with it)
+- **Not applicable** — the entry's `appliesTo` or preconditions don't match this project
+
+Validate each decision against the current codebase. Do not assume a change is missing just because the scaffold is old, and do not invent upgrade work when no entries apply — say so explicitly. Call out uncertainty when the project has heavily diverged from template conventions.
+
+Present the plan grouped by decision. In plan mode, stop here and do not edit files.
+
+## Phase 3 — apply
+
+Confirm with the user which entries to apply before editing anything. Then, for each selected entry, one at a time:
+
+1. Re-read the entry's Summary, `paths`, and Apply when / Safe to skip when sections.
+2. Apply the change in the project's own idiom — re-implement the behavior described by the entry rather than copying template files over customized code. Use the entry's `relatedSkills` when listed.
+3. Run the entry's Validation steps before moving to the next entry.
+4. Keep each entry's edits an isolated, reviewable unit. If the project uses git and the user wants commits, suggest one commit per `changeKey`.
+
+If an entry's validation fails, stop, report the failure, and ask whether to fix forward, skip the entry, or revert its edits before continuing.
+
+## Phase 4 — record and report
+
+Record every decision in `.vercel-shop/rollout-state.json` so future runs don't re-litigate settled entries. Keep decisions keyed by `changeKey`:
+
+```json
+{
+  "decisions": {
+    "storefront-typed-client": {
+      "decision": "adopted",
+      "decidedOn": "2026-07-06"
+    },
+    "pdp-metafields-specs": {
+      "decision": "skipped",
+      "decidedOn": "2026-07-06",
+      "note": "custom PDP replaced the specs section"
+    }
+  }
+}
+```
+
+Use `adopted`, `skipped`, `not-applicable`, or `already-present` as decision values. Do not modify `.vercel-shop/bootstrap.json` — `scaffoldedAt` must keep describing the original scaffold.
+
+Finish with a concise report: what was applied, what was skipped and why, validation results, and any entries deferred for manual review.
+
+{/* END SKILL CONTENT: update-shop */}

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -192,6 +192,7 @@ If the `vercel-shop` plugin is installed (see "Recommended Project Plugins" abov
 - Navigation menus: `/vercel-shop:enable-shopify-menus`
 - Analytics: `/vercel-shop:enable-analytics`
 - Storefront architecture, commerce behavior, and rendering performance: `/vercel-shop:build-shop`
+- Keeping the storefront current with template changes: `/vercel-shop:update-shop`
 
 These are agent-side conveniences. The template runs and deploys without them.
 

--- a/packages/plugin/commands/vercel-shop-check-drift.md
+++ b/packages/plugin/commands/vercel-shop-check-drift.md
@@ -1,44 +1,7 @@
 ---
-description: Audit an existing Vercel Shop project against the current recommended template version without modifying files.
+description: Compatibility alias for auditing Vercel Shop template drift.
 ---
 
 # Check Vercel Shop drift
 
-Use this command in an existing Vercel Shop project when the user wants to know how far the app has drifted from the current recommended template version.
-
-## Read these inputs
-
-1. `.vercel-shop/bootstrap.json` in the project root
-2. `template-version.json` from this plugin
-3. `AGENTS.md`
-4. `.claude/settings.json` if present
-
-## Audit goals
-
-Compare the bootstrapped template version against the current recommended template version that ships with this plugin. This is a read-only audit.
-
-## Report format
-
-Return a concise audit with:
-
-- original scaffold version
-- current recommended template version
-- version gap status
-- whether the project still has the expected plugin setup
-- whether the project still follows core Vercel Shop conventions
-- next recommended follow-up actions
-
-## Drift indicators to check
-
-- missing `.vercel-shop/bootstrap.json`
-- missing `AGENTS.md`
-- missing project-scoped plugin config in `.claude/settings.json`
-- legacy local skill files such as `.agents/skills/`
-- legacy `.claude/skills` symlink
-- obvious divergence from expected Vercel Shop structure such as missing `lib/shopify/` or `components/`
-
-## Important behavior
-
-- Do not edit files.
-- If `.vercel-shop/bootstrap.json` is missing, say that the project predates plugin bootstrap metadata and continue with a best-effort heuristic audit.
-- If the original scaffold version matches the current recommended version, say so explicitly.
+This command remains available for compatibility. Load and follow the `update-shop` skill in audit mode; it is the source of truth for the drift audit.

--- a/packages/plugin/commands/vercel-shop-plan-upgrade.md
+++ b/packages/plugin/commands/vercel-shop-plan-upgrade.md
@@ -1,54 +1,7 @@
 ---
-description: Plan which template updates should be rolled into an existing Vercel Shop project by combining scaffold metadata, the template rollout log, and the current project state.
+description: Compatibility alias for planning a Vercel Shop template upgrade.
 ---
 
 # Plan a Vercel Shop upgrade
 
-Use this command in an existing Vercel Shop project when the user wants to know which template updates are worth carrying forward into a customized storefront.
-
-## Read these inputs
-
-1. `.vercel-shop/bootstrap.json` in the project root if it exists
-2. `template-version.json` from this plugin
-3. every markdown entry in `template-rollout-log/` from this plugin except `README.md`
-4. `AGENTS.md`
-5. `.claude/settings.json` if present
-6. the current project structure and any obviously relevant files mentioned by matching rollout entries
-
-## Core rule
-
-Do not treat the template version as a complete migration plan. Use the rollout log to reason about individual changes because downstream projects may intentionally adopt only some of them. If bootstrap metadata includes `scaffoldedAt`, use that timestamp as the primary hint for which rollout entries are likely new to the project.
-
-## What to do
-
-1. Identify the original scaffold version if bootstrap metadata exists.
-2. Identify the scaffold timestamp if bootstrap metadata includes `scaffoldedAt`.
-3. Read the rollout log entries that are likely newer than the project based on `scaffoldedAt`, file dates, or version hints, plus any older entries that still look applicable from the current project state.
-4. For each relevant entry, decide one of:
-   - adopt now
-   - review manually
-   - not applicable
-   - already present
-5. Validate each decision against the current codebase. Do not assume a change is missing just because the version is old.
-6. Call out uncertainty when a project has heavily diverged from template conventions.
-
-## Report format
-
-Return a concise upgrade plan with:
-
-- original scaffold version if known
-- scaffold timestamp if known
-- current recommended template version
-- a short note on overall drift
-- `Adopt now` entries
-- `Review manually` entries
-- `Already present` entries
-- `Not applicable` entries
-- follow-up commands or skills to use for the selected work
-
-## Important behavior
-
-- This is a planning pass. Do not edit files unless the user explicitly asks you to apply selected updates.
-- Prefer rollout log evidence over broad version assumptions.
-- If `.vercel-shop/bootstrap.json` is missing, say the project predates bootstrap metadata and continue with a best-effort audit.
-- If the rollout log has no applicable entries, say so explicitly instead of inventing upgrade work.
+This command remains available for compatibility. Load and follow the `update-shop` skill in plan mode; it is the source of truth for change-level upgrade planning.

--- a/packages/plugin/skills/update-shop/SKILL.md
+++ b/packages/plugin/skills/update-shop/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: update-shop
+description: Update an existing Vercel Shop storefront with newer template changes. Use when the user wants to check drift, plan an upgrade, or apply template updates to a project scaffolded from Vercel Shop.
+---
+
+# Update Vercel Shop
+
+Bring an existing Vercel Shop project up to date with the template by reasoning about individual rollout entries, never by diffing against a template version. Downstream storefronts often adopt only part of the template, so every decision must be validated against the current codebase.
+
+## Pick a mode
+
+Infer the mode from the user's request:
+
+- **Audit** — report how far the project has drifted. Read-only; stop after the audit phase.
+- **Plan** — produce a change-level upgrade plan. Read-only; stop after the plan phase.
+- **Apply** — plan, confirm the selection with the user, then apply and validate. Use this when the user asks to "update" or "upgrade" the shop.
+
+## Read these inputs
+
+1. `.vercel-shop/bootstrap.json` in the project root — original `templateVersion` and `scaffoldedAt`
+2. `.vercel-shop/rollout-state.json` in the project root — decisions recorded by earlier runs of this skill (may not exist)
+3. `template-version.json` from this plugin
+4. Every markdown entry in `template-rollout-log/` from this plugin except `README.md`
+5. `AGENTS.md` and `.claude/settings.json` in the project if present
+6. The current project structure and any files named by matching rollout entries
+
+If `.vercel-shop/bootstrap.json` is missing, say the project predates plugin bootstrap metadata and continue with a best-effort heuristic audit.
+
+## Phase 1 — audit
+
+Compare the scaffold metadata against the current recommended template version and check for structural drift:
+
+- missing `.vercel-shop/bootstrap.json`
+- missing `AGENTS.md`
+- missing project-scoped plugin config in `.claude/settings.json`
+- legacy local skill files such as `.agents/skills/` or a legacy `.claude/skills` symlink
+- obvious divergence from the expected Vercel Shop structure such as missing `lib/shopify/` or `components/`
+
+Report the original scaffold version, the scaffold timestamp, the current recommended template version, and a short note on overall drift. If the scaffold version matches the current version, say so explicitly. In audit mode, stop here.
+
+## Phase 2 — plan
+
+Build the candidate list from the rollout log:
+
+1. If bootstrap metadata includes `scaffoldedAt`, treat entries with a newer `introducedOn` as the primary candidates. Versions are only hints.
+2. Add older entries that still look applicable from the current project state.
+3. Drop entries that `.vercel-shop/rollout-state.json` already records as adopted, skipped, or not applicable — unless the user asks to revisit them.
+
+For each remaining entry, decide one of:
+
+- **Adopt now** — clearly applicable and mechanical enough to apply confidently
+- **Review manually** — applicable but touches heavily customized code
+- **Already present** — the project has the change (adopted independently or scaffolded with it)
+- **Not applicable** — the entry's `appliesTo` or preconditions don't match this project
+
+Validate each decision against the current codebase. Do not assume a change is missing just because the scaffold is old, and do not invent upgrade work when no entries apply — say so explicitly. Call out uncertainty when the project has heavily diverged from template conventions.
+
+Present the plan grouped by decision. In plan mode, stop here and do not edit files.
+
+## Phase 3 — apply
+
+Confirm with the user which entries to apply before editing anything. Then, for each selected entry, one at a time:
+
+1. Re-read the entry's Summary, `paths`, and Apply when / Safe to skip when sections.
+2. Apply the change in the project's own idiom — re-implement the behavior described by the entry rather than copying template files over customized code. Use the entry's `relatedSkills` when listed.
+3. Run the entry's Validation steps before moving to the next entry.
+4. Keep each entry's edits an isolated, reviewable unit. If the project uses git and the user wants commits, suggest one commit per `changeKey`.
+
+If an entry's validation fails, stop, report the failure, and ask whether to fix forward, skip the entry, or revert its edits before continuing.
+
+## Phase 4 — record and report
+
+Record every decision in `.vercel-shop/rollout-state.json` so future runs don't re-litigate settled entries. Keep decisions keyed by `changeKey`:
+
+```json
+{
+  "decisions": {
+    "storefront-typed-client": {
+      "decision": "adopted",
+      "decidedOn": "2026-07-06"
+    },
+    "pdp-metafields-specs": {
+      "decision": "skipped",
+      "decidedOn": "2026-07-06",
+      "note": "custom PDP replaced the specs section"
+    }
+  }
+}
+```
+
+Use `adopted`, `skipped`, `not-applicable`, or `already-present` as decision values. Do not modify `.vercel-shop/bootstrap.json` — `scaffoldedAt` must keep describing the original scaffold.
+
+Finish with a concise report: what was applied, what was skipped and why, validation results, and any entries deferred for manual review.

--- a/packages/plugin/template-rollout-log/2026-07-06-update-shop-skill.md
+++ b/packages/plugin/template-rollout-log/2026-07-06-update-shop-skill.md
@@ -1,0 +1,39 @@
+---
+title: Consolidate drift audit and upgrade planning into the update-shop skill
+changeKey: update-shop-skill
+introducedOn: 2026-07-06
+changeType: meta
+defaultAction: adopt
+appliesTo:
+  - all
+paths:
+  - packages/plugin/skills/update-shop/SKILL.md
+  - packages/plugin/commands/vercel-shop-check-drift.md
+  - packages/plugin/commands/vercel-shop-plan-upgrade.md
+  - apps/template/AGENTS.md
+relatedSkills:
+  - /vercel-shop:update-shop
+---
+
+## Summary
+
+The `vercel-shop-check-drift` and `vercel-shop-plan-upgrade` commands are consolidated into a single `update-shop` skill with three modes: audit (read-only drift report), plan (read-only change-level upgrade plan), and apply (confirmed selection applied entry by entry with per-entry validation). Both commands remain as compatibility aliases pointing at the skill.
+
+The apply flow records decisions in `.vercel-shop/rollout-state.json`, keyed by `changeKey`, so repeat runs skip entries already adopted, skipped, or judged not applicable instead of re-litigating the full rollout log. `.vercel-shop/bootstrap.json` stays untouched — `scaffoldedAt` keeps describing the original scaffold.
+
+## Why it matters
+
+Downstream storefronts get one entry point for staying current with the template, and repeated upgrade runs stay incremental because settled decisions persist in the project.
+
+## Apply when
+
+- The storefront uses coding agents with the Vercel Shop plugin and wants to adopt template changes over time.
+
+## Safe to skip when
+
+- Nothing to apply in the project itself beyond optionally mentioning the skill in agent guidance; the skill ships with the plugin.
+
+## Validation
+
+1. With the plugin installed, invoke `/vercel-shop:update-shop` in plan mode and confirm it reads `.vercel-shop/bootstrap.json`, the rollout log, and `.vercel-shop/rollout-state.json` if present.
+2. After an apply run, confirm `.vercel-shop/rollout-state.json` records a decision per handled `changeKey` and `bootstrap.json` is unchanged.


### PR DESCRIPTION
## Summary

- Adds a single `/vercel-shop:update-shop` skill (`packages/plugin/skills/update-shop/SKILL.md`) covering the full upgrade flow for downstream storefronts: **audit** (drift report), **plan** (change-level plan from the rollout log), and **apply** (confirmed selection applied entry by entry with per-entry validation).
- Apply runs record decisions in `.vercel-shop/rollout-state.json` keyed by `changeKey` (`adopted` / `skipped` / `not-applicable` / `already-present`), so repeat runs stay incremental instead of re-litigating the full rollout log. `bootstrap.json` stays untouched — `scaffoldedAt` keeps describing the original scaffold.
- Converts `vercel-shop-check-drift` and `vercel-shop-plan-upgrade` commands into compatibility aliases pointing at the skill, following the existing `vercel-shop-bootstrap` → `init-vercel-shop` precedent.
- Docs: new `skills/update-shop` page (content embedded via `sync-skills.ts`), added to the skills index/meta, and linked from *Extending with agents*.
- Adds a rollout log entry (`2026-07-06-update-shop-skill.md`) and lists the skill in the template `AGENTS.md` optional-plugin section.

## Validation

- `sync-skills.ts` run — `update-shop.mdx` synced, all other pages unchanged.
- `oxfmt --check` clean on all touched docs files; `lint-doc-paths.ts` verifies the new `/docs/skills/update-shop` links; `fumadocs-mdx` compiles.
- (Pre-existing `pnpm lint` format failures in `app/[lang]/(home)/page.tsx`, `anatomy/agent.mdx`, `reference/env-vars.mdx` are untouched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)