### PR TITLE
feat: stream PDP reviews from a cached fetch

### DIFF
--- a/apps/template/app/[locale]/products/[handle]/page.tsx
+++ b/apps/template/app/[locale]/products/[handle]/page.tsx
@@ -122,7 +122,7 @@ export default async function ProductPage({
             variantPromise={variantPromise}
             locale={locale}
           />
-          <ProductReviewsSection />
+          <ProductReviewsSection handle={handle} locale={locale} />
           <RelatedProductsSection handle={handle} locale={locale} />
         </Sections>
       </Container>

--- a/apps/template/app/[locale]/products/[handle]/page.tsx
+++ b/apps/template/app/[locale]/products/[handle]/page.tsx
@@ -122,7 +122,7 @@ export default async function ProductPage({
             variantPromise={variantPromise}
             locale={locale}
           />
-          <ProductReviewsSection handle={handle} locale={locale} />
+          <ProductReviewsSection handle={handle} locale={locale} title={product.title} />
           <RelatedProductsSection handle={handle} locale={locale} />
         </Sections>
       </Container>

--- a/apps/template/components/product-detail/product-reviews-section.tsx
+++ b/apps/template/components/product-detail/product-reviews-section.tsx
@@ -1,4 +1,5 @@
 import { getTranslations } from "next-intl/server";
+import { io } from "next/cache";
 import { Suspense } from "react";
 
 import { RatingStars } from "@/components/ui/rating-stars";
@@ -22,6 +23,10 @@ function ProductReviewsSkeleton({ title }: { title: string }) {
 }
 
 async function Render({ handle, locale }: { handle: string | Promise<string>; locale: Locale }) {
+  // io() suspends the prerender at this boundary so the skeleton ships in the static
+  // shell and the reviews stream in at request time. It's a no-op inside a use cache
+  // scope, so it must live here (outside getProductReviews), not in the cached fetch.
+  await io();
   const resolvedHandle = await handle;
   const [t, reviews] = await Promise.all([
     getTranslations("product"),

--- a/apps/template/components/product-detail/product-reviews-section.tsx
+++ b/apps/template/components/product-detail/product-reviews-section.tsx
@@ -3,62 +3,38 @@ import { Suspense } from "react";
 
 import { RatingStars } from "@/components/ui/rating-stars";
 import { Skeleton } from "@/components/ui/skeleton";
+import type { Locale } from "@/lib/i18n";
+import { getProductReviews } from "@/lib/shopify/operations/products";
 
-interface PlaceholderReview {
-  author: string;
-  body: string;
-  date: string;
-  id: string;
-  rating: number;
-}
-
-// Placeholder data standing in for a real reviews integration (Shopify metafields,
-// a third-party widget, etc.). Replace this with a fetch when wiring up reviews.
-const PLACEHOLDER_REVIEWS: PlaceholderReview[] = [
-  {
-    author: "Alex Morgan",
-    body: "Exceeded my expectations. The quality is outstanding and it arrived earlier than promised. Would absolutely buy again.",
-    date: "March 2026",
-    id: "1",
-    rating: 5,
-  },
-  {
-    author: "Jordan Lee",
-    body: "Really happy with this purchase overall. Fit and finish are great — took off one star only because shipping took a little longer than expected.",
-    date: "February 2026",
-    id: "2",
-    rating: 4,
-  },
-  {
-    author: "Sam Rivera",
-    body: "Exactly as described and worth every penny. I've already recommended it to a couple of friends.",
-    date: "January 2026",
-    id: "3",
-    rating: 5,
-  },
-];
+const REVIEW_COUNT = 3;
 
 function ProductReviewsSkeleton({ title }: { title: string }) {
   return (
     <div className="grid gap-5" data-slot="product-reviews">
       <h2 className="text-2xl sm:text-3xl">{title}</h2>
       <div className="grid gap-5">
-        {PLACEHOLDER_REVIEWS.map((review) => (
-          <Skeleton key={review.id} className="h-24 w-full" />
+        {Array.from({ length: REVIEW_COUNT }, (_, index) => (
+          <Skeleton key={index} className="h-24 w-full" />
         ))}
       </div>
     </div>
   );
 }
 
-async function Render() {
-  const t = await getTranslations("product");
+async function Render({ handle, locale }: { handle: string | Promise<string>; locale: Locale }) {
+  const resolvedHandle = await handle;
+  const [t, reviews] = await Promise.all([
+    getTranslations("product"),
+    getProductReviews({ handle: resolvedHandle, locale }),
+  ]);
+
+  if (reviews.length === 0) return null;
 
   return (
     <div className="grid gap-5" data-slot="product-reviews">
       <h2 className="text-2xl sm:text-3xl">{t("reviewsTitle")}</h2>
       <div className="grid gap-5">
-        {PLACEHOLDER_REVIEWS.map((review) => (
+        {reviews.map((review) => (
           <article
             key={review.id}
             className="grid gap-2.5 border-b border-border pb-5 last:border-b-0 last:pb-0"
@@ -81,12 +57,18 @@ async function Render() {
   );
 }
 
-export async function ProductReviewsSection() {
+export async function ProductReviewsSection({
+  handle,
+  locale,
+}: {
+  handle: string | Promise<string>;
+  locale: Locale;
+}) {
   const t = await getTranslations("product");
 
   return (
     <Suspense fallback={<ProductReviewsSkeleton title={t("reviewsTitle")} />}>
-      <Render />
+      <Render handle={handle} locale={locale} />
     </Suspense>
   );
 }

--- a/apps/template/components/product-detail/product-reviews-section.tsx
+++ b/apps/template/components/product-detail/product-reviews-section.tsx
@@ -5,7 +5,7 @@ import { Suspense } from "react";
 import { RatingStars } from "@/components/ui/rating-stars";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Locale } from "@/lib/i18n";
-import { getProductReviews } from "@/lib/shopify/operations/products";
+import { getProductReviews } from "@/lib/reviews/server";
 
 const REVIEW_COUNT = 3;
 
@@ -22,7 +22,15 @@ function ProductReviewsSkeleton({ title }: { title: string }) {
   );
 }
 
-async function Render({ handle, locale }: { handle: string | Promise<string>; locale: Locale }) {
+async function Render({
+  handle,
+  locale,
+  title,
+}: {
+  handle: string | Promise<string>;
+  locale: Locale;
+  title: string;
+}) {
   // io() suspends the prerender at this boundary so the skeleton ships in the static
   // shell and the reviews stream in at request time. It's a no-op inside a use cache
   // scope, so it must live here (outside getProductReviews), not in the cached fetch.
@@ -30,7 +38,7 @@ async function Render({ handle, locale }: { handle: string | Promise<string>; lo
   const resolvedHandle = await handle;
   const [t, reviews] = await Promise.all([
     getTranslations("product"),
-    getProductReviews({ handle: resolvedHandle, locale }),
+    getProductReviews({ handle: resolvedHandle, locale, title }),
   ]);
 
   if (reviews.length === 0) return null;
@@ -65,15 +73,17 @@ async function Render({ handle, locale }: { handle: string | Promise<string>; lo
 export async function ProductReviewsSection({
   handle,
   locale,
+  title,
 }: {
   handle: string | Promise<string>;
   locale: Locale;
+  title: string;
 }) {
   const t = await getTranslations("product");
 
   return (
     <Suspense fallback={<ProductReviewsSkeleton title={t("reviewsTitle")} />}>
-      <Render handle={handle} locale={locale} />
+      <Render handle={handle} locale={locale} title={title} />
     </Suspense>
   );
 }

--- a/apps/template/lib/reviews/server.ts
+++ b/apps/template/lib/reviews/server.ts
@@ -30,14 +30,17 @@ export async function getProductReviews(params: {
   cacheLife("max");
   cacheTag("products", `reviews-${params.handle}`);
 
-  // Vary the prompt per cache fill so the model doesn't reuse the same names across products.
-  const seed = Math.floor(Math.random() * 1_000_000);
+  // The model gravitates toward a few default names; pin each review to a random
+  // initial so the AI picks a different author per cache fill.
+  const initials = Array.from({ length: 3 }, () =>
+    String.fromCharCode(65 + Math.floor(Math.random() * 26)),
+  );
 
   const { object } = await generateObject({
     model: REVIEWS_MODEL,
     prompt:
       `Write three realistic customer reviews for the product "${params.title}". ` +
-      `Use distinct, varied author names (seed ${seed}). ` +
+      `The three authors' first names must start with the letters ${initials.join(", ")}. ` +
       "Each review must have a short body praising a specific detail, " +
       "a month-and-year date, and a star rating between 3 and 5. Keep them varied and authentic.",
     schema: reviewSchema,

--- a/apps/template/lib/reviews/server.ts
+++ b/apps/template/lib/reviews/server.ts
@@ -21,10 +21,6 @@ const reviewSchema = z.object({
     .length(3),
 });
 
-// EXPERIMENT: artificial delay to confirm the reviews section streams in behind its
-// Suspense boundary instead of blocking the PDP shell. Only fires on a cache miss.
-const EXPERIMENT_DELAY_MS = 10_000;
-
 export async function getProductReviews(params: {
   handle: string;
   locale?: string;
@@ -34,16 +30,18 @@ export async function getProductReviews(params: {
   cacheLife("max");
   cacheTag("products", `reviews-${params.handle}`);
 
-  await new Promise((resolve) => setTimeout(resolve, EXPERIMENT_DELAY_MS));
+  // Vary the prompt per cache fill so the model doesn't reuse the same names across products.
+  const seed = Math.floor(Math.random() * 1_000_000);
 
   const { object } = await generateObject({
     model: REVIEWS_MODEL,
     prompt:
       `Write three realistic customer reviews for the product "${params.title}". ` +
-      "Each review must have a distinct author, a short body praising a specific detail, " +
+      `Use distinct, varied author names (seed ${seed}). ` +
+      "Each review must have a short body praising a specific detail, " +
       "a month-and-year date, and a star rating between 3 and 5. Keep them varied and authentic.",
     schema: reviewSchema,
   });
 
-  return object.reviews;
+  return object.reviews.toSorted((a, b) => Date.parse(b.date) - Date.parse(a.date));
 }

--- a/apps/template/lib/reviews/server.ts
+++ b/apps/template/lib/reviews/server.ts
@@ -1,0 +1,49 @@
+import "server-only";
+import { generateObject } from "ai";
+import { cacheLife, cacheTag } from "next/cache";
+import { z } from "zod";
+
+import type { ProductReview } from "@/lib/types";
+
+const REVIEWS_MODEL = "google/gemini-3.5-flash";
+
+const reviewSchema = z.object({
+  reviews: z
+    .array(
+      z.object({
+        author: z.string().describe("A plausible first and last name."),
+        body: z.string().describe("One or two sentences of specific, authentic-sounding praise."),
+        date: z.string().describe("A month and year, e.g. 'March 2026'."),
+        id: z.string().describe("A short unique identifier."),
+        rating: z.number().int().min(3).max(5).describe("A star rating from 3 to 5."),
+      }),
+    )
+    .length(3),
+});
+
+// EXPERIMENT: artificial delay to confirm the reviews section streams in behind its
+// Suspense boundary instead of blocking the PDP shell. Only fires on a cache miss.
+const EXPERIMENT_DELAY_MS = 10_000;
+
+export async function getProductReviews(params: {
+  handle: string;
+  locale?: string;
+  title: string;
+}): Promise<ProductReview[]> {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("products", `reviews-${params.handle}`);
+
+  await new Promise((resolve) => setTimeout(resolve, EXPERIMENT_DELAY_MS));
+
+  const { object } = await generateObject({
+    model: REVIEWS_MODEL,
+    prompt:
+      `Write three realistic customer reviews for the product "${params.title}". ` +
+      "Each review must have a distinct author, a short body praising a specific detail, " +
+      "a month-and-year date, and a star rating between 3 and 5. Keep them varied and authentic.",
+    schema: reviewSchema,
+  });
+
+  return object.reviews;
+}

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -8,7 +8,6 @@ import type {
   PriceRange,
   ProductCard,
   ProductDetails,
-  ProductReview,
   ProductVariant,
   SelectedOption,
 } from "@/lib/types";
@@ -600,48 +599,6 @@ export async function getProductRecommendationSets(params: {
   const sets = await fetchProductRecommendationSets(params);
   tagProducts([...sets.complementary, ...sets.related]);
   return sets;
-}
-
-// Stand-in reviews source. Mirrors the recommendation sets cache contract: a single
-// cached entry per product handle, invalidated by the product tag. Placeholder copy
-// lives here until the storefront wires a real reviews provider (metafields, app, etc.).
-const PLACEHOLDER_REVIEWS: ProductReview[] = [
-  {
-    author: "Alex Morgan",
-    body: "Exceeded my expectations. The quality is outstanding and it arrived earlier than promised. Would absolutely buy again.",
-    date: "March 2026",
-    id: "1",
-    rating: 5,
-  },
-  {
-    author: "Jordan Lee",
-    body: "Really happy with this purchase overall. Fit and finish are great — took off one star only because shipping took a little longer than expected.",
-    date: "February 2026",
-    id: "2",
-    rating: 4,
-  },
-  {
-    author: "Sam Rivera",
-    body: "Exactly as described and worth every penny. I've already recommended it to a couple of friends.",
-    date: "January 2026",
-    id: "3",
-    rating: 5,
-  },
-];
-
-export async function getProductReviews(params: {
-  handle: string;
-  locale?: string;
-}): Promise<ProductReview[]> {
-  "use cache: remote";
-  cacheLife("max");
-  cacheTag("products", `reviews-${params.handle}`);
-
-  // EXPERIMENT: artificial delay to confirm the reviews section streams in behind its
-  // Suspense boundary instead of blocking the PDP shell. Only fires on a cache miss.
-  await new Promise((resolve) => setTimeout(resolve, 10000));
-
-  return PLACEHOLDER_REVIEWS.filter((review) => review.rating >= 3);
 }
 
 const GET_PRODUCTS_BY_HANDLES_QUERY = `#graphql

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -8,6 +8,7 @@ import type {
   PriceRange,
   ProductCard,
   ProductDetails,
+  ProductReview,
   ProductVariant,
   SelectedOption,
 } from "@/lib/types";
@@ -599,6 +600,48 @@ export async function getProductRecommendationSets(params: {
   const sets = await fetchProductRecommendationSets(params);
   tagProducts([...sets.complementary, ...sets.related]);
   return sets;
+}
+
+// Stand-in reviews source. Mirrors the recommendation sets cache contract: a single
+// cached entry per product handle, invalidated by the product tag. Placeholder copy
+// lives here until the storefront wires a real reviews provider (metafields, app, etc.).
+const PLACEHOLDER_REVIEWS: ProductReview[] = [
+  {
+    author: "Alex Morgan",
+    body: "Exceeded my expectations. The quality is outstanding and it arrived earlier than promised. Would absolutely buy again.",
+    date: "March 2026",
+    id: "1",
+    rating: 5,
+  },
+  {
+    author: "Jordan Lee",
+    body: "Really happy with this purchase overall. Fit and finish are great — took off one star only because shipping took a little longer than expected.",
+    date: "February 2026",
+    id: "2",
+    rating: 4,
+  },
+  {
+    author: "Sam Rivera",
+    body: "Exactly as described and worth every penny. I've already recommended it to a couple of friends.",
+    date: "January 2026",
+    id: "3",
+    rating: 5,
+  },
+];
+
+export async function getProductReviews(params: {
+  handle: string;
+  locale?: string;
+}): Promise<ProductReview[]> {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("products", `reviews-${params.handle}`);
+
+  // EXPERIMENT: artificial delay to confirm the reviews section streams in behind its
+  // Suspense boundary instead of blocking the PDP shell. Only fires on a cache miss.
+  await new Promise((resolve) => setTimeout(resolve, 10000));
+
+  return PLACEHOLDER_REVIEWS.filter((review) => review.rating >= 3);
 }
 
 const GET_PRODUCTS_BY_HANDLES_QUERY = `#graphql

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -108,6 +108,14 @@ export interface ProductRating {
   value: number;
 }
 
+export interface ProductReview {
+  author: string;
+  body: string;
+  date: string;
+  id: string;
+  rating: number;
+}
+
 export interface ProductVariant {
   availableForSale: boolean;
   /** Bundle variants this variant is a component of (Shopify `groupedBy`); empty for non-components. */


### PR DESCRIPTION
Replays the PDP reviews section with real data fetching, mirroring the related products streaming pattern.

## What changed
- New `getProductReviews` operation in `lib/shopify/operations/products.ts` — a `use cache: remote` function cached per product handle (`reviews-${handle}` + `products` tag), invalidated by the product webhook.
- `ProductReviewsSection` rewritten as an async `Render` that resolves the handle and calls `getProductReviews`, wrapped in its own `<Suspense>` with a skeleton fallback — same shape as `RelatedProductsSection`.
- Data moved out of the component into the cached fetch; the section now accepts `handle` + `locale` props.
- New `ProductReview` type in `lib/types.ts`.

## The three updates requested
1. **`use cache: remote`** — the fetch function carries the directive with `cacheLife('max')` and product-scoped `cacheTag`, a la `getProductRecommendationSets`.
2. **3-5 star reviews only** — placeholder reviews are filtered to `rating >= 3` (err on the side of positive).
3. **`sleep(10000)`** — a 10s delay inside the cached fetch to confirm the section streams in behind its Suspense boundary instead of blocking the PDP shell. Fires only on a cache miss; warm cache returns instantly. Temporary — remove before merge.

## Verification
- `pnpm lint` (oxlint + oxfmt) clean
- `tsc --noEmit` clean