### PR TITLE
chore: bump packageManager to pnpm 11.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "turbo": "2.10.4"
   },
   "name": "@vercel/shop",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.13.0",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+allowBuilds:
+  '@parcel/watcher': false
+  '@swc/core': false
+  esbuild: false
+  sharp: false
+
 minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## What

Bumps the monorepo package manager from **pnpm 10.33.0 → 11.13.0** (current `latest`).

## Why

Move the repo onto the pnpm 11 line and confirm it builds on Vercel.

## Details

- **`package.json`** — `packageManager` → `pnpm@11.13.0`. Vercel and the release workflow (`pnpm/action-setup@v4`, unpinned) both read the version from this field via Corepack, so no CI or `vercel.json` changes are needed.
- **`pnpm-workspace.yaml`** — pnpm 11 records dependency build-script permissions in a new `allowBuilds` map. The four packages with install scripts (`@parcel/watcher`, `@swc/core`, `esbuild`, `sharp`) were **already ignored** under pnpm 10 (no allowlist existed), and the build works without them since each ships its native binary via optional dependencies. They're recorded as `false` to preserve current behavior and silence the ignored-builds prompt. Flip any to `true` later if we want those scripts to run.
- **`pnpm-lock.yaml`** — unchanged; resolution is identical.

## Verification

Under pnpm 11.13.0 locally:
- `pnpm install` clean (lockfile passes supply-chain / `minimumReleaseAge` policy, no resolution changes)
- `turbo run build` green for both `template` and `docs`

The Vercel preview deploy on this PR is the final check that it builds in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)