### PR TITLE
experiment: 10s delay on related products

### DIFF
--- a/apps/template/components/product/related-products-section.tsx
+++ b/apps/template/components/product/related-products-section.tsx
@@ -27,6 +27,8 @@ export function RelatedProductsSectionSkeleton({ title }: { title?: string }) {
 
 async function Render({ handle, locale }: { handle: string | Promise<string>; locale: Locale }) {
   const resolvedHandle = await handle;
+  // EXPERIMENT: artificial delay to observe PDP streaming behavior.
+  await new Promise((resolve) => setTimeout(resolve, 10000));
   const [t, { related }] = await Promise.all([
     getTranslations("product"),
     getProductRecommendationSets({ handle: resolvedHandle, locale }),

--- a/apps/template/components/product/related-products-section.tsx
+++ b/apps/template/components/product/related-products-section.tsx
@@ -27,8 +27,6 @@ export function RelatedProductsSectionSkeleton({ title }: { title?: string }) {
 
 async function Render({ handle, locale }: { handle: string | Promise<string>; locale: Locale }) {
   const resolvedHandle = await handle;
-  // EXPERIMENT: artificial delay to observe PDP streaming behavior.
-  await new Promise((resolve) => setTimeout(resolve, 10000));
   const [t, { related }] = await Promise.all([
     getTranslations("product"),
     getProductRecommendationSets({ handle: resolvedHandle, locale }),

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -596,6 +596,9 @@ export async function getProductRecommendationSets(params: {
   cacheLife("max");
   cacheTag("products", `complementary-${params.handle}`, `recommendations-${params.handle}`);
 
+  // EXPERIMENT: artificial delay to observe PDP streaming behavior on cache miss.
+  await new Promise((resolve) => setTimeout(resolve, 10000));
+
   const sets = await fetchProductRecommendationSets(params);
   tagProducts([...sets.complementary, ...sets.related]);
   return sets;


### PR DESCRIPTION
Experiment to observe PDP streaming/Suspense behavior. Adds an artificial 10s delay before the related products render resolves. Not for merge — revert after observing.