### PR TITLE
chore(docs): update @vercel/geistdocs to 1.11.4 to address layout shifts

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "19.2.3",
     "@vercel/agent-readability": "0.4.0",
     "@vercel/analytics": "2.0.1",
-    "@vercel/geistdocs": "1.11.1",
+    "@vercel/geistdocs": "1.11.4",
     "@vercel/speed-insights": "2.0.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
         specifier: 2.0.1
         version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
       '@vercel/geistdocs':
-        specifier: 1.11.1
-        version: 1.11.1(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)(unified@11.0.5)
+        specifier: 1.11.4
+        version: 1.11.4(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)(unified@11.0.5)
       '@vercel/speed-insights':
         specifier: 2.0.0
         version: 2.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vue@3.5.30(typescript@6.0.3))
@@ -4341,8 +4341,8 @@ packages:
       vue-router:
         optional: true
 
-  '@vercel/geistdocs@1.11.1':
-    resolution: {integrity: sha512-1rX5DEEfJpxqhoG/e/Ttu/qY3x77Asnl82qMV1ox3qK63yrL7vwt7/mipLbhiEZddGn0LQVLVgaPyvHWHaZbRQ==}
+  '@vercel/geistdocs@1.11.4':
+    resolution: {integrity: sha512-gAcyR6xfgqCbriK9UWTCVpTvdXkOwrjCLuLisFr/uSeNcFOwIKUhnoSv8V3EVZpvKRPDRIp7k02OcON05rISEg==}
     hasBin: true
     peerDependencies:
       next: 16.2.6
@@ -11303,7 +11303,7 @@ snapshots:
       react: 19.2.7
       vue: 3.5.30(typescript@7.0.2)
 
-  '@vercel/geistdocs@1.11.1(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)(unified@11.0.5)':
+  '@vercel/geistdocs@1.11.4(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)(unified@11.0.5)':
     dependencies:
       '@ai-sdk/react': 3.0.210(react@19.2.7)(zod@4.4.3)
       '@clack/prompts': 0.11.0


### PR DESCRIPTION
Updates `@vercel/geistdocs` from `1.11.1` to `1.11.4` in `apps/docs` to address layout shift in [1] docs sidebar and [2] docs breadcrumbs

| **Before**  | **After** |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/c66e72fd-2a70-437b-a8aa-bf8d3f9282b9" />  | <video src="https://github.com/user-attachments/assets/9995bc19-e21c-4de0-bc78-ae3b76b8fc22" />  |