### PR TITLE
fix(pdp): reduce Buy with Shop logo size

### DIFF
--- a/apps/template/components/product-detail/buy-buttons.tsx
+++ b/apps/template/components/product-detail/buy-buttons.tsx
@@ -165,7 +165,7 @@ export function BuyButtons({
           ) : (
             <>
               <span className="sr-only">{t("buyWithShop")}</span>
-              <BuyWithShopLogo aria-hidden="true" className="h-auto w-32.75" />
+              <BuyWithShopLogo aria-hidden="true" className="h-auto w-24.5" />
             </>
           )}
         </button>

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -415,7 +415,7 @@ function BuyButtonsFallback({
             !allInStock && "invisible",
           )}
         >
-          <BuyWithShopLogo aria-hidden="true" className="h-auto w-32.75" />
+          <BuyWithShopLogo aria-hidden="true" className="h-auto w-24.5" />
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- reduce the Buy with Shop lockup to approximately 75% of its previous width
- keep the live purchase button and Suspense fallback visually aligned
- preserve the official artwork proportions, button size, and clear space

## Testing
- `pnpm exec oxfmt --check components/product-detail/buy-buttons.tsx components/product-detail/product-detail-section.tsx`
- `pnpm exec oxlint components/product-detail/buy-buttons.tsx components/product-detail/product-detail-section.tsx`
- `git diff --check`