### PR TITLE
Add Shopify blog and article routes

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/content.mdx
+++ b/apps/docs/content/docs/anatomy/pages/content.mdx
@@ -1,6 +1,6 @@
 ---
 title: Content Pages
-description: Shopify-managed Pages and store policies rendered as localized storefront routes.
+description: Shopify-managed Pages, policies, blogs, and articles rendered as localized storefront routes.
 type: guide
 ---
 
@@ -8,8 +8,10 @@ The template renders Shopify's built-in editorial content without requiring a se
 
 - Shopify Pages render at `/pages/[handle]`.
 - Configured store policies render at `/policies/[handle]`.
+- Shopify blogs render at `/blogs/[blogHandle]`.
+- Blog articles render at `/blogs/[blogHandle]/[postHandle]`.
 
-Both route types use the active locale as Storefront API context, render Shopify's sanitized rich-text HTML in the shared prose layout, and return `404` for unknown handles.
+All route types use the active locale as Storefront API context and return `404` for unknown handles. Pages, policies, and articles render Shopify's sanitized rich-text HTML in the shared prose layout. There is intentionally no `/blogs` index route; storefront navigation links to individual blogs such as `/blogs/news`.
 
 ## Shopify Pages
 
@@ -27,14 +29,20 @@ The footer automatically links every configured policy. Policies are also includ
 
 Policy reads use plain `"use cache"` with `cacheLife("hours")` and the `policies` tag. Shopify does not expose a policy-specific webhook topic, so policy pages, footer links, and sitemap entries refresh on that bounded schedule.
 
+## Blogs and articles
+
+Create blogs and articles under **Shopify Admin → Content → Blog posts**. Each blog route lists its latest articles with publication date, excerpt, and optional image. Article routes render the title, author, publication date, image, and HTML body. For example, the `news` blog and its `hello-world` article resolve to `/blogs/news` and `/blogs/news/hello-world`.
+
+Blog and article reads use plain `"use cache"` with `cacheLife("hours")`, the shared `blogs` tag, and handle-specific `blog-{handle}` or `article-{blogHandle}-{postHandle}` tags. Shopify does not expose blog or article webhook topics, so edits refresh on that bounded schedule.
+
 ## Localization
 
-Both operations pass the locale's country and language through Shopify's `@inContext` directive. The default single-locale storefront therefore reads `en-US`; the Markets and i18n skills can move the routes under locale-aware routing without changing their data contract.
+All content operations pass the locale's country and language through Shopify's `@inContext` directive. The default single-locale storefront therefore reads `en-US`; the Markets and i18n skills can move the routes under locale-aware routing without changing their data contract.
 
 Translations must also be published in Shopify. If Shopify has no translation for the active language, its normal Storefront API fallback behavior applies.
 
 ## SEO and discovery
 
-Page metadata uses Shopify's page SEO fields and emits canonical and Open Graph metadata. Policies use their Shopify title and canonical policy URL.
+Page metadata uses Shopify's page SEO fields and emits canonical and Open Graph metadata. Policies use their Shopify title and canonical policy URL. Blogs use their Shopify SEO title and description, while articles add article Open Graph metadata and use the article image when one is available.
 
-The sitemap index includes paginated `pages-{n}` shards from Shopify's native sitemap query. Policies have no equivalent sitemap resource type, so the template adds configured policy URLs to the static shard.
+The sitemap index includes paginated `pages-{n}`, `blogs-{n}`, and `articles-{n}` shards from Shopify's native sitemap query. Policies have no equivalent sitemap resource type, so the template adds configured policy URLs to the static shard.

--- a/apps/docs/content/docs/anatomy/pages/content.mdx
+++ b/apps/docs/content/docs/anatomy/pages/content.mdx
@@ -33,7 +33,7 @@ Policy reads use plain `"use cache"` with `cacheLife("hours")` and the `policies
 
 Create blogs and articles under **Shopify Admin → Content → Blog posts**. Each blog route lists its latest articles with publication date, excerpt, and optional image. Article routes render the title, author, publication date, image, and HTML body. For example, the `news` blog and its `hello-world` article resolve to `/blogs/news` and `/blogs/news/hello-world`.
 
-Blog and article reads use plain `"use cache"` with `cacheLife("hours")`, the shared `blogs` tag, and handle-specific `blog-{handle}` or `article-{blogHandle}-{postHandle}` tags. Shopify does not expose blog or article webhook topics, so edits refresh on that bounded schedule.
+Blog and article reads use plain `"use cache"` with `cacheLife("max")`, broad `blogs` and `articles` tags, and handle-specific `blog-{handle}` or `article-{blogHandle}-{postHandle}` tags. This matches product caching: content stays long-lived, ready for Shopify webhooks to invalidate the affected resource tags. The webhook integration should invalidate an article's parent blog tag so listings refresh, while create and delete events should invalidate the relevant index tag for sitemap membership changes.
 
 ## Localization
 

--- a/apps/docs/content/docs/anatomy/sitemap.mdx
+++ b/apps/docs/content/docs/anatomy/sitemap.mdx
@@ -24,7 +24,7 @@ The storefront exposes a sitemap index at `/sitemap.xml` and paged children at `
 
 ## Cache behavior
 
