### PR TITLE
Redesign product detail layout

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -17,7 +17,7 @@ The Product Detail Page (PDP) is a single product page — title, price, media, 
 ## Out of the box
 
 - **Variant picker** — color, size, and other options rendered as links, with swatch availability decoded from Shopify's encoded variant data.
-- **Color-aware image gallery** — a desktop grid with lightbox and a mobile snap carousel, leading with the selected color's image when color options have distinct media.
+- **Color-aware image gallery** — a narrow snap carousel on every viewport, leading with the selected color's image when color options have distinct media, with an animated product-title layer behind the media.
 - **Add to cart** — optimistic add of the selected variant.
 - **Quantity picker** — a 1–99 picker beside the cart action.
 - **Buy with Shop** — Shopify's official lock-up that creates a checkout and redirects to it.

--- a/apps/template/app/globals.css
+++ b/apps/template/app/globals.css
@@ -61,6 +61,17 @@
   --radius-xl: calc(var(--radius) + 4px);
 
   --shadow-line: 0 1px 0 0 #0000001a;
+
+  --animate-marquee: marquee var(--marquee-duration, 30s) linear infinite;
+
+  @keyframes marquee {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(-50%);
+    }
+  }
 }
 
 :root {

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/components/product-detail/product-info";
 import {
   ColorImageCarouselItems,
-  ColorImageGrid,
   ProductMedia,
   ProductMediaSkeleton,
 } from "@/components/product-detail/product-media";
@@ -71,14 +70,22 @@ export function ProductDetailSection({
           { name: product.title, path: `/products/${product.handle}` },
         ]}
       />
-      <div className="grid gap-10 lg:grid-cols-10 lg:items-start lg:gap-5">
-        <ProductMediaArea product={product} selectedOptionsPromise={selectedOptionsPromise} />
-        <ProductInfoArea
-          product={product}
-          selectedOptionsPromise={selectedOptionsPromise}
-          variantPromise={variantPromise}
-          locale={locale}
-        />
+      <div className="relative left-1/2 -ml-[50vw] w-screen overflow-hidden pb-10">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-0 z-0 flex h-[min(100vw,36rem)] items-center overflow-hidden md:h-[min(calc(100vw_-_2.5rem),33.5rem)]"
+        >
+          <ProductMarquee title={product.title} />
+        </div>
+        <div className="relative z-10 mx-auto grid w-full max-w-xl gap-5 px-5">
+          <ProductMediaArea product={product} selectedOptionsPromise={selectedOptionsPromise} />
+          <ProductInfoArea
+            product={product}
+            selectedOptionsPromise={selectedOptionsPromise}
+            variantPromise={variantPromise}
+            locale={locale}
+          />
+        </div>
       </div>
     </>
   );
