### PR TITLE
Add global mutation error toasts

### DIFF
--- a/apps/docs/content/docs/anatomy/cart.mdx
+++ b/apps/docs/content/docs/anatomy/cart.mdx
@@ -22,7 +22,7 @@ The `CartProvider` in `context.tsx` exposes a `useCart()` hook with the followin
 - **lastError** - the most recent failed add, quantity update, or removal
 - **pendingQuantity** - accumulated quantity from rapid add-to-cart clicks before the debounce fires
 
-The provider tracks an `originalCart` snapshot for rollback if a mutation fails. Failed mutations also set `lastError`, and the shared cart message banner announces a localized retry message in both the overlay and full cart page. Starting another mutation clears the previous error.
+The provider tracks an `originalCart` snapshot for rollback if a mutation fails. Failed mutations also set `lastError`, and a root-level notification adapter announces a localized retry message as a toast from any route. Starting another mutation clears the previous error. Shopify warnings remain inline in the overlay and full cart page because they describe cart state the shopper may need to inspect.
 
 ## Optimistic updates
 

--- a/apps/template/app/cart/page.tsx
+++ b/apps/template/app/cart/page.tsx
@@ -9,7 +9,7 @@ import { Header } from "@/components/cart-page/header";
 import { PageSkeleton } from "@/components/cart-page/skeletons";
 import { Summary } from "@/components/cart-page/summary";
 import { CartContextSync } from "@/components/cart/context-sync";
-import { CartMessages } from "@/components/cart/messages";
+import { CartWarnings } from "@/components/cart/warnings";
 import { RelatedProductsSection } from "@/components/product/related-products-section";
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
@@ -56,7 +56,7 @@ async function CartContent({ locale }: { locale: Locale }) {
             <Container>
               <Sections>
                 <Header />
-                <CartMessages />
+                <CartWarnings />
                 <div className="grid gap-5 lg:grid-cols-12">
                   <div className="lg:col-span-8 xl:col-span-9">
                     <CartItemsList locale={locale} />

--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -9,10 +9,12 @@ import { ActionBar } from "@/components/action-bar";
 import { AgentButton } from "@/components/agent/agent-button";
 import { AnalyticsComponents } from "@/components/analytics";
 import { CartProvider } from "@/components/cart/context";
+import { CartNotifications } from "@/components/cart/notifications";
 import { CartOverlay } from "@/components/cart/overlay";
 import { Footer } from "@/components/footer";
 import { Nav } from "@/components/nav";
 import { SiteSchema } from "@/components/schema/site-schema";
+import { Toaster } from "@/components/ui/sonner";
 import { getLocale } from "@/lib/params";
 import { buildAlternates } from "@/lib/seo";
 import { shopConfig } from "@/shop.config";
@@ -49,6 +51,7 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
         <SiteSchema locale={locale} />
         <NextIntlClientProvider locale={locale} messages={messages}>
           <CartProvider initialCart={null}>
+            <CartNotifications />
             <Nav locale={locale} />
             <main id="main-content" className="flex flex-1 flex-col min-w-0">
               {children}
@@ -61,6 +64,7 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
               <ActionBar>{shopConfig.agent.enabled && <AgentButton />}</ActionBar>
             </Suspense>
           </CartProvider>
+          <Toaster closeButton />
         </NextIntlClientProvider>
         <AnalyticsComponents />
       </body>

--- a/apps/template/components/cart/notifications.tsx
+++ b/apps/template/components/cart/notifications.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect } from "react";
+import { toast } from "sonner";
+
+import { useCart } from "@/components/cart/context";
+
+export function CartNotifications() {
+  const { clearError, lastError } = useCart();
+  const t = useTranslations("cart");
+
+  useEffect(() => {
+    if (!lastError) return;
+
+    toast.error(t(`errors.${lastError}`), {
+      id: `cart-${lastError}`,
+      onAutoClose: clearError,
+      onDismiss: clearError,
+    });
+  }, [clearError, lastError, t]);
+
+  return null;
+}

--- a/apps/template/components/cart/overlay-content.tsx
+++ b/apps/template/components/cart/overlay-content.tsx
@@ -9,9 +9,9 @@ import { Button } from "@/components/ui/button";
 import { prepareCheckoutAction } from "@/lib/cart/action";
 
 import { useCart } from "./context";
-import { CartMessages } from "./messages";
 import { OverlayItem } from "./overlay-item";
 import { OverlaySummary } from "./overlay-summary";
