### PR TITLE
Make product media square by default

### DIFF
--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -61,6 +61,7 @@ npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 - Add each new page to the relevant `meta.json` so it appears in the sidebar.
 - Plain markdown copied into MDX must have `{`, `}`, and bare `<` escaped outside code blocks.
 - Do not add `Key files`, file inventory, or file-to-purpose table sections. Mention a path inline only when it directly supports the surrounding instruction or explanation.
+- Keep customization suggestions concise and user-facing: say what can be changed and why someone might change it. Avoid implementation steps, code symbols, and file paths unless they are necessary to complete the customization or the reader asks for them.
 - Keep slugs stable unless the task explicitly includes redirects or link updates.
 
 ## Commands

--- a/apps/docs/content/docs/anatomy/product-card.mdx
+++ b/apps/docs/content/docs/anatomy/product-card.mdx
@@ -10,13 +10,13 @@ Used in the home featured grid, collection (PLP) and search grids, the related-p
 
 **Compound component with stable styling hooks.** `ProductCard` is a server component that wraps the product in a `Link` to `/products/[handle]` — the bare product URL, which renders the first-available (default) variant. Each part — image container, image, content, title, price, optional badge — exposes a `data-slot` attribute (`product-card`, `product-card-image`, etc.), so the pieces can be composed or restyled independently without touching the underlying markup.
 
-**Loading, empty, and out-of-stock states share one footprint.** The skeleton, the no-image placeholder, and the loaded image all render inside the same aspect-ratio box using the same `ImagePlaceholder` element, so grids never shift as cards move between states. An out-of-stock overlay draws on top of the image rather than replacing it, keeping that same footprint.
+**Loading, empty, and out-of-stock states share one footprint.** The skeleton, the no-image placeholder, and the loaded image all render inside the same square box using the same `ImagePlaceholder` element, so grids never shift as cards move between states. An out-of-stock overlay draws on top of the image rather than replacing it, keeping that same footprint.
 
 ## Out of the box
 
 - **Two variants** — `default` for standard grids and sliders, and `featured`, which adds a "Featured" badge and a top-down gradient behind the image for highlighting hero products.
 - **Price ranges** — when a product's variants span a price range, the card shows both bounds (_$48.00 – $96.00_) instead of a single price; compare-at strike-through and the discount badge only appear for a single price, since per-variant discounts differ across a range.
-- **Configurable aspect ratio** — `square` (default), `portrait`, or `landscape`, applied to both the loaded image and its skeleton.
+- **Square media** — loaded images, no-image placeholders, and skeletons use the same square footprint by default.
 - **Image fallback** — products with no featured image render a placeholder icon instead of a broken image, so grids stay visually aligned.
 - **Out-of-stock overlay** — a darkened image with a localized "out of stock" label when the product is unavailable.
 
@@ -24,6 +24,7 @@ Used in the home featured grid, collection (PLP) and search grids, the related-p
 
 The card doesn't ship these, but they're common additions teams layer on top.
 
+- **Non-square media** — replace `aspect-square` on `ProductCardImage` and `ProductCardSkeleton` in `components/product-card/components.tsx` with the same portrait or landscape aspect utility so loaded and loading states keep matching footprints.
 - **Hover image carousel** — reveal additional product images on desktop hover instead of showing only the featured image.
 - **Variant selection from the grid** — swatches on the card itself (usually color) so shoppers can preview or add a specific variant without opening the PDP.
 - **Quick add** — an add-to-cart action on the card that skips the PDP for simple, single-variant products.

--- a/apps/docs/content/docs/anatomy/product-card.mdx
+++ b/apps/docs/content/docs/anatomy/product-card.mdx
@@ -24,7 +24,7 @@ Used in the home featured grid, collection (PLP) and search grids, the related-p
 
 The card doesn't ship these, but they're common additions teams layer on top.
 
-- **Non-square media** — replace `aspect-square` on `ProductCardImage` and `ProductCardSkeleton` in `components/product-card/components.tsx` with the same portrait or landscape aspect utility so loaded and loading states keep matching footprints.
+- **Image aspect ratio** — change the aspect ratio of product images to fit your storefront.
 - **Hover image carousel** — reveal additional product images on desktop hover instead of showing only the featured image.
 - **Variant selection from the grid** — swatches on the card itself (usually color) so shoppers can preview or add a specific variant without opening the PDP.
 - **Quick add** — an add-to-cart action on the card that skips the PDP for simple, single-variant products.

--- a/apps/template/components/product-card/components.tsx
+++ b/apps/template/components/product-card/components.tsx
@@ -57,18 +57,12 @@ function ProductCardImageContainer({
   );
 }
 
-type ProductCardAspectRatio = "landscape" | "portrait" | "square";
-
-const aspectRatioClasses =
-  "data-[aspect-ratio=landscape]:aspect-[4/3] data-[aspect-ratio=portrait]:aspect-[3/4] data-[aspect-ratio=square]:aspect-square";
-
 interface ProductCardImageProps {
   src?: string | null;
   alt: string;
   sizes?: string;
   outOfStock?: boolean;
   outOfStockText?: string;
-  aspectRatio?: ProductCardAspectRatio;
   className?: string;
 }
 
