### PR TITLE
fix(template): relax cart cookie to SameSite=Lax off production

### DIFF
--- a/apps/docs/content/docs/anatomy/cart.mdx
+++ b/apps/docs/content/docs/anatomy/cart.mdx
@@ -78,6 +78,8 @@ Below the items, a `RelatedProductsSection` shows product recommendations based 
 
 Cart operations in `lib/shopify/operations/cart.ts` use GraphQL mutations: `cartLinesAdd`, `cartLinesUpdate`, and `cartLinesRemove`. Each mutation returns the full cart through `CartFields`; the operation normalizes that response and the server action uses it directly without a follow-up `getCart()` query. The cart ID is stored in a `shopify_cartId` HTTP-only cookie with a 7-day expiry. Every mutation calls `invalidateCartCache()` to ensure subsequent reads reflect the latest state.
 
+The cookie's `SameSite` attribute is derived from `VERCEL_ENV`: `Strict` on the production deployment, `Lax` on preview and every other environment. Preview deployments sit behind Vercel Authentication, whose SSO flow bounces the browser cross-site and redirects back to the deployment — a `Strict` cookie is withheld on that return navigation, so the cart id is dropped and the cart reads empty. `Lax` still rides top-level GET navigations back into the site (the SSO return, and the return from Shopify's checkout domain) while staying off cross-site subrequests, which is the right level for a cart identifier. The production custom domain is public, so it keeps `Strict`.
+
 The transform layer in `lib/shopify/transforms/cart.ts` converts Shopify's GraphQL response shape into a domain `Cart` type used throughout the application. This isolates the rest of the codebase from Shopify's API structure.
 
 ## Key files

--- a/apps/template/lib/cart/server.ts
+++ b/apps/template/lib/cart/server.ts
@@ -4,6 +4,8 @@ import { cookies } from "next/headers";
 
 const CART_ID_COOKIE = "shopify_cartId";
 const CART_ID_COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+// Preview sits behind Vercel Authentication; its cross-site SSO return hop drops a SameSite=Strict cookie, so only prod gets Strict.
+const CART_ID_COOKIE_SAME_SITE = process.env.VERCEL_ENV === "production" ? "strict" : "lax";
 
 export async function getCartIdFromCookie(): Promise<string | undefined> {
   return (await cookies()).get(CART_ID_COOKIE)?.value;
@@ -13,7 +15,7 @@ export async function setCartIdCookie(id: string): Promise<void> {
   (await cookies()).set(CART_ID_COOKIE, id, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
-    sameSite: "strict",
+    sameSite: CART_ID_COOKIE_SAME_SITE,
     maxAge: CART_ID_COOKIE_MAX_AGE,
     path: "/",
   });
@@ -22,7 +24,8 @@ export async function setCartIdCookie(id: string): Promise<void> {
 /** Streaming contexts can't call cookies().set(); they must emit Set-Cookie via response headers. */
 export function buildCartIdSetCookieHeader(id: string): string {
   const secure = process.env.NODE_ENV === "production";
-  return `${CART_ID_COOKIE}=${id}; Path=/; HttpOnly; SameSite=Strict; Max-Age=${CART_ID_COOKIE_MAX_AGE}${secure ? "; Secure" : ""}`;
+  const sameSite = CART_ID_COOKIE_SAME_SITE === "strict" ? "Strict" : "Lax";
+  return `${CART_ID_COOKIE}=${id}; Path=/; HttpOnly; SameSite=${sameSite}; Max-Age=${CART_ID_COOKIE_MAX_AGE}${secure ? "; Secure" : ""}`;
 }
 
 export function invalidateCartCache(): void {


### PR DESCRIPTION
## Problem

The cart doesn't persist on **preview** deployments but does on `template.vercel.shop`.

The `shopify_cartId` cookie was set with `SameSite=Strict` in every environment. Preview deployments sit behind **Vercel Authentication**, whose SSO flow bounces the browser cross-site through `vercel.com` and redirects back to the `*.vercel.app` host. `SameSite=Strict` withholds the cookie on that cross-site top-level return navigation, so the server renders with no cart id and the cart reads empty. The production custom domain is public (no SSO bounce), so `Strict` is never exercised there — hence the preview-only symptom.

This is distinct from the leading-edge debounce timing fix on `blurrah/hydrogen-cart-persist-fix` (which affects prod and preview equally); the two are complementary.

## Change

Derive `SameSite` from `VERCEL_ENV`:

- `production` → `Strict` (unchanged behavior on the canonical domain)
- preview / other branches → `Lax`

`Lax` is still sent on top-level GET navigations back into the site (SSO return, Shopify checkout return) but withheld on cross-site subrequests — the correct level for a cart identifier. Cart mutations are same-site Server Action POSTs, so they're unaffected. Applied to both the `cookies().set()` path and the streaming `Set-Cookie` header builder via a single constant.

`VERCEL_ENV` is already in `turbo.json` globalEnv and read elsewhere in the template, so no new env plumbing and no `.env.example` row (it's a Vercel system var).

## Test plan

- [ ] On this PR's preview deployment: add an item to the cart, reload — cart persists.
- [ ] Confirm the `shopify_cartId` response cookie shows `SameSite=Lax` on preview.
- [ ] Production remains `SameSite=Strict` (verify after promotion / on `template.vercel.shop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)