### PR TITLE
feat(template): swag demo home wall and simplified nav

### DIFF
--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -1,14 +1,17 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 
-import { ProductsGrid } from "@/components/product/products-grid";
-import { BannerSection } from "@/components/sections/banner-section";
+import { ProductCard, ProductCardSkeleton } from "@/components/product-card/product-card";
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
-import { Sections } from "@/components/ui/sections";
 import { getLocale } from "@/lib/params";
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
+import { searchIndexProducts } from "@/lib/shopify/operations/products";
 import { shopConfig } from "@/shop.config";
+
+const WALL_SIZE = 40;
+const GRID_CLASS = "grid grid-cols-2 gap-5 sm:grid-cols-4 lg:grid-cols-8";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("seo");
@@ -29,30 +32,43 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function HomePage() {
-  const [locale, t] = await Promise.all([getLocale(), getTranslations("home")]);
+  return (
+    <Page>
+      <Container>
+        <Suspense fallback={<ProductWallSkeleton />}>
+          <ProductWall />
+        </Suspense>
+      </Container>
+    </Page>
+  );
+}
+
+function ProductWallSkeleton() {
+  return (
+    <div className={GRID_CLASS}>
+      {Array.from({ length: WALL_SIZE }, (_, index) => (
+        <ProductCardSkeleton key={index} />
+      ))}
+    </div>
+  );
+}
+
+async function ProductWall() {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations("product")]);
+  const { products } = await searchIndexProducts({ limit: WALL_SIZE, locale });
+
+  if (products.length === 0) return null;
 
   return (
-    <Page className="pt-0">
-      <Sections>
-        <BannerSection
-          hero={{
-            id: "homepage-hero",
-            headline: t("headline"),
-            subheadline: t("subheadline"),
-            ctaText: t("ctaText"),
-            ctaLink: "/collections/all",
-          }}
+    <div className={GRID_CLASS}>
+      {products.map((product) => (
+        <ProductCard
+          key={product.id}
+          product={product}
+          locale={locale}
+          outOfStockText={t("outOfStock")}
         />
-
-        <Container>
-          <ProductsGrid
-            title={t("productsTitle")}
-            limit={8}
-            locale={locale}
-            collectionUrl="/collections/all"
-          />
-        </Container>
-      </Sections>
-    </Page>
+      ))}
+    </div>
   );
 }

--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -5,11 +5,8 @@ import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
-  ProductCardContent,
   ProductCardImage,
   ProductCardImageContainer,
-  ProductCardPrice,
-  ProductCardTitle,
   ProductCard as ProductCardRoot,
 } from "@/components/product-card/components";
 import type { PageInfo, ProductCard } from "@/lib/types";
