### PR TITLE
Audit template code comments

### DIFF
--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -127,6 +127,8 @@ Avoid the word "client" in a filename to mean an HTTP/SDK client wrapper — tha
 
 Default to writing none. Well-named identifiers, types, and tests already document WHAT the code does. Add a comment only when removing it would leave a future reader genuinely confused — and the reason is something they couldn't recover by reading the surrounding code.
 
+**Comments are terse guardrails for agents, not documentation.** Use one sentence on one physical line and state only the irreducible hidden WHY. Omit background, examples, history, setup, and consequences that are recoverable from the code. If the comment needs more than one line, improve the names or move the explanation to docs or the PR.
+
 A comment earns its place when it captures one of:
 
 - A hidden constraint (e.g. "cookies can't be set during stream").
@@ -134,7 +136,7 @@ A comment earns its place when it captures one of:
 - A non-obvious algorithmic choice or invariant.
 - A cross-system quirk (e.g. "Shopify's `productFilters` only affects facet counts, not results").
 
-**One line max.** If you can't say it in a single line, the code probably needs renaming, splitting, or extracting a constant — not more prose. Long-form context belongs in the PR description, not the source file.
+Before keeping a comment, ask: would an agent reasonably break behavior without this warning? If not, delete it.
 
 Don't write:
 
@@ -143,7 +145,7 @@ Don't write:
 - References to current work (`// added for cart refactor`, `// part of issue #123`, `// new`). That belongs in the PR description.
 - File-top banner comments and `// ── Section ──`-style dividers. If a file is large enough that you reach for one, split the file instead.
 - Bare `// TODO` without an owner or actionable reason. Either write `// TODO(handle): explain blocker` or fix the thing now.
-- Multi-paragraph docstrings on simple functions. If the JSDoc fits on one line, inline it; if you reach for multiple paragraphs, that's a signal to split or rename, not to write more prose.
+- Multi-line prose comments or docstrings. Preserve generated headers, licenses, and tooling-required blocks only.
 
 Keep `// eslint-disable-*`, `// @ts-expect-error`, `// biome-ignore`, and other tooling directives — those are not prose comments.
 

--- a/apps/template/app/api/webhooks/shopify/route.ts
+++ b/apps/template/app/api/webhooks/shopify/route.ts
@@ -19,7 +19,6 @@ async function verifyWebhook(body: string, hmacHeader: string | null): Promise<b
   return crypto.timingSafeEqual(Buffer.from(hash, "base64"), Buffer.from(hmacHeader, "base64"));
 }
 
