### PR TITLE
feat(plugin): update-shop reads the rollout log from upstream

### DIFF
--- a/apps/docs/content/docs/skills/update-shop.mdx
+++ b/apps/docs/content/docs/skills/update-shop.mdx
@@ -32,12 +32,25 @@ Infer the mode from the user's request:
 
 1. `.vercel-shop/bootstrap.json` in the project root — original `templateVersion` and `scaffoldedAt`
 2. `.vercel-shop/rollout-state.json` in the project root — decisions recorded by earlier runs of this skill (may not exist)
-3. `template-version.json` from this plugin
-4. Every markdown entry in `template-rollout-log/` from this plugin except `README.md`
-5. `AGENTS.md` and `.claude/settings.json` in the project if present
-6. The current project structure and any files named by matching rollout entries
+3. The current rollout log and template version, fetched from upstream (see below)
+4. `AGENTS.md` and `.claude/settings.json` in the project if present
+5. The current project structure and any files named by matching rollout entries
 
 If `.vercel-shop/bootstrap.json` is missing, say the project predates plugin bootstrap metadata and continue with a best-effort heuristic audit.
+
+### Fetch the current rollout log
+
+The rollout log is maintained upstream in `github.com/vercel/shop`. The plugin bundles a copy of `template-rollout-log/` and `template-version.json`, but it is only as fresh as the installed plugin, so prefer the upstream copy:
+
+```bash
+dir=$(mktemp -d)
+curl -fsSL https://codeload.github.com/vercel/shop/tar.gz/refs/heads/main |
+  tar -xz --strip-components=3 -C "$dir" \
+    shop-main/packages/plugin/template-rollout-log \
+    shop-main/packages/plugin/template-version.json
+```
+
+Read every markdown entry in the extracted `template-rollout-log/` except `README.md`. If the fetch fails (offline or restricted network), fall back to the copies bundled with this plugin and say in the report that the log may be stale until the plugin is updated.
 
 ## Phase 1 — audit
 

--- a/packages/plugin/skills/update-shop/SKILL.md
+++ b/packages/plugin/skills/update-shop/SKILL.md
@@ -19,12 +19,25 @@ Infer the mode from the user's request:
 
 1. `.vercel-shop/bootstrap.json` in the project root — original `templateVersion` and `scaffoldedAt`
 2. `.vercel-shop/rollout-state.json` in the project root — decisions recorded by earlier runs of this skill (may not exist)
-3. `template-version.json` from this plugin
-4. Every markdown entry in `template-rollout-log/` from this plugin except `README.md`
-5. `AGENTS.md` and `.claude/settings.json` in the project if present
-6. The current project structure and any files named by matching rollout entries
+3. The current rollout log and template version, fetched from upstream (see below)
+4. `AGENTS.md` and `.claude/settings.json` in the project if present
+5. The current project structure and any files named by matching rollout entries
 
 If `.vercel-shop/bootstrap.json` is missing, say the project predates plugin bootstrap metadata and continue with a best-effort heuristic audit.
+
+### Fetch the current rollout log
+
+The rollout log is maintained upstream in `github.com/vercel/shop`. The plugin bundles a copy of `template-rollout-log/` and `template-version.json`, but it is only as fresh as the installed plugin, so prefer the upstream copy:
+
+```bash
+dir=$(mktemp -d)
+curl -fsSL https://codeload.github.com/vercel/shop/tar.gz/refs/heads/main |
+  tar -xz --strip-components=3 -C "$dir" \
+    shop-main/packages/plugin/template-rollout-log \
+    shop-main/packages/plugin/template-version.json
+```
+
+Read every markdown entry in the extracted `template-rollout-log/` except `README.md`. If the fetch fails (offline or restricted network), fall back to the copies bundled with this plugin and say in the report that the log may be stale until the plugin is updated.
 
 ## Phase 1 — audit
 

--- a/packages/plugin/template-rollout-log/2026-07-06-update-shop-skill.md
+++ b/packages/plugin/template-rollout-log/2026-07-06-update-shop-skill.md
@@ -19,6 +19,8 @@ relatedSkills:
 
 The `vercel-shop-check-drift` and `vercel-shop-plan-upgrade` commands are consolidated into a single `update-shop` skill with three modes: audit (read-only drift report), plan (read-only change-level upgrade plan), and apply (confirmed selection applied entry by entry with per-entry validation). Both commands remain as compatibility aliases pointing at the skill.
 
+The skill reads the rollout log and template version from upstream `github.com/vercel/shop` (main-branch tarball) so plans always reflect the current log, falling back to the plugin-bundled copy when offline.
+
 The apply flow records decisions in `.vercel-shop/rollout-state.json`, keyed by `changeKey`, so repeat runs skip entries already adopted, skipped, or judged not applicable instead of re-litigating the full rollout log. `.vercel-shop/bootstrap.json` stays untouched — `scaffoldedAt` keeps describing the original scaffold.
 
 ## Why it matters
@@ -35,5 +37,5 @@ Downstream storefronts get one entry point for staying current with the template
 
 ## Validation
 
-1. With the plugin installed, invoke `/vercel-shop:update-shop` in plan mode and confirm it reads `.vercel-shop/bootstrap.json`, the rollout log, and `.vercel-shop/rollout-state.json` if present.
+1. With the plugin installed, invoke `/vercel-shop:update-shop` in plan mode and confirm it reads `.vercel-shop/bootstrap.json`, fetches the upstream rollout log, and reads `.vercel-shop/rollout-state.json` if present.
 2. After an apply run, confirm `.vercel-shop/rollout-state.json` records a decision per handled `changeKey` and `bootstrap.json` is unchanged.


### PR DESCRIPTION
## Summary

Follow-up to #401. The `update-shop` skill now fetches `template-rollout-log/` and `template-version.json` from the `vercel/shop` main-branch tarball instead of relying on the copy bundled with the installed plugin, which is only as fresh as the last plugin update. The bundled copy remains the offline fallback, with the skill instructed to flag that the log may be stale when it has to fall back.

This decouples upgrade-plan freshness from plugin update cadence — the same upstream-first pattern the CLI already uses for scaffolding (`codeload.github.com/vercel/shop/tar.gz/refs/heads/main`).

- `packages/plugin/skills/update-shop/SKILL.md` — new "Fetch the current rollout log" section with the tarball one-liner and fallback behavior
- `packages/plugin/template-rollout-log/2026-07-06-update-shop-skill.md` — entry updated to describe upstream-first reading
- `apps/docs/content/docs/skills/update-shop.mdx` — re-synced via `sync-skills.ts`

## Validation

- The tarball fetch command was run locally and extracts `template-rollout-log/` (all entries) and `template-version.json` correctly.
- `sync-skills.ts` re-run; `oxfmt --check` and `fumadocs-mdx` pass on the synced page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)