### PR TITLE
Update default Shopify API version to unstable

### DIFF
--- a/apps/docs/content/docs/reference/env-vars.mdx
+++ b/apps/docs/content/docs/reference/env-vars.mdx
@@ -40,6 +40,7 @@ Required when `NEXT_PUBLIC_ENABLE_AUTH="1"`. Powers built-in customer authentica
 | `CMS_DRAFT_MODE_SECRET`       | Secret token guarding the `/api/draft` route for CMS preview links. Generate with `openssl rand -base64 32`.                               |
 | `DEBUG_SHOPIFY`               | Set to `true` to log every Shopify Storefront API request and response in the server console.                                              |
 | `NEXT_PUBLIC_BASE_URL`        | Absolute base URL used for sitemap entries, OG tags, and auth callbacks. Defaults to `https://${VERCEL_PROJECT_PRODUCTION_URL}` on Vercel. |
+| `SHOPIFY_API_VERSION`         | Override the Shopify Storefront and Customer Account API version. Defaults to `unstable`.                                                  |
 | `SHOPIFY_WEBHOOK_SECRET`      | Shared secret used to verify HMAC signatures on incoming Shopify webhooks at `/api/webhooks/shopify`.                                      |
 
 System variables auto-injected on Vercel that the build reads (`VERCEL_PROJECT_PRODUCTION_URL`, `NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL`, `V0_CALLBACK_URL`) are listed in `turbo.json` `globalEnv` so Turbo's strict-mode build sees them. You don't set these yourself.

--- a/apps/template/.env.example
+++ b/apps/template/.env.example
@@ -33,8 +33,8 @@ NEXT_PUBLIC_SITE_NAME="Your Store Name"
 # Required if you use /api/draft for CMS preview links.
 # CMS_DRAFT_MODE_SECRET="generate-with-openssl-rand-base64-32"
 
-# Optional — Pin the Shopify Storefront API version. Defaults to the latest stable known at release time.
-# SHOPIFY_API_VERSION="2026-04"
+# Optional — Override the Shopify Storefront and Customer Account API version. Defaults to unstable.
+# SHOPIFY_API_VERSION="unstable"
 
 # Optional — Verbose Shopify Storefront API request logging in the server console.
 # DEBUG_SHOPIFY="true"

--- a/apps/template/.graphqlrc.ts
+++ b/apps/template/.graphqlrc.ts
@@ -1,6 +1,6 @@
 import { ApiType, shopifyApiProject } from "@shopify/api-codegen-preset";
 
-const apiVersion = process.env.SHOPIFY_API_VERSION ?? "2026-04";
+const apiVersion = process.env.SHOPIFY_API_VERSION ?? "unstable";
 const documents = ["lib/shopify/**/*.ts", "!lib/shopify/types/generated/**"];
 
 export default {

--- a/apps/template/lib/shopify/customer-account.ts
+++ b/apps/template/lib/shopify/customer-account.ts
@@ -11,7 +11,7 @@ import { getAuthBaseUrl } from "@/lib/auth/server";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 
 const SHOPIFY_STORE_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN as string;
-const SHOPIFY_API_VERSION = process.env.SHOPIFY_API_VERSION ?? "2026-04";
+const SHOPIFY_API_VERSION = process.env.SHOPIFY_API_VERSION ?? "unstable";
 const DEBUG = process.env.DEBUG_SHOPIFY === "true";
 
 // Hydrogen needs the numeric shop ID embedded in Shopify's OIDC issuer.

--- a/apps/template/lib/shopify/storefront.ts
+++ b/apps/template/lib/shopify/storefront.ts
@@ -11,7 +11,7 @@ import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 
 const SHOPIFY_STORE_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN as string;
 const SHOPIFY_ACCESS_TOKEN = process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN as string;
-const SHOPIFY_API_VERSION = process.env.SHOPIFY_API_VERSION ?? "2026-04";
+const SHOPIFY_API_VERSION = process.env.SHOPIFY_API_VERSION ?? "unstable";
 const DEBUG = process.env.DEBUG_SHOPIFY === "true";
 
 function operationName(body: RequestInit["body"]): string {

--- a/packages/plugin/template-rollout-log/2026-07-11-shopify-api-unstable-default.md
+++ b/packages/plugin/template-rollout-log/2026-07-11-shopify-api-unstable-default.md
@@ -1,0 +1,38 @@
+---
+title: Default Shopify APIs to unstable
+changeKey: shopify-api-unstable-default
+introducedOn: 2026-07-11
+changeType: breaking
+defaultAction: review
+appliesTo:
+  - all
+paths:
+  - apps/template/.env.example
+  - apps/template/.graphqlrc.ts
+  - apps/template/lib/shopify/customer-account.ts
+  - apps/template/lib/shopify/storefront.ts
+---
+
+## Summary
+
+The template now defaults `SHOPIFY_API_VERSION` to `unstable` for Storefront API runtime requests, Customer Account API requests, and Storefront GraphQL codegen. Setting `SHOPIFY_API_VERSION` still overrides the default across all three paths.
+
+## Why it matters
+
+The template can use and validate against Shopify's latest preview schema without waiting for a dated stable API release. Because the unstable schema can change without the guarantees of a stable version, downstream storefronts should adopt this default intentionally.
+
+## Apply when
+
+- The storefront should track Shopify's newest Storefront and Customer Account API capabilities.
+- The storefront's GraphQL operations pass codegen against the unstable Storefront schema.
+
+## Safe to skip when
+
+- Production stability requires a dated Shopify API version.
+- The storefront has not validated its operations and customer account flows against unstable.
+
+## Validation
+
+1. Run `pnpm --filter template codegen` with `SHOPIFY_API_VERSION` unset.
+2. Run `pnpm --filter template lint`.
+3. If authentication is enabled, exercise login and an authenticated Customer Account API request.


### PR DESCRIPTION
## Summary

- default Storefront API runtime and GraphQL codegen to `unstable`
- default Customer Account API requests to the same version
- update the environment-variable reference and add downstream rollout guidance

## Verification

- `pnpm --filter template codegen`
- `pnpm --filter template lint`
- `pnpm --filter docs lint`
- `git diff --check`