-// Configure webhook topics in Shopify Admin → Settings → Notifications → Webhooks.
 export async function POST(request: Request) {
   const body = await request.text();
   const hmacHeader = request.headers.get("x-shopify-hmac-sha256");
@@ -42,9 +41,7 @@ export async function POST(request: Request) {
   const tagsInvalidated: string[] = [];
 
   if (topic.startsWith("products/")) {
-    // Per-product tags only — never the broad "products" tag. tagProducts() stamps every
-    // list/search/collection/recommendation entry with the contained products' product-<id>
-    // tag, so busting one product cascades to every surface showing it without nuking the catalog.
+    // Product tags cascade through every surface without purging the full catalog.
     const productTags: string[] = [];
 
     try {
@@ -72,10 +69,7 @@ export async function POST(request: Request) {
   }
 
   if (topic.startsWith("collections/")) {
-    // collection-{handle} busts the collection's PLP and — via tagCollections stamping — the
-    // all-collections listing for edits. create/delete change the *set* of collections, so they
-    // also fire "collections-index" (the listing page + collections sitemap). The broad
-    // "collections" tag is a manual break-glass purge of all collection data and is never fired here.
+    // Create/delete also invalidate the collection index; the broad tag is break-glass only.
     const collectionTags: string[] = [];
 
     if (topic === "collections/create" || topic === "collections/delete") {

--- a/apps/template/app/collections/[handle]/page.tsx
+++ b/apps/template/app/collections/[handle]/page.tsx
@@ -93,8 +93,7 @@ export default async function CollectionPage({
   const collection = await getCollection({ handle, locale });
   if (!collection) notFound();
 
-  // Keep searchParams unawaited so only the results/filters/sort stream; the
-  // collection header resolves here and renders into the static shell.
+  // Keep searchParams unawaited so the collection header stays in the static shell.
   const searchStatePromise = getCollectionSearchState(searchParams);
   const collectionResultsDataPromise = getCollectionResultsData({
     handle,

--- a/apps/template/app/collections/all/page.tsx
+++ b/apps/template/app/collections/all/page.tsx
@@ -49,8 +49,7 @@ const ALL_PRODUCTS_SORT_EXCLUDE = [
 export default async function AllProductsPage({ searchParams }: PageProps<"/collections/all">) {
   const [locale, collection] = await Promise.all([getLocale(), getAllProductsCollection()]);
 
-  // Keep searchParams unawaited so only the results/filters/sort stream; the
-  // collection header resolves here and renders into the static shell.
+  // Keep searchParams unawaited so the collection header stays in the static shell.
   const searchStatePromise = getCollectionSearchState(searchParams);
   const collectionResultsDataPromise = getAllProductsResultsData({
     locale,

--- a/apps/template/app/md/collections/[handle]/route.ts
+++ b/apps/template/app/md/collections/[handle]/route.ts
@@ -29,8 +29,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ hand
   const searchParams = searchParamsToRecord(url.searchParams);
 
   try {
-    // /collections/all is a virtual route with no Shopify equivalent; mirror the HTML
-    // page's data path so the same URL is legible to markdown-negotiating agents.
+    // /collections/all is local-only, so markdown must mirror the HTML data path.
     if (handle === ALL_PRODUCTS_HANDLE) {
       const searchStatePromise = getCollectionSearchState(Promise.resolve(searchParams));
       const [collection, data] = await Promise.all([

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -93,11 +93,7 @@ export default async function ProductPage({
   const product = await getProduct({ handle, locale });
   if (!product) notFound();
 
-  // Keep searchParams unawaited so only the variant-dependent UI streams. The
-  // picker highlight and color image depend only on searchParams (fast), so they
-  // ride a separate promise from the per-selection variant query (the network
-  // round-trip that price + add-to-cart need) — otherwise the picker would wait
-  // on the network and the selected option would visibly snap in after load.
+  // Keep selection separate from the variant query so the static shell stays coherent and the picker never waits on Shopify.
   const selectedOptionsPromise: Promise<SelectedOptions> = searchParams.then((sp) => ({
     ...defaultSelectedOptions(product),
     ...parseSelectedOptions(product.options, sp ?? {}),

--- a/apps/template/components/agent/client.tsx
+++ b/apps/template/components/agent/client.tsx
@@ -2,9 +2,6 @@
 
 import dynamic from "next/dynamic";
 
-/**
- * AgentPanel is heavy, not needed on the server, so just dynamically load it once hydrated
- */
 const AgentPanel = dynamic(() => import("./agent-panel").then((mod) => mod.AgentPanel), {
   ssr: false,
 });

--- a/apps/template/components/agent/thinking.tsx
+++ b/apps/template/components/agent/thinking.tsx
@@ -2,8 +2,6 @@
 
 import { useTranslations } from "next-intl";
 
-/** A minimal "Thinking…" indicator shown while the assistant works, before any
- *  text or card appears. No step-by-step chain-of-thought — it's noise for shoppers. */
 export function AgentThinking({ active }: { active: boolean }) {
   const t = useTranslations("agent");
   if (!active) return null;

--- a/apps/template/components/cart/context.tsx
+++ b/apps/template/components/cart/context.tsx
@@ -233,7 +233,6 @@ export function CartProvider({
   const isOverlayOpenRef = useRef(isOverlayOpen);
   isOverlayOpenRef.current = isOverlayOpen;
 
-  // Pending line item ops use leading-edge debounce.
   const lineOpsRef = useRef<Map<string, LineOperation>>(new Map());
   // Per-line request versioning ignores stale responses that return out of order.
   const latestLineRequestIdRef = useRef<Map<string, number>>(new Map());
@@ -281,7 +280,6 @@ export function CartProvider({
 
   const pendingProductInfoRef = useRef<Map<string, OptimisticProductInfo>>(new Map());
 
-  /** Debounced — accumulates rapid clicks into a single request per variant. */
   const addToCartOptimistic = (
     variantId: string,
     quantity: number,
@@ -389,7 +387,6 @@ export function CartProvider({
 
     startTransition(async () => {
       const result = await updateCartQuantityAction(lineId, quantity);
-      // Ignore stale responses from older requests for this line.
       if (latestLineRequestIdRef.current.get(lineId) !== requestId) {
         endTracking();
         return;
@@ -398,8 +395,7 @@ export function CartProvider({
       const pending = lineOpsRef.current.get(lineId);
 
       if (result.success && result.cart) {
-        // If the user changed quantity during the request, keep the optimistic
-        // state — the debounce timer will fire the final request.
+        // Preserve newer optimistic input; its debounce will issue the final request.
         if (!pending || pending.targetQuantity === quantity) {
           setCartInternal(result.cart);
           setLastWarnings(result.warnings ?? []);
@@ -407,8 +403,7 @@ export function CartProvider({
         }
       } else if (originalCart) {
         setCartInternal(originalCart);
-        // If quantity changed again during the request, leave the pending
-        // entry so the debounce timer will retry.
+        // Preserve newer pending input so the debounce can retry it.
         if (!pending || pending.targetQuantity === quantity) {
           lineOpsRef.current.delete(lineId);
         }
@@ -465,7 +460,6 @@ export function CartProvider({
 
     if (pending.timer) clearTimeout(pending.timer);
 
-    // Leading edge — first update fires immediately, the rest are debounced.
     if (!pending.hasFiredInitial) {
       pending.hasFiredInitial = true;
       fireUpdateRequest(lineId, quantity, pending.originalCart);
@@ -497,7 +491,6 @@ export function CartProvider({
     };
   }, []);
 
-  // Drop pending ops for lines the revalidated cart no longer contains.
   useEffect(() => {
     const lineIds = new Set(cart?.lines.map((l) => l.id) ?? []);
     for (const [lineId, pending] of lineOpsRef.current) {
@@ -544,7 +537,7 @@ export function useCart() {
   return context;
 }
 
-/** Seeds the root provider once from a server-fetched cart. Safe to call from every boundary. */
+// Idempotent so every server boundary may seed the root provider.
 export function useSeedCart(initialCart: Cart | null) {
   const { cart, setCart } = useCart();
   useEffect(() => {

--- a/apps/template/components/cart/overlay-content.tsx
+++ b/apps/template/components/cart/overlay-content.tsx
@@ -69,7 +69,6 @@ export function OverlayContent({ locale }: OverlayContentProps) {
     window.location.href = checkoutUrl || cart?.checkoutUrl || displayCart?.checkoutUrl || "";
   };
 
-  // Use cartWithPending for display - it includes optimistic lines
   const displayCart = cartWithPending;
 
   if (!displayCart || displayCart.lines.length === 0) {
@@ -100,11 +99,9 @@ export function OverlayContent({ locale }: OverlayContentProps) {
         </ul>
       </div>
 
-      {/* Summary Section */}
       <footer className="px-5 py-5 space-y-5">
         <OverlaySummary cart={displayCart} locale={locale} />
 
-        {/* Checkout Button */}
         <Button
           onClick={handleCheckout}
           className="w-full h-12 justify-center"

--- a/apps/template/components/cart/overlay-item.tsx
+++ b/apps/template/components/cart/overlay-item.tsx
@@ -20,7 +20,6 @@ export function OverlayItem({ item, locale }: OverlayItemProps) {
   const { cartWithPending, updateItemOptimistic } = useCart();
   const t = useTranslations("cart");
 
-  // Read quantity from cartWithPending (includes optimistic updates)
   const currentLine = cartWithPending?.lines.find((l) => l.id === item.id);
   const quantity = currentLine?.quantity ?? item.quantity;
 

--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -44,7 +44,6 @@ export function InfiniteProductGrid<TParams>({
   // Live cursor pages can re-emit a boundary product if the ranking shifts mid-scroll; skip ids already shown.
   const seenIdsRef = useRef<Set<string>>(new Set(initialProducts.map((product) => product.id)));
 
-  // Reset when initial data changes (filter/sort navigation)
   useEffect(() => {
     setAdditionalProducts([]);
     setPageInfo(initialPageInfo);

--- a/apps/template/components/collections/results-grid.tsx
+++ b/apps/template/components/collections/results-grid.tsx
@@ -52,8 +52,7 @@ async function Render({
     />
   ));
 
-  // /collections/all is backed by the catalog-browse search() field, not the collection
-  // field — load-more has to call the same backend the initial page used.
+  // /collections/all pagination must use the same search backend as its initial page.
   if (collection === ALL_PRODUCTS_HANDLE) {
     return (
       <InfiniteProductGrid

--- a/apps/template/components/collections/toolbar.tsx
+++ b/apps/template/components/collections/toolbar.tsx
@@ -3,7 +3,6 @@ import type * as React from "react";
 interface CollectionToolbarProps {
   filterSheet: React.ReactNode;
   sortSelect: React.ReactNode;
-  // Omit on pages without a count so the slot doesn't reserve space.
   resultCount?: React.ReactNode;
 }
 

--- a/apps/template/components/nav/search-modal.tsx
+++ b/apps/template/components/nav/search-modal.tsx
@@ -124,7 +124,6 @@ function SearchDialogContent({ onClose }: { onClose: () => void }) {
         <div className="w-full max-w-xl h-fit">
           <DialogTitle className="sr-only">{t("search")}</DialogTitle>
           <div className="bg-background rounded-xl shadow-lg overflow-hidden duration-200">
-            {/* Search input */}
             <form onSubmit={handleSubmit} className="flex items-center gap-3 px-4 py-3">
               <Search className="size-4 shrink-0 text-foreground/40" />
               <input
@@ -165,7 +164,6 @@ function SearchDialogContent({ onClose }: { onClose: () => void }) {
               </DialogPrimitive.Close>
             </form>
 
-            {/* Results */}
             {show && (
               <div
                 id="search-modal-results"

--- a/apps/template/components/product-card/components.tsx
+++ b/apps/template/components/product-card/components.tsx
@@ -130,7 +130,6 @@ function ProductCardTitle({ className, children, ...props }: React.ComponentProp
 interface ProductCardPriceProps {
   amount: string;
   currencyCode: string;
-  /** Highest variant price; when it differs from amount the card renders a "min – max" range. */
   maxAmount?: string;
   compareAtAmount?: string;
   compareAtCurrencyCode?: string;

--- a/apps/template/components/product-detail/bundle-components.tsx
+++ b/apps/template/components/product-detail/bundle-components.tsx
@@ -37,8 +37,7 @@ interface BundleParentsProps {
 }
 
 export function BundleParents({ title, variants }: BundleParentsProps) {
-  // A component variant is grouped into many bundle variant combinations that all
-  // belong to the same bundle product — collapse to one link per bundle product.
+  // Shopify groups components by bundle variant, but this surface links each product once.
   const byProduct = new Map<string, ProductVariantReference>();
   for (const variant of variants) {
     if (!byProduct.has(variant.product.handle)) byProduct.set(variant.product.handle, variant);

--- a/apps/template/components/product-detail/buy-buttons.tsx
+++ b/apps/template/components/product-detail/buy-buttons.tsx
@@ -13,9 +13,7 @@ import { cn } from "@/lib/utils";
 
 import { ShopLogo } from "./shop-logo";
 
-// Client-facing projection of the selected variant — only the fields the buy
-// controls need. Bundle relationship arrays stay on the server; the gating they
-// imply is collapsed to the requiresBundleConfiguration boolean.
+// Keep bundle relationship arrays server-side; the client only needs their gating boolean.
 export interface BuyButtonVariant {
   availableForSale: boolean;
   id: string;

--- a/apps/template/components/product-detail/open-graph.tsx
+++ b/apps/template/components/product-detail/open-graph.tsx
@@ -5,12 +5,7 @@ interface ProductOpenGraphProps {
   price: Money;
 }
 
-// Renders the OpenGraph "product" object tags as raw <meta property> elements
-// (React 19 hoists them to <head>). Next's Metadata API has no product OG variant,
-// and its `other` field emits name= rather than the property= that OG parsers need.
-// Both the product:* (Facebook) and og:price/availability (Pinterest, older parsers)
-// namespaces are emitted for broad compatibility. Priced off the "from" (min) price
-// to match the displayed price and the JSON-LD AggregateOffer lowPrice.
+// Next Metadata cannot emit product `property=` tags, so React hoists these raw meta elements.
 export function ProductOpenGraph({ availableForSale, price }: ProductOpenGraphProps) {
   return (
     <>

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -264,9 +264,7 @@ async function ProductInfoArea({
   );
 }
 
-// Bundle relationships are product-level (which products a bundle contains / which
-// bundles a product belongs to), so they render eagerly from the cached default
-// variant in the static shell rather than streaming in behind the variant query.
+// Bundle relationships are product-level, so keep them in the static shell.
 function BundleRelationships({
   variant,
   t,
@@ -328,8 +326,7 @@ async function ResolvedProductInfoOptions({
   );
 }
 
-// Bundle relationship arrays stay server-side; the client buy controls only need
-// the gating boolean (a customized bundle parent has no fixed components to ship).
+// Customized bundle parents have no fixed components; only their gating boolean crosses the client boundary.
 function toBuyButtonVariant(variant: ProductVariant | undefined): BuyButtonVariant | undefined {
   if (!variant) return undefined;
   return {

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -82,7 +82,6 @@ function MediaVideo({
   );
 }
 
-/** Snap-scroll carousel for mobile viewports. */
 function Carousel({
   mediaItems,
   title,
@@ -100,7 +99,6 @@ function Carousel({
   const prevMediaRef = useRef<string>("");
   const t = useTranslations("product");
 
-  // Reset carousel to first item when the filtered media change
   const joinedKey = mediaItems.map(mediaKey).join(",");
   if (prevMediaRef.current && prevMediaRef.current !== joinedKey) {
     scrollContainerRef.current?.scrollTo({ left: 0 });
@@ -242,7 +240,6 @@ function GridItem({
   );
 }
 
-/** 2-column grid with lightbox for desktop viewports. */
 function Grid({
   mediaItems,
   title,
@@ -278,10 +275,6 @@ function Grid({
   return interactive ? <Lightbox label={title}>{grid}</Lightbox> : grid;
 }
 
-/**
- * Renders color-specific images as grid items (desktop).
- * Designed to be used inside a Suspense boundary as children of ProductMedia.
- */
 export function ColorImageGrid({ images, title }: { images: ImageType[]; title: string }) {
   return images.map((image, idx) => (
     <GridItem
@@ -295,10 +288,6 @@ export function ColorImageGrid({ images, title }: { images: ImageType[]; title: 
   ));
 }
 
-/**
- * Renders color-specific images as carousel items (mobile).
- * Matches the Carousel item structure for consistent snap-scroll behavior.
- */
 export function ColorImageCarouselItems({ images, title }: { images: ImageType[]; title: string }) {
   return images.map((image, idx) => {
     const priority = idx === 0;
@@ -353,9 +342,7 @@ export function ProductMedia({
   videos: Video[];
   title: string;
   className?: string;
-  /** Color images rendered as grid items (desktop). */
   desktopSlot?: React.ReactNode;
-  /** Color images rendered as carousel items (mobile). */
   mobileSlot?: React.ReactNode;
 }) {
   const sharedMediaItems: MediaItem[] = [

--- a/apps/template/components/product-detail/shop-logo.tsx
+++ b/apps/template/components/product-detail/shop-logo.tsx
@@ -1,6 +1,5 @@
 import type { SVGProps } from "react";
 
-// https://help.shopify.com/en/manual/payments/shop-pay/assets
 export function ShopLogo(props: SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/apps/template/components/ui/input-group.tsx
+++ b/apps/template/components/ui/input-group.tsx
@@ -16,16 +16,13 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
         "group/input-group border-input relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none",
         "h-9 min-w-0 has-[>textarea]:h-auto",
 
-        // Variants based on alignment.
         "has-[>[data-align=inline-start]]:[&>input]:pl-2",
         "has-[>[data-align=inline-end]]:[&>input]:pr-2",
         "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-2.5",
         "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-2.5",
 
-        // Focus state.
         "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-3",
 
-        // Error state.
         "has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive",
 
         className,

--- a/apps/template/hooks/use-controllable-state.ts
+++ b/apps/template/hooks/use-controllable-state.ts
@@ -1,6 +1,5 @@
 import { useCallback, useRef, useState } from "react";
 
-/** Replaces `@radix-ui/react-use-controllable-state`. */
 export function useControllableState<T>({
   prop,
   defaultProp,

--- a/apps/template/hooks/use-media-query.ts
+++ b/apps/template/hooks/use-media-query.ts
@@ -15,7 +15,7 @@ export function useMediaQuery(query: string): boolean {
   }, [query]);
 
   const getServerSnapshot = useCallback(() => {
-    // Default to false (mobile-first) on server
+    // SSR uses the mobile-first snapshot because matchMedia is unavailable.
     return false;
   }, []);
 

--- a/apps/template/hooks/use-predictive-search.ts
+++ b/apps/template/hooks/use-predictive-search.ts
@@ -41,7 +41,7 @@ export function usePredictiveSearch(locale: string) {
             setResults(data);
           }
         } catch {
-          // Silently fail — user can still press Enter for full search
+          // Predictive failure must not block full search submission.
         }
       });
     }, DEBOUNCE_MS);

--- a/apps/template/hooks/use-scroll-contain.ts
+++ b/apps/template/hooks/use-scroll-contain.ts
@@ -7,11 +7,6 @@ function isAtScrollBoundary(el: HTMLElement, deltaY: number) {
   return false;
 }
 
-/**
- * Prevents scroll events (wheel + touch) from propagating through a panel
- * to the page behind it, while still allowing a designated scrollable child
- * to scroll normally within its bounds.
- */
 export function useScrollContain(
   ref: RefObject<HTMLElement | null>,
   enabled: boolean,

--- a/apps/template/lib/auth/server.ts
+++ b/apps/template/lib/auth/server.ts
@@ -76,8 +76,7 @@ function decodeIdTokenPayload(idToken: string): {
   return JSON.parse(decoded);
 }
 
-// Skip betterAuth construction when auth is disabled — calling it without a real
-// BETTER_AUTH_SECRET logs a default-secret warning at module load during build.
+// Disabled auth must not construct betterAuth; it warns about the absent secret at module load.
 export const auth = isAuthEnabled
   ? betterAuth({
       baseURL: authBaseUrl,

--- a/apps/template/lib/cart/action.ts
+++ b/apps/template/lib/cart/action.ts
@@ -122,7 +122,6 @@ export async function addToCartAction(
   }
 }
 
-/** Aligns cart country/currency with the locale; call on locale change or initial page load. */
 export async function syncCartLocaleAction(locale: string): Promise<CartActionResult> {
   if (!isEnabledLocale(locale)) {
     return {
@@ -134,7 +133,6 @@ export async function syncCartLocaleAction(locale: string): Promise<CartActionRe
   try {
     const result = await updateCartBuyerIdentity(locale);
 
-    // No cart exists yet — nothing to sync, treat as success.
     if (!result) {
       return { success: true };
     }
@@ -185,10 +183,7 @@ export async function applyDiscountCodeAction(code: string): Promise<CartActionR
   }
 
   try {
-    // `cartDiscountCodesUpdate` replaces the entire code set, so we must read
-    // the current codes authoritatively before writing. A read failure has to
-    // surface as a failure here — falling back to `[]` would silently wipe
-    // every previously-applied code.
+    // Shopify replaces the entire discount-code set; never fall back to [] after a read failure.
     const current = await getCart();
     if (!current) {
       return { success: false, error: "Cart not found" };
@@ -204,8 +199,7 @@ export async function applyDiscountCodeAction(code: string): Promise<CartActionR
       return { success: false, error: "Cart not found" };
     }
 
-    // Shopify accepts unknown codes and marks them applicable:false. Reject those
-    // (undo the apply, surface the warning as a form error — no chip, no banner).
+    // Shopify accepts unknown codes as applicable:false, so undo and reject them.
     const applied = result.cart.discountCodes.find((d) => d.code.toUpperCase() === normalized);
     if (applied && !applied.applicable) {
       const reverted = await updateCartDiscountCodes(existing);
@@ -231,8 +225,7 @@ export async function removeDiscountCodeAction(code: string): Promise<CartAction
   }
 
   try {
-    // Same constraint as apply: the mutation replaces, so a read failure here
-    // would silently wipe every other applied code.
+    // The mutation replaces the whole set; a failed read must not wipe other codes.
     const current = await getCart();
     if (!current) {
       return { success: false, error: "Cart not found" };
@@ -271,7 +264,6 @@ export async function buyNowAction(
     return { checkoutUrl: null, error: "Store domain not configured" };
   }
 
-  // Extract numeric ID from GID (e.g. "gid://shopify/ProductVariant/123" → "123")
   let numericId: string | null = merchandiseId;
   if (merchandiseId.startsWith("gid://") || !merchandiseId.match(/^\d+$/)) {
     let decoded = merchandiseId;

--- a/apps/template/lib/cart/server.ts
+++ b/apps/template/lib/cart/server.ts
@@ -3,7 +3,7 @@ import { revalidateTag, updateTag } from "next/cache";
 import { cookies } from "next/headers";
 
 const CART_ID_COOKIE = "shopify_cartId";
-const CART_ID_COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+const CART_ID_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 // Preview sits behind Vercel Authentication; its cross-site SSO return hop drops a SameSite=Strict cookie, so only prod gets Strict.
 const CART_ID_COOKIE_SAME_SITE = process.env.VERCEL_ENV === "production" ? "strict" : "lax";
 

--- a/apps/template/lib/collections/server.ts
+++ b/apps/template/lib/collections/server.ts
@@ -11,10 +11,7 @@ import type { ProductFilter } from "@/lib/shopify/types/filters";
 import type { Collection, Filter, PriceRange } from "@/lib/types";
 import { RESULTS_PER_PAGE, parseFiltersFromSearchParams } from "@/lib/utils";
 
-// Shopify's /collections/all is a Liquid-storefront convention with no Storefront API
-// equivalent — the "all" virtual collection is owned entirely by this module and the
-// dedicated app/collections/all/page.tsx route. The data layer (lib/shopify/operations)
-// stays unaware of it.
+// /collections/all is a local virtual collection with no Storefront API equivalent.
 export const ALL_PRODUCTS_HANDLE = "all";
 
 export interface CollectionSearchState {

--- a/apps/template/lib/customer/action.ts
+++ b/apps/template/lib/customer/action.ts
@@ -35,8 +35,7 @@ const ADDRESS_FIELDS = [
 
 const UPPERCASE_FIELDS = new Set<keyof CustomerAddressInput>(["territoryCode", "zoneCode"]);
 
-// Customer Account API userErrors carry a `field` path like ["address", "zip"];
-// the last segment is the input field a form can highlight.
+// Customer Account API field paths end with the form field to highlight.
 function mapUserErrors(errors: CustomerUserError[]): AccountActionResult {
   if (errors.length === 0) return { success: true };
 

--- a/apps/template/lib/i18n/index.ts
+++ b/apps/template/lib/i18n/index.ts
@@ -2,8 +2,6 @@ export const locales = ["en-US"] as const;
 
 export type Locale = (typeof locales)[number];
 
-// Deployment-level locale mode. By default the storefront runs in single-locale
-// mode, but additional locales can be enabled here when the app is ready.
 export const defaultLocale: Locale = "en-US";
 export const enabledLocales: readonly Locale[] = [defaultLocale];
 export const localeSwitchingEnabled = enabledLocales.length > 1;
@@ -20,7 +18,6 @@ export function asLocale(value: string): Locale {
   return isLocale(value) ? value : defaultLocale;
 }
 
-/** Unsupported or disabled values fall back to `defaultLocale`. */
 export function resolveLocale(value: string | null | undefined): Locale {
   return value && isEnabledLocale(value) ? value : defaultLocale;
 }
@@ -42,7 +39,6 @@ export function getLocaleData(locale: string): LocaleData {
   const [lang, country] = locale.split("-");
   const currencyData = localeCurrency[locale as Locale] ?? localeCurrency[defaultLocale];
 
-  // Native language name (e.g., "Deutsch" for de-DE).
   const languageNames = new Intl.DisplayNames([locale], { type: "language" });
   const languageName = languageNames.of(lang) ?? lang;
 

--- a/apps/template/lib/markdown/utils.ts
+++ b/apps/template/lib/markdown/utils.ts
@@ -6,7 +6,6 @@ export function formatPrice(money: Money, locale: string): string {
   return formatMoney(money, { currencyDisplay: "narrowSymbol", locale }).localizedString;
 }
 
-/** Handles: | (table pipes), * (bold/italic), _ (italic), ` (code), # (headers). */
 export function escapeMarkdown(text: string): string {
   return text
     .replace(/\|/g, "\\|")
@@ -16,7 +15,6 @@ export function escapeMarkdown(text: string): string {
     .replace(/^#/gm, "\\#");
 }
 
-/** Empty rows are dropped; mismatched cell counts are truncated or padded with empty cells. */
 export function createTable(headers: string[], rows: string[][]): string {
   if (headers.length === 0 || rows.length === 0) return "";
 

--- a/apps/template/lib/product.ts
+++ b/apps/template/lib/product.ts
@@ -2,7 +2,6 @@ import type { Image, Money, ProductDetails, ProductOption, SelectedOption } from
 
 export type SelectedOptions = Record<string, string>;
 
-/** Selected options from `?color=Blue&size=XS` params, keyed by canonical option name. */
 export function parseSelectedOptions(
   options: ProductOption[],
   searchParams: Record<string, string | string[] | undefined>,
@@ -18,7 +17,6 @@ export function parseSelectedOptions(
   return selected;
 }
 
-/** The default variant's options — the selection shown when no params are present. */
 export function defaultSelectedOptions(product: ProductDetails): SelectedOptions {
   const selected: SelectedOptions = {};
   for (const option of product.defaultVariant?.selectedOptions ??
@@ -33,7 +31,6 @@ export function toSelectedOptionList(selectedOptions: SelectedOptions): Selected
   return Object.entries(selectedOptions).map(([name, value]) => ({ name, value }));
 }
 
-/** Option-based PDP URL, e.g. `/products/handle?color=Blue&size=XS`. */
 export function buildOptionUrl(
   handle: string,
   currentOptions: SelectedOptions,
@@ -47,7 +44,6 @@ export function buildOptionUrl(
   return parts.length > 0 ? `/products/${handle}?${parts.join("&")}` : `/products/${handle}`;
 }
 
-/** The color option, detected by swatch data or name — the only axis that partitions the gallery. */
 function findColorOption(options: ProductOption[]): ProductOption | undefined {
   return options.find(
     (option) =>
@@ -56,18 +52,13 @@ function findColorOption(options: ProductOption[]): ProductOption | undefined {
   );
 }
 
-/**
- * True only when the color axis has multiple values with distinct representative
- * images — so the gallery should lead with the selected color's image. Other
- * multi-value axes (size, etc.) share imagery and must not trigger a streamed slot.
- */
+// Only color partitions the gallery; other option axes share imagery.
 export function hasColorImagePartitioning(options: ProductOption[]): boolean {
   const color = findColorOption(options);
   if (!color || color.values.length <= 1) return false;
   return color.values.filter((value) => value.image).length > 1;
 }
 
-/** Product images that aren't a specific color's representative image. */
 export function getSharedImages(images: Image[], options: ProductOption[]): Image[] {
   const color = findColorOption(options);
   if (!color) return images;
@@ -79,7 +70,6 @@ export function getSharedImages(images: Image[], options: ProductOption[]): Imag
   return shared.length > 0 ? shared : images;
 }
 
-/** The selected color's representative image, resolved from options alone (no variant query). */
 export function getSelectedColorImage(
   product: ProductDetails,
   selectedOptions: SelectedOptions,

--- a/apps/template/lib/seo.ts
+++ b/apps/template/lib/seo.ts
@@ -85,8 +85,7 @@ export function buildOpenGraph({
       }
   >;
 }): Metadata["openGraph"] {
-  // Omitting `type` emits no og:type, letting product pages own og:type=product
-  // via a dedicated meta block (Next only emits og:type when the key is present).
+  // Omit type so product pages can emit og:type=product through raw meta tags.
   return {
     ...(type ? { type } : {}),
     title,

--- a/apps/template/lib/shopify/customer-account.ts
+++ b/apps/template/lib/shopify/customer-account.ts
@@ -14,11 +14,7 @@ const SHOPIFY_STORE_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN as string;
 const SHOPIFY_API_VERSION = process.env.SHOPIFY_API_VERSION ?? "2026-04";
 const DEBUG = process.env.DEBUG_SHOPIFY === "true";
 
-// The Customer Account API lives at a per-shop endpoint keyed by the numeric
-// {shopId} embedded in the store's OIDC issuer. Derive it from the discovery
-// document — cached for the process lifetime — so the template needs no config
-// beyond SHOPIFY_STORE_DOMAIN. Hydrogen's client builds the endpoint from
-// shopId, so cache the id rather than the full URL.
+// Hydrogen needs the numeric shop ID embedded in Shopify's OIDC issuer.
 let shopIdPromise: Promise<string> | undefined;
 
 function resolveShopId(): Promise<string> {
@@ -45,12 +41,7 @@ function resolveShopId(): Promise<string> {
   return shopIdPromise;
 }
 
-// Customer Account API is a separate GraphQL endpoint and schema from the
-// Storefront API. It authenticates with the customer's OAuth access token and
-// is always per-request (POST), so responses are never shared across customers.
-// Hydrogen's client requires a request context carrying the resolved i18n and
-// an HTTPS origin (used for the mandatory `Origin` header); reuse the app's
-// configured base URL so it matches the OAuth-registered origin.
+// Hydrogen requires an HTTPS Origin matching the OAuth-registered auth base URL.
 export async function customerAccountFetch<T>({
   accessToken,
   operation,
@@ -76,8 +67,7 @@ export async function customerAccountFetch<T>({
   });
 
   const start = DEBUG ? performance.now() : 0;
-  // Operations pass plain-string queries; brand the runtime document so the
-  // client accepts our variables instead of inferring `never` from the string.
+  // Brand runtime strings so Hydrogen does not infer `never` variables.
   const doc = gql(query) as CustomerAccountDocument<T, Record<string, unknown>>;
   const { data, errors } = await client.graphql(doc, { accessToken, variables });
 

--- a/apps/template/lib/shopify/encoded-variants.ts
+++ b/apps/template/lib/shopify/encoded-variants.ts
@@ -1,9 +1,6 @@
 import type { ProductOption } from "@/lib/types";
 
-// Decoder for Shopify's encodedVariantExistence / encodedVariantAvailability trie
-// strings (Storefront API 2024-10+). Control chars: ":" descends an option level,
-// "," ends a repeated prefix (consecutive commas pop multiple levels), " " marks a
-// gap between non-contiguous sibling values, "-" a contiguous range of values.
+// Shopify trie controls: `:` descends, `,` pops, space separates, and `-` spans a range.
 export function decodeEncodedVariant(encoded: string): number[][] {
   if (!encoded) return [];
   if (!encoded.startsWith("v1_")) throw new Error("Unsupported option value encoding");
@@ -48,7 +45,6 @@ function v1Decoder(encoded: string): number[][] {
         result.push(combination.slice(0, depth + 1));
       }
     } else {
-      // ","
       if (rangeStart !== null) {
         pushRange(value ?? rangeStart);
       } else if (prevControl !== ",") {
@@ -78,11 +74,7 @@ function v1Decoder(encoded: string): number[][] {
   return result;
 }
 
-// Maps decoded availability combinations to the set of in-stock value names per
-// option. Falls back to "all available" on missing data, decode failure, or the
-// empty result Shopify returns for synthetic single-option products (a known
-// upstream quirk) — the authoritative per-variant availability still gates the
-// add-to-cart button via the suspended variant query.
+// Shopify may return an empty trie for synthetic options; variant lookup still gates purchase.
 export function getAvailableOptionValues(
   options: ProductOption[],
   encodedAvailability: string | undefined,

--- a/apps/template/lib/shopify/fetch.ts
+++ b/apps/template/lib/shopify/fetch.ts
@@ -1,4 +1,3 @@
-// Shared Storefront fetch cores used by cached operations and MCP result enrichment.
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import type {
   Cart,
@@ -267,8 +266,6 @@ export type CollectionProductsResult = {
   products: ProductCard[];
 };
 
-// COMPLEMENTARY is the merchant-curated "pair it with" set (Search & Discovery app);
-// RELATED is Shopify's auto-generated "you may also like" set.
 export interface ProductRecommendationSets {
   complementary: ProductCard[];
   related: ProductCard[];
@@ -276,7 +273,6 @@ export interface ProductRecommendationSets {
 
 export type CartMutationResult = { cart: Cart; warnings: CartWarning[] };
 
-// Shopify's CartLineInput. `parent` links a line to a bundle/add-on parent.
 export interface CartLineInput {
   merchandiseId: string;
   parent?: { lineId?: string; merchandiseId?: string };
@@ -291,9 +287,7 @@ export function applyCartMutation(
   return { cart: transformShopifyCart(cart), warnings };
 }
 
-// Relevance-ranked search via the Storefront `search` field. Accepts the full ProductFilter set
-// (variant options, metafields, etc.) — the products(...) query string in getCatalogProducts
-// silently drops variantOption/productMetafield, so /search uses this path even for no-query browse.
+// `products` drops variant/metafield filters, so /search must use the `search` field.
 export async function fetchSearchIndexProducts(
   params: SearchIndexProductsParams,
 ): Promise<SearchIndexProductsResult> {
@@ -409,8 +403,6 @@ export async function fetchCollectionProducts(
   };
 }
 
-// Slim shell + full variant matrix; for the AI agent and markdown routes that
-// enumerate variants. The PDP uses getProduct + getProductVariant instead.
 export async function fetchProductWithVariants({
   handle,
   locale = defaultLocale,
@@ -432,8 +424,6 @@ export async function fetchProductWithVariants({
   return transformShopifyProductDetails(data.productByHandle);
 }
 
-// Both intents ride one aliased request, so the PDP's two recommendation surfaces
-// dedupe to a single Shopify call.
 export async function fetchProductRecommendationSets({
   handle,
   locale = defaultLocale,
@@ -491,7 +481,6 @@ const NODE_HANDLES_QUERY = `#graphql
   }
 ` as const;
 
-// Resolves product GIDs to storefront handles (e.g. to route MCP catalog results on-site).
 export async function fetchProductHandlesByIds(ids: string[]): Promise<Map<string, string>> {
   const handles = new Map<string, string>();
   if (ids.length === 0) return handles;

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -14,7 +14,7 @@ export const IMAGE_FRAGMENT = `#graphql
   }
 ` as const;
 
-// Note: Does not include IMAGE_FRAGMENT - expects parent to include it
+// Parent documents must include IMAGE_FRAGMENT.
 export const PRODUCT_VARIANT_FRAGMENT = `#graphql
   ${MONEY_FRAGMENT}
   fragment ProductVariantFields on ProductVariant {
@@ -37,8 +37,6 @@ export const PRODUCT_VARIANT_FRAGMENT = `#graphql
   }
 ` as const;
 
-// Lightweight variant reference for bundle relationships. Relies on the parent
-// to include IMAGE_FRAGMENT (matches PRODUCT_VARIANT_FRAGMENT).
 export const BUNDLE_COMPONENT_VARIANT_FRAGMENT = `#graphql
   fragment BundleComponentVariantFields on ProductVariant {
     id
@@ -57,9 +55,7 @@ export const BUNDLE_COMPONENT_VARIANT_FRAGMENT = `#graphql
   }
 ` as const;
 
-// The selected/purchasable variant: base fields plus Shopify bundle relationships.
-// Used only where one variant is resolved (the shell default + the suspended query),
-// never for the full matrix or cards. Relies on the parent to include IMAGE_FRAGMENT.
+// Parent documents must include IMAGE_FRAGMENT.
 export const PURCHASABLE_PRODUCT_VARIANT_FRAGMENT = `#graphql
   ${PRODUCT_VARIANT_FRAGMENT}
   ${BUNDLE_COMPONENT_VARIANT_FRAGMENT}
@@ -103,9 +99,7 @@ export const METAFIELD_FRAGMENT = `#graphql
   }
 ` as const;
 
-// A bundle's component lines carry Shopify edit instructions (e.g. canRemove:false
-// so a shopper can't pull one product out of a fixed bundle); the parent bundle line
-// is a ComponentizableCartLine whose lineComponents are ordinary CartLines.
+// Fixed bundle components carry Shopify edit restrictions on nested CartLines.
 export const CART_FRAGMENT = `#graphql
   ${IMAGE_FRAGMENT}
   ${MONEY_FRAGMENT}
@@ -393,9 +387,6 @@ export const PRODUCT_FRAGMENT = `#graphql
   }
 ` as const;
 
-// Extends the slim shell with the full variant matrix. Used by the AI agent and
-// markdown routes, which enumerate variants; the PDP uses the slim ProductFields
-// plus a per-selection variant query instead.
 export const PRODUCT_WITH_VARIANTS_FRAGMENT = `#graphql
   ${PRODUCT_FRAGMENT}
   fragment ProductWithVariantsFields on Product {

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -133,7 +133,6 @@ const CART_DELIVERY_ADDRESSES_UPDATE_MUTATION = `#graphql
   }
 ` as const;
 
-/** Request-deduped via React.cache so every server boundary in a render shares one fetch. */
 export const getCart = cache(async (): Promise<Cart | undefined> => {
   const cartId = await getCartIdFromCookie();
   if (!cartId) return undefined;
@@ -144,10 +143,7 @@ export async function getCartById(cartId: string): Promise<Cart | undefined> {
   return fetchCart(cartId);
 }
 
-/**
- * Use in streaming contexts (e.g., the AI agent) where `cookies().set()` won't work.
- * The caller is responsible for setting the cookie via response headers.
- */
+// Streaming callers must emit the cart cookie through response headers.
 export async function createCartWithoutCookie(
   locale: string = defaultLocale,
 ): Promise<CartMutationResult> {

--- a/apps/template/lib/shopify/operations/collections.ts
+++ b/apps/template/lib/shopify/operations/collections.ts
@@ -83,8 +83,7 @@ export async function getCollection({
   handle: string;
   locale?: string;
 }): Promise<Collection | undefined> {
-  // Plain "use cache" (not remote) so the resolved collection bakes into the
-  // PLP static shell; "use cache: remote" defers to request time and won't inline.
+  // Plain cache is required to bake the collection into the PLP shell.
   "use cache";
   cacheLife("max");
   cacheTag("collections", `collection-${handle}`);
@@ -125,8 +124,7 @@ export async function getCollectionsListing({
 
   const nodes = data.collections.edges.map((edge) => edge.node);
 
-  // Per-collection and per-first-product tags so the listing busts on a collection edit
-  // (collection-{handle}) or a fallback image change (product-{numericId}).
+  // The first product tag covers collection thumbnails that fall back to product imagery.
   tagCollections(nodes);
   for (const node of nodes) {
     const firstProductId = node.products.edges[0]?.node.id;

--- a/apps/template/lib/shopify/operations/customer.ts
+++ b/apps/template/lib/shopify/operations/customer.ts
@@ -299,7 +299,6 @@ export async function getCustomerAddresses(): Promise<CustomerAddress[]> {
     transformCustomerAddress(address, defaultId),
   );
 
-  // Surface the default address first; it's the one customers act on most.
   return addresses.sort((a, b) => Number(b.isDefault) - Number(a.isDefault));
 }
 

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -47,8 +47,6 @@ import {
 import type { ProductFilter, ShopifyFilter } from "../types/filters";
 import { getNumericShopifyId } from "../utils";
 
-// Re-export the Next-free cores so existing importers of these from
-// "operations/products" keep working; the cached wrappers below add cacheTag.
 export {
   fetchCollectionProducts,
   fetchProductRecommendationSets,
@@ -79,9 +77,7 @@ const GET_PRODUCT_BY_HANDLE_QUERY = `#graphql
   }
 ` as const;
 
-// Opt-in metafields variant, selected when pdp.specifications.metafields is non-empty.
-// Identifiers ride a $metafieldIdentifiers variable (not string interpolation) so the
-// document stays static and codegen-validatable.
+// Metafield identifiers stay variables so the document remains codegen-validatable.
 const GET_PRODUCT_BY_HANDLE_WITH_METAFIELDS_QUERY = `#graphql
   ${METAFIELD_FRAGMENT}
   ${PRODUCT_FRAGMENT}
@@ -147,9 +143,7 @@ const GET_PRODUCT_VARIANT_QUERY = `#graphql
   }
 ` as const;
 
-// Resolves the active variant from selected options (the suspended PDP query).
-// Empty selectedOptions returns the first available variant — matches the
-// no-params / partial-selection fallback the PDP relies on.
+// Empty selections intentionally resolve Shopify's first available variant.
 export async function getProductVariant({
   handle,
   locale = defaultLocale,
@@ -177,8 +171,6 @@ export async function getProductVariant({
   return variant ? transformVariant(variant) : undefined;
 }
 
-// Slim shell + full variant matrix; for the AI agent and markdown routes that
-// enumerate variants. The PDP uses getProduct + getProductVariant instead.
 export async function getProductWithVariants(params: {
   handle: string;
   locale?: string;
@@ -251,7 +243,6 @@ const SEARCH_FACETS_QUERY = `#graphql
   }
 ` as const;
 
-// QueryRoot.products(sortKey: ProductSortKeys) — used for the catalog browse path.
 const CATALOG_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolean }> = {
   "best-matches": { sortKey: "RELEVANCE", reverse: false },
   "best-selling": { sortKey: "BEST_SELLING", reverse: false },
@@ -338,7 +329,6 @@ export function buildProductFiltersFromParams(
   for (const [key, value] of Object.entries(searchParams)) {
     if (!key.startsWith("filter.") || !value) continue;
 
-    // filter.v.option.{name} → variantOption
     const optionMatch = key.match(/^filter\.v\.option\.(.+)$/i);
     if (optionMatch) {
       const name = optionMatch[1];
@@ -348,17 +338,14 @@ export function buildProductFiltersFromParams(
       continue;
     }
 
-    // filter.v.availability → available
     if (key === "filter.v.availability") {
       const v = Array.isArray(value) ? value[0] : value;
       filters.push({ available: v === "1" });
       continue;
     }
 
-    // filter.v.price.gte / filter.v.price.lte → handled after loop
     if (key.startsWith("filter.v.price.")) continue;
 
-    // filter.p.vendor → productVendor
     if (key === "filter.p.vendor") {
       for (const v of toArray(value)) {
         filters.push({ productVendor: v });
@@ -366,7 +353,6 @@ export function buildProductFiltersFromParams(
       continue;
     }
 
-    // filter.p.product_type → productType
     if (key === "filter.p.product_type") {
       for (const v of toArray(value)) {
         filters.push({ productType: v });
@@ -374,7 +360,6 @@ export function buildProductFiltersFromParams(
       continue;
     }
 
-    // filter.p.tag → tag
     if (key === "filter.p.tag") {
       for (const v of toArray(value)) {
         filters.push({ tag: v });
@@ -382,7 +367,6 @@ export function buildProductFiltersFromParams(
       continue;
     }
 
-    // filter.p.m.{namespace}.{key} → productMetafield
     const metaMatch = key.match(/^filter\.p\.m\.([^.]+)\.(.+)$/i);
     if (metaMatch) {
       for (const v of toArray(value)) {
@@ -393,7 +377,6 @@ export function buildProductFiltersFromParams(
       continue;
     }
 
-    // filter.{v|p}.t.{namespace}.{key} → taxonomyMetafield (e.g. Color via shopify.color-pattern)
     const taxonomyMatch = key.match(/^filter\.[vp]\.t\.([^.]+)\.(.+)$/i);
     if (taxonomyMatch) {
       for (const v of toArray(value)) {
@@ -405,7 +388,6 @@ export function buildProductFiltersFromParams(
     }
   }
 
-  // Combine price.gte and price.lte into a single price filter
   const min = parsePrice(searchParams["filter.v.price.gte"]);
   const max = parsePrice(searchParams["filter.v.price.lte"]);
   if (min !== undefined || max !== undefined) {
@@ -515,9 +497,7 @@ type SearchFacetsParams = {
 
 type SearchFacetsResult = { filters: Filter[]; priceRange?: PriceRange; total: number };
 
-// Uncached so browse/search facets reflect live Search & Discovery config (newly
-// enabled filters, swatch setup) rather than a long-lived snapshot; the cached
-// getSearchFacets wrapper below stays for non-paginated /md + agent reads.
+// Browse facets stay uncached so Search & Discovery changes appear immediately.
 export async function fetchSearchFacets(params: SearchFacetsParams): Promise<SearchFacetsResult> {
   const { activeFilters = {}, collection, filters = [], locale = defaultLocale, query } = params;
   const country = getCountryCode(locale);
@@ -585,9 +565,7 @@ export async function getCollectionProducts(
   return result;
 }
 
-// Both intents ride one aliased request, so the PDP's two recommendation surfaces
-// dedupe to a single Shopify call. The entry carries both the complementary- and
-// recommendations- tags so either webhook invalidation still busts it.
+// Both intents share one request and both invalidation tags.
 export async function getProductRecommendationSets(params: {
   handle: string;
   locale?: string;
@@ -678,7 +656,6 @@ export async function getProductById({
   return transformShopifyProductDetails(product);
 }
 
-/** Results are returned in the same order as the input IDs. */
 export async function getProductsByIds({
   ids,
   locale = defaultLocale,
@@ -714,7 +691,6 @@ export async function getProductsByIds({
   return shopifyProducts.map(transformShopifyProductCard);
 }
 
-/** Results are reordered to match the input handle order. */
 export async function getProductsByHandles({
   handles,
   locale = defaultLocale,
@@ -733,7 +709,6 @@ export async function getProductsByHandles({
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 
-  // Build search query: "handle:foo OR handle:bar OR handle:baz"
   const searchQuery = handles.map((h) => `handle:${h}`).join(" OR ");
 
   const response = await storefront.request<{

--- a/apps/template/lib/shopify/operations/sitemap.ts
+++ b/apps/template/lib/shopify/operations/sitemap.ts
@@ -35,8 +35,7 @@ const GET_SITEMAP_PAGE_QUERY = `#graphql
 ` as const;
 
 function cacheTagsFor(type: ShopifySitemapType): string[] {
-  // Collection sitemap lists the full set, so it also carries "collections-index" —
-  // busted on collections/create and collections/delete alongside the listing page.
+  // Collection sitemap membership changes with the collection index.
   return type === "PRODUCT" ? ["products"] : ["collections", "collections-index"];
 }
 

--- a/apps/template/lib/shopify/storefront.ts
+++ b/apps/template/lib/shopify/storefront.ts
@@ -24,9 +24,7 @@ function operationName(body: RequestInit["body"]): string {
   }
 }
 
-// Preserve the prior shopifyFetch behavior the SDK doesn't replicate: the
-// ?operation= URL annotation for network-tab/debug visibility, brotli, and the
-// DEBUG_SHOPIFY timing log. Caching stays at the operation-function level.
+// Hydrogen lacks operation URL annotations and debug timing, so custom fetch preserves them.
 const customFetchApi: typeof fetch = async (input, init) => {
   const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
   const operation = operationName(init?.body);
@@ -42,10 +40,7 @@ const customFetchApi: typeof fetch = async (input, init) => {
   return response;
 };
 
-// The Hydrogen client injects its own i18n config into `$country`/`$language`,
-// overriding per-request variables — so the client must be created with the
-// call's locale pair. Creation is just config/closure allocation, so a fresh
-// client per call is fine.
+// Hydrogen overrides locale variables from client config, requiring a client per locale pair.
 function getClient(country: string, language: string): StorefrontClient {
   return createStorefrontClient({
     type: "public",
@@ -71,7 +66,6 @@ interface StorefrontResponse<T> {
   errors?: GraphQLFormattedError[];
 }
 
-// The Storefront token is public; server-only consumers are enforced at their call sites.
 export const storefront = {
   async request<T>(
     query: string,
@@ -83,15 +77,13 @@ export const storefront = {
     const language =
       typeof variables?.language === "string" ? variables.language : getLanguageCode(defaultLocale);
 
-    // Operations pass codegen-typed queries as plain strings; brand them so the
-    // client accepts our variables instead of inferring `never` from `string`.
+    // Brand runtime strings so Hydrogen does not infer `never` variables.
     const doc = query as StorefrontQueryString<T, Record<string, unknown>>;
     const { data, errors } = await getClient(country, language).graphql(doc, { variables });
     return { data, errors };
   },
 };
 
-// Storefront MCP — the store's hosted agentic-commerce tools over JSON-RPC 2.0 (/api/mcp).
 const MCP_ENDPOINT = `https://${SHOPIFY_STORE_DOMAIN}/api/mcp`;
 const UCP_AGENT_PROFILE_URL = process.env.UCP_AGENT_PROFILE_URL;
 
@@ -148,7 +140,7 @@ export async function callStorefrontMcp<T>(
 }
 
 export interface McpMoney {
-  amount: number; // minor units (52800 = 528.00)
+  amount: number;
   currency: string;
 }
 
@@ -194,8 +186,7 @@ export async function searchCatalog(params: {
   });
 }
 
-// get_product_details encodes money as major-unit strings with a sibling currency,
-// unlike search_catalog's minor-unit McpMoney objects.
+// MCP details use major-unit strings while search uses minor-unit numbers.
 export interface McpProductDetails {
   description?: string;
   image_url?: string | null;

--- a/apps/template/lib/shopify/transforms/cart.ts
+++ b/apps/template/lib/shopify/transforms/cart.ts
@@ -44,13 +44,11 @@ interface ShopifyCartLine {
   };
   discountAllocations: ShopifyDiscountAllocation[];
   id: string;
-  // Present on CartLine (and a bundle's nested component lines), absent on the
-  // ComponentizableCartLine parent — defaults to editable in the transform.
+  // ComponentizableCartLine parents omit instructions and default to editable.
   instructions?: {
     canRemove: boolean;
     canUpdateQuantity: boolean;
   };
-  // Present only on a ComponentizableCartLine (the bundle parent's contents).
   lineComponents?: ShopifyCartLine[];
   merchandise: {
     id: string;

--- a/apps/template/lib/shopify/transforms/filters.ts
+++ b/apps/template/lib/shopify/transforms/filters.ts
@@ -33,8 +33,6 @@ export interface ActiveFilterBadge {
 }
 
 export function getParamKeyFromShopifyId(filterId: string): string {
-  // Shopify filter IDs already use the standard format (e.g. "filter.v.option.color",
-  // "filter.p.vendor", "filter.v.availability"). Return them as-is for URL params.
   return filterId.toLowerCase();
 }
 
@@ -135,9 +133,7 @@ function extractPriceRange(priceFilter: ShopifyFilter): PriceRange {
           max: input.price.max ?? 1000,
         };
       }
-    } catch {
-      // Ignore malformed filter input.
-    }
+    } catch {}
   }
 
   return { min: 0, max: 1000 };
@@ -179,8 +175,7 @@ export function transformShopifyFilters(
       .filter((filter) => filter.values.length > 0);
   }
 
-  // Drop facet groups that resolve to a single choice — unless that lone value is
-  // active, so a selected filter never silently vanishes from the UI.
+  // Keep an active singleton facet so the shopper can still clear it.
   filters = filters.filter(
     (filter) =>
       filter.values.length > 1 ||

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -46,7 +46,6 @@ export interface ShopifyVariant {
   compareAtPrice: ShopifyMoney | null;
   selectedOptions: Array<{ name: string; value: string }>;
   image: ShopifyImage | null;
-  // Bundle relationships — present only on variants fetched via PurchasableProductVariantFields.
   requiresComponents?: boolean;
   groupedBy?: { nodes: ShopifyBundleComponentVariant[] };
   components?: {
@@ -205,7 +204,6 @@ function extractMediaFromProduct(product: ShopifyProduct): {
       const img = transformImage(node.image);
       if (img) images.push(img);
     } else if (node.mediaContentType === "VIDEO") {
-      // Pick the best mp4 source (largest width)
       const mp4Sources = node.sources.filter((s) => s.mimeType.startsWith("video/mp4"));
       const bestSource = mp4Sources.sort((a, b) => b.width - a.width)[0] ?? node.sources[0];
       if (bestSource) {
@@ -224,7 +222,6 @@ function extractMediaFromProduct(product: ShopifyProduct): {
 
 function transformCategory(category: ShopifyCategory | null | undefined): Category | null {
   if (!category) return null;
-  // Cap to 3 levels (Shopify menu limit): keep only the last 2 ancestors
   const cappedAncestors = category.ancestors.slice(-2);
   return {
     id: category.id,
@@ -322,8 +319,6 @@ const METAFIELD_LABELS: Record<string, string> = {
   model_number: "Model Number",
 };
 
-// A single scalar metafield value, already parsed from its JSON envelope: an object
-// for measurement/money/rating types, a primitive otherwise.
 function formatScalarMetafield(type: string, value: unknown): string {
   switch (type) {
     case "boolean":
@@ -349,9 +344,7 @@ function formatScalarMetafield(type: string, value: unknown): string {
 
 const STRUCTURED_METAFIELD_TYPES = new Set(["dimension", "money", "rating", "volume", "weight"]);
 
-// Shopify stores measurement/money/rating values as JSON, and list.* values as a JSON
-// array of those. Reference types resolve to GIDs we can't render without extra queries,
-// so they're skipped (null); every list element is formatted by its element type.
+// Reference metafields require follow-up queries, so this formatter skips them.
 function formatMetafieldValue(type: string, value: string): string | null {
   if (type.includes("_reference")) return null;
 

--- a/apps/template/lib/shopify/utils.ts
+++ b/apps/template/lib/shopify/utils.ts
@@ -4,7 +4,6 @@ export function flattenEdges<T>(connection: ShopifyEdges<T>): T[] {
   return connection.edges.map((edge) => edge.node);
 }
 
-/** "gid://shopify/Product/1234567890" → "1234567890". Accepts raw or base64-encoded GIDs. */
 export function getNumericShopifyId(gid: string): string | null {
   let decoded = gid;
 
@@ -22,16 +21,6 @@ export function getNumericShopifyId(gid: string): string | null {
 
 const SHOPIFY_STORE_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN ?? "";
 
-/**
- * Transform a Shopify menu item URL into a locale-independent internal path
- * or pass through external URLs as-is.
- *
- * - Strips the store domain, returning path only (e.g. `/collections/electronics`)
- * - Maps `products/handle` → `product/handle` (app uses singular)
- * - Maps FRONTPAGE → `/`, SEARCH → `/search`
- * - External URLs (different domain) pass through unchanged
- * - Internal paths are used directly (no locale prefix)
- */
 export function transformShopifyMenuItemUrl(
   url: string | null,
   type: import("./types/menu").MenuItemType,
@@ -50,12 +39,10 @@ export function transformShopifyMenuItemUrl(
     if (!isInternal) return url;
 
     let path = parsed.pathname;
-    // Strip Shopify Markets locale prefix (e.g. /nl/, /fr/, /pt-br/)
     path = path.replace(/^\/[a-z]{2}(-[a-z]{2,4})?\//i, "/");
 
     return path;
   } catch {
-    // Not a valid URL — treat as a relative path
     return url;
   }
 }

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -14,9 +14,6 @@ export function normalizeSearchParams(
   );
 }
 
-// These types are the contract between data sources and components. Each
-// integration (Shopify, Algolia, etc.) transforms its API responses into these.
-
 export interface Money {
   amount: string;
   currencyCode: string;
@@ -50,16 +47,13 @@ export interface ProductCard {
   featuredImage: Image | null;
   handle: string;
   id: string;
-  /** Highest variant price; equals price for single-price products, else the top of the range. */
   maxPrice: Money;
-  /** Lowest variant price; the card shows a "min – max" range when maxPrice differs. */
   price: Money;
   title: string;
   vendor?: string;
 }
 
 export interface ProductDetails extends ProductCard {
-  /** True when every existing variant is in stock (existence trie == availability trie). */
   allVariantsInStock: boolean;
   category?: Category | null;
   categoryId?: string;
@@ -69,15 +63,11 @@ export interface ProductDetails extends ProductCard {
     minVariantPrice: Money;
   };
   currencyCode: string;
-  /** Selected-or-first-available variant; powers the eager/no-params render. */
   defaultVariant?: ProductVariant;
   description: string;
   descriptionHtml: string;
-  /** Trie of option-value combinations with an available variant (Storefront 2024-10+). */
   encodedVariantAvailability?: string;
-  /** Trie of option-value combinations that exist (Storefront 2024-10+). */
   encodedVariantExistence?: string;
-  /** True when min/max price (and compare-at) bounds match, so price renders without a variant. */
   hasUniformPricing: boolean;
   images: Image[];
   manufacturerName: string;
@@ -92,34 +82,28 @@ export interface ProductDetails extends ProductCard {
   updatedAt: string;
   /** Only populated by getProductWithVariants (agent + markdown); the PDP omits it. */
   variants?: ProductVariant[];
-  /** Exact variant count from Shopify; authoritative single-variant signal (=== 1). */
   variantsCount: number;
   videos: Video[];
 }
 
 export interface ProductVariant {
   availableForSale: boolean;
-  /** Bundle variants this variant is a component of (Shopify `groupedBy`); empty for non-components. */
   bundleParents: ProductVariantReference[];
   compareAtPrice?: Money;
-  /** Fixed-bundle contents (Shopify `components`); empty unless this is a bundle variant. */
   components: ProductVariantComponent[];
   id: string;
   image: Image | null;
   price: Money;
-  /** True when the variant cannot be purchased without components (bundle parent). */
   requiresComponents: boolean;
   selectedOptions: SelectedOption[];
   title: string;
 }
 
-/** A bundle component: a referenced variant and how many of it the bundle includes. */
 export interface ProductVariantComponent {
   quantity: number;
   variant: ProductVariantReference;
 }
 
-/** Lightweight variant pointer used by bundle relationships (no price/availability). */
 export interface ProductVariantReference {
   id: string;
   image: Image | null;
@@ -145,7 +129,6 @@ export interface OptionValueSwatch {
 
 export interface OptionValue {
   id: string;
-  /** Representative variant image for this value (first selectable variant). */
   image?: string;
   name: string;
   swatch?: OptionValueSwatch;
@@ -185,11 +168,8 @@ export interface Cart {
 }
 
 export interface CartLine {
-  /** Shopify edit instruction — false for a fixed bundle's component lines. */
   canRemove: boolean;
-  /** Shopify edit instruction — false for a fixed bundle's component lines. */
   canUpdateQuantity: boolean;
-  /** Nested bundle component lines; empty for ordinary lines. */
   components: CartLine[];
   cost: {
     totalAmount: Money;
@@ -249,7 +229,6 @@ export interface Collection {
 }
 
 export interface CollectionWithThumbnail extends Collection {
-  /** Collection's own image, falling back to the first product's featured image. */
   thumbnail: Image | null;
 }
 
@@ -351,10 +330,6 @@ export interface BannerSection {
   id: string;
   subheadline: string | null;
 }
-
-// Customer account — populated from the Shopify Customer Account API (a separate
-// schema from the Storefront API). Status fields hold raw Shopify enum values
-// (e.g. "FULFILLED", "PAID"); humanize them at the display layer.
 
 export interface CustomerProfile {
   email: string;

--- a/apps/template/lib/utils.ts
+++ b/apps/template/lib/utils.ts
@@ -13,8 +13,7 @@ export function formatPrice(amount: number, currencyCode: string, locale: string
   ).localizedString;
 }
 
-// Price keys are scalar (gte/lte) — buildProductFiltersFromParams' parsePrice
-// bails on arrays, so don't comma-split them.
+// Price filters are scalar; comma-splitting would make parsePrice reject them.
 const PRICE_FILTER_KEYS = new Set(["filter.v.price.gte", "filter.v.price.lte"]);
 
 export function parseFiltersFromSearchParams(


### PR DESCRIPTION
## Summary
- remove section labels, implementation narration, historical notes, and redundant JSDoc across the template
- condense retained comments to hidden runtime, cache, schema, browser, compatibility, and race-condition constraints
- keep tooling directives and behavior-critical Shopify/Next.js context intact

## Verification
- `pnpm --filter template lint`
- `pnpm --filter template exec tsc --noEmit`
- `git diff --check`