### PR TITLE
fix(template): keep cart on quick reload after add-to-cart

### DIFF
--- a/apps/docs/content/docs/anatomy/cart.mdx
+++ b/apps/docs/content/docs/anatomy/cart.mdx
@@ -27,7 +27,7 @@ The provider tracks an `originalCart` snapshot for rollback if a mutation fails.
 
 All cart mutations update the UI before the server responds. The implementation uses two distinct debounce strategies:
 
-**Add to cart** - trailing-edge debounce at 400ms. Rapid clicks accumulate into `pendingQuantity` and display as an optimistic line via `OptimisticProductInfo`. When the debounce fires, a single request sends the accumulated quantity.
+**Add to cart** - leading-edge debounce at 400ms. The first add fires immediately so the cart (and its `shopify_cartId` cookie) is created without waiting out the debounce window - otherwise a reload right after adding could drop the item. Rapid follow-up clicks accumulate into `pendingQuantity`, display as an optimistic line via `OptimisticProductInfo`, and coalesce into a single trailing request.
 
 **Update quantity** - leading-edge debounce. The first change fires immediately so the user sees instant feedback. Subsequent changes within the debounce window are batched. Removals (quantity set to 0) bypass debounce entirely and fire immediately.
 
@@ -76,7 +76,7 @@ Below the items, a `RelatedProductsSection` shows product recommendations based 
 
 ## Shopify integration
 
-Cart operations in `lib/shopify/operations/cart.ts` use GraphQL mutations: `cartLinesAdd`, `cartLinesUpdate`, and `cartLinesRemove`. Each mutation returns the full cart through `CartFields`; the operation normalizes that response and the server action uses it directly without a follow-up `getCart()` query. The cart ID is stored in a `shopify_cartId` HTTP-only cookie with a 7-day expiry. Every mutation calls `invalidateCartCache()` to ensure subsequent reads reflect the latest state.
+Cart operations in `lib/shopify/operations/cart.ts` use GraphQL mutations: `cartLinesAdd`, `cartLinesUpdate`, and `cartLinesRemove`. The first add to an empty cart creates the cart with its lines in a single `cartCreate` mutation rather than creating an empty cart and adding lines in a second round-trip, so the `shopify_cartId` cookie is committed as early as possible. Each mutation returns the full cart through `CartFields`; the operation normalizes that response and the server action uses it directly without a follow-up `getCart()` query. The cart ID is stored in a `shopify_cartId` HTTP-only cookie with a 7-day expiry. Every mutation calls `invalidateCartCache()` to ensure subsequent reads reflect the latest state.
 
 The transform layer in `lib/shopify/transforms/cart.ts` converts Shopify's GraphQL response shape into a domain `Cart` type used throughout the application. This isolates the rest of the codebase from Shopify's API structure.
 