+import { CartWarnings } from "./warnings";
 
 interface OverlayContentProps {
   locale: string;
@@ -48,7 +48,7 @@ function CheckoutButtonContent({
 
 export function OverlayContent({ locale }: OverlayContentProps) {
   const router = useRouter();
-  const { cart, cartWithPending, isUpdatingCart, lastError, setOverlayOpen } = useCart();
+  const { cart, cartWithPending, isUpdatingCart, setOverlayOpen } = useCart();
   const [isCheckingOut, setIsCheckingOut] = useState(false);
   const t = useTranslations("cart");
 
@@ -74,11 +74,6 @@ export function OverlayContent({ locale }: OverlayContentProps) {
   if (!displayCart || displayCart.lines.length === 0) {
     return (
       <div className="flex h-full flex-col px-5">
-        {lastError ? (
-          <div className="pt-5">
-            <CartMessages />
-          </div>
-        ) : null}
         <div className="flex flex-1 flex-col items-center justify-center text-center">
           <h3 className="mb-6 text-2xl">{t("empty")}</h3>
           <Button
@@ -98,7 +93,7 @@ export function OverlayContent({ locale }: OverlayContentProps) {
   return (
     <div className="flex flex-col h-full">
       <div className="flex-1 overflow-y-auto p-5 space-y-5">
-        <CartMessages />
+        <CartWarnings />
         <ul className="space-y-5" aria-label={t("cartItemsLabel")}>
           {displayCart.lines.map((item) => (
             <OverlayItem key={item.id} item={item} locale={locale} />

--- a/apps/template/components/cart/warnings.tsx
+++ b/apps/template/components/cart/warnings.tsx
@@ -1,35 +1,13 @@
 "use client";
 
-import { AlertCircle, AlertTriangle, X } from "lucide-react";
+import { AlertTriangle, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { useCart } from "@/components/cart/context";
 
-export function CartMessages() {
-  const { clearError, clearWarnings, lastError, lastWarnings } = useCart();
+export function CartWarnings() {
+  const { clearWarnings, lastWarnings } = useCart();
   const t = useTranslations("cart");
-
-  if (lastError) {
-    return (
-      <div
-        role="alert"
-        className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
-      >
-        <div className="flex items-start gap-2.5">
-          <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
-          <p className="flex-1">{t(`errors.${lastError}`)}</p>
-          <button
-            type="button"
-            onClick={clearError}
-            aria-label={t("dismissError")}
-            className="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md hover:bg-destructive/10"
-          >
-            <X className="size-4" aria-hidden="true" />
-          </button>
-        </div>
-      </div>
-    );
-  }
 
   if (lastWarnings.length === 0) return null;
 
@@ -44,8 +22,8 @@ export function CartMessages() {
         <div className="grid flex-1 gap-1">
           <p className="font-medium">{t("warningsTitle")}</p>
           <ul className="grid gap-0.5 text-amber-800 dark:text-amber-200/90">
-            {lastWarnings.map((w) => (
-              <li key={`${w.code}:${w.target}`}>{w.message}</li>
+            {lastWarnings.map((warning) => (
+              <li key={`${warning.code}:${warning.target}`}>{warning.message}</li>
             ))}
           </ul>
         </div>

--- a/apps/template/components/ui/sonner.tsx
+++ b/apps/template/components/ui/sonner.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+export function Toaster(props: ToasterProps) {
+  return (
+    <Sonner
+      className="toaster group"
+      icons={{
+        error: <OctagonXIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+        success: <CircleCheckIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+      }}
+      position="bottom-right"
+      richColors
+      toastOptions={{
+        classNames: {
+          actionButton: "cursor-pointer",
+          cancelButton: "cursor-pointer",
+          closeButton: "cursor-pointer",
+          toast: "font-sans",
+        },
+      }}
+      {...props}
+    />
+  );
+}

--- a/apps/template/components/ui/sonner.tsx
+++ b/apps/template/components/ui/sonner.tsx
@@ -13,6 +13,8 @@ export function Toaster(props: ToasterProps) {
   return (
     <Sonner
       className="toaster group"
+      duration={5000}
+      expand
       icons={{
         error: <OctagonXIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,
@@ -22,6 +24,7 @@ export function Toaster(props: ToasterProps) {
       }}
       position="bottom-right"
       richColors
+      visibleToasts={4}
       toastOptions={{
         classNames: {
           actionButton: "cursor-pointer",

--- a/apps/template/lib/cart/action.ts
+++ b/apps/template/lib/cart/action.ts
@@ -105,6 +105,13 @@ export async function addToCartAction(
     };
   }
 
+  if (process.env.VERCEL_ENV === "preview") {
+    return {
+      success: false,
+      error: "Forced add-to-cart failure for toast preview",
+    };
+  }
+
   try {
     const { cart, warnings } = await addToCart([{ merchandiseId, quantity }]);
 

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -40,6 +40,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "server-only": "0.0.1",
+    "sonner": "2.0.7",
     "streamdown": "2.5.0",
     "tailwind-merge": "3.6.0",
     "tailwindcss": "4.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       server-only:
         specifier: 0.0.1
         version: 0.0.1
+      sonner:
+        specifier: 2.0.7
+        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       streamdown:
         specifier: 2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6052,11 +6055,6 @@ packages:
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@5.1.16:
-    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
-    engines: {node: ^18 || >=20}
     hasBin: true
 
   native-promise-only@0.8.1:
@@ -13563,8 +13561,6 @@ snapshots:
   mux-embed@5.18.1: {}
 
   nanoid@3.3.12: {}
-
-  nanoid@5.1.16: {}
 
   native-promise-only@0.8.1: {}
 


### PR DESCRIPTION
## Summary

- add the shadcn-recommended Sonner toaster at the root layout
- surface cart add, update, and remove failures as localized global error toasts
- keep Shopify cart warnings inline because they describe persistent cart corrections
- document the new cart error surface

## Preview behavior

Add to cart is intentionally forced to fail only when `VERCEL_ENV=preview`, so the deployment makes the toast easy to review. Local development and production still use Shopify normally.

The forced failure is isolated in commit `e4a3897d` and must be dropped before this PR is marked ready to merge.

## Recommended rollout

1. Use typed expected-error return values from server actions; do not throw normal commerce failures.
2. Map stable client-facing error codes to localized copy at the UI boundary; keep raw provider messages in logs.
3. Use toasts for transient, route-independent failures and confirmations.
4. Keep validation near forms and persistent correction warnings near the affected cart content.
5. Add adapters per domain rather than importing `toast` into server actions or data modules.
6. Extend the pattern next to checkout preparation, discount codes, account forms, and other client-triggered mutations.

## Verification

- `pnpm lint` (`apps/template`)
- `pnpm build` (`apps/template`) — 33 routes generated
- `pnpm exec oxfmt --check content/docs/anatomy/cart.mdx` (`apps/docs`)
- `git diff --check main...HEAD`
