### PR TITLE
fix(template): size lightbox to image aspect ratio, no white band

### DIFF
--- a/apps/template/components/product-detail/lightbox.tsx
+++ b/apps/template/components/product-detail/lightbox.tsx
@@ -39,7 +39,10 @@ export function Lightbox({ label, children }: { label: string; children: ReactNo
             </DialogPrimitive.Close>
 
             {activeItem?.type === "image" && (
-              <div className="pointer-events-none relative h-full w-full bg-background">
+              <div
+                className="pointer-events-none relative h-full max-w-full bg-background"
+                style={{ aspectRatio: `${activeItem.image.width} / ${activeItem.image.height}` }}
+              >
                 <Image
                   src={activeItem.image.url}
                   alt={activeItem.image.altText || `${label} enlarged`}


### PR DESCRIPTION
The PDP lightbox image container was `h-full w-full bg-background`, so on wide screens an `object-contain` portrait image was letterboxed and the white `bg-background` filled the leftover width as a solid white block — most obvious on the virtual try-on result.

Size the container to the image's own aspect ratio (`h-full max-w-full` + `aspectRatio: width / height`) so the background hugs the image on all sides instead of spanning the viewport.