--- a/apps/template/components/cart/context.tsx
+++ b/apps/template/components/cart/context.tsx
@@ -281,7 +281,61 @@ export function CartProvider({
 
   const pendingProductInfoRef = useRef<Map<string, OptimisticProductInfo>>(new Map());
 
-  /** Debounced — accumulates rapid clicks into a single request per variant. */
+  // Flushes buffered adds: one `addToCartAction` per variant, resolving each
+  // caller's promise. Clears the timer so the next click starts a fresh burst.
+  const flushPendingAddToCart = () => {
+    const debounce = addToCartDebounceRef.current;
+    debounce.timer = null;
+
+    const items = new Map(debounce.pending);
+    debounce.pending.clear();
+    pendingProductInfoRef.current.clear();
+
+    if (items.size === 0) return;
+
+    const flushedResolvers = new Map<string, Array<(success: boolean) => void>>();
+    for (const [vid] of items) {
+      flushedResolvers.set(vid, addToCartResolversRef.current.get(vid) ?? []);
+      addToCartResolversRef.current.delete(vid);
+    }
+
+    for (const [vid, qty] of items) {
+      startTransition(async () => {
+        let success = false;
+
+        try {
+          const result = await addToCartAction(vid, qty);
+          success = result.success;
+
+          if (result.success && result.cart) {
+            setCartInternal(result.cart);
+            setLastWarnings(result.warnings ?? []);
+          }
+        } catch (error) {
+          console.error("Failed to add item to cart:", error);
+        } finally {
+          const resolvers = flushedResolvers.get(vid) ?? [];
+          for (const resolve of resolvers) {
+            resolve(success);
+          }
+        }
+
+        // Only clear pending state if nothing was queued while in-flight.
+        if (debounce.pending.size === 0) {
+          setIsAddingToCart(false);
+          setPendingQuantity(0);
+          setPendingLines([]);
+        }
+      });
+    }
+  };
+
+  /**
+   * Leading edge: the first add fires immediately so the cart and its httpOnly id
+   * cookie are created without waiting out the debounce — a reload inside that
+   * window would otherwise drop the item. Rapid follow-up clicks coalesce into a
+   * single trailing flush.
+   */
   const addToCartOptimistic = (
     variantId: string,
     quantity: number,
@@ -318,55 +372,12 @@ export function CartProvider({
       setOverlayOpen(true);
     }
 
-    if (debounce.timer !== null) {
-      clearTimeout(debounce.timer);
+    if (debounce.timer === null) {
+      // No burst in flight — fire now, then hold a window open to coalesce follow-ups.
+      flushPendingAddToCart();
+      debounce.timer = setTimeout(flushPendingAddToCart, DEBOUNCE_MS);
     }
-
-    debounce.timer = setTimeout(() => {
-      debounce.timer = null;
-
-      const items = new Map(debounce.pending);
-      debounce.pending.clear();
-      pendingProductInfoRef.current.clear();
-
-      if (items.size === 0) return;
-
-      const flushedResolvers = new Map<string, Array<(success: boolean) => void>>();
-      for (const [vid] of items) {
-        flushedResolvers.set(vid, addToCartResolversRef.current.get(vid) ?? []);
-        addToCartResolversRef.current.delete(vid);
-      }
-
-      for (const [vid, qty] of items) {
-        startTransition(async () => {
-          let success = false;
-
-          try {
-            const result = await addToCartAction(vid, qty);
-            success = result.success;
-
-            if (result.success && result.cart) {
-              setCartInternal(result.cart);
-              setLastWarnings(result.warnings ?? []);
-            }
-          } catch (error) {
-            console.error("Failed to add item to cart:", error);
-          } finally {
-            const resolvers = flushedResolvers.get(vid) ?? [];
-            for (const resolve of resolvers) {
-              resolve(success);
-            }
-          }
-
-          // Only clear pending state if nothing was queued while in-flight.
-          if (debounce.pending.size === 0) {
-            setIsAddingToCart(false);
-            setPendingQuantity(0);
-            setPendingLines([]);
-          }
-        });
-      }
-    }, DEBOUNCE_MS);
+    // Within an open window the click is buffered above; the trailing timer flushes it.
 
     return requestPromise;
   };

--- a/apps/template/lib/shopify/fetch.ts
+++ b/apps/template/lib/shopify/fetch.ts
@@ -480,13 +480,21 @@ export async function fetchCart(cartId: string): Promise<Cart | undefined> {
   return response.data.cart ? transformShopifyCart(response.data.cart) : undefined;
 }
 
-export async function createCartCore(locale: string = defaultLocale): Promise<CartMutationResult> {
+export async function createCartCore(
+  locale: string = defaultLocale,
+  lines?: CartLineInput[],
+): Promise<CartMutationResult> {
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 
+  const input = {
+    buyerIdentity: { countryCode: country },
+    ...(lines?.length ? { lines } : {}),
+  };
+
   const response = await storefront.request<{ cartCreate: CartMutationPayload<ShopifyCart> }>(
     CART_CREATE_MUTATION,
-    { variables: { input: { buyerIdentity: { countryCode: country } }, country, language } },
+    { variables: { input, country, language } },
   );
   assertStorefrontOk(response, "cartCreate");
   return applyCartMutation(response.data.cartCreate, "cartCreate");

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -143,14 +143,18 @@ export async function getCart(cartId?: string): Promise<Cart | undefined> {
  */
 export async function createCartWithoutCookie(
   locale: string = defaultLocale,
+  lines?: CartLineInput[],
 ): Promise<CartMutationResult> {
-  const result = await createCartCore(locale);
+  const result = await createCartCore(locale, lines);
   invalidateCartCache();
   return result;
 }
 
-export async function createCart(locale: string = defaultLocale): Promise<CartMutationResult> {
-  const result = await createCartWithoutCookie(locale);
+export async function createCart(
+  locale: string = defaultLocale,
+  lines?: CartLineInput[],
+): Promise<CartMutationResult> {
+  const result = await createCartWithoutCookie(locale, lines);
 
   if (result.cart.id) {
     await setCartIdCookie(result.cart.id);
@@ -164,11 +168,15 @@ export async function addToCart(
   cartId?: string,
   locale: string = defaultLocale,
 ): Promise<CartMutationResult> {
-  let resolvedCartId = cartId ?? (await getCartIdFromCookie());
+  const resolvedCartId = cartId ?? (await getCartIdFromCookie());
+
+  // First add (no cart yet): create the cart *with* the lines in a single
+  // round-trip. Creating an empty cart and adding lines separately means the
+  // httpOnly cart-id cookie only commits after the second request, widening the
+  // window where a reload drops the cart.
   if (!resolvedCartId) {
-    resolvedCartId = (await createCart(locale)).cart.id;
+    return createCart(locale, lines);
   }
-  if (!resolvedCartId) throw new Error("Cart ID not found");
 
   const result = await addToCartCore(lines, resolvedCartId);
   invalidateCartCache();

--- a/packages/plugin/template-rollout-log/2026-07-07-cart-persist-leading-edge.md
+++ b/packages/plugin/template-rollout-log/2026-07-07-cart-persist-leading-edge.md
@@ -1,0 +1,53 @@
+---
+title: Cart — leading-edge add + single-call cart creation so a quick reload after adding keeps the item
+changeKey: cart-persist-leading-edge
+introducedOn: 2026-07-07
+changeType: fix
+defaultAction: adopt
+appliesTo:
+  - apps/template/components/cart/context.tsx
+  - apps/template/lib/shopify/operations/cart.ts
+  - apps/template/lib/shopify/fetch.ts
+paths:
+  - apps/template/components/cart/context.tsx
+  - apps/template/lib/shopify/operations/cart.ts
+  - apps/template/lib/shopify/fetch.ts
+relatedSkills:
+  - /vercel-shop:build-shop
+---
+
+## Summary
+
+Adding the first item to an empty cart, then reloading the page a beat later, could land on an empty cart. The cart id lives in the `shopify_cartId` HTTP-only cookie, which a server action only commits when it finishes — and two things widened the window between the click and that commit:
+
+1. **Add-to-cart used a trailing-edge 400ms debounce.** The header count updated optimistically at t≈0, but `addToCartAction` did not fire until 400ms after the click. A reload inside that window never even sent the request.
+2. **The first add did two sequential Shopify round-trips** — `cartCreate` (empty) then `cartLinesAdd` — so the cookie only committed after both completed.
+
+Both are now addressed:
+
+- **Leading-edge add** (`components/cart/context.tsx`): the first add fires immediately (mirroring the existing `updateItemOptimistic` leading-edge pattern); rapid follow-up clicks still coalesce into a single trailing flush. The flush body is extracted to `flushPendingAddToCart`.
+- **Single-call creation** (`lib/shopify/operations/cart.ts`, `lib/shopify/fetch.ts`): when no cart exists, `addToCart` now calls `createCart(locale, lines)`, which creates the cart *with* its lines via one `cartCreate` mutation. `createCartCore`/`createCartWithoutCookie`/`createCart` take an optional `lines` argument; existing no-lines callers (e.g. the eve agent tool) are unchanged. `CartInput.lines` is validated against the codegen'd Storefront schema.
+
+This is browser-agnostic — the same race reproduces in Chrome — but surfaced during Safari testing. Measured on local dev, the add-to-cart server action dropped from ~1520ms (two calls) to ~910ms (one call), on top of removing the 400ms debounce delay. `invalidateCartCache()` still runs on every mutation (the first-add path routes through `createCartWithoutCookie`).
+
+## Why it matters
+
+Downstream storefronts get a materially smaller window in which an add-then-reload drops the cart, and one fewer Shopify round-trip on the first add.
+
+## Apply when
+
+- The storefront uses the template's `components/cart/context.tsx` optimistic cart and `lib/shopify/operations/cart.ts` add/create flow.
+
+## Adopt with changes
+
+- Storefronts that customized the add-to-cart debounce or the `createCart*` signatures should port those changes onto the new leading-edge flush and the optional `lines` parameter.
+
+## Safe to skip when
+
+- The storefront replaced the cart context or cart operations with a different implementation (e.g. Hydrogen's cart handlers).
+
+## Validation
+
+1. On a product page with an empty cart, add an item and reload ~1-2s later; the item remains in the cart.
+2. With `DEBUG_SHOPIFY=true`, a first add logs a single `[shopify] cartCreate` with no following `cartLinesAdd`.
+3. Rapid repeated add clicks still coalesce (no one-request-per-click storm) while the first request fires immediately.


### PR DESCRIPTION
Stacked on top of #396 (`blurrah/hydrogen-preview`).

## Problem

Adding the first item to an empty cart and then reloading a beat later could land on an **empty cart**. The `shopify_cartId` cookie is httpOnly and a Server Action only commits its `Set-Cookie` when it **finishes**. Two things widened the gap between the click and that commit:

1. **Add-to-cart used a trailing-edge 400ms debounce** — the header count updated optimistically at t≈0, but `addToCartAction` didn't fire until 400ms after the click. A reload inside that window never even sent the request.
2. **The first add did two sequential Shopify round-trips** — `cartCreate` (empty) then `cartLinesAdd` — so the cookie only committed after both completed.

This is **not browser-specific** (Chrome reproduces it identically) — it surfaced during Safari testing.

## Fix

- **`components/cart/context.tsx`** — add-to-cart now fires on the **leading edge** (cart + cookie created immediately); rapid follow-up clicks still coalesce into a single trailing flush. Mirrors the existing `updateItemOptimistic` pattern. Flush body extracted to `flushPendingAddToCart`.
- **`lib/shopify/operations/cart.ts` + `lib/shopify/fetch.ts`** — first add creates the cart **with its lines in one `cartCreate` mutation** instead of empty-create-then-add. Optional `lines` threaded through `createCart*`; existing no-lines callers (eve agent tool) unchanged. `CartInput.lines` validated against the codegen'd Storefront schema.

`invalidateCartCache()` still runs on every mutation (first-add routes through `createCartWithoutCookie`).

## Verification (local dev)

- `DEBUG_SHOPIFY`: first add is now a single `[shopify] cartCreate` (~910ms), no `cartLinesAdd` — down from ~1520ms.
- Add → reload ~2s later keeps the item.
- Typecheck + oxlint clean.

## Caveat

Shrinks the window substantially but not to zero — an *instant* reload during the single remaining round-trip still can't persist (inherent to lazily creating the cart server-side). Eliminating entirely would require eagerly creating a cart before the first add.

## Docs / rollout

- Corrects `apps/docs/content/docs/anatomy/cart.mdx` (documented the old trailing-edge behavior).
- Adds `packages/plugin/template-rollout-log/2026-07-07-cart-persist-leading-edge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)