@@ -30,7 +27,6 @@ interface InfiniteProductGridProps<TParams> {
 export function InfiniteProductGrid<TParams>({
   initialProducts,
   initialPageInfo,
-  locale,
   outOfStockText,
   loadMore,
   loadMoreParams,
@@ -91,12 +87,7 @@ export function InfiniteProductGrid<TParams>({
       <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
         {children}
         {additionalProducts.map((product) => (
-          <ClientProductCard
-            key={product.id}
-            product={product}
-            locale={locale}
-            outOfStockText={outOfStockText}
-          />
+          <ClientProductCard key={product.id} product={product} outOfStockText={outOfStockText} />
         ))}
       </div>
 
@@ -111,11 +102,9 @@ export function InfiniteProductGrid<TParams>({
 
 function ClientProductCard({
   product,
-  locale,
   outOfStockText,
 }: {
   product: ProductCard;
-  locale: string;
   outOfStockText: string;
 }) {
   const href = product.defaultVariantNumericId
@@ -133,17 +122,6 @@ function ClientProductCard({
             outOfStock={!product.availableForSale}
             outOfStockText={outOfStockText}
           />
-          <ProductCardContent>
-            <ProductCardTitle>{product.title}</ProductCardTitle>
-            <ProductCardPrice
-              amount={product.price.amount}
-              currencyCode={product.price.currencyCode}
-              maxAmount={product.maxPrice.amount}
-              compareAtAmount={product.compareAtPrice?.amount}
-              compareAtCurrencyCode={product.compareAtPrice?.currencyCode}
-              locale={locale}
-            />
-          </ProductCardContent>
         </ProductCardImageContainer>
       </ProductCardRoot>
     </Link>

--- a/apps/template/components/nav/index.tsx
+++ b/apps/template/components/nav/index.tsx
@@ -2,14 +2,11 @@ import Link from "next/link";
 import { Suspense } from "react";
 
 import { Container } from "@/components/ui/container";
-import { isAuthEnabled } from "@/lib/auth";
 import { shopConfig } from "@/shop.config";
 
-import { NavAccount, NavAccountFallback } from "./account";
 import { CartIcon, CartIconFallback } from "./cart";
 import { MobileMenu } from "./mobile-menu";
 import { QuickLinks } from "./quick-links";
-import { SearchModal } from "./search-modal";
 
 export async function Nav({ locale }: { locale: string }) {
   const items = shopConfig.navigation.nav;
@@ -29,12 +26,6 @@ export async function Nav({ locale }: { locale: string }) {
         <QuickLinks items={items} />
 
         <div className="flex items-center gap-5 ml-auto">
-          <SearchModal />
-          {isAuthEnabled && (
-            <Suspense fallback={<NavAccountFallback />}>
-              <NavAccount />
-            </Suspense>
-          )}
           <Suspense fallback={<CartIconFallback />}>
             <CartIcon />
           </Suspense>

--- a/apps/template/components/product-card/components.tsx
+++ b/apps/template/components/product-card/components.tsx
@@ -15,7 +15,7 @@ function ProductCard({ variant = "default", className, children, ...props }: Pro
     <article
       data-slot="product-card"
       data-variant={variant}
-      className={cn("flex flex-col h-full overflow-hidden", className)}
+      className={cn("group flex flex-col h-full overflow-hidden", className)}
       {...props}
     >
       {children}
@@ -88,7 +88,13 @@ function ProductCardImage({
       className={cn("relative overflow-hidden", aspectRatioClasses, className)}
     >
       {src ? (
-        <Image src={src} alt={alt} fill className="object-cover" sizes={sizes} />
+        <Image
+          src={src}
+          alt={alt}
+          fill
+          className="object-cover transition-transform duration-300 ease-out motion-safe:group-hover:scale-[1.03] motion-safe:group-hover:rotate-[1.5deg]"
+          sizes={sizes}
+        />
       ) : (
         <ImagePlaceholder className="size-full" />
       )}
@@ -213,10 +219,6 @@ function ProductCardSkeleton({
         data-aspect-ratio={aspectRatio}
         className={cn("animate-pulse", aspectRatioClasses)}
       />
-      <div className="py-2.5 h-12 box-content grid gap-2">
-        <div className="h-4 w-full bg-accent animate-pulse" />
-        <div className="h-4 w-12 bg-accent animate-pulse" />
-      </div>
     </div>
   );
 }

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -7,13 +7,10 @@ import type { ProductCard as ProductCardType } from "@/lib/types";
 import {
   type ProductCardAspectRatio,
   ProductCardBadge,
-  ProductCardContent,
   ProductCardImage,
   ProductCardImageContainer,
-  ProductCardPrice,
   ProductCard as ProductCardRoot,
   ProductCardSkeleton,
-  ProductCardTitle,
 } from "./components";
 
 export interface ProductCardProps {
@@ -28,7 +25,6 @@ export interface ProductCardProps {
 
 export async function ProductCard({
   product,
-  locale,
   aspectRatio = "square",
   variant = "default",
   outOfStockText,
@@ -57,18 +53,6 @@ export async function ProductCard({
             outOfStockText={outOfStockText}
             aspectRatio={aspectRatio}
           />
-          <ProductCardContent>
-            <ProductCardTitle>{product.title}</ProductCardTitle>
-            <ProductCardPrice
-              amount={product.price.amount}
-              currencyCode={product.price.currencyCode}
-              maxAmount={product.maxPrice.amount}
-              compareAtAmount={product.compareAtPrice?.amount}
-              compareAtCurrencyCode={product.compareAtPrice?.currencyCode}
-              locale={locale}
-              discountVariant={isFeatured ? "blue" : "green"}
-            />
-          </ProductCardContent>
         </ProductCardImageContainer>
       </ProductCardRoot>
     </Link>

--- a/apps/template/components/product-detail/buy-buttons.tsx
+++ b/apps/template/components/product-detail/buy-buttons.tsx
@@ -111,7 +111,7 @@ export function BuyButtons({
         {quantityPicker ? (
           <div
             aria-label={tCart("itemQuantity")}
-            className="grid h-12 w-36 shrink-0 grid-cols-3 rounded-lg bg-background ring-1 ring-border ring-inset"
+            className="grid h-12 w-32 shrink-0 grid-cols-[3rem_2rem_3rem] rounded-lg bg-background ring-1 ring-border ring-inset"
             role="group"
           >
             <button
@@ -125,7 +125,7 @@ export function BuyButtons({
             </button>
             <span
               aria-live="polite"
-              className="flex size-12 items-center justify-center text-sm font-medium tabular-nums"
+              className="flex h-12 w-8 items-center justify-center text-sm font-medium tabular-nums"
               role="status"
             >
               {quantity}

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -109,7 +109,8 @@ function ProductMediaArea({
       title={product.title}
       className="lg:col-span-6"
       desktopSlot={
-        <Suspense fallback={<Skeleton className="w-full rounded-none aspect-square" />}>
+        // Color image is the LCP slot; a pulsing skeleton background flashes harder than empty space.
+        <Suspense fallback={<div className="aspect-square w-full" />}>
           <ResolvedColorImageGrid
             product={product}
             selectedOptionsPromise={selectedOptionsPromise}
@@ -119,9 +120,7 @@ function ProductMediaArea({
       mobileSlot={
         <Suspense
           fallback={
-            <div className="relative shrink-0 w-full snap-start snap-always overflow-hidden aspect-square">
-              <Skeleton className="size-full rounded-none" />
-            </div>
+            <div className="relative shrink-0 w-full snap-start snap-always overflow-hidden aspect-square" />
           }
         >
           <ResolvedColorImageCarousel
@@ -379,12 +378,12 @@ function QuantityPickerFallback() {
   return (
     <div
       aria-hidden="true"
-      className="grid h-12 w-36 shrink-0 grid-cols-3 rounded-lg bg-background ring-1 ring-border ring-inset"
+      className="grid h-12 w-32 shrink-0 grid-cols-[3rem_2rem_3rem] rounded-lg bg-background ring-1 ring-border ring-inset"
     >
       <span className="flex size-12 items-center justify-center opacity-50">
         <MinusIcon className="size-4 shrink-0" />
       </span>
-      <span className="flex size-12 items-center justify-center text-sm font-medium tabular-nums">
+      <span className="flex h-12 w-8 items-center justify-center text-sm font-medium tabular-nums">
         1
       </span>
       <span className="flex size-12 items-center justify-center">

--- a/apps/template/shop.config.ts
+++ b/apps/template/shop.config.ts
@@ -87,15 +87,7 @@ export const shopConfig = {
   },
   navigation: {
     footer: [],
-    nav: [
-      {
-        id: "default-nav-shop",
-        title: "Shop",
-        url: "/collections/all",
-        type: "HTTP",
-        items: [],
-      },
-    ],
+    nav: [],
   },
   pdp: {
     bundles: {
@@ -115,7 +107,7 @@ export const shopConfig = {
     },
   },
   site: {
-    name: process.env.NEXT_PUBLIC_SITE_NAME ?? "Vercel Shop",
+    name: process.env.NEXT_PUBLIC_SITE_NAME ?? "▲",
     socialLinks: [],
     url: trimTrailingSlash(process.env.NEXT_PUBLIC_BASE_URL || defaultUrl),
   },


### PR DESCRIPTION
## Summary
Sets up the `demo/swag` variant of the template.

- Home page is now a single wall of 40 products, 8 columns per row on large screens (`grid-cols-2 sm:grid-cols-4 lg:grid-cols-8`). Removed the banner hero and titled products section.
- Removed search and account controls from the nav.
- Removed the `/collections/all` link from the nav menu.
- Store name defaults to `▲` (`NEXT_PUBLIC_SITE_NAME` still overrides if set).

## Verification
- `pnpm lint` (oxlint + oxfmt --check) — exit 0, 0 warnings/errors
- `pnpm exec tsc --noEmit` — exit 0, no errors