### PR TITLE
fix(template): give cart overlay item list symmetric vertical padding

### DIFF
--- a/apps/template/components/cart/overlay-content.tsx
+++ b/apps/template/components/cart/overlay-content.tsx
@@ -91,7 +91,7 @@ export function OverlayContent({ locale }: OverlayContentProps) {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex-1 overflow-y-auto px-5 space-y-5">
+      <div className="flex-1 overflow-y-auto p-5 space-y-5">
         <CartWarnings />
         <ul className="space-y-5" aria-label={t("cartItemsLabel")}>
           {displayCart.lines.map((item) => (


### PR DESCRIPTION
## Problem

The cart overlay's heading was cutting off the outline of the first product image. The scrollable item list (`components/cart/overlay-content.tsx`) had only horizontal padding (`px-5`), so the first item sat flush against the fixed-height (`h-16`) header. Because the list is `overflow-y-auto`, the focus outline/ring around the product image overflowed upward and was clipped by the scroll container's top edge.

## Fix

Change the scroll region's `px-5` → `p-5` so it has matching top and bottom vertical padding. The first item now gets 20px of breathing room above it, and its outline renders fully instead of being clipped by the heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)