@@ -93,12 +100,7 @@ function ProductMediaArea({
 }) {
   if (!hasColorImagePartitioning(product.options)) {
     return (
-      <ProductMedia
-        otherImages={product.images}
-        videos={product.videos}
-        title={product.title}
-        className="lg:col-span-6"
-      />
+      <ProductMedia otherImages={product.images} videos={product.videos} title={product.title} />
     );
   }
 
@@ -107,20 +109,10 @@ function ProductMediaArea({
       otherImages={getSharedImages(product.images, product.options)}
       videos={product.videos}
       title={product.title}
-      className="lg:col-span-6"
-      desktopSlot={
-        // Color image is the LCP slot; a pulsing skeleton background flashes harder than empty space.
-        <Suspense fallback={<div className="aspect-square w-full" />}>
-          <ResolvedColorImageGrid
-            product={product}
-            selectedOptionsPromise={selectedOptionsPromise}
-          />
-        </Suspense>
-      }
       mobileSlot={
         <Suspense
           fallback={
-            <div className="relative shrink-0 w-full snap-start snap-always overflow-hidden aspect-square" />
+            <div className="relative aspect-square w-full shrink-0 snap-start snap-always overflow-hidden" />
           }
         >
           <ResolvedColorImageCarousel
@@ -133,18 +125,6 @@ function ProductMediaArea({
   );
 }
 
-async function ResolvedColorImageGrid({
-  product,
-  selectedOptionsPromise,
-}: {
-  product: ProductDetails;
-  selectedOptionsPromise: Promise<SelectedOptions>;
-}) {
-  const image = getSelectedColorImage(product, await selectedOptionsPromise);
-  if (!image) return null;
-  return <ColorImageGrid images={[image]} title={product.title} />;
-}
-
 async function ResolvedColorImageCarousel({
   product,
   selectedOptionsPromise,
@@ -155,6 +135,17 @@ async function ResolvedColorImageCarousel({
   const image = getSelectedColorImage(product, await selectedOptionsPromise);
   if (!image) return null;
   return <ColorImageCarouselItems images={[image]} title={product.title} />;
+}
+
+function ProductMarquee({ title }: { title: string }) {
+  return (
+    <div className="animate-marquee flex shrink-0 whitespace-nowrap font-mono text-[16rem] leading-none font-bold tracking-tight text-background [-webkit-text-stroke:2px_var(--foreground)] [paint-order:stroke_fill] motion-reduce:animate-none">
+      <span className="pr-[1ch]">{title}</span>
+      <span className="pr-[1ch]">{title}</span>
+      <span className="pr-[1ch]">{title}</span>
+      <span className="pr-[1ch]">{title}</span>
+    </div>
+  );
 }
 
 async function ProductInfoArea({
@@ -181,9 +172,9 @@ async function ProductInfoArea({
   const allInStock = product.defaultVariant?.availableForSale ?? availableForSale;
 
   return (
-    <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
-      <div data-slot="product-info-header">
-        <h1 className="text-foreground text-3xl">{title}</h1>
+    <div className="grid gap-10">
+      <div data-slot="product-info-header" className="font-mono text-sm">
+        <h1 className="font-bold text-foreground">{title}</h1>
         {uniformPrice ? (
           <ProductPrice
             amount={product.priceRange.minVariantPrice.amount}
@@ -424,11 +415,13 @@ function BuyButtonsFallback({
 
 export function ProductDetailSectionSkeleton() {
   return (
-    <div className="grid gap-10 lg:grid-cols-10 lg:items-start lg:gap-5">
-      <ProductMediaSkeleton className="lg:col-span-6" />
-      <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
-        <Skeleton className="h-40 w-full" />
-        <Skeleton className="h-32 w-full" />
+    <div className="relative left-1/2 -ml-[50vw] w-screen overflow-hidden pb-10">
+      <div className="relative z-10 mx-auto grid w-full max-w-xl gap-5 px-5">
+        <ProductMediaSkeleton />
+        <div className="grid gap-10">
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-32 w-full" />
+        </div>
       </div>
     </div>
   );

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -9,8 +9,6 @@ import { ImagePlaceholder } from "@/components/ui/image-placeholder";
 import type { Image as ImageType, Video } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-import { Lightbox, LightboxTrigger } from "./lightbox";
-
 type MediaItem =
   | { type: "image"; image: ImageType }
   | { type: "placeholder" }
@@ -149,7 +147,7 @@ function Carousel({
     <div className="grid gap-5">
       <div
         ref={scrollContainerRef}
-        className="relative overflow-x-auto flex snap-x snap-mandatory overscroll-x-contain scrollbar-hide -mx-5 w-[calc(100%+2.5rem)]"
+        className="relative -mx-5 flex w-[calc(100%+2.5rem)] snap-x snap-mandatory overflow-x-auto overscroll-x-contain scrollbar-hide md:mx-0 md:w-full"
         style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
       >
         {children}
@@ -201,93 +199,6 @@ function Carousel({
   );
 }
 
-function GridItem({
-  item,
-  title,
-  idx,
-  priority,
-  eager,
-}: {
-  item: MediaItem;
-  title: string;
-  idx: number;
-  priority: boolean;
-  eager: boolean;
-}) {
-  return (
-    <div className="relative w-full overflow-hidden aspect-square">
-      {item.type === "video" ? (
-        <MediaVideo
-          item={item}
-          sizes="(min-width: 1024px) 25vw, 50vw"
-          priority={priority || eager}
-        />
-      ) : item.type === "placeholder" ? (
-        <ImagePlaceholder className="size-full" />
-      ) : (
-        <LightboxTrigger item={item}>
-          <MediaImage
-            item={item}
-            title={title}
-            idx={idx}
-            sizes="(min-width: 1024px) 25vw, 50vw"
-            priority={priority}
-            eager={eager}
-          />
-        </LightboxTrigger>
-      )}
-    </div>
-  );
-}
-
-function Grid({
-  mediaItems,
-  title,
-  hasColorSlot,
-  interactive = true,
-  children,
-}: {
-  mediaItems: MediaItem[];
-  title: string;
-  hasColorSlot: boolean;
-  interactive?: boolean;
-  children?: React.ReactNode;
-}) {
-  const grid = (
-    <div className="grid grid-cols-2 gap-2.5">
-      {children}
-      {mediaItems.map((item, idx) => {
-        const priority = !hasColorSlot && idx === 0;
-        return (
-          <GridItem
-            key={mediaKey(item)}
-            item={item}
-            title={title}
-            idx={idx}
-            priority={priority}
-            eager
-          />
-        );
-      })}
-    </div>
-  );
-
-  return interactive ? <Lightbox label={title}>{grid}</Lightbox> : grid;
-}
-
-export function ColorImageGrid({ images, title }: { images: ImageType[]; title: string }) {
-  return images.map((image, idx) => (
-    <GridItem
-      key={image.url}
-      item={{ type: "image", image }}
-      title={title}
-      idx={idx}
-      priority={idx === 0}
-      eager
-    />
-  ));
-}
-
 export function ColorImageCarouselItems({ images, title }: { images: ImageType[]; title: string }) {
   return images.map((image, idx) => {
     const priority = idx === 0;
@@ -313,19 +224,10 @@ export function ColorImageCarouselItems({ images, title }: { images: ImageType[]
 }
 
 export function ProductMediaSkeleton({ className }: { className?: string }) {
-  const tile = "aspect-square w-full animate-pulse";
   return (
-    <div className={className}>
-      <div className="grid gap-5 lg:hidden -mx-5">
-        <ImagePlaceholder className={tile} />
-        <div className="h-1.5" />
-      </div>
-      <div className="hidden lg:grid grid-cols-2 gap-2.5">
-        <ImagePlaceholder className={tile} />
-        <ImagePlaceholder className={tile} />
-        <ImagePlaceholder className={tile} />
-        <ImagePlaceholder className={tile} />
-      </div>
+    <div className={cn("grid gap-5", className)}>
+      <ImagePlaceholder className="-mx-5 aspect-square w-[calc(100%+2.5rem)] animate-pulse md:mx-0 md:w-full" />
+      <div className="h-1.5" />
     </div>
   );
 }
@@ -356,21 +258,9 @@ export function ProductMedia({
 
   return (
     <div className={className}>
-      <div className="lg:hidden">
-        <Carousel mediaItems={mediaItems} title={title} hasColorSlot={hasColorSlot}>
-          {mobileSlot}
-        </Carousel>
-      </div>
-      <div className="hidden lg:block">
-        <Grid
-          mediaItems={mediaItems}
-          title={title}
-          hasColorSlot={hasColorSlot}
-          interactive={!isEmpty}
-        >
-          {desktopSlot}
-        </Grid>
-      </div>
+      <Carousel mediaItems={mediaItems} title={title} hasColorSlot={hasColorSlot}>
+        {mobileSlot ?? desktopSlot}
+      </Carousel>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- center the PDP in a narrow content column
- add a scrolling product-title marquee behind the media
- use the snap carousel across viewport sizes while preserving current variant and cart behavior
- update the PDP anatomy docs

## Verification
- `pnpm lint` (apps/template)
- `pnpm exec tsc --noEmit` (apps/template)
- `pnpm exec oxfmt --check content/docs/anatomy/pages/pdp.mdx` (apps/docs)
- `git diff --check`