### PR TITLE
chore(docs): fix oxfmt table alignment in five MDX pages

### DIFF
--- a/apps/docs/content/docs/anatomy/aeo-geo.mdx
+++ b/apps/docs/content/docs/anatomy/aeo-geo.mdx
@@ -35,7 +35,7 @@ Every markdown route lives under this single top-level `app/md/` directory so al
 ## Out of the box
 
 | Surface                          | What it does                                                                                           |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | **Content negotiation**          | Serves clean markdown to AI clients via `Accept: text/markdown`                                        |
 | **Schema.org JSON-LD**           | Embeds structured `Product`, `BreadcrumbList`, and `Organization` data                                 |
 | **Sitemap**                      | [Sitemap index + paged children](/docs/anatomy/sitemap) for products and collections                   |

--- a/apps/docs/content/docs/anatomy/sitemap.mdx
+++ b/apps/docs/content/docs/anatomy/sitemap.mdx
@@ -15,14 +15,14 @@ The storefront exposes a sitemap index at `/sitemap.xml` and paged children at `
 ## Out of the box
 
 | URL                            | Contents                                  |
-| ------------------------------ | ------------------------------------------ |
-| `/sitemap.xml`                 | Sitemap index listing every child shard    |
-| `/sitemap/static.xml`          | Home page and configured Shopify policies  |
-| `/sitemap/products-{n}.xml`    | Up to 250 products per shard               |
-| `/sitemap/collections-{n}.xml` | Up to 250 collections per shard            |
-| `/sitemap/pages-{n}.xml`       | Up to 250 Shopify Pages per shard          |
-| `/sitemap/blogs-{n}.xml`       | Up to 250 Shopify blogs per shard          |
-| `/sitemap/articles-{n}.xml`    | Up to 250 Shopify articles per shard       |
+| ------------------------------ | ----------------------------------------- |
+| `/sitemap.xml`                 | Sitemap index listing every child shard   |
+| `/sitemap/static.xml`          | Home page and configured Shopify policies |
+| `/sitemap/products-{n}.xml`    | Up to 250 products per shard              |
+| `/sitemap/collections-{n}.xml` | Up to 250 collections per shard           |
+| `/sitemap/pages-{n}.xml`       | Up to 250 Shopify Pages per shard         |
+| `/sitemap/blogs-{n}.xml`       | Up to 250 Shopify blogs per shard         |
+| `/sitemap/articles-{n}.xml`    | Up to 250 Shopify articles per shard      |
 
 ## Common customizations
 

--- a/apps/docs/content/docs/anatomy/webhooks.mdx
+++ b/apps/docs/content/docs/anatomy/webhooks.mdx
@@ -42,7 +42,7 @@ Payload parsing is wrapped in `try`/`catch`. Metaobject topics seed the broad `m
 A single route (`POST /api/webhooks/shopify`) handles every supported topic. Shopify sets the topic on each request via the `x-shopify-topic` header, and the handler dispatches to the appropriate tag set:
 
 | Webhook topic        | Tags invalidated                                                                        |
-| --------------------- | ----------------------------------------------------------------------------------------- |
+| -------------------- | --------------------------------------------------------------------------------------- |
 | `products/create`    | `products-index`, `product-{handle}`, `product-{numericId}`, `recommendations-{handle}` |
 | `products/update`    | `product-{handle}`, `product-{numericId}`, `recommendations-{handle}`                   |
 | `products/delete`    | `products-index`, `product-{handle}`, `product-{numericId}`, `recommendations-{handle}` |
@@ -64,7 +64,7 @@ You can register only the topics you care about. Skipping `collections/*`, for e
 **Environment variables:**
 
 | Variable                 | When to set                                                                                                                                              |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `SHOPIFY_WEBHOOK_SECRET` | Set in every environment where Shopify posts to `/api/webhooks/shopify`. Without it, the endpoint is disabled and returns `404` before reading the body. |
 
 See [Environment Variables](/docs/reference/env-vars) for the full reference.

