### PR TITLE
fix(template): restore PDP suspense shell

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -10,7 +10,7 @@ The Product Detail Page (PDP) is a single product page — title, price, media, 
 
 ## How it works
 
-**Static-first rendering.** Product data is awaited at the top of the page and baked into the static shell, so the title, price, gallery, and description ship as one coherent copy. Freshness comes from cache invalidation — a Shopify webhook calling `revalidateTag`, plus the `cacheLife` window — not a per-request fetch, so the body never re-renders at request time.
+**Instant loading shell.** The page renders a full PDP skeleton immediately while product data resolves behind a top-level Suspense boundary. Product reads are cached, so cold visits can stream the resolved title, price, gallery, and description into that shell while repeat visits usually reuse the rendered result. Shopify webhook invalidation and the `cacheLife` window keep that cached product data fresh.
 
 **Variant selection through URL searchParams.** Each option change is a navigation (`/products/tee?color=Blue&size=XS`), not client state. That gives you shareable URLs, working browser back/forward, and a fully server-rendered page with zero layout shift. The selected variant resolves from a second, per-selection Shopify query kept off the critical path, so the picker highlights at URL speed rather than waiting on the network.
 

--- a/apps/docs/content/docs/anatomy/pages/plp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/plp.mdx
@@ -10,7 +10,7 @@ The Product Listing Page (PLP) covers two routes — `/collections/[handle]` for
 
 ## How it works
 
-**Static header, live grid.** Collection metadata (title, description, image) is awaited at the top of the page and baked into the static shell, the same pattern as the [PDP](/docs/anatomy/pages/pdp). The product grid is the opposite: it's read live from Shopify on every request, deliberately uncached. Caching it produced duplicate products at page boundaries, because two cached cursor pages could be snapshotted at different times and drift out of order. Reading every page live keeps a scroll session's cursors consistent. `/search` has no cacheable header at all — its body is entirely query-driven — so it skips the static-shell step altogether.
+**Static header, live grid.** Collection metadata (title, description, image) is awaited at the top of the page and baked into the static shell. The product grid is the opposite: it's read live from Shopify on every request, deliberately uncached. Caching it produced duplicate products at page boundaries, because two cached cursor pages could be snapshotted at different times and drift out of order. Reading every page live keeps a scroll session's cursors consistent. `/search` has no cacheable header at all — its body is entirely query-driven — so it skips the static-shell step altogether.
 
 **Filter, sort, and cursor state live in the URL.** Changing a filter or sort is a `searchParams` update, not client state, so results are shareable and bookmarkable. `useOptimistic` shows the new filter state instantly while the server request is in flight, and `useTransition` keeps sort changes non-blocking — so the UI feels instant even though every result comes from a live request.
 

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -1,8 +1,15 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 
-import { ProductDetailSection } from "@/components/product-detail/product-detail-section";
-import { RelatedProductsSection } from "@/components/product/related-products-section";
+import {
+  ProductDetailSection,
+  ProductDetailSectionSkeleton,
+} from "@/components/product-detail/product-detail-section";
+import {
+  RelatedProductsSection,
+  RelatedProductsSectionSkeleton,
+} from "@/components/product/related-products-section";
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
@@ -83,17 +90,25 @@ export async function generateMetadata({
   return buildProductMetadata(handle, locale, `/products/${handle}`);
 }
 
-export default async function ProductPage({
-  params,
-  searchParams,
-}: PageProps<"/products/[handle]">) {
+export default function ProductPage(props: PageProps<"/products/[handle]">) {
+  return (
+    <Page className="pt-0">
+      <Container className="bg-background">
+        <Suspense fallback={<ProductPageFallback />}>
+          <ProductPageContent {...props} />
+        </Suspense>
+      </Container>
+    </Page>
+  );
+}
+
+async function ProductPageContent({ params, searchParams }: PageProps<"/products/[handle]">) {
   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
   if (handle === PLACEHOLDER_HANDLE) notFound();
 
   const product = await getProduct({ handle, locale });
   if (!product) notFound();
 
-  // Keep selection separate from the variant query so the static shell stays coherent and the picker never waits on Shopify.
   const selectedOptionsPromise: Promise<SelectedOptions> = searchParams.then(
     (resolvedSearchParams) => ({
       ...defaultSelectedOptions(product),
@@ -119,20 +134,25 @@ export default async function ProductPage({
   );
 
   return (
-    <Page className="pt-0">
-      <Container className="bg-background">
-        <Sections>
-          <ProductDetailSection
-            product={product}
-            selectedOptionsPromise={selectedOptionsPromise}
-            variantPromise={variantPromise}
-            locale={locale}
-          />
-          {shopConfig.pdp.relatedProducts.enabled ? (
-            <RelatedProductsSection handle={handle} limit={4} locale={locale} />
-          ) : null}
-        </Sections>
-      </Container>
-    </Page>
+    <Sections>
+      <ProductDetailSection
+        product={product}
+        selectedOptionsPromise={selectedOptionsPromise}
+        variantPromise={variantPromise}
+        locale={locale}
+      />
+      {shopConfig.pdp.relatedProducts.enabled ? (
+        <RelatedProductsSection handle={handle} limit={4} locale={locale} />
+      ) : null}
+    </Sections>
+  );
+}
+
+function ProductPageFallback() {
+  return (
+    <Sections>
+      <ProductDetailSectionSkeleton />
+      {shopConfig.pdp.relatedProducts.enabled ? <RelatedProductsSectionSkeleton limit={4} /> : null}
+    </Sections>
   );
 }


### PR DESCRIPTION
## Summary

- restore a top-level Suspense boundary around PDP product resolution
- reuse the product-detail and related-products skeletons for the instant shell
- update PDP and PLP docs to describe the revised rendering behavior

## Verification

- `pnpm exec oxfmt --check 'app/products/[handle]/page.tsx'`
- `pnpm exec oxlint 'app/products/[handle]/page.tsx'`
- `pnpm exec oxfmt --check 'content/docs/anatomy/pages/pdp.mdx' 'content/docs/anatomy/pages/plp.mdx'`
- `pnpm build` in `apps/template`
