### PR TITLE
fix(template): navigate to /account/login with a plain anchor

### DIFF
--- a/apps/template/components/nav/account.tsx
+++ b/apps/template/components/nav/account.tsx
@@ -8,14 +8,16 @@ export async function NavAccount() {
   const [loggedIn, t] = await Promise.all([isCustomerLoggedIn(), getTranslations("nav")]);
 
   if (!loggedIn) {
+    // Sign-in must be a full document navigation; the proxy auth route issues an OAuth redirect and must never be prefetched.
     return (
-      <Link
+      // eslint-disable-next-line next/no-html-link-for-pages
+      <a
         href="/account/login"
         className="flex items-center justify-center text-foreground hover:text-foreground/80 transition-colors"
       >
         <UserRoundIcon className="size-5" />
         <span className="sr-only">{t("signIn")}</span>
-      </Link>
+      </a>
     );
   }
 


### PR DESCRIPTION
## Problem

On template.vercel.shop, an auth route appeared to get called and 404 on every request after the customer account auth routes moved into `proxy.ts` (#465).

## Root cause

The nav renders the sign-in control on every page as a client `<Link href="/account/login">` (components/nav/account.tsx). Next.js auto-prefetches in-viewport `<Link>` targets in production. With the old `app/account/[action]/route.ts` that prefetch was harmless, but now the route is intercepted in proxy and `handleShopifyRoutes` answers with a **bare 303 + `text/plain`**, while also **setting PKCE session cookies** (it starts a real OAuth login).

So an idempotent prefetch was triggering a stateful login plus a redirect the App Router prefetch/navigation pipeline can't consume — surfacing as repeated auth requests that 404/405 on every page view.

## Fix

Render sign-in as a plain `<a href="/account/login">` so it's always a full document navigation and **never prefetched**. The logged-in `/account` link stays a `<Link>` (safe, cacheable page).

Logout (`sign-out-button.tsx`) was already a native `<form method="post">`, so no change needed there.

## Verification

- `pnpm lint` → 0 warnings, 0 errors; format check passes.
- Reproduced the prefetch→303→OAuth chain against production before the change.