### PR TITLE
fix(pdp): capture gift card timezone offset in the browser

### DIFF
--- a/apps/template/components/product-detail/gift-card-purchase-form.tsx
+++ b/apps/template/components/product-detail/gift-card-purchase-form.tsx
@@ -37,6 +37,8 @@ export function GiftCardPurchaseForm({ merchandiseId }: GiftCardPurchaseFormProp
     const sendOn = String(formData.get("sendOn") ?? "");
     const form = event.currentTarget;
 
+    const scheduled = sendOnEnabled && sendOn;
+
     startTransition(async () => {
       const result = await addGiftCardAction({
         merchandiseId,
@@ -44,7 +46,9 @@ export function GiftCardPurchaseForm({ merchandiseId }: GiftCardPurchaseFormProp
           email,
           message: message || undefined,
           name: name || undefined,
-          sendOn: sendOnEnabled && sendOn ? sendOn : undefined,
+          sendOn: scheduled ? sendOn : undefined,
+          // Captured in the browser so Shopify schedules delivery in the buyer's timezone, not the server's.
+          timezoneOffset: scheduled ? new Date().getTimezoneOffset() : undefined,
         },
       });
 

--- a/apps/template/lib/cart/action.ts
+++ b/apps/template/lib/cart/action.ts
@@ -136,6 +136,7 @@ export async function addGiftCardAction(input: {
     message?: string;
     name?: string;
     sendOn?: string;
+    timezoneOffset?: number;
   };
 }): Promise<CartActionResult> {
   const { merchandiseId, recipient } = input;
@@ -166,7 +167,10 @@ export async function addGiftCardAction(input: {
     attributes.push({ key: "Message", value: recipient.message.trim() });
   if (recipient.sendOn) {
     attributes.push({ key: "Send on", value: recipient.sendOn });
-    attributes.push({ key: "__shopify_offset", value: String(new Date().getTimezoneOffset()) });
+    // Offset must reflect the buyer's browser, so it is captured client-side and passed in — never computed here (server runs in UTC).
+    if (typeof recipient.timezoneOffset === "number" && Number.isFinite(recipient.timezoneOffset)) {
+      attributes.push({ key: "__shopify_offset", value: String(recipient.timezoneOffset) });
+    }
   }
 
   try {


### PR DESCRIPTION
## What

Fast-follow to #460. The `__shopify_offset` gift card attribute was computed server-side via `new Date().getTimezoneOffset()`, which captures the server's timezone (UTC in production) rather than the buyer's browser timezone. Scheduled gift cards were therefore delivered at the wrong local time.

## Fix

- Capture `new Date().getTimezoneOffset()` in the client form (`gift-card-purchase-form.tsx`) at submit time, only when scheduling is enabled.
- Pass it through `addGiftCardAction` as `recipient.timezoneOffset`; the action now emits `__shopify_offset` from that value instead of recomputing it server-side, guarding on a finite number.

## Verification

- `pnpm format` — clean
- `pnpm lint` (oxlint + oxfmt --check) — 0 warnings, 0 errors
- `pnpm exec tsc --noEmit` — passes
