### PR TITLE
Add canonical shop configuration

### DIFF
--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -10,7 +10,9 @@ The storefront includes an opt-in AI shopping assistant built with [AI SDK](http
 
 ## Configuration
 
-Set `NEXT_PUBLIC_ENABLE_AGENT="1"` to enable the assistant. When unset, the button is hidden and `POST /api/chat` returns `404` before reading the request body or creating a cart. On Vercel, the model uses the project's OIDC token automatically; elsewhere set `AI_GATEWAY_API_KEY` or run `vercel link` to mint a local `VERCEL_OIDC_TOKEN`.
+The assistant defaults to disabled through `agent.enabledByDefault` in `shop.config.ts`. Set `NEXT_PUBLIC_ENABLE_AGENT="1"` to enable it for a deployment, or `"0"` to override an enabled file default. When disabled, the button is hidden and `POST /api/chat` returns `404` before reading the request body or creating a cart.
+
+The same config block owns the AI Gateway `model`, maximum loop `maxSteps`, and the `tools` allowlist exposed to the model. On Vercel, the model uses the project's OIDC token automatically; elsewhere set `AI_GATEWAY_API_KEY` or run `vercel link` to mint a local `VERCEL_OIDC_TOKEN`. See [Shop Configuration](/docs/reference/shop-config) for the complete schema.
 
 ## Architecture
 
@@ -106,6 +108,7 @@ Run bot and rate-limit checks before `request.json()` and before cart creation. 
 
 | File                                   | Purpose                                                       |
 | -------------------------------------- | ------------------------------------------------------------- |
+| `shop.config.ts`                       | Default enablement, model, step limit, and tool allowlist     |
 | `app/api/chat/route.ts`                | Feature guard, validation, page context, cart cookie, stream  |
 | `lib/agent/server.ts`                  | ToolLoopAgent, prompt, request-scoped context, tool registry  |
 | `lib/agent/tools/`                     | One AI SDK tool per file                                      |

--- a/apps/docs/content/docs/anatomy/authentication.mdx
+++ b/apps/docs/content/docs/anatomy/authentication.mdx
@@ -5,7 +5,7 @@ description: Built-in customer authentication with better-auth and Shopify Custo
 
 The template includes built-in customer authentication using [better-auth](https://www.better-auth.com/) with the Shopify Customer Account API. When configured, customers can sign in via Shopify OIDC, view their profile, order history, and address book.
 
-Authentication is **opt-in via environment variables**. Without them, the storefront works as a guest-only experience and no auth UI is rendered.
+Authentication is opt-in by default. The canonical default lives in `shop.config.ts`, and a deployment can override it with `NEXT_PUBLIC_ENABLE_AUTH`. When disabled, the storefront works as a guest-only experience and no auth UI is rendered.
 
 ## Configuration
 
@@ -18,7 +18,7 @@ SHOPIFY_CUSTOMER_CLIENT_ID="your-customer-client-id"
 SHOPIFY_CUSTOMER_CLIENT_SECRET="your-customer-client-secret"
 ```
 
-`next.config.ts` throws at build time if `NEXT_PUBLIC_ENABLE_AUTH="1"` is set without the three secrets. The flag must be `NEXT_PUBLIC_` so its value is available identically on server and client — probing the server-only secrets directly inside a component causes hydration mismatches under cache components.
+`auth.enabledByDefault` in `shop.config.ts` is `false`. Set `NEXT_PUBLIC_ENABLE_AUTH="1"` to enable auth for a deployment, or `"0"` to override an enabled file default. `next.config.ts` throws at build time whenever the resolved auth setting is enabled without the three secrets. The override must be `NEXT_PUBLIC_` so its value is available identically on server and client — probing the server-only secrets directly inside a component causes hydration mismatches under cache components. See [Shop Configuration](/docs/reference/shop-config) for the static config schema.
 
 Generate the auth secret with `openssl rand -base64 32`. The client ID and secret come from Shopify's Customer Account API.
 
@@ -48,7 +48,7 @@ The API route at `/api/auth/[...all]` handles all OAuth callbacks, session manag
 
 ### Feature gating
 
-The `isAuthEnabled` flag (from `lib/auth`) reads `auth.enabled` from `lib/config`, which is `process.env.NEXT_PUBLIC_ENABLE_AUTH === "1"`. When `false`:
+The `isAuthEnabled` flag (from `lib/auth`) reads the resolved `auth.enabled` value from `lib/config`. That value uses `NEXT_PUBLIC_ENABLE_AUTH` when set and otherwise falls back to `shopConfig.auth.enabledByDefault`. When `false`:
 
 - The account icon does not appear in the nav
 - `/account/login` and `/account/*` return 404
@@ -124,12 +124,12 @@ function AccountMenu() {
 
 The account pages read and write customer data through the Shopify Customer Account API — a separate GraphQL endpoint and schema from the Storefront API.
 
-| Module                               | Purpose                                                                                                                                                                                                                                                                                                                               |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `lib/shopify/customer-account.ts`    | `customerAccountFetch()` — wraps `@shopify/hydrogen/customer-account`'s `createCustomerAccountClient`, which POSTs to `https://shopify.com/{shopId}/account/customer/api/{version}/graphql` with the customer's access token. The `shopId` is derived from the OIDC discovery document's `issuer` and cached. The endpoint is **not** on the storefront domain.                       |
-| `lib/shopify/operations/customer.ts` | Queries (profile, orders, order detail, addresses) and mutations (address create/update/delete, profile update). Each call resolves the token via `requireSession()`.                                                                                                                                                                 |
-| `lib/shopify/transforms/customer.ts` | Maps Customer Account API responses to the provider-agnostic domain types in `lib/types.ts`.                                                                                                                                                                                                                                          |
-| `lib/customer/action.ts`             | `"use server"` actions for the address and profile forms. They validate input, surface Shopify `userErrors`, and `revalidatePath` on success.                                                                                                                                                                                         |
+| Module                               | Purpose                                                                                                                                                                                                                                                                                                                                                         |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lib/shopify/customer-account.ts`    | `customerAccountFetch()` — wraps `@shopify/hydrogen/customer-account`'s `createCustomerAccountClient`, which POSTs to `https://shopify.com/{shopId}/account/customer/api/{version}/graphql` with the customer's access token. The `shopId` is derived from the OIDC discovery document's `issuer` and cached. The endpoint is **not** on the storefront domain. |
+| `lib/shopify/operations/customer.ts` | Queries (profile, orders, order detail, addresses) and mutations (address create/update/delete, profile update). Each call resolves the token via `requireSession()`.                                                                                                                                                                                           |
+| `lib/shopify/transforms/customer.ts` | Maps Customer Account API responses to the provider-agnostic domain types in `lib/types.ts`.                                                                                                                                                                                                                                                                    |
+| `lib/customer/action.ts`             | `"use server"` actions for the address and profile forms. They validate input, surface Shopify `userErrors`, and `revalidatePath` on success.                                                                                                                                                                                                                   |
 
 Order and profile pages are read-only server components wrapped in Suspense. Addresses and profile editing use client forms that call the server actions. Order requests are per-customer `POST`s, so responses are never shared across customers.
 

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -70,7 +70,7 @@ A single `BuyButtons` component renders identically on both mobile and desktop. 
 
 ### Bundles
 
-`bundle-components.tsx` renders Shopify's [bundle relationships](/docs/shopify/pdp#bundles) below the buy buttons:
+When `pdp.bundles.enabled` is `true` in `shop.config.ts`, `bundle-components.tsx` renders Shopify's [bundle relationships](/docs/shopify/pdp#bundles) below the buy buttons:
 
 - **Bundle Includes** — a fixed bundle's component products, from `components` (`BundleComponents`).
 - **Available in Bundles** — bundles containing the current product, collapsed to one link per bundle, from `groupedBy` (`BundleParents`).
@@ -81,19 +81,19 @@ A customized bundle parent (`requiresComponents` with no fixed `components`) dis
 
 ### Complementary products
 
-`complementary-products.tsx` renders the merchant-curated "Pairs Well With" set below the bundle relationships — Shopify's [complementary products](/docs/shopify/pdp#complementary-products) from `productRecommendations(intent: COMPLEMENTARY)`. These are distinct from the algorithmic related products below the fold (`intent: RELATED`): complementary products are deliberately chosen add-ons, so they sit beside the buy section like bundle relationships rather than in the footer grid.
+When `pdp.upsells.enabled` is `true` in `shop.config.ts`, `complementary-products.tsx` renders the merchant-curated "Pairs Well With" set below the bundle relationships — Shopify's [complementary products](/docs/shopify/pdp#complementary-products) from `productRecommendations(intent: COMPLEMENTARY)`. These are distinct from the algorithmic related products below the fold (`intent: RELATED`): complementary products are deliberately chosen add-ons, so they sit beside the buy section like bundle relationships rather than in the footer grid.
 
-Like bundle relationships, the section renders **eagerly into the prerendered shell** rather than streaming. Both recommendation surfaces — this set and the [related grid](#related-products) below the fold — come from a single cached (`use cache: remote`) `getProductRecommendationSets()` operation that fetches both intents in one aliased `productRecommendations` request and is tagged with both `complementary-{handle}` and `recommendations-{handle}`. Because both surfaces call it with the same arguments, they dedupe to **one** Shopify request; this section reads the `complementary` slice, baked into the static PPR/ISR document — there's no skeleton fallback and no layout shift on cached hits (a `Suspense` boundary would instead make it a streamed hole). It shows up to four products as thumbnail + title + price rows and renders nothing when none are configured.
+Like bundle relationships, the section renders **eagerly into the prerendered shell** rather than streaming. Both recommendation surfaces — this set and the [related grid](#related-products) below the fold — come from a single cached (`use cache: remote`) `getProductRecommendationSets()` operation that fetches both intents in one aliased `productRecommendations` request and is tagged with both `complementary-{handle}` and `recommendations-{handle}`. Because both surfaces call it with the same arguments, they dedupe to **one** Shopify request; this section reads the `complementary` slice, baked into the static PPR/ISR document — there's no skeleton fallback and no layout shift on cached hits (a `Suspense` boundary would instead make it a streamed hole). It shows up to `pdp.upsells.limit` products as thumbnail + title + price rows and renders nothing when none are configured.
 
 ### Specifications
 
-`product-specs.tsx` renders configured product [metafields](/docs/shopify/pdp#metafields) as a label/value "Specifications" list below the description. The set is **opt-in**: `productMetafieldIdentifiers` in `lib/config.ts` is empty by default, so the product query is unchanged and the section renders nothing until a storefront lists the namespaces and keys it populates. Like bundle relationships, it renders eagerly from the cached product in the static shell. Values are formatted by metafield type (measurements, ratings, lists, booleans); reference (product/metaobject) types are skipped pending GID resolution.
+`product-specs.tsx` renders configured product [metafields](/docs/shopify/pdp#metafields) as a label/value "Specifications" list below the description. The set is **opt-in**: `pdp.specifications.metafields` in `shop.config.ts` is empty by default, so the product query is unchanged and the section renders nothing until a storefront lists the namespaces and keys it populates. Like bundle relationships, it renders eagerly from the cached product in the static shell. Values are formatted by metafield type (measurements, ratings, lists, booleans); reference (product/metaobject) types are skipped pending GID resolution.
 
 ## Related Products
 
-Below the product details, a `RelatedProductsSection` component renders Shopify's algorithmic "you might also like" set. It reads the `related` slice of the same cached `getProductRecommendationSets()` operation the [complementary set](#complementary-products) consumes — so the two surfaces share one Shopify request — and renders inside a `Suspense` boundary with a skeleton grid fallback.
+When `pdp.relatedProducts.enabled` is `true` in `shop.config.ts`, a `RelatedProductsSection` component renders Shopify's algorithmic "you might also like" set below the product details and on non-empty cart pages. It reads the `related` slice of the same cached `getProductRecommendationSets()` operation the [complementary set](#complementary-products) consumes — so the two surfaces share one Shopify request — and renders inside a `Suspense` boundary with a skeleton grid fallback.
 
-Related products display as a fixed grid of up to four product cards — two columns on mobile, four on `lg:` and up — matching the homepage's featured-products grid. The Shopify recommendation API typically returns more, but only the first four are rendered so the section reads as a small "you might also like" footer rather than a second browse surface.
+Related products display as a fixed grid of up to `pdp.relatedProducts.limit` product cards — two columns on mobile, four on `lg:` and up — matching the homepage's featured-products grid. The configured limit also determines the skeleton count. Shopify typically returns more recommendations, but the section intentionally remains a small footer rather than a second browse surface.
 
 ## Layout
 
@@ -114,6 +114,7 @@ The page emits two JSON-LD schemas:
 
 | File                                                   | Purpose                                                                                                              |
 | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `shop.config.ts`                                       | PDP bundle, upsell, related-product, and specification policy                                                        |
 | `app/products/[handle]/page.tsx`                       | Route entry: metadata, awaits the product at the top (baked into the shell), streams the per-selection variant query |
 | `components/product-detail/product-detail-section.tsx` | Orchestrates media, options, pricing, and buy buttons with per-section Suspense; emits JSON-LD                       |
 | `components/product-detail/product-media.tsx`          | Responsive image gallery (mobile carousel, desktop grid + lightbox)                                                  |

--- a/apps/docs/content/docs/reference/env-vars.mdx
+++ b/apps/docs/content/docs/reference/env-vars.mdx
@@ -14,12 +14,12 @@ type: reference
 
 ## Feature flags
 
-Both optional features are opt-in via explicit `NEXT_PUBLIC_ENABLE_*` flags. The `NEXT_PUBLIC_` prefix is required so the conditional rendering matches between server and client under cache components.
+The canonical feature defaults live in [`shop.config.ts`](/docs/reference/shop-config) and are disabled initially. The `NEXT_PUBLIC_ENABLE_*` variables override those defaults per deployment; set them to `"1"` or `"0"`. The `NEXT_PUBLIC_` prefix is required so conditional rendering matches between server and client under cache components.
 
-| Variable                   | Description                                                                                                                                                                                                    |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_ENABLE_AUTH`  | Set to `"1"` to enable the auth UI and the `/account/*` routes. Requires the three Customer Authentication secrets below — `next.config.ts` throws at build time if any are missing.                           |
-| `NEXT_PUBLIC_ENABLE_AGENT` | Set to `"1"` to show the AI SDK shopping assistant and enable `POST /api/chat`. Its model routes through the Vercel AI Gateway — uses the project OIDC token on Vercel, or set `AI_GATEWAY_API_KEY` elsewhere. |
+| Variable                   | Description                                                                                                                                                                                  |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_ENABLE_AUTH`  | Set to `"1"` or `"0"` to override `auth.enabledByDefault`. Enabled auth requires the three Customer Authentication secrets below — `next.config.ts` throws at build time if any are missing. |
+| `NEXT_PUBLIC_ENABLE_AGENT` | Set to `"1"` or `"0"` to override `agent.enabledByDefault`, showing or hiding the assistant and `POST /api/chat`. The configured model routes through the Vercel AI Gateway.                 |
 
 ## Customer Authentication
 

--- a/apps/docs/content/docs/reference/meta.json
+++ b/apps/docs/content/docs/reference/meta.json
@@ -1,4 +1,11 @@
 {
   "title": "Reference",
-  "pages": ["routes", "env-vars", "storefront-api-permissions", "storefront-api", "troubleshooting"]
+  "pages": [
+    "routes",
+    "env-vars",
+    "shop-config",
+    "storefront-api-permissions",
+    "storefront-api",
+    "troubleshooting"
+  ]
 }

--- a/apps/docs/content/docs/reference/shop-config.mdx
+++ b/apps/docs/content/docs/reference/shop-config.mdx
@@ -1,0 +1,88 @@
+---
+title: Shop Configuration
+description: Configure canonical storefront behavior for the agent, authentication, and product merchandising.
+type: reference
+---
+
+`shop.config.ts` is the template's canonical, secret-free configuration file. Use it for behavior that should be consistent across deployments and easy for a coding agent to discover, such as the shopping assistant model, authentication defaults, and PDP merchandising surfaces.
+
+Environment variables still own credentials and deployment-specific overrides. Shopify remains the source of product, recommendation, bundle, and metafield data.
+
+## Default configuration
+
+```ts
+export const shopConfig = {
+  agent: {
+    enabledByDefault: false,
+    maxSteps: 10,
+    model: "google/gemini-3.5-flash",
+    tools: [
+      "addCartNote",
+      "addToCart",
+      "browseCollection",
+      "getCart",
+      "getCatalogProduct",
+      "getProductDetails",
+      "getProductRecommendations",
+      "listCollections",
+      "navigateUser",
+      "removeFromCart",
+      "searchCatalog",
+      "searchProducts",
+      "searchShopPoliciesAndFaqs",
+      "updateCartItemQuantity",
+    ],
+  },
+  auth: {
+    enabledByDefault: false,
+    providerId: "shopify",
+  },
+  pdp: {
+    bundles: { enabled: true },
+    relatedProducts: { enabled: true, limit: 4 },
+    specifications: { metafields: [] },
+    upsells: { enabled: true, limit: 4 },
+  },
+} satisfies ShopConfig;
+```
+
+`lib/config.ts` resolves this static configuration with deployment environment variables and exports the values consumed by the app.
+
+## Agent
+
+- `enabledByDefault` controls whether the assistant is available when `NEXT_PUBLIC_ENABLE_AGENT` is unset.
+- `model` is the AI Gateway model passed to `ToolLoopAgent`.
+- `maxSteps` bounds the agent loop with AI SDK's `isStepCount()`.
+- `tools` is the allowlist exposed to the model. Remove a tool name to keep its implementation in the codebase without making it available to the agent.
+
+Set `NEXT_PUBLIC_ENABLE_AGENT="1"` or `"0"` to override `enabledByDefault` for a deployment.
+
+## Authentication
+
+- `enabledByDefault` controls whether customer authentication is active when `NEXT_PUBLIC_ENABLE_AUTH` is unset.
+- `providerId` is the better-auth OAuth provider identifier used by the Shopify Customer Account integration.
+
+Set `NEXT_PUBLIC_ENABLE_AUTH="1"` or `"0"` to override the default. Enabling auth still requires the server-only better-auth and Shopify Customer Account credentials documented in [Environment Variables](/docs/reference/env-vars). The build validates those credentials whether auth is enabled by the file or by the environment override.
+
+## PDP merchandising
+
+- `bundles.enabled` shows or hides Shopify bundle relationships beside the buy section.
+- `upsells.enabled` shows or hides merchant-curated complementary products. `upsells.limit` controls the number of rows.
+- `relatedProducts.enabled` shows or hides Shopify's algorithmic related-product grid on PDP and cart pages. `relatedProducts.limit` controls its product and skeleton counts.
+- `specifications.metafields` lists Shopify product metafield namespace/key pairs to request and render as specifications.
+
+Disabling a surface prevents its component from rendering. The recommendation operation and existing cache strategy remain unchanged for enabled surfaces, so complementary and related products continue sharing one cached Shopify request when both are shown.
+
+## What does not belong here
+
+Do not put secrets, access tokens, store-specific product handles, or fetched Shopify data in `shop.config.ts`. Keep credentials in environment variables and merchandising data in Shopify.
+
+## Key files
+
+| File                                                   | Purpose                                                                |
+| ------------------------------------------------------ | ---------------------------------------------------------------------- |
+| `shop.config.ts`                                       | Canonical static defaults and feature policy                           |
+| `lib/config.ts`                                        | Environment resolution plus site, navigation, and footer configuration |
+| `lib/agent/server.ts`                                  | Consumes agent model, step limit, and tool allowlist                   |
+| `components/product-detail/product-detail-section.tsx` | Consumes bundle and complementary-product visibility                   |
+| `components/product/related-products-section.tsx`      | Consumes the configured related-product limit                          |

--- a/apps/docs/content/docs/shopify/pdp.mdx
+++ b/apps/docs/content/docs/shopify/pdp.mdx
@@ -22,13 +22,17 @@ The PDP shell fetches the product's options and Shopify's encoded variant-availa
 
 The template ships with **no metafields wired in** by default. Namespaces and keys are shop-specific (Shopify's only standard product metafield namespaces are `descriptors`, `facts`, `reviews`, `shopify`, etc. — not generic spec namespaces like `custom` or `specs`), so the template doesn't presume any defaults: an empty config means the product query is unchanged and nothing renders.
 
-To surface metafields on the PDP for your store, list the ones you populate in `productMetafieldIdentifiers` in `lib/config.ts`:
+To surface metafields on the PDP for your store, list the ones you populate in `pdp.specifications.metafields` in `shop.config.ts`:
 
 ```ts
-export const productMetafieldIdentifiers: Array<{ key: string; namespace: string }> = [
-  { namespace: "custom", key: "material" },
-  { namespace: "custom", key: "warranty" },
-];
+pdp: {
+  specifications: {
+    metafields: [
+      { key: "material", namespace: "custom" },
+      { key: "warranty", namespace: "custom" },
+    ],
+  },
+}
 ```
 
 The product-detail query (`getProductByHandle` in `lib/shopify/operations/products.ts`) appends a `metafields(identifiers: [...])` selection built from that list, and `ProductSpecs` (`components/product-detail/product-specs.tsx`) renders them as a label/value "Specifications" list below the description. Optionally extend the `METAFIELD_LABELS` map in `lib/shopify/transforms/product.ts` with friendly labels for your keys — keys without an entry fall back to a humanized version of the key.

--- a/apps/template/.env.example
+++ b/apps/template/.env.example
@@ -5,7 +5,7 @@ SHOPIFY_STOREFRONT_ACCESS_TOKEN="your-storefront-access-token"
 # Store display name (shown in header, metadata, etc.)
 NEXT_PUBLIC_SITE_NAME="Your Store Name"
 
-# Optional — AI shopping assistant (AI SDK). Set the flag to show the assistant.
+# Optional — AI shopping assistant (AI SDK). Overrides shop.config.ts; use "1" or "0".
 # The agent's model routes through the Vercel AI Gateway: on Vercel the project's
 # OIDC token is used automatically; elsewhere set AI_GATEWAY_API_KEY, or run
 # `vercel link` to mint a VERCEL_OIDC_TOKEN for local dev.
@@ -13,6 +13,7 @@ NEXT_PUBLIC_SITE_NAME="Your Store Name"
 # AI_GATEWAY_API_KEY="your-vercel-ai-gateway-key"
 
 # Optional — Customer Authentication (better-auth + Shopify OIDC).
+# The flag overrides shop.config.ts; use "1" or "0".
 # NEXT_PUBLIC_ENABLE_AUTH="1"
 # BETTER_AUTH_SECRET="generate-with-openssl-rand-base64-32"
 # SHOPIFY_CUSTOMER_CLIENT_ID="your-customer-client-id"

--- a/apps/template/app/cart/page.tsx
+++ b/apps/template/app/cart/page.tsx
@@ -14,6 +14,7 @@ import { RelatedProductsSection } from "@/components/product/related-products-se
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
+import { pdp } from "@/lib/config";
 import type { Locale } from "@/lib/i18n";
 import { getLocale } from "@/lib/params";
 import { withFallback } from "@/lib/shopify/errors";
@@ -66,9 +67,10 @@ async function CartContent({ locale }: { locale: Locale }) {
                     </div>
                   </aside>
                 </div>
-                {cart.lines[0]?.merchandise.product.handle ? (
+                {pdp.relatedProducts.enabled && cart.lines[0]?.merchandise.product.handle ? (
                   <RelatedProductsSection
                     handle={cart.lines[0].merchandise.product.handle}
+                    limit={pdp.relatedProducts.limit}
                     locale={locale}
                   />
                 ) : null}

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -6,6 +6,7 @@ import { RelatedProductsSection } from "@/components/product/related-products-se
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
+import { pdp } from "@/lib/config";
 import { getLocale } from "@/lib/params";
 import {
   defaultSelectedOptions,
@@ -121,7 +122,13 @@ export default async function ProductPage({
             variantPromise={variantPromise}
             locale={locale}
           />
-          <RelatedProductsSection handle={handle} locale={locale} />
+          {pdp.relatedProducts.enabled ? (
+            <RelatedProductsSection
+              handle={handle}
+              limit={pdp.relatedProducts.limit}
+              locale={locale}
+            />
+          ) : null}
         </Sections>
       </Container>
     </Page>

--- a/apps/template/components/product-detail/complementary-products.tsx
+++ b/apps/template/components/product-detail/complementary-products.tsx
@@ -2,11 +2,10 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
+import { pdp } from "@/lib/config";
 import { getProductRecommendationSets } from "@/lib/shopify/operations/products";
 import type { ProductCard } from "@/lib/types";
 import { formatPrice } from "@/lib/utils";
-
-const COMPLEMENTARY_LIMIT = 4;
 
 export async function ComplementaryProducts({
   handle,
@@ -17,6 +16,8 @@ export async function ComplementaryProducts({
   locale: string;
   title: string;
 }) {
+  if (!pdp.upsells.enabled) return null;
+
   const { complementary } = await getProductRecommendationSets({ handle, locale });
   if (complementary.length === 0) return null;
 
@@ -24,7 +25,7 @@ export async function ComplementaryProducts({
     <div className="grid gap-2.5" data-slot="complementary-products">
       <h2 className="font-medium text-foreground/70 text-sm">{title}</h2>
       <ul className="grid gap-2.5">
-        {complementary.slice(0, COMPLEMENTARY_LIMIT).map((product: ProductCard) => (
+        {complementary.slice(0, pdp.upsells.limit).map((product: ProductCard) => (
           <li key={product.id}>
             <Link
               href={`/products/${product.handle}`}

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -21,7 +21,7 @@ import { ProductSchema } from "@/components/product-detail/schema";
 import { ShopLogo } from "@/components/product-detail/shop-logo";
 import { BreadcrumbSchema } from "@/components/schema/breadcrumb-schema";
 import { Skeleton } from "@/components/ui/skeleton";
-import { siteConfig } from "@/lib/config";
+import { pdp, siteConfig } from "@/lib/config";
 import type { Locale } from "@/lib/i18n";
 import {
   defaultSelectedOptions,
@@ -251,9 +251,11 @@ async function ProductInfoArea({
         </Suspense>
       )}
 
-      <BundleRelationships variant={product.defaultVariant} t={t} />
+      {pdp.bundles.enabled ? <BundleRelationships variant={product.defaultVariant} t={t} /> : null}
 
-      <ComplementaryProducts handle={handle} locale={locale} title={t("pairsWith")} />
+      {pdp.upsells.enabled ? (
+        <ComplementaryProducts handle={handle} locale={locale} title={t("pairsWith")} />
+      ) : null}
 
       <ProductInfoDescription descriptionHtml={descriptionHtml} />
 

--- a/apps/template/components/product/related-products-section.tsx
+++ b/apps/template/components/product/related-products-section.tsx
@@ -6,9 +6,13 @@ import { Skeleton } from "@/components/ui/skeleton";
 import type { Locale } from "@/lib/i18n";
 import { getProductRecommendationSets } from "@/lib/shopify/operations/products";
 
-const RECOMMENDATION_LIMIT = 4;
-
-export function RelatedProductsSectionSkeleton({ title }: { title?: string }) {
+export function RelatedProductsSectionSkeleton({
+  limit,
+  title,
+}: {
+  limit: number;
+  title?: string;
+}) {
   return (
     <div className="grid gap-4">
       {title ? (
@@ -17,7 +21,7 @@ export function RelatedProductsSectionSkeleton({ title }: { title?: string }) {
         <Skeleton className="h-9 w-48" />
       )}
       <div className="grid grid-cols-2 gap-5 lg:grid-cols-4">
-        {Array.from({ length: RECOMMENDATION_LIMIT }, (_, index) => (
+        {Array.from({ length: limit }, (_, index) => (
           <ProductCardSkeleton key={index} />
         ))}
       </div>
@@ -25,7 +29,15 @@ export function RelatedProductsSectionSkeleton({ title }: { title?: string }) {
   );
 }
 
-async function Render({ handle, locale }: { handle: string | Promise<string>; locale: Locale }) {
+async function Render({
+  handle,
+  limit,
+  locale,
+}: {
+  handle: string | Promise<string>;
+  limit: number;
+  locale: Locale;
+}) {
   const resolvedHandle = await handle;
   const [t, { related }] = await Promise.all([
     getTranslations("product"),
@@ -38,7 +50,7 @@ async function Render({ handle, locale }: { handle: string | Promise<string>; lo
     <div className="grid gap-4">
       <h2 className="text-2xl sm:text-3xl">{t("recommendations")}</h2>
       <div className="grid grid-cols-2 gap-5 lg:grid-cols-4">
-        {related.slice(0, RECOMMENDATION_LIMIT).map((product) => (
+        {related.slice(0, limit).map((product) => (
           <ProductCard
             key={product.id}
             product={product}
@@ -53,15 +65,19 @@ async function Render({ handle, locale }: { handle: string | Promise<string>; lo
 
 export async function RelatedProductsSection({
   handle,
+  limit,
   locale,
 }: {
   handle: string | Promise<string>;
+  limit: number;
   locale: Locale;
 }) {
   const t = await getTranslations("product");
   return (
-    <Suspense fallback={<RelatedProductsSectionSkeleton title={t("recommendations")} />}>
-      <Render handle={handle} locale={locale} />
+    <Suspense
+      fallback={<RelatedProductsSectionSkeleton limit={limit} title={t("recommendations")} />}
+    >
+      <Render handle={handle} limit={limit} locale={locale} />
     </Suspense>
   );
 }

--- a/apps/template/lib/agent/server.ts
+++ b/apps/template/lib/agent/server.ts
@@ -1,7 +1,7 @@
 import { isStepCount, ToolLoopAgent } from "ai";
 
 import { catalog } from ".";
-import { siteConfig } from "../config";
+import { agent as agentConfig, siteConfig } from "../config";
 import type { Locale } from "../i18n";
 import type { ProductDetails } from "../types";
 import { addCartNoteTool } from "./tools/add-cart-note";
@@ -86,7 +86,7 @@ function createSystemPrompt(context: AgentContext): string {
   })}`;
 }
 
-const tools = {
+const availableTools = {
   addCartNote: addCartNoteTool(),
   addToCart: addToCartTool(),
   browseCollection: browseCollectionTool(),
@@ -103,11 +103,15 @@ const tools = {
   updateCartItemQuantity: updateCartItemTool(),
 };
 
+const tools = Object.fromEntries(
+  agentConfig.tools.map((name) => [name, availableTools[name]]),
+) as Pick<typeof availableTools, (typeof agentConfig.tools)[number]>;
+
 export function createAgent() {
   return new ToolLoopAgent({
     instructions: createSystemPrompt(getAgentContext()),
-    model: "google/gemini-3.5-flash",
-    stopWhen: isStepCount(10),
+    model: agentConfig.model,
+    stopWhen: isStepCount(agentConfig.maxSteps),
     tools,
   });
 }

--- a/apps/template/lib/auth/client.ts
+++ b/apps/template/lib/auth/client.ts
@@ -3,6 +3,8 @@
 import { genericOAuthClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
+import { auth } from "@/lib/config";
+
 import type { CustomerSession } from "./server";
 
 export const authClient = createAuthClient({
@@ -41,7 +43,7 @@ export function useSession(): SessionState {
 }
 
 export function signIn(callbackURL = "/account"): void {
-  authClient.signIn.oauth2({ providerId: "shopify", callbackURL });
+  authClient.signIn.oauth2({ providerId: auth.providerId, callbackURL });
 }
 
 export async function signOut(): Promise<void> {

--- a/apps/template/lib/auth/server.ts
+++ b/apps/template/lib/auth/server.ts
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import { cache } from "react";
 
 import { isAuthEnabled } from "@/lib/auth";
+import { auth as authConfig } from "@/lib/config";
 
 const SHOPIFY_STORE_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN;
 
@@ -100,7 +101,7 @@ export const auth = isAuthEnabled
         genericOAuth({
           config: [
             {
-              providerId: "shopify",
+              providerId: authConfig.providerId,
               clientId: process.env.SHOPIFY_CUSTOMER_CLIENT_ID ?? "",
               clientSecret: process.env.SHOPIFY_CUSTOMER_CLIENT_SECRET ?? "",
               discoveryUrl: SHOPIFY_STORE_DOMAIN
@@ -195,7 +196,7 @@ const getAccessToken = cache(async (): Promise<string> => {
   try {
     const tokenResponse = await auth.api.getAccessToken({
       headers: reqHeaders,
-      body: { providerId: "shopify" },
+      body: { providerId: authConfig.providerId },
     });
     accessToken = tokenResponse?.accessToken || "";
   } catch (error) {

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -1,4 +1,5 @@
 import type { MenuItem } from "@/lib/shopify/types/menu";
+import { shopConfig } from "@/shop.config";
 
 function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
@@ -29,21 +30,21 @@ export const siteConfig = {
   url: trimTrailingSlash(process.env.NEXT_PUBLIC_BASE_URL || defaultUrl),
 } as const;
 
-export const auth = {
-  enabled: process.env.NEXT_PUBLIC_ENABLE_AUTH === "1",
-} as const;
-
 export const agent = {
-  enabled: process.env.NEXT_PUBLIC_ENABLE_AGENT === "1",
+  ...shopConfig.agent,
+  enabled: process.env.NEXT_PUBLIC_ENABLE_AGENT
+    ? process.env.NEXT_PUBLIC_ENABLE_AGENT === "1"
+    : shopConfig.agent.enabledByDefault,
 } as const;
 
-// Product metafields to surface on the PDP, by namespace + key. Empty by default:
-// namespaces are shop-specific, so a storefront opts in to the ones it populates.
-// Friendly labels for each key live in METAFIELD_LABELS (lib/shopify/transforms/product.ts).
-export const productMetafieldIdentifiers: Array<{ key: string; namespace: string }> = [
-  // { namespace: "custom", key: "material" },
-  // { namespace: "reviews", key: "rating" },
-];
+export const auth = {
+  ...shopConfig.auth,
+  enabled: process.env.NEXT_PUBLIC_ENABLE_AUTH
+    ? process.env.NEXT_PUBLIC_ENABLE_AUTH === "1"
+    : shopConfig.auth.enabledByDefault,
+} as const;
+
+export const pdp = shopConfig.pdp;
 
 export const navItems: MenuItem[] = [
   {

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -1,6 +1,6 @@
 import { cacheLife, cacheTag } from "next/cache";
 
-import { productMetafieldIdentifiers } from "@/lib/config";
+import { pdp } from "@/lib/config";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import type {
   Filter,
@@ -79,7 +79,7 @@ const GET_PRODUCT_BY_HANDLE_QUERY = `#graphql
   }
 ` as const;
 
-// Opt-in metafields variant, selected when productMetafieldIdentifiers is non-empty.
+// Opt-in metafields variant, selected when pdp.specifications.metafields is non-empty.
 // Identifiers ride a $metafieldIdentifiers variable (not string interpolation) so the
 // document stays static and codegen-validatable.
 const GET_PRODUCT_BY_HANDLE_WITH_METAFIELDS_QUERY = `#graphql
@@ -108,13 +108,13 @@ export async function getProduct({
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 
-  const response = productMetafieldIdentifiers.length
+  const response = pdp.specifications.metafields.length
     ? await storefront.request<{ productByHandle: ShopifyProduct }>(
         GET_PRODUCT_BY_HANDLE_WITH_METAFIELDS_QUERY,
         {
           variables: {
             handle,
-            metafieldIdentifiers: productMetafieldIdentifiers,
+            metafieldIdentifiers: pdp.specifications.metafields,
             country,
             language,
           },

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -6,6 +6,12 @@ import {
   PHASE_PRODUCTION_SERVER,
 } from "next/constants";
 
+import { shopConfig } from "./shop.config";
+
+function isFeatureEnabled(envValue: string | undefined, enabledByDefault: boolean): boolean {
+  return envValue ? envValue === "1" : enabledByDefault;
+}
+
 function assertRequiredEnv() {
   const missingShopify = ["SHOPIFY_STORE_DOMAIN", "SHOPIFY_STOREFRONT_ACCESS_TOKEN"].filter(
     (key) => !process.env[key],
@@ -17,7 +23,7 @@ function assertRequiredEnv() {
     );
   }
 
-  if (process.env.NEXT_PUBLIC_ENABLE_AUTH === "1") {
+  if (isFeatureEnabled(process.env.NEXT_PUBLIC_ENABLE_AUTH, shopConfig.auth.enabledByDefault)) {
     const missing = [
       "BETTER_AUTH_SECRET",
       "SHOPIFY_CUSTOMER_CLIENT_ID",
@@ -26,8 +32,8 @@ function assertRequiredEnv() {
 
     if (missing.length > 0) {
       throw new Error(
-        `NEXT_PUBLIC_ENABLE_AUTH=1 requires: ${missing.join(", ")}. ` +
-          `Set the missing variables or unset NEXT_PUBLIC_ENABLE_AUTH.`,
+        `Enabled auth requires: ${missing.join(", ")}. ` +
+          `Set the missing variables or disable auth in shop.config.ts or NEXT_PUBLIC_ENABLE_AUTH.`,
       );
     }
   }

--- a/apps/template/shop.config.ts
+++ b/apps/template/shop.config.ts
@@ -1,0 +1,93 @@
+export type AgentToolName =
+  | "addCartNote"
+  | "addToCart"
+  | "browseCollection"
+  | "getCart"
+  | "getCatalogProduct"
+  | "getProductDetails"
+  | "getProductRecommendations"
+  | "listCollections"
+  | "navigateUser"
+  | "removeFromCart"
+  | "searchCatalog"
+  | "searchProducts"
+  | "searchShopPoliciesAndFaqs"
+  | "updateCartItemQuantity";
+
+export interface MetafieldIdentifier {
+  key: string;
+  namespace: string;
+}
+
+export interface ShopConfig {
+  agent: {
+    enabledByDefault: boolean;
+    maxSteps: number;
+    model: string;
+    tools: AgentToolName[];
+  };
+  auth: {
+    enabledByDefault: boolean;
+    providerId: "shopify";
+  };
+  pdp: {
+    bundles: {
+      enabled: boolean;
+    };
+    relatedProducts: {
+      enabled: boolean;
+      limit: number;
+    };
+    specifications: {
+      metafields: MetafieldIdentifier[];
+    };
+    upsells: {
+      enabled: boolean;
+      limit: number;
+    };
+  };
+}
+
+export const shopConfig = {
+  agent: {
+    enabledByDefault: false,
+    maxSteps: 10,
+    model: "google/gemini-3.5-flash",
+    tools: [
+      "addCartNote",
+      "addToCart",
+      "browseCollection",
+      "getCart",
+      "getCatalogProduct",
+      "getProductDetails",
+      "getProductRecommendations",
+      "listCollections",
+      "navigateUser",
+      "removeFromCart",
+      "searchCatalog",
+      "searchProducts",
+      "searchShopPoliciesAndFaqs",
+      "updateCartItemQuantity",
+    ],
+  },
+  auth: {
+    enabledByDefault: false,
+    providerId: "shopify",
+  },
+  pdp: {
+    bundles: {
+      enabled: true,
+    },
+    relatedProducts: {
+      enabled: true,
+      limit: 4,
+    },
+    specifications: {
+      metafields: [],
+    },
+    upsells: {
+      enabled: true,
+      limit: 4,
+    },
+  },
+} satisfies ShopConfig;

--- a/packages/plugin/template-rollout-log/2026-07-11-base-shop-config.md
+++ b/packages/plugin/template-rollout-log/2026-07-11-base-shop-config.md
@@ -1,0 +1,48 @@
+---
+title: Add canonical shop configuration
+changeKey: base-shop-config
+introducedOn: 2026-07-11
+changeType: feature
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/shop.config.ts
+  - apps/template/lib/config.ts
+  - apps/template/lib/agent/server.ts
+  - apps/template/lib/auth/
+  - apps/template/components/product-detail/
+  - apps/template/components/product/
+  - apps/template/app/products/[handle]/page.tsx
+  - apps/template/app/cart/page.tsx
+---
+
+## Summary
+
+The template now has a typed, secret-free `shop.config.ts` for canonical storefront behavior. It owns the shopping assistant model, maximum steps, tool allowlist, and default enablement; the authentication default and provider ID; and PDP bundle, complementary-product, related-product, and specification settings.
+
+`NEXT_PUBLIC_ENABLE_AGENT` and `NEXT_PUBLIC_ENABLE_AUTH` remain deployment overrides. When an override is unset, `lib/config.ts` uses the corresponding `enabledByDefault` value. Shopify and environment variables remain the sources for data and credentials.
+
+## Why it matters
+
+Storefront policy was previously split across hardcoded component constants, agent setup, and environment-only feature gates. A central config gives developers and agents one discoverable place to change canonical behavior without moving secrets or merchant data into source code.
+
+## Apply when
+
+- The storefront wants a central typed configuration surface.
+- Agent model, step count, or tool availability should be customizable without editing agent internals.
+- PDP bundles, upsells, related products, limits, or specifications should be configurable.
+- Auth or agent defaults should live in source while remaining overridable per deployment.
+
+## Safe to skip when
+
+- The storefront already has an equivalent configuration layer.
+- These policies are intentionally managed in a separate CMS or deployment system.
+
+## Validation
+
+1. Run `pnpm --filter template exec tsc --noEmit` and `pnpm --filter template lint`.
+2. Run the docs path linter for the new config references.
+3. Remove an agent tool from the allowlist and confirm it is absent from `agent.tools`.
+4. Set each `enabled` PDP value to `false` and confirm its surface does not render; confirm disabled recommendation surfaces do not fetch.
+5. Set auth enabled by default without credentials and confirm the build-time environment validation fails.


### PR DESCRIPTION
## Summary
- add a typed, secret-free `shop.config.ts` for agent, auth, and PDP merchandising policy
- wire agent model/steps/tools, auth defaults/provider, and PDP bundle/upsell/related/specification settings
- document configuration, environment overrides, and downstream rollout guidance

## Verification
- `pnpm --filter template exec tsc --noEmit`
- `pnpm --filter template lint`
- `pnpm --filter docs lint` (passes with one existing Satori `<img>` warning; 81 doc paths verified)
- `pnpm --filter template build`
- `git diff --check`