-Product and collection page counts and resources use `cacheLife("max")`. Each resource shard carries the same `product-{handle}` or `collection-{handle}` tags as its storefront page, so update webhooks refresh the affected shard and its `lastmod` value. Create and delete webhooks also invalidate `products-index` or `collections-index`, refreshing page counts and every shard whose membership may have shifted. Page sitemap data uses `cacheLife("hours")` and the `pages` tag because Shopify does not expose Page webhook topics. Blog and article sitemap data uses the same hourly lifetime with the `blogs` tag. The static shard reads configured policies through the same hourly `policies` cache used by policy pages and the footer.
+Product, collection, blog, and article page counts and resources use `cacheLife("max")`. Each resource shard carries the same handle-specific tag as its storefront page, so the corresponding webhook can refresh the affected shard and its `lastmod` value. Product and collection create/delete webhooks invalidate `products-index` or `collections-index`; the blog webhook integration should likewise invalidate `blogs-index` or `articles-index` when membership may have shifted. Page sitemap data uses `cacheLife("hours")` and the `pages` tag because Shopify does not expose Page webhook topics. The static shard reads configured policies through the same hourly `policies` cache used by policy pages and the footer.
 
 ## Adding more resource types
 

--- a/apps/docs/content/docs/anatomy/sitemap.mdx
+++ b/apps/docs/content/docs/anatomy/sitemap.mdx
@@ -6,7 +6,7 @@ type: guide
 
 The storefront exposes a sitemap index at `/sitemap.xml` and paged children at `/sitemap/{shard}.xml`. Each child holds up to 250 entries — Shopify's Storefront `sitemap(type:)` query computes the pagination, so the storefront just iterates.
 
-`robots.ts` points crawlers at `/sitemap.xml`; that URL alone is enough to discover every product, collection, Shopify Page, and configured policy.
+`robots.ts` points crawlers at `/sitemap.xml`; that URL alone is enough to discover every product, collection, Shopify Page, blog, article, and configured policy.
 
 ## URLs
 