@@ -78,14 +72,12 @@ function ProductCardImage({
   sizes = "(max-width: 640px) 50vw, (max-width: 1024px) 33vw, (max-width: 1280px) 25vw, 20vw",
   outOfStock = false,
   outOfStockText,
-  aspectRatio = "square",
   className,
 }: ProductCardImageProps) {
   return (
     <div
       data-slot="product-card-image"
-      data-aspect-ratio={aspectRatio}
-      className={cn("relative overflow-hidden", aspectRatioClasses, className)}
+      className={cn("relative aspect-square overflow-hidden", className)}
     >
       {src ? (
         <Image src={src} alt={alt} fill className="object-cover" sizes={sizes} />
@@ -197,22 +189,13 @@ function ProductCardPrice({
   );
 }
 
-function ProductCardSkeleton({
-  aspectRatio = "square",
-  className,
-}: {
-  aspectRatio?: ProductCardAspectRatio;
-  className?: string;
-}) {
+function ProductCardSkeleton({ className }: { className?: string }) {
   return (
     <div
       data-slot="product-card-skeleton"
       className={cn("flex flex-col overflow-hidden", className)}
     >
-      <ImagePlaceholder
-        data-aspect-ratio={aspectRatio}
-        className={cn("animate-pulse", aspectRatioClasses)}
-      />
+      <ImagePlaceholder className="aspect-square animate-pulse" />
       <div className="py-2.5 h-12 box-content grid gap-2">
         <div className="h-4 w-full bg-accent animate-pulse" />
         <div className="h-4 w-12 bg-accent animate-pulse" />
@@ -223,7 +206,6 @@ function ProductCardSkeleton({
 
 export {
   ProductCard,
-  type ProductCardAspectRatio,
   ProductCardBadge,
   ProductCardContent,
   ProductCardImage,

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -5,7 +5,6 @@ import type { Locale } from "@/lib/i18n";
 import type { ProductCard as ProductCardType } from "@/lib/types";
 
 import {
-  type ProductCardAspectRatio,
   ProductCardBadge,
   ProductCardContent,
   ProductCardImage,
@@ -19,7 +18,6 @@ import {
 export interface ProductCardProps {
   product: ProductCardType;
   locale: Locale;
-  aspectRatio?: ProductCardAspectRatio;
   variant?: "default" | "featured";
   outOfStockText?: string;
   sizes?: string;
@@ -29,7 +27,6 @@ export interface ProductCardProps {
 export async function ProductCard({
   product,
   locale,
-  aspectRatio = "square",
   variant = "default",
   outOfStockText,
   sizes = "(max-width: 640px) 50vw, (max-width: 1024px) 33vw, (max-width: 1280px) 25vw, 20vw",
@@ -55,7 +52,6 @@ export async function ProductCard({
             sizes={sizes}
             outOfStock={!product.availableForSale}
             outOfStockText={outOfStockText}
-            aspectRatio={aspectRatio}
           />
           <ProductCardContent>
             <ProductCardTitle>{product.title}</ProductCardTitle>

--- a/apps/template/components/product/products-slider.tsx
+++ b/apps/template/components/product/products-slider.tsx
@@ -1,6 +1,5 @@
 import { getTranslations } from "next-intl/server";
 
-import type { ProductCardAspectRatio } from "@/components/product-card/components";
 import { ProductCard } from "@/components/product-card/product-card";
 import {
   Slider,
@@ -17,15 +16,9 @@ interface ProductsSliderProps {
   title: string;
   products: ProductCardType[];
   locale: Locale;
-  aspectRatio?: ProductCardAspectRatio;
 }
 
-export async function ProductsSlider({
-  title,
-  products,
-  locale,
-  aspectRatio = "square",
-}: ProductsSliderProps) {
+export async function ProductsSlider({ title, products, locale }: ProductsSliderProps) {
   const t = await getTranslations("product");
   return (
     <Slider>
@@ -36,12 +29,7 @@ export async function ProductsSlider({
       <SliderContent>
         {products.map((product) => (
           <SliderItem key={product.id}>
-            <ProductCard
-              product={product}
-              locale={locale}
-              outOfStockText={t("outOfStock")}
-              aspectRatio={aspectRatio}
-            />
+            <ProductCard product={product} locale={locale} outOfStockText={t("outOfStock")} />
           </SliderItem>
         ))}
       </SliderContent>


### PR DESCRIPTION
## Summary

- remove the product-card aspect-ratio type and props
- render product-card images and skeletons as square media
- document non-square product cards as a customization
- keep the PDP gallery on its existing square-only implementation

## Verification

- `pnpm exec oxlint components/product-card/components.tsx components/product-card/product-card.tsx components/product/products-slider.tsx`
- `pnpm exec oxfmt --check components/product-card/components.tsx components/product-card/product-card.tsx components/product/products-slider.tsx`
- `pnpm exec tsc --noEmit` (apps/template)
- `pnpm exec oxfmt --check content/docs/anatomy/product-card.mdx`
- `pnpm exec fumadocs-mdx`
- `pnpm typecheck` (apps/docs)
- `git diff --check`