### PR TITLE
refactor(template): drop experimental instant/prefetch exports from search

### DIFF
--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -64,10 +64,6 @@ export async function generateMetadata({ searchParams }: PageProps<"/search">): 
   };
 }
 
-export const instant = true;
-
-export const prefetch = "allow-runtime";
-
 export default async function SearchPage({ searchParams }: PageProps<"/search">) {
   const [locale, t] = await Promise.all([getLocale(), getTranslations("search")]);
 


### PR DESCRIPTION
## What

Removes the two experimental route-segment config exports from `app/template/app/search/page.tsx`:

```ts
export const instant = true;
export const prefetch = "allow-runtime";
```

## Why

These are bleeding-edge, experimental Next.js route configs — churn-prone surface area that doesn't belong in a reference template meant to model stable best practice.

Crucially, **this is not a behavior change.** The search page's actual rendering strategy — keeping `searchParams` as an *unawaited* promise and threading it into the smallest Suspense boundaries — is what produces the instant static shell + streamed results. That code is untouched; only the experimental sugar layered on top is gone.

## Notes

Confirmed these exports appeared nowhere else in the repo (no other route configs, no docs references, no template-rollout-log entry), so nothing else needs updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)