--- a/apps/docs/content/docs/reference/routes.mdx
+++ b/apps/docs/content/docs/reference/routes.mdx
@@ -6,19 +6,19 @@ type: reference
 
 ## Pages
 
-| Route                              | Description                                                                                        |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `/`                                | Home page with hero, products grid, info section                                                   |
-| `/products/[handle]`               | Product detail page; `?color=…&size=…` option params select a variant                              |
-| `/collections`                     | All-collections index; each card links to a collection, image falls back to its first product      |
-| `/collections/[handle]`            | Collection listing with filters, sort, pagination                                                  |
-| `/collections/all`                 | Virtual "All Products" listing; synthesized since Shopify's Storefront API has no `all` collection |
-| `/search`                          | Search results (same grid as collections)                                                          |
-| `/cart`                            | Full cart page with related products                                                               |
-| `/blogs/[blogHandle]`              | Shopify blog listing with latest articles                                                          |
-| `/blogs/[blogHandle]/[articleHandle]` | Shopify article with localized rich text and SEO metadata                                       |
-| `/pages/[handle]`                  | Shopify Page with localized rich text and SEO metadata                                             |
-| `/policies/[handle]`               | Configured Shopify store policy                                                                    |
+| Route                                 | Description                                                                                        |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `/`                                   | Home page with hero, products grid, info section                                                   |
+| `/products/[handle]`                  | Product detail page; `?color=…&size=…` option params select a variant                              |
+| `/collections`                        | All-collections index; each card links to a collection, image falls back to its first product      |
+| `/collections/[handle]`               | Collection listing with filters, sort, pagination                                                  |
+| `/collections/all`                    | Virtual "All Products" listing; synthesized since Shopify's Storefront API has no `all` collection |
+| `/search`                             | Search results (same grid as collections)                                                          |
+| `/cart`                               | Full cart page with related products                                                               |
+| `/blogs/[blogHandle]`                 | Shopify blog listing with latest articles                                                          |
+| `/blogs/[blogHandle]/[articleHandle]` | Shopify article with localized rich text and SEO metadata                                          |
+| `/pages/[handle]`                     | Shopify Page with localized rich text and SEO metadata                                             |
+| `/policies/[handle]`                  | Configured Shopify store policy                                                                    |
 
 ## API routes
 

--- a/apps/docs/content/docs/reference/storefront-api-permissions.mdx
+++ b/apps/docs/content/docs/reference/storefront-api-permissions.mdx
@@ -22,9 +22,9 @@ After you create a storefront in Shopify Headless, open **Settings → Apps and 
 
 Enable these only when you add the corresponding feature:
 
-| Scope                                | Required by                                             |
-| ------------------------------------ | ------------------------------------------------------- |
-| `unauthenticated_read_customer_tags` | [Authentication](/docs/anatomy/authentication)          |
+| Scope                                | Required by                                    |
+| ------------------------------------ | ---------------------------------------------- |
+| `unauthenticated_read_customer_tags` | [Authentication](/docs/anatomy/authentication) |
 
 ## Related docs
 


### PR DESCRIPTION
`pnpm lint` in `apps/docs` fails on `main` — five content pages have markdown table separator rows whose widths don't match oxfmt's expected column alignment.

Whitespace only. No prose, table content, or link changes; the diff is padding inside separator rows and cell trailing space.

- `content/docs/anatomy/aeo-geo.mdx`
- `content/docs/anatomy/sitemap.mdx`
- `content/docs/anatomy/webhooks.mdx`
- `content/docs/reference/routes.mdx`
- `content/docs/reference/storefront-api-permissions.mdx`

## Verification

| Check | Before | After |
| --- | --- | --- |
| `pnpm lint` | exit 1, 5 files | exit 0, "All matched files use the correct format" |
| `pnpm typecheck` | clean | clean |
| `pnpm build` | exit 0 | exit 0 |

The one remaining oxlint warning (`next(no-img-element)` in the OG image route) also pre-exists and is untouched here — it's a warning, so lint still exits 0.

Split out of #469 so that PR's diff stays limited to the files it actually changes.
