### PR TITLE
fix(pdp): prefer color swatch over variant image

### DIFF
--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -41,7 +41,7 @@ export function ColorPicker({
           const isAvailable = !available || available.has(value.name);
           const imageUrl = hideImages
             ? undefined
-            : value.swatch?.image || (!value.swatch?.color && value.image);
+            : value.swatch?.image || (value.swatch?.color ? undefined : value.image);
           const href = buildOptionUrl(handle, selectedOptions, option.name, value.name);
 
           const swatch = (

--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -39,7 +39,9 @@ export function ColorPicker({
         {option.values.map((value) => {
           const isSelected = selectedValue === value.name;
           const isAvailable = !available || available.has(value.name);
-          const imageUrl = hideImages ? undefined : value.swatch?.image || value.image;
+          const imageUrl = hideImages
+            ? undefined
+            : value.swatch?.image || (!value.swatch?.color && value.image);
           const href = buildOptionUrl(handle, selectedOptions, option.name, value.name);
 
           const swatch = (


### PR DESCRIPTION
## What

A color option value with a merchant-configured `swatch.color` now renders the color swatch instead of falling back to the first selectable variant's product photo.

## Why

On the PDP, color picker swatches resolve their image URL in `color-picker.tsx`:

```ts
const imageUrl = hideImages ? undefined : value.swatch?.image || value.image;
```

That value then feeds into `Swatch`, which renders an image whenever `imageUrl` is truthy and ignores `swatch.color`. As a result, a value like "Blue" with a merchant color swatch configured still rendered as the variant's product photo (e.g. `/products/flowguard-jacket-mens-5fc163?color=Blue&size=XS`).

The merchant-configured swatch should take precedence over the auto-derived variant image.

## Change

```ts
const imageUrl = hideImages
  ? undefined
  : value.swatch?.image || (!value.swatch?.color && value.image);
```

New precedence per color value:
1. `swatch.image` — merchant-configured swatch image (highest)
2. `swatch.color` — merchant color swatch; blocks the variant-photo fallback so the color renders
3. `value.image` — first selectable variant photo, only used when there is no swatch image and no swatch color

`hideImages` (used for the Suspense fallback shell) is unchanged.

## Verification
- `oxlint` on the touched file: 0 warnings, 0 errors.