### PR TITLE
feat(template): standardize heading weight to 400 with size-based tracking

### DIFF
--- a/apps/template/app/collections/page.tsx
+++ b/apps/template/app/collections/page.tsx
@@ -45,9 +45,7 @@ export default async function CollectionsPage() {
     <Page className="pt-2.5 md:pt-10">
       <Container>
         <Sections className="gap-5">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-medium tracking-display">
-            {t("title")}
-          </h1>
+          <h1 className="text-3xl sm:text-4xl md:text-5xl">{t("title")}</h1>
 
           {collections.length > 0 ? (
             <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4">

--- a/apps/template/app/global-error.tsx
+++ b/apps/template/app/global-error.tsx
@@ -19,9 +19,7 @@ export default function GlobalError({
               <AlertCircleIcon className="h-12 w-12 text-muted-foreground" />
             </div>
           </div>
-          <h1 className="mb-2 text-2xl font-semibold tracking-tight lg:text-3xl">
-            Something went wrong
-          </h1>
+          <h1 className="mb-2 text-2xl lg:text-3xl">Something went wrong</h1>
           <p className="mb-8 max-w-md text-muted-foreground">
             An unexpected error occurred. Please try again.
           </p>

--- a/apps/template/app/globals.css
+++ b/apps/template/app/globals.css
@@ -13,7 +13,15 @@
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
   --text-xxs: 0.625rem;
-  --tracking-display: -0.04em;
+  /* Headings track tighter as they grow (Geist behavior); attaches to every text-* utility. */
+  --text-lg--letter-spacing: -0.01em;
+  --text-xl--letter-spacing: -0.015em;
+  --text-2xl--letter-spacing: -0.02em;
+  --text-3xl--letter-spacing: -0.025em;
+  --text-4xl--letter-spacing: -0.03em;
+  --text-5xl--letter-spacing: -0.035em;
+  --text-6xl--letter-spacing: -0.04em;
+  --text-7xl--letter-spacing: -0.045em;
 
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -100,7 +108,7 @@
 @layer components {
   .prose :where(h1, h2, h3, h4):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
     letter-spacing: -0.025em; /* tracking-tight */
-    font-weight: 500; /* font-medium */
+    font-weight: 400;
   }
 }
 

--- a/apps/template/app/not-found.tsx
+++ b/apps/template/app/not-found.tsx
@@ -11,9 +11,7 @@ export default async function NotFoundError() {
     <Page className="flex flex-1 flex-col">
       <Container className="flex flex-1 flex-col items-center justify-center text-center">
         <div className="flex flex-col items-center text-center gap-2.5">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-semibold tracking-tight">
-            {t("notFound")}
-          </h1>
+          <h1 className="text-3xl sm:text-4xl md:text-5xl">{t("notFound")}</h1>
           <p className="text-sm md:text-base text-muted-foreground max-w-xl">{t("notFoundDesc")}</p>
           <Link
             href="/search"

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -87,7 +87,7 @@ export default async function SearchPage({ searchParams }: PageProps<"/search">)
         <FilterTransitionProvider>
           <Sections className="gap-5">
             <div>
-              <h1 className="text-3xl sm:text-4xl md:text-5xl font-medium tracking-display">
+              <h1 className="text-3xl sm:text-4xl md:text-5xl">
                 <Link href="/search">{t("title")}</Link>
                 <Suspense fallback={null}>
                   <SearchQueryLabel searchParamsPromise={searchParams} />

--- a/apps/template/components/account/page-header.tsx
+++ b/apps/template/components/account/page-header.tsx
@@ -1,7 +1,7 @@
 export function AccountPageHeader({ title, description }: { title: string; description?: string }) {
   return (
     <div>
-      <h1 className="text-3xl sm:text-4xl md:text-5xl font-medium tracking-display">{title}</h1>
+      <h1 className="text-3xl sm:text-4xl md:text-5xl">{title}</h1>
       {description && <p className="mt-1 text-sm leading-6 text-muted-foreground">{description}</p>}
     </div>
   );

--- a/apps/template/components/cart-page/empty-cart.tsx
+++ b/apps/template/components/cart-page/empty-cart.tsx
@@ -6,7 +6,7 @@ export async function Empty() {
 
   return (
     <div className="flex flex-col items-center justify-center gap-5 py-10 px-5">
-      <h2 className="text-2xl sm:text-3xl font-medium tracking-tight">{t("empty")}</h2>
+      <h2 className="text-2xl sm:text-3xl">{t("empty")}</h2>
       <Link
         href="/"
         className="inline-flex items-center justify-center h-12 px-8 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"

--- a/apps/template/components/cart-page/header.tsx
+++ b/apps/template/components/cart-page/header.tsx
@@ -11,9 +11,7 @@ export function Header() {
 
   return (
     <div className="flex items-center gap-2.5">
-      <h1 className="text-3xl sm:text-4xl md:text-5xl font-medium tracking-display">
-        {t("shoppingCart")}
-      </h1>
+      <h1 className="text-3xl sm:text-4xl md:text-5xl">{t("shoppingCart")}</h1>
       {count > 0 && (
         <span className="flex size-7 items-center justify-center rounded-full bg-foreground text-sm text-background">
           {count}

--- a/apps/template/components/cart/overlay-content.tsx
+++ b/apps/template/components/cart/overlay-content.tsx
@@ -75,7 +75,7 @@ export function OverlayContent({ locale }: OverlayContentProps) {
   if (!displayCart || displayCart.lines.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full px-5 text-center">
-        <h3 className="text-2xl font-medium tracking-tight mb-6">{t("empty")}</h3>
+        <h3 className="text-2xl mb-6">{t("empty")}</h3>
         <Button
           onClick={() => {
             setOverlayOpen(false);

--- a/apps/template/components/collections/collection-page.tsx
+++ b/apps/template/components/collections/collection-page.tsx
@@ -115,7 +115,7 @@ function CollectionHeader({
       <BreadcrumbSchema items={breadcrumbItems} />
       <CollectionSchema collection={{ handle, title, description, updatedAt }} />
       <div>
-        <h1 className="text-3xl sm:text-4xl md:text-5xl font-semibold tracking-tight">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl">
           <Link href={`/collections/${handle}`}>{title}</Link>
         </h1>
         {description && <p className="mt-1 leading-6 text-muted-foreground">{description}</p>}

--- a/apps/template/components/collections/filter-primitives.tsx
+++ b/apps/template/components/collections/filter-primitives.tsx
@@ -48,7 +48,7 @@ function FilterSidebarHeader({
       className={cn("flex items-center gap-2", className)}
       {...props}
     >
-      <h2 className="text-xl font-semibold tracking-tight text-foreground">
+      <h2 className="text-xl text-foreground">
         {title}
         {activeCount !== undefined && activeCount > 0 && (
           <span className="ml-1">({activeCount})</span>

--- a/apps/template/components/collections/results-grid.tsx
+++ b/apps/template/components/collections/results-grid.tsx
@@ -37,7 +37,7 @@ async function Render({
   if (products.length === 0) {
     return (
       <div className="py-10 text-center">
-        <h2 className="mb-2 text-2xl font-semibold">{t("noResults")}</h2>
+        <h2 className="mb-2 text-2xl">{t("noResults")}</h2>
         <p className="text-muted-foreground">{t("noResultsAvailable")}</p>
       </div>
     );

--- a/apps/template/components/nav/index.tsx
+++ b/apps/template/components/nav/index.tsx
@@ -23,7 +23,7 @@ export async function Nav({ locale }: { locale: string }) {
         <MobileMenu items={items} />
 
         <Link className="flex items-center shrink-0" href="/">
-          <span className="text-xl font-semibold leading-4 tracking-tight">{siteConfig.name}</span>
+          <span className="text-xl leading-4">{siteConfig.name}</span>
         </Link>
 
         <QuickLinks items={items} />

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -184,7 +184,7 @@ async function ProductInfoArea({
   return (
     <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
       <div data-slot="product-info-header">
-        <h1 className="font-medium text-foreground tracking-display text-3xl">{title}</h1>
+        <h1 className="text-foreground text-3xl">{title}</h1>
         {uniformPrice ? (
           <ProductPrice
             amount={product.priceRange.minVariantPrice.amount}

--- a/apps/template/components/product-detail/product-info.tsx
+++ b/apps/template/components/product-detail/product-info.tsx
@@ -24,7 +24,7 @@ function ProductInfoHeader({
 }: ProductInfoHeaderProps) {
   return (
     <div data-slot="product-info-header" className={className} {...props}>
-      <h1 className={cn("font-semibold text-foreground tracking-tight", "text-3xl")}>{title}</h1>
+      <h1 className={cn("text-foreground", "text-3xl")}>{title}</h1>
 
       {selectedVariant && (
         <ProductPrice

--- a/apps/template/components/product/products-grid.tsx
+++ b/apps/template/components/product/products-grid.tsx
@@ -35,7 +35,7 @@ export async function ProductsGrid({ collectionUrl, limit, locale, title }: Prod
   return (
     <div className="grid gap-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl sm:text-3xl font-semibold tracking-tighter">{title}</h2>
+        <h2 className="text-2xl sm:text-3xl">{title}</h2>
         {collectionUrl && (
           <Link
             href={collectionUrl}

--- a/apps/template/components/product/related-products-section.tsx
+++ b/apps/template/components/product/related-products-section.tsx
@@ -12,7 +12,7 @@ export function RelatedProductsSectionSkeleton({ title }: { title?: string }) {
   return (
     <div className="grid gap-4">
       {title ? (
-        <h2 className="text-2xl sm:text-3xl font-medium tracking-tight">{title}</h2>
+        <h2 className="text-2xl sm:text-3xl">{title}</h2>
       ) : (
         <Skeleton className="h-9 w-48" />
       )}
@@ -36,7 +36,7 @@ async function Render({ handle, locale }: { handle: string | Promise<string>; lo
 
   return (
     <div className="grid gap-4">
-      <h2 className="text-2xl sm:text-3xl font-medium tracking-tight">{t("recommendations")}</h2>
+      <h2 className="text-2xl sm:text-3xl">{t("recommendations")}</h2>
       <div className="grid grid-cols-2 gap-5 lg:grid-cols-4">
         {related.slice(0, RECOMMENDATION_LIMIT).map((product) => (
           <ProductCard

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -112,7 +112,7 @@ async function SearchResultsGridRender({
   if (products.length === 0) {
     return (
       <div className="text-center py-10">
-        <h2 className="text-2xl font-medium tracking-tight mb-2">{t("noResults")}</h2>
+        <h2 className="text-2xl mb-2">{t("noResults")}</h2>
         <p className="text-muted-foreground">
           {query ? t("noResultsQuery", { query }) : t("noResultsAvailable")}
         </p>

--- a/apps/template/components/sections/banner-section.tsx
+++ b/apps/template/components/sections/banner-section.tsx
@@ -73,7 +73,7 @@ export function BannerSection({ hero, headingLevel = "h1" }: BannerSectionProps)
           <div className="flex flex-col items-center text-center gap-2.5">
             <Heading
               className={cn(
-                "text-3xl md:text-5xl font-semibold tracking-tight max-w-3xl",
+                "text-3xl md:text-5xl max-w-3xl",
                 hasMedia ? "text-white" : "text-foreground",
               )}
             >

--- a/apps/template/components/ui/error-boundary-content.tsx
+++ b/apps/template/components/ui/error-boundary-content.tsx
@@ -16,7 +16,7 @@ export function ErrorBoundaryContent({ reset }: { reset: () => void }) {
           <AlertCircleIcon className="h-12 w-12 text-muted-foreground" />
         </div>
       </div>
-      <h1 className="mb-2 text-2xl font-medium lg:text-3xl">{t("error")}</h1>
+      <h1 className="mb-2 text-2xl lg:text-3xl">{t("error")}</h1>
       <p className="mb-8 max-w-md text-muted-foreground">{t("errorDesc")}</p>
       <div className="flex flex-col gap-2.5 sm:flex-row">
         <Button onClick={reset}>{t("tryAgain")}</Button>


### PR DESCRIPTION
## Problem

Heading weight and letter-spacing had drifted across the storefront:

- **Page titles** alternated between `font-medium tracking-display` (search, collections, cart, account) and `font-semibold tracking-tight` (not-found, collection page).
- **The PDP `<h1>` was styled two different ways** — `product-detail-section.tsx` (`font-medium tracking-display`) vs `product-info.tsx` (`font-semibold tracking-tight`).
- **Section headings** mixed `tracking-tight`, `tracking-tighter`, and none.
- Display headings used `font-semibold` (600) or `font-medium` (500) — never 400.

Goal: match Geist / vercel.com/home heading behavior — **weight 400** with **negative tracking that tightens as size grows**, applied systematically so it can't drift again.

## Approach

Encode tracking into the Tailwind v4 type scale rather than per heading. Tailwind v4 defines `--text-{size}` and `--text-{size}--line-height` but no `letter-spacing`, so adding `--text-{size}--letter-spacing` modifiers in `@theme` makes every `text-*` utility — including responsive steps like `sm:text-4xl` — carry the right tracking automatically:

| size | tracking | | size | tracking |
|---|---|---|---|---|
| `lg` | -0.01em | | `4xl` | -0.03em |
| `xl` | -0.015em | | `5xl` | -0.035em |
| `2xl` | -0.02em | | `6xl` | -0.04em |
| `3xl` | -0.025em | | `7xl` | -0.045em |

`xs`/`sm`/`base` stay at normal for body readability.

Display headings then only specify size: removing their explicit `font-*` lets them inherit the 400 body default, and removing their explicit `tracking-*` lets the scale own letter-spacing.

## Scope

- **In scope:** display headings, `text-xl` and up (page titles, hero, PDP `<h1>`, section headings, filter title) — 19 headings across 18 files.
- **Left as-is:** small `text-sm`/`text-xs` label-headings (footer, filter labels, cart line item, agent tool labels) — they read as UI labels where 400 is under-weighted.
- `.prose` headings drop 500 → 400 to match; the now-unused `--tracking-display` token is removed.

## Verification

- `pnpm lint` and `pnpm format` clean.
- Grep confirms no `font-*`/explicit `tracking-*` left on display headings and no `tracking-display` repo-wide.
- Visual spot-check across pages to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)