### PR TITLE
feat(template): first-party Shopify analytics

### DIFF
--- a/apps/docs/content/docs/skills/enable-analytics.mdx
+++ b/apps/docs/content/docs/skills/enable-analytics.mdx
@@ -16,7 +16,9 @@ type: guide
 
 # Enable Analytics
 
-The current storefront includes Vercel Analytics and Vercel Speed Insights by default. This skill adds the same default wiring to older storefronts and can also add Google Tag Manager using the recommended integration.
+The current storefront includes Vercel Analytics, Vercel Speed Insights, and first-party Shopify analytics (`ShopifyAnalytics` in `components/analytics.tsx`, backed by `@shopify/hydrogen`'s `createStorefrontAnalytics`) by default. This skill adds the Vercel wiring to older storefronts and can also add Google Tag Manager using the recommended integration. To adopt the Shopify first-party events on an older storefront, use `/vercel-shop:update-shop` with the `shopify-first-party-analytics` rollout-log entry instead.
+
+When editing `components/analytics.tsx` in a current storefront, preserve the `ShopifyAnalytics` export — this skill's snippets only cover the Vercel `AnalyticsComponents` portion of that file.
 
 ## Before you start
 

--- a/apps/template/app/cart/page.tsx
+++ b/apps/template/app/cart/page.tsx
@@ -3,6 +3,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
+import { CartViewTracker } from "@/components/analytics-client";
 import { CartItemsList } from "@/components/cart-page/cart-items-list";
 import { Empty } from "@/components/cart-page/empty-cart";
 import { Header } from "@/components/cart-page/header";
@@ -35,6 +36,7 @@ export default async function CartPage() {
 
   return (
     <main>
+      <CartViewTracker />
       <Suspense fallback={<PageSkeleton />}>
         <CartContent locale={locale} />
       </Suspense>

--- a/apps/template/app/collections/[handle]/page.tsx
+++ b/apps/template/app/collections/[handle]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 
+import { CollectionViewTracker } from "@/components/analytics-client";
 import { CollectionDetailPage } from "@/components/collections/collection-page";
 import { getCollectionResultsData, getCollectionSearchState } from "@/lib/collections/server";
 import { getLocale } from "@/lib/params";
@@ -103,12 +104,17 @@ export default async function CollectionPage({
   });
 
   return (
-    <CollectionDetailPage
-      collection={collection}
-      collectionResultsDataPromise={collectionResultsDataPromise}
-      handle={handle}
-      locale={locale}
-      searchStatePromise={searchStatePromise}
-    />
+    <>
+      {collection.id && (
+        <CollectionViewTracker collection={{ handle: collection.handle, id: collection.id }} />
+      )}
+      <CollectionDetailPage
+        collection={collection}
+        collectionResultsDataPromise={collectionResultsDataPromise}
+        handle={handle}
+        locale={locale}
+        searchStatePromise={searchStatePromise}
+      />
+    </>
   );
 }

--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -7,7 +7,7 @@ import { Suspense } from "react";
 
 import { ActionBar } from "@/components/action-bar";
 import { AgentButton } from "@/components/agent/agent-button";
-import { AnalyticsComponents } from "@/components/analytics";
+import { AnalyticsComponents, ShopifyAnalytics } from "@/components/analytics";
 import { CartProvider } from "@/components/cart/context";
 import { CartOverlay } from "@/components/cart/overlay";
 import { Footer } from "@/components/footer";
@@ -60,6 +60,7 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
             <Suspense>
               <ActionBar>{agent.enabled && <AgentButton />}</ActionBar>
             </Suspense>
+            <ShopifyAnalytics locale={locale} />
           </CartProvider>
         </NextIntlClientProvider>
         <AnalyticsComponents />

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import { ProductViewTracker } from "@/components/analytics-client";
 import { ProductDetailSection } from "@/components/product-detail/product-detail-section";
 import { RelatedProductsSection } from "@/components/product/related-products-section";
 import { Container } from "@/components/ui/container";
@@ -113,6 +114,16 @@ export default async function ProductPage({
 
   return (
     <Page className="pt-0">
+      <ProductViewTracker
+        product={{
+          id: product.id,
+          price: (product.defaultVariant?.price ?? product.price).amount,
+          title: product.title,
+          variantId: product.defaultVariant?.id ?? product.defaultVariantId ?? product.id,
+          variantTitle: product.defaultVariant?.title ?? product.title,
+          vendor: product.vendor ?? "",
+        }}
+      />
       <Container className="bg-background">
         <Sections>
           <ProductDetailSection

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 import { Suspense } from "react";
 
+import { SearchViewTracker } from "@/components/analytics-client";
 import {
   FilterPendingScope,
   FilterTransitionProvider,
@@ -83,6 +84,9 @@ export default async function SearchPage({ searchParams }: PageProps<"/search">)
 
   return (
     <Page className="pt-2.5 md:pt-10">
+      <Suspense>
+        <SearchViewTracker />
+      </Suspense>
       <Container>
         <FilterTransitionProvider>
           <Sections className="gap-5">

--- a/apps/template/components/analytics-client.tsx
+++ b/apps/template/components/analytics-client.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import type { ShopAnalytics } from "@shopify/hydrogen";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+import { useCart } from "@/components/cart/context";
+import {
+  initAnalytics,
+  syncCartAnalytics,
+  trackCartView,
+  trackCollectionView,
+  trackPageView,
+  trackProductView,
+  trackSearchView,
+  type ProductViewPayload,
+} from "@/lib/analytics/client";
+
+interface ShopifyAnalyticsClientProps {
+  consentDomain: string;
+  publicStorefrontAccessToken: string;
+  shop: ShopAnalytics;
+}
+
+export function ShopifyAnalyticsClient({
+  consentDomain,
+  publicStorefrontAccessToken,
+  shop,
+}: ShopifyAnalyticsClientProps) {
+  const { cart } = useCart();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const search = searchParams.toString();
+
+  useEffect(() => {
+    initAnalytics({ consentDomain, publicStorefrontAccessToken, shop });
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- the bus is a create-once singleton
+  }, []);
+
+  useEffect(() => {
+    trackPageView();
+  }, [pathname, search]);
+
+  useEffect(() => {
+    syncCartAnalytics(cart);
+  }, [cart]);
+
+  return null;
+}
+
+export function ProductViewTracker({ product }: { product: ProductViewPayload }) {
+  useEffect(() => {
+    trackProductView(product);
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- one view per product navigation
+  }, [product.id, product.variantId]);
+
+  return null;
+}
+
+export function CollectionViewTracker({
+  collection,
+}: {
+  collection: { handle: string; id: string };
+}) {
+  useEffect(() => {
+    trackCollectionView(collection);
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- one view per collection navigation
+  }, [collection.id]);
+
+  return null;
+}
+
+export function SearchViewTracker() {
+  const searchParams = useSearchParams();
+  const searchTerm = searchParams.get("q") ?? "";
+
+  useEffect(() => {
+    if (searchTerm) trackSearchView(searchTerm);
+  }, [searchTerm]);
+
+  return null;
+}
+
+export function CartViewTracker() {
+  useEffect(() => {
+    trackCartView();
+  }, []);
+
+  return null;
+}

--- a/apps/template/components/analytics-client.tsx
+++ b/apps/template/components/analytics-client.tsx
@@ -2,7 +2,7 @@
 
 import type { ShopAnalytics } from "@shopify/hydrogen";
 import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useEffectEvent } from "react";
 
 import { useCart } from "@/components/cart/context";
 import {
@@ -32,9 +32,12 @@ export function ShopifyAnalyticsClient({
   const searchParams = useSearchParams();
   const search = searchParams.toString();
 
+  const init = useEffectEvent(() =>
+    initAnalytics({ consentDomain, publicStorefrontAccessToken, shop }),
+  );
+
   useEffect(() => {
-    initAnalytics({ consentDomain, publicStorefrontAccessToken, shop });
-    // oxlint-disable-next-line react-hooks/exhaustive-deps -- the bus is a create-once singleton
+    init();
   }, []);
 
   useEffect(() => {
@@ -49,9 +52,10 @@ export function ShopifyAnalyticsClient({
 }
 
 export function ProductViewTracker({ product }: { product: ProductViewPayload }) {
+  const fireProductView = useEffectEvent(() => trackProductView(product));
+
   useEffect(() => {
-    trackProductView(product);
-    // oxlint-disable-next-line react-hooks/exhaustive-deps -- one view per product navigation
+    fireProductView();
   }, [product.id, product.variantId]);
 
   return null;
@@ -62,9 +66,10 @@ export function CollectionViewTracker({
 }: {
   collection: { handle: string; id: string };
 }) {
+  const fireCollectionView = useEffectEvent(() => trackCollectionView(collection));
+
   useEffect(() => {
-    trackCollectionView(collection);
-    // oxlint-disable-next-line react-hooks/exhaustive-deps -- one view per collection navigation
+    fireCollectionView();
   }, [collection.id]);
 
   return null;

--- a/apps/template/components/analytics.tsx
+++ b/apps/template/components/analytics.tsx
@@ -1,5 +1,11 @@
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { Suspense } from "react";
+
+import { ShopifyAnalyticsClient } from "@/components/analytics-client";
+import { getCurrencyCode, getLanguageCode } from "@/lib/i18n";
+import { withFallback } from "@/lib/shopify/errors";
+import { getShopId } from "@/lib/shopify/operations/shop";
 
 export function AnalyticsComponents() {
   return (
@@ -7,5 +13,36 @@ export function AnalyticsComponents() {
       <Analytics />
       <SpeedInsights />
     </>
+  );
+}
+
+async function ShopifyAnalyticsLoader({ locale }: { locale: string }) {
+  const domain = process.env.SHOPIFY_STORE_DOMAIN;
+  const token = process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN;
+  if (!domain || !token) return null;
+
+  const shopId = await withFallback(getShopId(), undefined);
+  if (!shopId) return null;
+
+  return (
+    <ShopifyAnalyticsClient
+      consentDomain={domain}
+      // The Storefront token is public (see lib/shopify/storefront.ts); the consent API requires it client-side.
+      publicStorefrontAccessToken={token}
+      shop={{
+        acceptedLanguage: getLanguageCode(locale),
+        currency: getCurrencyCode(locale),
+        hydrogenSubchannelId: "0",
+        shopId,
+      }}
+    />
+  );
+}
+
+export function ShopifyAnalytics({ locale }: { locale: string }) {
+  return (
+    <Suspense>
+      <ShopifyAnalyticsLoader locale={locale} />
+    </Suspense>
   );
 }

--- a/apps/template/lib/analytics/client.ts
+++ b/apps/template/lib/analytics/client.ts
@@ -30,7 +30,10 @@ let bus: StorefrontAnalytics | null = null;
 let shopConfig: ShopAnalytics | null = null;
 let lastCart: AnalyticsCart | null = null;
 // Trackers are leaf components whose effects run before the initializer's, so
-// pre-init publishes queue until the bus exists.
+// pre-init publishes queue until the bus exists. The bus may never initialize
+// (e.g. the analytics loader bails out for the session), so the queue is capped
+// to drop the oldest entries and avoid unbounded growth / a memory leak.
+const MAX_QUEUE_LENGTH = 100;
 let queue: Array<(bus: StorefrontAnalytics) => void> = [];
 
 export function initAnalytics({
@@ -56,6 +59,9 @@ function withBus(publish: (bus: StorefrontAnalytics) => void): void {
   if (bus) {
     publish(bus);
   } else {
+    // Cap the pre-init queue: if the bus never initializes, drop the oldest
+    // pending publishes so the queue cannot grow without bound.
+    if (queue.length >= MAX_QUEUE_LENGTH) queue.shift();
     queue.push(publish);
   }
 }

--- a/apps/template/lib/analytics/client.ts
+++ b/apps/template/lib/analytics/client.ts
@@ -1,0 +1,152 @@
+"use client";
+
+import {
+  AnalyticsEvent,
+  createStorefrontAnalytics,
+  type AnalyticsCart,
+  type AnalyticsCartLine,
+  type ShopAnalytics,
+  type StorefrontAnalytics,
+} from "@shopify/hydrogen";
+
+import type { Cart, CartLine } from "@/lib/types";
+
+export interface AnalyticsConfig {
+  consentDomain: string;
+  publicStorefrontAccessToken: string;
+  shop: ShopAnalytics;
+}
+
+export interface ProductViewPayload {
+  id: string;
+  price: string;
+  title: string;
+  variantId: string;
+  variantTitle: string;
+  vendor: string;
+}
+
+let bus: StorefrontAnalytics | null = null;
+let shopConfig: ShopAnalytics | null = null;
+let lastCart: AnalyticsCart | null = null;
+// Trackers are leaf components whose effects run before the initializer's, so
+// pre-init publishes queue until the bus exists.
+let queue: Array<(bus: StorefrontAnalytics) => void> = [];
+
+export function initAnalytics({
+  consentDomain,
+  publicStorefrontAccessToken,
+  shop,
+}: AnalyticsConfig): void {
+  if (typeof window === "undefined" || bus) return;
+
+  shopConfig = shop;
+  bus = createStorefrontAnalytics({
+    consent: { consentDomain, publicStorefrontAccessToken },
+    shop,
+  });
+
+  const pending = queue;
+  queue = [];
+  for (const publish of pending) publish(bus);
+}
+
+function withBus(publish: (bus: StorefrontAnalytics) => void): void {
+  if (typeof window === "undefined") return;
+  if (bus) {
+    publish(bus);
+  } else {
+    queue.push(publish);
+  }
+}
+
+export function trackPageView(): void {
+  withBus((b) =>
+    b.publish(AnalyticsEvent.PAGE_VIEWED, { shop: shopConfig, url: window.location.href }),
+  );
+}
+
+export function trackProductView(product: ProductViewPayload): void {
+  withBus((b) =>
+    b.publish(AnalyticsEvent.PRODUCT_VIEWED, {
+      products: [{ ...product, quantity: 1 }],
+      shop: shopConfig,
+      url: window.location.href,
+    }),
+  );
+}
+
+export function trackCollectionView(collection: { handle: string; id: string }): void {
+  withBus((b) =>
+    b.publish(AnalyticsEvent.COLLECTION_VIEWED, {
+      collection,
+      shop: shopConfig,
+      url: window.location.href,
+    }),
+  );
+}
+
+export function trackSearchView(searchTerm: string): void {
+  withBus((b) =>
+    b.publish(AnalyticsEvent.SEARCH_VIEWED, {
+      searchTerm,
+      shop: shopConfig,
+      url: window.location.href,
+    }),
+  );
+}
+
+export function trackCartView(): void {
+  withBus((b) =>
+    b.publish(AnalyticsEvent.CART_VIEWED, {
+      cart: lastCart,
+      prevCart: null,
+      shop: shopConfig,
+      url: window.location.href,
+    }),
+  );
+}
+
+/** Feed server-confirmed carts; the tracker dedupes by updatedAt, so optimistic copies are skipped. */
+export function syncCartAnalytics(cart: Cart | null): void {
+  if (!cart?.id || !cart.updatedAt) return;
+  if (lastCart?.id === cart.id && lastCart.updatedAt === cart.updatedAt) return;
+
+  const analyticsCart = toAnalyticsCart(cart.id, cart.updatedAt, cart.lines);
+  lastCart = analyticsCart;
+  withBus((b) => b.updateCart(analyticsCart));
+}
+
+function toAnalyticsCart(id: string, updatedAt: string, lines: CartLine[]): AnalyticsCart {
+  return {
+    id,
+    updatedAt,
+    lines: {
+      nodes: lines
+        .filter((line): line is CartLine & { id: string } => Boolean(line.id))
+        .map(toAnalyticsCartLine),
+    },
+  };
+}
+
+function toAnalyticsCartLine(line: CartLine & { id: string }): AnalyticsCartLine {
+  return {
+    id: line.id,
+    merchandise: {
+      id: line.merchandise.id,
+      price: {
+        amount: line.merchandise.price?.amount ?? "0",
+        currencyCode: line.merchandise.price?.currencyCode,
+      },
+      product: {
+        handle: line.merchandise.product.handle,
+        id: line.merchandise.product.id,
+        title: line.merchandise.product.title,
+        vendor: line.merchandise.product.vendor ?? "",
+      },
+      sku: line.merchandise.sku,
+      title: line.merchandise.title,
+    },
+    quantity: line.quantity,
+  };
+}

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -140,6 +140,7 @@ export const CART_FRAGMENT = `#graphql
       ... on ProductVariant {
         id
         title
+        sku
         selectedOptions {
           name
           value
@@ -154,6 +155,7 @@ export const CART_FRAGMENT = `#graphql
           id
           title
           handle
+          vendor
           featuredImage {
             ...ImageFields
           }
@@ -188,6 +190,7 @@ export const CART_FRAGMENT = `#graphql
       ... on ProductVariant {
         id
         title
+        sku
         selectedOptions {
           name
           value
@@ -202,6 +205,7 @@ export const CART_FRAGMENT = `#graphql
           id
           title
           handle
+          vendor
           featuredImage {
             ...ImageFields
           }
@@ -214,6 +218,7 @@ export const CART_FRAGMENT = `#graphql
   }
   fragment CartFields on Cart {
     id
+    updatedAt
     checkoutUrl
     totalQuantity
     note
@@ -276,6 +281,7 @@ export const CART_FRAGMENT = `#graphql
 export const COLLECTION_FIELDS_FRAGMENT = `#graphql
   ${IMAGE_FRAGMENT}
   fragment CollectionFields on Collection {
+    id
     handle
     title
     description

--- a/apps/template/lib/shopify/operations/shop.ts
+++ b/apps/template/lib/shopify/operations/shop.ts
@@ -1,0 +1,22 @@
+import { cacheLife, cacheTag } from "next/cache";
+
+import { assertStorefrontOk } from "../errors";
+import { storefront } from "../storefront";
+
+const GET_SHOP_ID_QUERY = `#graphql
+  query getShopId {
+    shop {
+      id
+    }
+  }
+` as const;
+
+export async function getShopId(): Promise<string> {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("shop");
+
+  const response = await storefront.request<{ shop: { id: string } }>(GET_SHOP_ID_QUERY);
+  assertStorefrontOk(response, "getShopId");
+  return response.data.shop.id;
+}

--- a/apps/template/lib/shopify/transforms/cart.ts
+++ b/apps/template/lib/shopify/transforms/cart.ts
@@ -62,8 +62,10 @@ interface ShopifyCartLine {
       handle: string;
       id: string;
       title: string;
+      vendor: string;
     };
     selectedOptions: Array<{ name: string; value: string }>;
+    sku?: string | null;
     title: string;
   };
   quantity: number;
@@ -90,6 +92,7 @@ export interface ShopifyCart {
   lines: { nodes: ShopifyCartLine[] };
   note: string | null;
   totalQuantity: number;
+  updatedAt: string;
 }
 
 function transformImage(image: ShopifyImage | null): Image {
@@ -106,6 +109,7 @@ function transformCartProduct(product: ShopifyCartLine["merchandise"]["product"]
     id: product.id,
     handle: product.handle,
     title: product.title,
+    vendor: product.vendor,
     featuredImage: transformImage(product.featuredImage),
   };
 }
@@ -165,6 +169,7 @@ function transformCartLine(line: ShopifyCartLine): CartLine {
     merchandise: {
       id: line.merchandise.id,
       title: line.merchandise.title,
+      sku: line.merchandise.sku,
       image: line.merchandise.image ? transformImage(line.merchandise.image) : undefined,
       price: line.merchandise.price,
       selectedOptions: line.merchandise.selectedOptions,
@@ -193,6 +198,7 @@ function transformShippingCost(cart: ShopifyCart): Money | null {
 export function transformShopifyCart(cart: ShopifyCart): Cart {
   return {
     id: cart.id,
+    updatedAt: cart.updatedAt,
     checkoutUrl: cart.checkoutUrl,
     totalQuantity: cart.totalQuantity,
     note: cart.note,

--- a/apps/template/lib/shopify/transforms/collection.ts
+++ b/apps/template/lib/shopify/transforms/collection.ts
@@ -1,6 +1,7 @@
 import type { Collection } from "@/lib/types";
 
 interface ShopifyCollection {
+  id: string;
   handle: string;
   title: string;
   description: string;
@@ -19,6 +20,7 @@ interface ShopifyCollection {
 
 export function transformShopifyCollection(collection: ShopifyCollection): Collection {
   return {
+    id: collection.id,
     handle: collection.handle,
     title: collection.title,
     description: collection.description,

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -182,6 +182,7 @@ export interface Cart {
   note: string | null;
   shippingCost: Money | null;
   totalQuantity: number;
+  updatedAt?: string;
 }
 
 export interface CartLine {
@@ -228,6 +229,7 @@ export interface CartMerchandise {
   price?: Money;
   product: CartProduct;
   selectedOptions: SelectedOption[];
+  sku?: string | null;
   title: string;
 }
 
@@ -236,11 +238,13 @@ export interface CartProduct {
   handle: string;
   id: string;
   title: string;
+  vendor?: string;
 }
 
 export interface Collection {
   description: string;
   handle: string;
+  id?: string;
   image?: Image | null;
   path: string;
   seo: SEO;

--- a/packages/plugin/skills/enable-analytics/SKILL.md
+++ b/packages/plugin/skills/enable-analytics/SKILL.md
@@ -5,7 +5,9 @@ description: Add Vercel Analytics, Vercel Speed Insights, and Google Tag Manager
 
 # Enable Analytics
 
-The current storefront includes Vercel Analytics and Vercel Speed Insights by default. This skill adds the same default wiring to older storefronts and can also add Google Tag Manager using the recommended integration.
+The current storefront includes Vercel Analytics, Vercel Speed Insights, and first-party Shopify analytics (`ShopifyAnalytics` in `components/analytics.tsx`, backed by `@shopify/hydrogen`'s `createStorefrontAnalytics`) by default. This skill adds the Vercel wiring to older storefronts and can also add Google Tag Manager using the recommended integration. To adopt the Shopify first-party events on an older storefront, use `/vercel-shop:update-shop` with the `shopify-first-party-analytics` rollout-log entry instead.
+
+When editing `components/analytics.tsx` in a current storefront, preserve the `ShopifyAnalytics` export — this skill's snippets only cover the Vercel `AnalyticsComponents` portion of that file.
 
 ## Before you start
 

--- a/packages/plugin/template-rollout-log/2026-07-08-shopify-first-party-analytics.md
+++ b/packages/plugin/template-rollout-log/2026-07-08-shopify-first-party-analytics.md
@@ -1,0 +1,58 @@
+---
+title: First-party Shopify analytics via @shopify/hydrogen createStorefrontAnalytics
+changeKey: shopify-first-party-analytics
+introducedOn: 2026-07-08
+changeType: feature
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/app/cart/page.tsx
+  - apps/template/app/collections/[handle]/page.tsx
+  - apps/template/app/layout.tsx
+  - apps/template/app/products/[handle]/page.tsx
+  - apps/template/app/search/page.tsx
+  - apps/template/components/analytics-client.tsx
+  - apps/template/components/analytics.tsx
+  - apps/template/lib/analytics/client.ts
+  - apps/template/lib/shopify/fragments.ts
+  - apps/template/lib/shopify/operations/shop.ts
+  - apps/template/lib/shopify/transforms/cart.ts
+  - apps/template/lib/shopify/transforms/collection.ts
+  - apps/template/lib/types.ts
+---
+
+## Summary
+
+Wired Shopify's first-party analytics (the preview `@shopify/hydrogen` package the template already uses for its storefront client) into the storefront:
+
+- `lib/analytics/client.ts` — client singleton around `createStorefrontAnalytics` with typed publish helpers (`trackPageView`, `trackProductView`, `trackCollectionView`, `trackSearchView`, `trackCartView`) and `syncCartAnalytics`, which maps the domain `Cart` to the bus's `AnalyticsCart`. Publishes before init are queued (tracker leaf effects run before the initializer's).
+- `components/analytics.tsx` — new `ShopifyAnalytics` server component (Suspense-wrapped) that resolves the shop id and passes the store domain + public Storefront token to the client. Renders nothing if env or the shop query is unavailable, so mock/no-env clones build unchanged.
+- `components/analytics-client.tsx` — `ShopifyAnalyticsClient` (init + `page_viewed` on route change + cart sync from the cart context) and per-route view trackers.
+- Trackers mounted on PDP (`product_viewed`), collection (`collection_viewed`), search (`search_viewed`), and cart (`cart_viewed`) pages; the provider mounts in the root layout inside `CartProvider`.
+- Data plumbing the events require: `CART_FRAGMENT` now queries cart `updatedAt`, variant `sku`, and product `vendor` (threaded through the cart transform and domain types as optional fields); `COLLECTION_FIELDS_FRAGMENT` now queries `id`; new cached `getShopId()` operation (`lib/shopify/operations/shop.ts`).
+
+Consent uses the Customer Privacy API in its default `no-banner` mode; the Storefront token is passed to the client because the consent script requires it, and it is a public token by design (see `lib/shopify/storefront.ts`). No new environment variables.
+
+## Why it matters
+
+Merchant-side reporting, conversion attribution, and app-installed pixels depend on Shopify's first-party events. Storefronts built from the template previously emitted none of them, so headless traffic was invisible in Shopify analytics dashboards.
+
+The cart tracker dedupes by `cart.updatedAt`, so the template's optimistic cart updates (which carry a stale `updatedAt`) are skipped automatically and only server-confirmed mutations emit `product_added_to_cart` / `product_removed_from_cart`.
+
+## Apply when
+
+- The storefront still uses the template's `CartProvider`, cart fragment/transform, and route structure.
+- The merchant wants headless sessions attributed in Shopify's analytics dashboards.
+
+## Safe to skip when
+
+- A downstream analytics stack (e.g. a CMP or tag manager) already publishes Shopify's Monorail events.
+- The storefront replaced the cart context or fragments wholesale — the fragment/type additions (`updatedAt`, `sku`, `vendor`, collection `id`) would need manual porting first.
+
+## Validation
+
+1. `pnpm --filter template lint` and `pnpm --filter template build` (all routes should keep their PPR status).
+2. With real store env vars, load any page and check `document.cookie` for `_shopify_y` after the consent script loads, and the network tab for a `monorail-edge.shopifysvc.com` request on navigation.
+3. Add an item to the cart; a `product_added_to_cart` publish should follow the server-confirmed cart (subscribe via `getAnalytics`-style `bus.subscribe` or check Monorail requests).
+4. Without `SHOPIFY_STORE_DOMAIN`/`SHOPIFY_STOREFRONT_ACCESS_TOKEN`, the build renders no analytics client and nothing is published.


### PR DESCRIPTION
Wires Shopify's first-party analytics (from the `@shopify/hydrogen` preview package the template already uses for its storefront client) into the storefront. No new env vars; a clone without store env builds unchanged.

- `lib/analytics/client.ts` — singleton around `createStorefrontAnalytics` with typed publish helpers and `syncCartAnalytics` (domain `Cart` → `AnalyticsCart`); pre-init publishes are queued
- `components/analytics.tsx` — `ShopifyAnalytics` server component (Suspense-wrapped) resolving shop id + passing store domain and the public Storefront token to the client
- `components/analytics-client.tsx` — initializer (consent, `page_viewed` on route change, cart sync from cart context) + view trackers mounted on PDP, collection, search, and cart pages
- Data plumbing: `CART_FRAGMENT` gains `updatedAt`/`sku`/`vendor`, `COLLECTION_FIELDS_FRAGMENT` gains `id`, new cached `getShopId()` operation — all schema-validated
- Cart add/remove events derive from the tracker's `updatedAt` diffing, so optimistic cart updates are skipped automatically; no mutation call sites touched
- Rollout log entry `shopify-first-party-analytics` + `enable-analytics` skill note (docs synced via sync-skills)

Build passes with all routes keeping PPR. Not verified against a live store: consent script load and Monorail requests (validation steps in the rollout entry). Known quirk: `cart_viewed` on a direct `/cart` landing fires before the first cart sync and reports a null cart.