@@ -17,16 +17,18 @@ The storefront exposes a sitemap index at `/sitemap.xml` and paged children at `
 | `/sitemap/products-{n}.xml`    | Up to 250 products per shard              |
 | `/sitemap/collections-{n}.xml` | Up to 250 collections per shard           |
 | `/sitemap/pages-{n}.xml`       | Up to 250 Shopify Pages per shard         |
+| `/sitemap/blogs-{n}.xml`       | Up to 250 Shopify blogs per shard         |
+| `/sitemap/articles-{n}.xml`    | Up to 250 Shopify articles per shard      |
 
 `{n}` is 1-indexed and runs to the `pagesCount` Shopify returns for each type.
 
 ## Cache behavior
 
-Product and collection page counts and resources use `cacheLife("max")`. Each resource shard carries the same `product-{handle}` or `collection-{handle}` tags as its storefront page, so update webhooks refresh the affected shard and its `lastmod` value. Create and delete webhooks also invalidate `products-index` or `collections-index`, refreshing page counts and every shard whose membership may have shifted. Page sitemap data uses `cacheLife("hours")` and the `pages` tag because Shopify does not expose Page webhook topics. The static shard reads configured policies through the same hourly `policies` cache used by policy pages and the footer.
+Product and collection page counts and resources use `cacheLife("max")`. Each resource shard carries the same `product-{handle}` or `collection-{handle}` tags as its storefront page, so update webhooks refresh the affected shard and its `lastmod` value. Create and delete webhooks also invalidate `products-index` or `collections-index`, refreshing page counts and every shard whose membership may have shifted. Page sitemap data uses `cacheLife("hours")` and the `pages` tag because Shopify does not expose Page webhook topics. Blog and article sitemap data uses the same hourly lifetime with the `blogs` tag. The static shard reads configured policies through the same hourly `policies` cache used by policy pages and the footer.
 
 ## Adding more resource types
 
-The template scopes paginated Shopify sitemaps to products, collections, and Pages. Shopify's `SitemapType` enum also covers `BLOG`, `ARTICLE`, and `METAOBJECT`. Both routes name the supported types explicitly, so adding one touches three places:
+The template scopes paginated Shopify sitemaps to products, collections, Pages, blogs, and articles. Shopify's `SitemapType` enum also covers `METAOBJECT`. Both routes name the supported types explicitly, so adding one touches three places:
 
 1. **`lib/shopify/operations/sitemap.ts`** — extend the `ShopifySitemapType` union.
 2. **`app/sitemap.xml/route.ts`** — fetch the new type's `getShopifySitemapPagesCount(...)` and spread its `{type}-{n}` ids into the index alongside the product and collection shards. The index lists only what you add here — it does not discover new types on its own.

--- a/apps/docs/content/docs/reference/routes.mdx
+++ b/apps/docs/content/docs/reference/routes.mdx
@@ -6,17 +6,19 @@ type: reference
 
 ## Pages
 
-| Route                   | Description                                                                                        |
-| ----------------------- | -------------------------------------------------------------------------------------------------- |
-| `/`                     | Home page with hero, products grid, info section                                                   |
-| `/products/[handle]`    | Product detail page; `?color=…&size=…` option params select a variant                              |
-| `/collections`          | All-collections index; each card links to a collection, image falls back to its first product      |
-| `/collections/[handle]` | Collection listing with filters, sort, pagination                                                  |
-| `/collections/all`      | Virtual "All Products" listing; synthesized since Shopify's Storefront API has no `all` collection |
-| `/search`               | Search results (same grid as collections)                                                          |
-| `/cart`                 | Full cart page with related products                                                               |
-| `/pages/[handle]`       | Shopify Page with localized rich text and SEO metadata                                             |
-| `/policies/[handle]`    | Configured Shopify store policy                                                                    |
+| Route                              | Description                                                                                        |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `/`                                | Home page with hero, products grid, info section                                                   |
+| `/products/[handle]`               | Product detail page; `?color=…&size=…` option params select a variant                              |
+| `/collections`                     | All-collections index; each card links to a collection, image falls back to its first product      |
+| `/collections/[handle]`            | Collection listing with filters, sort, pagination                                                  |
+| `/collections/all`                 | Virtual "All Products" listing; synthesized since Shopify's Storefront API has no `all` collection |
+| `/search`                          | Search results (same grid as collections)                                                          |
+| `/cart`                            | Full cart page with related products                                                               |
+| `/blogs/[blogHandle]`              | Shopify blog listing with latest articles                                                          |
+| `/blogs/[blogHandle]/[postHandle]` | Shopify article with localized rich text and SEO metadata                                          |
+| `/pages/[handle]`                  | Shopify Page with localized rich text and SEO metadata                                             |
+| `/policies/[handle]`               | Configured Shopify store policy                                                                    |
 
 ## API routes
 

--- a/apps/docs/content/docs/reference/storefront-api-permissions.mdx
+++ b/apps/docs/content/docs/reference/storefront-api-permissions.mdx
@@ -10,13 +10,13 @@ After you create a storefront in Shopify Headless, open **Settings → Apps and 
 
 ## Required for the default storefront
 
-| Scope                                      | Purpose                                            |
-| ------------------------------------------ | -------------------------------------------------- |
-| `unauthenticated_read_product_listings`    | Product pages, search, and recommendations         |
-| `unauthenticated_read_product_inventory`   | Stock availability on product and collection pages |
-| `unauthenticated_read_collection_listings` | Collection pages and navigation                    |
-| `unauthenticated_write_checkouts`          | Cart operations and checkout                       |
-| `unauthenticated_read_content`             | Shopify Pages, policies, and metaobjects           |
+| Scope                                      | Purpose                                                   |
+| ------------------------------------------ | --------------------------------------------------------- |
+| `unauthenticated_read_product_listings`    | Product pages, search, and recommendations                |
+| `unauthenticated_read_product_inventory`   | Stock availability on product and collection pages        |
+| `unauthenticated_read_collection_listings` | Collection pages and navigation                           |
+| `unauthenticated_write_checkouts`          | Cart operations and checkout                              |
+| `unauthenticated_read_content`             | Shopify Pages, policies, blogs, articles, and metaobjects |
 
 ## Optional skills
 

--- a/apps/template/app/blogs/[blogHandle]/[postHandle]/page.tsx
+++ b/apps/template/app/blogs/[blogHandle]/[postHandle]/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { ArticlePage } from "@/components/blog/article-page";
+import { getLocale } from "@/lib/params";
+import { buildAlternates, buildOpenGraph } from "@/lib/seo";
+import { getBlog, getBlogArticle } from "@/lib/shopify/operations/blogs";
+import { getShopifySitemapPage } from "@/lib/shopify/operations/sitemap";
+
+const PLACEHOLDER_HANDLE = "__placeholder__";
+
+export async function generateStaticParams() {
+  try {
+    const { items } = await getShopifySitemapPage("BLOG", 1);
+    const firstBlog = items[0];
+    if (!firstBlog) {
+      return [{ blogHandle: PLACEHOLDER_HANDLE, postHandle: PLACEHOLDER_HANDLE }];
+    }
+
+    const blog = await getBlog({ handle: firstBlog.handle, limit: 1 });
+    const firstArticle = blog?.articles[0];
+    return [
+      firstArticle
+        ? { blogHandle: blog.handle, postHandle: firstArticle.handle }
+        : { blogHandle: PLACEHOLDER_HANDLE, postHandle: PLACEHOLDER_HANDLE },
+    ];
+  } catch {
+    return [{ blogHandle: PLACEHOLDER_HANDLE, postHandle: PLACEHOLDER_HANDLE }];
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps<"/blogs/[blogHandle]/[postHandle]">): Promise<Metadata> {
+  const [{ blogHandle, postHandle }, locale] = await Promise.all([params, getLocale()]);
+  if (blogHandle === PLACEHOLDER_HANDLE || postHandle === PLACEHOLDER_HANDLE) return {};
+
+  const article = await getBlogArticle({ articleHandle: postHandle, blogHandle, locale });
+  if (!article) notFound();
+
+  const pathname = `/blogs/${article.blogHandle}/${article.handle}`;
+  const images = article.image
+    ? [
+        {
+          alt: article.image.altText,
+          height: article.image.height,
+          url: article.image.url,
+          width: article.image.width,
+        },
+      ]
+    : ["/og-default.png"];
+
+  return {
+    alternates: buildAlternates({ pathname }),
+    description: article.seo.description,
+    openGraph: buildOpenGraph({
+      description: article.seo.description,
+      images,
+      title: article.seo.title,
+      type: "article",
+      url: pathname,
+    }),
+    title: article.seo.title,
+    twitter: {
+      card: "summary_large_image",
+      description: article.seo.description,
+      images,
+      title: article.seo.title,
+    },
+  };
+}
+
+export default async function BlogArticlePage({
+  params,
+}: PageProps<"/blogs/[blogHandle]/[postHandle]">) {
+  const [{ blogHandle, postHandle }, locale] = await Promise.all([params, getLocale()]);
+  if (blogHandle === PLACEHOLDER_HANDLE || postHandle === PLACEHOLDER_HANDLE) notFound();
+
+  const article = await getBlogArticle({ articleHandle: postHandle, blogHandle, locale });
+  if (!article) notFound();
+
+  return <ArticlePage article={article} locale={locale} />;
+}

--- a/apps/template/app/blogs/[blogHandle]/page.tsx
+++ b/apps/template/app/blogs/[blogHandle]/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
+
+import { ArticleCard } from "@/components/blog/article-card";
+import { Container } from "@/components/ui/container";
+import { Page } from "@/components/ui/page";
+import { Sections } from "@/components/ui/sections";
+import { getLocale } from "@/lib/params";
+import { buildAlternates, buildOpenGraph } from "@/lib/seo";
+import { getBlog } from "@/lib/shopify/operations/blogs";
+import { getShopifySitemapPage } from "@/lib/shopify/operations/sitemap";
+
+const PLACEHOLDER_HANDLE = "__placeholder__";
+
+export async function generateStaticParams() {
+  try {
+    const { items } = await getShopifySitemapPage("BLOG", 1);
+    const first = items[0];
+    return [{ blogHandle: first ? first.handle : PLACEHOLDER_HANDLE }];
+  } catch {
+    return [{ blogHandle: PLACEHOLDER_HANDLE }];
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps<"/blogs/[blogHandle]">): Promise<Metadata> {
+  const [{ blogHandle }, locale] = await Promise.all([params, getLocale()]);
+  if (blogHandle === PLACEHOLDER_HANDLE) return {};
+
+  const blog = await getBlog({ handle: blogHandle, locale });
+  if (!blog) notFound();
+
+  const pathname = `/blogs/${blog.handle}`;
+  return {
+    alternates: buildAlternates({ pathname }),
+    description: blog.seo.description,
+    openGraph: buildOpenGraph({
+      description: blog.seo.description,
+      title: blog.seo.title,
+      type: "website",
+      url: pathname,
+    }),
+    title: blog.seo.title,
+  };
+}
+
+export default async function BlogPage({ params }: PageProps<"/blogs/[blogHandle]">) {
+  const [{ blogHandle }, locale, t] = await Promise.all([
+    params,
+    getLocale(),
+    getTranslations("blog"),
+  ]);
+  if (blogHandle === PLACEHOLDER_HANDLE) notFound();
+
+  const blog = await getBlog({ handle: blogHandle, locale });
+  if (!blog) notFound();
+
+  return (
+    <Page className="pt-2.5 md:pt-10">
+      <Container>
+        <Sections className="gap-5">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl">{blog.title}</h1>
+          {blog.articles.length > 0 ? (
+            <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-3">
+              {blog.articles.map((article) => (
+                <ArticleCard article={article} key={article.handle} locale={locale} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-muted-foreground">{t("empty")}</p>
+          )}
+        </Sections>
+      </Container>
+    </Page>
+  );
+}

--- a/apps/template/app/sitemap.xml/route.ts
+++ b/apps/template/app/sitemap.xml/route.ts
@@ -6,7 +6,9 @@ function escapeXml(value: string): string {
 }
 
 export async function GET(): Promise<Response> {
-  const [collectionPages, pagePages, productPages] = await Promise.all([
+  const [articlePages, blogPages, collectionPages, pagePages, productPages] = await Promise.all([
+    getShopifySitemapPagesCount("ARTICLE"),
+    getShopifySitemapPagesCount("BLOG"),
     getShopifySitemapPagesCount("COLLECTION"),
     getShopifySitemapPagesCount("PAGE"),
     getShopifySitemapPagesCount("PRODUCT"),
@@ -17,6 +19,8 @@ export async function GET(): Promise<Response> {
     ...Array.from({ length: productPages }, (_, i) => `products-${i + 1}`),
     ...Array.from({ length: collectionPages }, (_, i) => `collections-${i + 1}`),
     ...Array.from({ length: pagePages }, (_, i) => `pages-${i + 1}`),
+    ...Array.from({ length: blogPages }, (_, i) => `blogs-${i + 1}`),
+    ...Array.from({ length: articlePages }, (_, i) => `articles-${i + 1}`),
   ];
 
   const entries = childIds

--- a/apps/template/app/sitemap/[shard]/route.ts
+++ b/apps/template/app/sitemap/[shard]/route.ts
@@ -43,7 +43,7 @@ async function renderShard(
 
   const entries = items
     .map((item) => {
-      const loc = escapeXml(toAbsoluteUrl(`/${segment}/${item.handle}`));
+      const loc = escapeXml(toAbsoluteUrl(item.pathname ?? `/${segment}/${item.handle}`));
       const lastmod = escapeXml(item.updatedAt);
       return `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </url>`;
     })
@@ -61,11 +61,13 @@ export async function GET(
 
   if (id === "static") return renderStatic();
 
-  const match = id.match(/^(collections|pages|products)-(\d+)$/);
+  const match = id.match(/^(articles|blogs|collections|pages|products)-(\d+)$/);
   if (!match) notFound();
 
   const segment = match[1];
   const types: Record<string, ShopifySitemapType> = {
+    articles: "ARTICLE",
+    blogs: "BLOG",
     collections: "COLLECTION",
     pages: "PAGE",
     products: "PRODUCT",

--- a/apps/template/components/blog/article-card.tsx
+++ b/apps/template/components/blog/article-card.tsx
@@ -1,0 +1,48 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { ImagePlaceholder } from "@/components/ui/image-placeholder";
+import type { BlogArticle } from "@/lib/types";
+
+export interface ArticleCardProps {
+  article: BlogArticle;
+  locale: string;
+}
+
+export function ArticleCard({ article, locale }: ArticleCardProps) {
+  const href = `/blogs/${article.blogHandle}/${article.handle}`;
+  const publishedAt = new Intl.DateTimeFormat(locale, { dateStyle: "long" }).format(
+    new Date(article.publishedAt),
+  );
+
+  return (
+    <article className="grid content-start gap-4">
+      <Link className="relative aspect-3/2 overflow-hidden rounded-xl" href={href}>
+        {article.image ? (
+          <Image
+            alt={article.image.altText}
+            className="object-cover transition-transform duration-300 hover:scale-105"
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
+            src={article.image.url}
+          />
+        ) : (
+          <ImagePlaceholder className="size-full bg-muted" />
+        )}
+      </Link>
+      <div className="grid gap-2.5">
+        <time className="text-muted-foreground text-sm" dateTime={article.publishedAt}>
+          {publishedAt}
+        </time>
+        <h2 className="font-medium text-xl tracking-tight">
+          <Link className="hover:underline" href={href}>
+            {article.title}
+          </Link>
+        </h2>
+        {article.excerpt && (
+          <p className="text-muted-foreground text-sm leading-6 line-clamp-3">{article.excerpt}</p>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/apps/template/components/blog/article-page.tsx
+++ b/apps/template/components/blog/article-page.tsx
@@ -1,0 +1,60 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { Container } from "@/components/ui/container";
+import { Page } from "@/components/ui/page";
+import { Prose } from "@/components/ui/prose";
+import { Sections } from "@/components/ui/sections";
+import type { BlogArticle } from "@/lib/types";
+
+export interface ArticlePageProps {
+  article: BlogArticle;
+  locale: string;
+}
+
+export function ArticlePage({ article, locale }: ArticlePageProps) {
+  const publishedAt = new Intl.DateTimeFormat(locale, { dateStyle: "long" }).format(
+    new Date(article.publishedAt),
+  );
+
+  return (
+    <Page>
+      <Container className="max-w-4xl">
+        <Sections className="gap-5">
+          <header className="grid gap-4 text-center">
+            <Link
+              className="justify-self-center text-muted-foreground text-sm hover:text-foreground"
+              href={`/blogs/${article.blogHandle}`}
+            >
+              {article.blogTitle}
+            </Link>
+            <h1 className="text-3xl tracking-tight sm:text-4xl md:text-5xl">{article.title}</h1>
+            <div className="flex flex-wrap justify-center gap-x-2 text-muted-foreground text-sm">
+              {article.author && <span>{article.author}</span>}
+              {article.author && <span aria-hidden>·</span>}
+              <time dateTime={article.publishedAt}>{publishedAt}</time>
+            </div>
+          </header>
+          {article.image && (
+            <div className="relative aspect-3/2 overflow-hidden rounded-xl">
+              <Image
+                alt={article.image.altText}
+                className="object-cover"
+                fill
+                priority
+                sizes="(max-width: 896px) 100vw, 896px"
+                src={article.image.url}
+              />
+            </div>
+          )}
+          <Prose className="mx-auto w-full max-w-2xl">
+            <div
+              // oxlint-disable-next-line react/no-danger -- Shopify sanitizes article HTML.
+              dangerouslySetInnerHTML={{ __html: article.body ?? "" }}
+            />
+          </Prose>
+        </Sections>
+      </Container>
+    </Page>
+  );
+}

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -59,6 +59,9 @@
     "thinking": "Thinking…",
     "title": ""
   },
+  "blog": {
+    "empty": "No articles found."
+  },
   "cart": {
     "addedToCart": "Added to cart",
     "addToCart": "Add to Cart",

--- a/apps/template/lib/shopify/operations/blogs.ts
+++ b/apps/template/lib/shopify/operations/blogs.ts
@@ -146,8 +146,8 @@ export async function getBlog({
   locale?: string;
 }): Promise<Blog | undefined> {
   "use cache";
-  cacheLife("hours");
-  cacheTag("blogs", `blog-${handle}`);
+  cacheLife("max");
+  cacheTag("articles", "blogs", `blog-${handle}`);
 
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
@@ -180,8 +180,8 @@ export async function getBlogArticle({
   locale?: string;
 }): Promise<BlogArticle | undefined> {
   "use cache";
-  cacheLife("hours");
-  cacheTag("blogs", `blog-${blogHandle}`, `article-${blogHandle}-${articleHandle}`);
+  cacheLife("max");
+  cacheTag("articles", "blogs", `article-${blogHandle}-${articleHandle}`, `blog-${blogHandle}`);
 
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);

--- a/apps/template/lib/shopify/operations/blogs.ts
+++ b/apps/template/lib/shopify/operations/blogs.ts
@@ -1,0 +1,197 @@
+import { cacheLife, cacheTag } from "next/cache";
+
+import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
+import type { Blog, BlogArticle } from "@/lib/types";
+
+import { assertStorefrontOk } from "../errors";
+import { storefront } from "../storefront";
+
+interface ShopifyArticle {
+  authorV2: { name: string } | null;
+  content: string;
+  contentHtml?: string;
+  excerpt: string | null;
+  handle: string;
+  image: {
+    altText: string | null;
+    height: number;
+    url: string;
+    width: number;
+  } | null;
+  publishedAt: string;
+  seo?: {
+    description: string | null;
+    title: string | null;
+  } | null;
+  tags?: string[];
+  title: string;
+}
+
+interface ShopifyBlog {
+  handle: string;
+  seo: {
+    description: string | null;
+    title: string | null;
+  } | null;
+  title: string;
+}
+
+interface GetBlogResponse {
+  blog: (ShopifyBlog & { articles: { nodes: ShopifyArticle[] } }) | null;
+}
+
+interface GetBlogArticleResponse {
+  blog: (ShopifyBlog & { articleByHandle: ShopifyArticle | null }) | null;
+}
+
+const GET_BLOG_QUERY = `#graphql
+  query getBlog($handle: String!, $first: Int!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    blog(handle: $handle) {
+      handle
+      seo {
+        description
+        title
+      }
+      title
+      articles(first: $first, sortKey: PUBLISHED_AT, reverse: true) {
+        nodes {
+          authorV2 {
+            name
+          }
+          content(truncateAt: 240)
+          excerpt
+          handle
+          image {
+            altText
+            height
+            url
+            width
+          }
+          publishedAt
+          title
+        }
+      }
+    }
+  }
+` as const;
+
+const GET_BLOG_ARTICLE_QUERY = `#graphql
+  query getBlogArticle($blogHandle: String!, $articleHandle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
+    blog(handle: $blogHandle) {
+      handle
+      seo {
+        description
+        title
+      }
+      title
+      articleByHandle(handle: $articleHandle) {
+        authorV2 {
+          name
+        }
+        content(truncateAt: 240)
+        contentHtml
+        excerpt
+        handle
+        image {
+          altText
+          height
+          url
+          width
+        }
+        publishedAt
+        seo {
+          description
+          title
+        }
+        tags
+        title
+      }
+    }
+  }
+` as const;
+
+function transformArticle(article: ShopifyArticle, blog: ShopifyBlog): BlogArticle {
+  return {
+    author: article.authorV2?.name,
+    blogHandle: blog.handle,
+    blogTitle: blog.title,
+    body: article.contentHtml,
+    excerpt: article.excerpt ?? article.content,
+    handle: article.handle,
+    image: article.image
+      ? {
+          altText: article.image.altText ?? article.title,
+          height: article.image.height,
+          url: article.image.url,
+          width: article.image.width,
+        }
+      : null,
+    publishedAt: article.publishedAt,
+    seo: {
+      description: article.seo?.description ?? article.excerpt ?? article.content,
+      title: article.seo?.title ?? article.title,
+    },
+    tags: article.tags ?? [],
+    title: article.title,
+  };
+}
+
+export async function getBlog({
+  handle,
+  limit = 50,
+  locale = defaultLocale,
+}: {
+  handle: string;
+  limit?: number;
+  locale?: string;
+}): Promise<Blog | undefined> {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("blogs", `blog-${handle}`);
+
+  const country = getCountryCode(locale);
+  const language = getLanguageCode(locale);
+  const response = await storefront.request<GetBlogResponse>(GET_BLOG_QUERY, {
+    variables: { country, first: limit, handle, language },
+  });
+  assertStorefrontOk(response, "getBlog");
+
+  const blog = response.data.blog;
+  if (!blog) return undefined;
+
+  return {
+    articles: blog.articles.nodes.map((article) => transformArticle(article, blog)),
+    handle: blog.handle,
+    seo: {
+      description: blog.seo?.description ?? "",
+      title: blog.seo?.title ?? blog.title,
+    },
+    title: blog.title,
+  };
+}
+
+export async function getBlogArticle({
+  articleHandle,
+  blogHandle,
+  locale = defaultLocale,
+}: {
+  articleHandle: string;
+  blogHandle: string;
+  locale?: string;
+}): Promise<BlogArticle | undefined> {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("blogs", `blog-${blogHandle}`, `article-${blogHandle}-${articleHandle}`);
+
+  const country = getCountryCode(locale);
+  const language = getLanguageCode(locale);
+  const response = await storefront.request<GetBlogArticleResponse>(GET_BLOG_ARTICLE_QUERY, {
+    variables: { articleHandle, blogHandle, country, language },
+  });
+  assertStorefrontOk(response, "getBlogArticle");
+
+  const blog = response.data.blog;
+  if (!blog?.articleByHandle) return undefined;
+
+  return transformArticle(blog.articleByHandle, blog);
+}

--- a/apps/template/lib/shopify/operations/sitemap.ts
+++ b/apps/template/lib/shopify/operations/sitemap.ts
@@ -1,14 +1,53 @@
+import type { GraphQLFormattedError } from "@shopify/hydrogen";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { assertStorefrontOk } from "../errors";
 import { storefront } from "../storefront";
 
-export type ShopifySitemapType = "COLLECTION" | "PAGE" | "PRODUCT";
+export type ShopifySitemapType = "ARTICLE" | "BLOG" | "COLLECTION" | "PAGE" | "PRODUCT";
 
 export interface SitemapResource {
   handle: string;
+  pathname?: string;
   updatedAt: string;
 }
+
+interface StorefrontResponse<T> {
+  data?: T | null;
+  errors?: GraphQLFormattedError[];
+}
+
+interface ArticleSitemapPageResponse {
+  articles: {
+    nodes: Array<{
+      blog: { handle: string };
+      handle: string;
+      publishedAt: string;
+    }>;
+    pageInfo: {
+      endCursor: string | null;
+      hasNextPage: boolean;
+    };
+  };
+}
+
+const GET_ARTICLE_SITEMAP_PAGE_QUERY = `#graphql
+  query getArticleSitemapPage($first: Int!, $after: String) {
+    articles(first: $first, after: $after, sortKey: UPDATED_AT) {
+      nodes {
+        blog {
+          handle
+        }
+        handle
+        publishedAt
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+` as const;
 
 const GET_SITEMAP_PAGES_COUNT_QUERY = `#graphql
   query getSitemapPagesCount($type: SitemapType!) {
@@ -35,12 +74,13 @@ const GET_SITEMAP_PAGE_QUERY = `#graphql
 ` as const;
 
 function cacheTagsFor(type: ShopifySitemapType): string[] {
+  if (type === "ARTICLE" || type === "BLOG") return ["blogs"];
   if (type === "COLLECTION") return ["collections", "collections-index"];
   return type === "PAGE" ? ["pages"] : ["products", "products-index"];
 }
 
 function tagSitemapResources(type: ShopifySitemapType, resources: SitemapResource[]): void {
-  if (type === "PAGE") return;
+  if (type === "ARTICLE" || type === "BLOG" || type === "PAGE") return;
 
   const prefix = type === "COLLECTION" ? "collection" : "product";
   for (const resource of resources) {
@@ -50,7 +90,7 @@ function tagSitemapResources(type: ShopifySitemapType, resources: SitemapResourc
 
 export async function getShopifySitemapPagesCount(type: ShopifySitemapType): Promise<number> {
   "use cache: remote";
-  if (type === "PAGE") {
+  if (type === "ARTICLE" || type === "BLOG" || type === "PAGE") {
     cacheLife("hours");
   } else {
     cacheLife("max");
@@ -73,12 +113,41 @@ export async function getShopifySitemapPage(
   page: number,
 ): Promise<{ hasNextPage: boolean; items: SitemapResource[] }> {
   "use cache: remote";
-  if (type === "PAGE") {
+  if (type === "ARTICLE" || type === "BLOG" || type === "PAGE") {
     cacheLife("hours");
   } else {
     cacheLife("max");
   }
   cacheTag(...cacheTagsFor(type));
+
+  if (type === "ARTICLE") {
+    let after: string | null = null;
+    let articlePage: ArticleSitemapPageResponse["articles"] | undefined;
+
+    for (let currentPage = 1; currentPage <= page; currentPage += 1) {
+      const response: StorefrontResponse<ArticleSitemapPageResponse> =
+        await storefront.request<ArticleSitemapPageResponse>(GET_ARTICLE_SITEMAP_PAGE_QUERY, {
+          variables: { after, first: 250 },
+        });
+      assertStorefrontOk(response, "getArticleSitemapPage");
+      articlePage = response.data.articles;
+      after = articlePage.pageInfo.endCursor;
+
+      if (!articlePage.pageInfo.hasNextPage && currentPage < page) {
+        return { hasNextPage: false, items: [] };
+      }
+    }
+
+    return {
+      hasNextPage: articlePage?.pageInfo.hasNextPage ?? false,
+      items:
+        articlePage?.nodes.map((article) => ({
+          handle: article.handle,
+          pathname: `/blogs/${article.blog.handle}/${article.handle}`,
+          updatedAt: article.publishedAt,
+        })) ?? [],
+    };
+  }
 
   const response = await storefront.request<{
     sitemap: { resources: { hasNextPage: boolean; items: SitemapResource[] } };

--- a/apps/template/lib/shopify/operations/sitemap.ts
+++ b/apps/template/lib/shopify/operations/sitemap.ts
@@ -74,15 +74,16 @@ const GET_SITEMAP_PAGE_QUERY = `#graphql
 ` as const;
 
 function cacheTagsFor(type: ShopifySitemapType): string[] {
-  if (type === "ARTICLE" || type === "BLOG") return ["blogs"];
+  if (type === "ARTICLE") return ["articles", "articles-index"];
+  if (type === "BLOG") return ["blogs", "blogs-index"];
   if (type === "COLLECTION") return ["collections", "collections-index"];
   return type === "PAGE" ? ["pages"] : ["products", "products-index"];
 }
 
 function tagSitemapResources(type: ShopifySitemapType, resources: SitemapResource[]): void {
-  if (type === "ARTICLE" || type === "BLOG" || type === "PAGE") return;
+  if (type === "ARTICLE" || type === "PAGE") return;
 
-  const prefix = type === "COLLECTION" ? "collection" : "product";
+  const prefix = type === "BLOG" ? "blog" : type === "COLLECTION" ? "collection" : "product";
   for (const resource of resources) {
     cacheTag(`${prefix}-${resource.handle}`);
   }
@@ -90,7 +91,7 @@ function tagSitemapResources(type: ShopifySitemapType, resources: SitemapResourc
 
 export async function getShopifySitemapPagesCount(type: ShopifySitemapType): Promise<number> {
   "use cache: remote";
-  if (type === "ARTICLE" || type === "BLOG" || type === "PAGE") {
+  if (type === "PAGE") {
     cacheLife("hours");
   } else {
     cacheLife("max");
@@ -113,7 +114,7 @@ export async function getShopifySitemapPage(
   page: number,
 ): Promise<{ hasNextPage: boolean; items: SitemapResource[] }> {
   "use cache: remote";
-  if (type === "ARTICLE" || type === "BLOG" || type === "PAGE") {
+  if (type === "PAGE") {
     cacheLife("hours");
   } else {
     cacheLife("max");
@@ -141,11 +142,14 @@ export async function getShopifySitemapPage(
     return {
       hasNextPage: articlePage?.pageInfo.hasNextPage ?? false,
       items:
-        articlePage?.nodes.map((article) => ({
-          handle: article.handle,
-          pathname: `/blogs/${article.blog.handle}/${article.handle}`,
-          updatedAt: article.publishedAt,
-        })) ?? [],
+        articlePage?.nodes.map((article) => {
+          cacheTag(`article-${article.blog.handle}-${article.handle}`);
+          return {
+            handle: article.handle,
+            pathname: `/blogs/${article.blog.handle}/${article.handle}`,
+            updatedAt: article.publishedAt,
+          };
+        }) ?? [],
     };
   }
 

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -225,6 +225,27 @@ export interface CollectionWithThumbnail extends Collection {
   thumbnail: Image | null;
 }
 
+export interface Blog {
+  articles: BlogArticle[];
+  handle: string;
+  seo: SEO;
+  title: string;
+}
+
+export interface BlogArticle {
+  author?: string;
+  blogHandle: string;
+  blogTitle: string;
+  body?: string;
+  excerpt: string;
+  handle: string;
+  image: Image | null;
+  publishedAt: string;
+  seo: SEO;
+  tags: string[];
+  title: string;
+}
+
 export interface ContentPage {
   body: string;
   handle: string;


### PR DESCRIPTION
## Summary

- add localized Shopify blog listings at `/blogs/[blogHandle]`
- add Shopify article pages at `/blogs/[blogHandle]/[postHandle]` with article metadata and imagery
- keep `/blogs` intentionally unimplemented so it returns 404
- add blog and article discovery to sitemap shards
- document routes, caching, SEO, sitemap behavior, and Storefront API permissions

## Verification

- `SHOPIFY_API_VERSION=2026-04 pnpm codegen` — passed
- `pnpm lint` in `apps/template` — passed with 0 warnings and 0 errors
- `pnpm build` in `apps/template` — passed; generated `/blogs/news` and no `/blogs` route
- `pnpm exec oxlint . && pnpm exec oxfmt --check` in `apps/docs` — passed with 0 errors; one existing Satori `<img>` warning in `app/[lang]/og/[...slug]/route.tsx`
- `git diff --check` — passed
