### PR TITLE
refactor(template): rename config enabled to isEnabled, drop alias re-exports

### DIFF
--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -10,7 +10,7 @@ The storefront includes an opt-in AI shopping assistant built with [AI SDK](http
 
 ## How it works
 
-**Feature-flagged, single-file runtime.** The assistant defaults to disabled through `agent.enabled` in `lib/config.ts`. When disabled, the button is hidden and `POST /api/chat` returns `404` before reading the request body or creating a cart. The model, loop limit, prompts, and tool registry all live together in `lib/agent/server.ts`, since they form one runtime implementation rather than a storefront configuration API: `AgentPanel` (`useChat`) posts to `/api/chat`, which runs a request-scoped `ToolLoopAgent` against the Shopify tools and streams the result back.
+**Feature-flagged, single-file runtime.** The assistant defaults to disabled through `agent.isEnabled` in `lib/config.ts`. When disabled, the button is hidden and `POST /api/chat` returns `404` before reading the request body or creating a cart. The model, loop limit, prompts, and tool registry all live together in `lib/agent/server.ts`, since they form one runtime implementation rather than a storefront configuration API: `AgentPanel` (`useChat`) posts to `/api/chat`, which runs a request-scoped `ToolLoopAgent` against the Shopify tools and streams the result back.
 
 **Bot protection is on by default.** The chat endpoint is anonymous and every message costs model tokens, so it is a natural target for automated abuse. Enabling the assistant also enables [Vercel BotID](https://vercel.com/docs/botid), an invisible CAPTCHA that turns away automated traffic before it can reach the model or touch a cart. See [Shop Configuration](/docs/reference/shop-config) to change the detection level or turn it off.
 

--- a/apps/docs/content/docs/anatomy/authentication.mdx
+++ b/apps/docs/content/docs/anatomy/authentication.mdx
@@ -6,7 +6,7 @@ type: guide
 
 The template includes opt-in customer authentication using the framework-neutral session and OAuth helpers from `@shopify/hydrogen/customer-account`. Customers can sign in through Shopify, view their profile, order history, and address book, refresh expired access tokens, and sign out of both the storefront and Shopify identity provider.
 
-Authentication is disabled by default. The canonical default lives in `lib/config.ts` as `auth.enabled`. When disabled, the storefront works as a guest-only experience and no auth UI is rendered.
+Authentication is disabled by default. The canonical default lives in `lib/config.ts` as `auth.isEnabled`. When disabled, the storefront works as a guest-only experience and no auth UI is rendered.
 
 ## Configuration
 
@@ -42,7 +42,7 @@ Shopify does not support wildcard callback or logout URIs — register each prod
 
 ## How it works
 
-**No client-side auth SDK.** Sign-in is a normal GET navigation to `/account/login`; sign-out is a same-origin POST form to `/account/logout`. The universal `isAuthEnabled` flag (`lib/auth/index.ts`) re-exports `shopConfig.auth.enabled`, safe to import from server and client code alike. When it's false: the account icon disappears from the nav, the Hydrogen auth routes and protected account pages return `404`, and the shared session/access-token helpers in `lib/auth/server.ts` fail before initializing Hydrogen — no auth-related code runs at request time.
+**No client-side auth SDK.** Sign-in is a normal GET navigation to `/account/login`; sign-out is a same-origin POST form to `/account/logout`. The `shopConfig.auth.isEnabled` flag (`lib/config.ts`) gates every auth surface and is safe to read from server and client code alike. When it's false: the account icon disappears from the nav, the Hydrogen auth routes and protected account pages return `404`, and the shared session/access-token helpers in `lib/auth/server.ts` fail before initializing Hydrogen — no auth-related code runs at request time.
 
 **The session lives in an encrypted cookie, not a server store.** `/account/login` asks Hydrogen to generate state, nonce, and PKCE values, which the app encrypts into chunked AES-256-GCM HttpOnly cookies. Shopify redirects to `/account/authorize`, where Hydrogen validates state, nonce, issuer, audience, and ID-token expiry before exchanging the authorization code — access, refresh, and ID tokens then replace the pending-login state in that same cookie. Server Components only perform read-only login and token checks; they never mutate cookies.
 

--- a/apps/docs/content/docs/reference/env-vars.mdx
+++ b/apps/docs/content/docs/reference/env-vars.mdx
@@ -13,7 +13,7 @@ type: reference
 
 ## Customer Authentication
 
-Required when `auth.enabled` is set to `true` in [`lib/config.ts`](/docs/reference/shop-config). These variables have different owners: Shopify provides the Customer Account API client ID, while you generate the session secret for this application.
+Required when `auth.isEnabled` is set to `true` in [`lib/config.ts`](/docs/reference/shop-config). These variables have different owners: Shopify provides the Customer Account API client ID, while you generate the session secret for this application.
 
 The template stores Hydrogen's OAuth session data in encrypted HttpOnly cookies. `CUSTOMER_ACCOUNT_SESSION_SECRET` is the private application key used to derive the AES-256-GCM encryption key for those cookies; it is not a Shopify credential. Generate it with `openssl rand -base64 32`, keep one stable value across all instances of a deployment, and store it only in server-side environment variables. Rotating it invalidates all existing customer sessions. The variable is required by the template's encrypted-cookie implementation, but an application that replaces it with protected server-side session storage can use that storage system's key management instead.
 

--- a/apps/docs/content/docs/reference/shop-config.mdx
+++ b/apps/docs/content/docs/reference/shop-config.mdx
@@ -44,24 +44,24 @@ Consumers import `shopConfig` directly from `@/lib/config`. Feature flags are li
 
 ## Agent
 
-`agent.enabled` controls whether the shopping assistant is available. It defaults to `false`. When disabled, the assistant button is hidden and the chat endpoint returns `404`. The model, tools, prompts, and loop limits are implementation details in the agent module, not shop configuration.
+`agent.isEnabled` controls whether the shopping assistant is available. It defaults to `false`. When disabled, the assistant button is hidden and the chat endpoint returns `404`. The model, tools, prompts, and loop limits are implementation details in the agent module, not shop configuration.
 
 ## Analytics
 
-- `vercel.enabled` controls Vercel Web Analytics.
-- `speedInsights.enabled` controls Vercel Speed Insights.
+- `vercel.isEnabled` controls Vercel Web Analytics.
+- `speedInsights.isEnabled` controls Vercel Speed Insights.
 
 Each integration is disabled by default. Set an individual integration to `true` to render it. The root analytics component owns these gates and does not mount disabled provider components. Additional storefront-wide analytics integrations can be added alongside them.
 
 ## Authentication
 
-`auth.enabled` controls whether customer authentication is active. It defaults to `false`.
+`auth.isEnabled` controls whether customer authentication is active. It defaults to `false`.
 
 Enabling auth still requires the Hydrogen session secret and Shopify Customer Account API client ID documented in [Environment Variables](/docs/reference/env-vars). The build validates those variables when auth is enabled.
 
 ## BotID
 
-`botid.enabled` controls [Vercel BotID](https://vercel.com/docs/botid) protection on the assistant's chat endpoint. It defaults to `false`; enable it alongside `agent.enabled` to protect the assistant.
+`botid.isEnabled` controls [Vercel BotID](https://vercel.com/docs/botid) protection on the assistant's chat endpoint. It defaults to `false`; enable it alongside `agent.isEnabled` to protect the assistant.
 
 `botid.checkLevel` selects the detection level. It defaults to `basic`, which is free on all plans. Setting it to `deepAnalysis` enables Vercel's machine-learning detection, which is [billed per check](https://vercel.com/docs/botid#pricing) on Pro plans.
 
@@ -75,11 +75,11 @@ The primary navigation and footer menus are not part of `shopConfig`. Each is an
 
 The PDP capability flags are enabled by default so storefronts render Shopify's merchandising features whenever the catalog provides data:
 
-- `bundles.enabled` adds Shopify's `components`, `groupedBy`, and `requiresComponents` fields to the existing product and selected-variant requests, then renders bundle relationships and purchase restrictions.
-- `buyWithShop.enabled` renders the full-width Buy with Shop accelerated checkout action below Add to Cart.
-- `complementaryProducts.enabled` adds one cached `COMPLEMENTARY` recommendation request per product and renders merchant-curated cross-sells near the buy section.
-- `quantityPicker.enabled` renders a 1–99 quantity control beside Add to Cart and applies the selected quantity to both purchase actions.
-- `relatedProducts.enabled` adds one cached `RELATED` recommendation request per product and renders algorithmic recommendations on PDP and cart pages.
+- `bundles.isEnabled` adds Shopify's `components`, `groupedBy`, and `requiresComponents` fields to the existing product and selected-variant requests, then renders bundle relationships and purchase restrictions.
+- `buyWithShop.isEnabled` renders the full-width Buy with Shop accelerated checkout action below Add to Cart.
+- `complementaryProducts.isEnabled` adds one cached `COMPLEMENTARY` recommendation request per product and renders merchant-curated cross-sells near the buy section.
+- `quantityPicker.isEnabled` renders a 1–99 quantity control beside Add to Cart and applies the selected quantity to both purchase actions.
+- `relatedProducts.isEnabled` adds one cached `RELATED` recommendation request per product and renders algorithmic recommendations on PDP and cart pages.
 
 Sections with no applicable Shopify data render nothing. Set an individual flag to `false` to skip its fields or recommendation request. Display counts and component composition remain implementation details rather than configuration.
 

--- a/apps/docs/content/docs/shopify/pdp.mdx
+++ b/apps/docs/content/docs/shopify/pdp.mdx
@@ -23,9 +23,9 @@ This page covers the Shopify admin configuration the PDP expects. For how the pa
 - **Basic fields** — title, `descriptionHtml`, variants, featured image, and up to 10 media items (images or videos). Products must belong to at least one collection to appear on collection listing pages.
 - **Color swatches** — configure in Shopify admin: edit a product → open an option like "Color" → assign a swatch color or image to each value.
 - **SEO fields** — `seo.title` and `seo.description`, editable per product.
-- **Related products** — Shopify's automatic recommendation API. On by default; disable with `pdp.relatedProducts.enabled: false` in `lib/config.ts`.
-- **Complementary products** — hand-curated in the Search & Discovery app. On by default; disable with `pdp.complementaryProducts.enabled: false`.
-- **Bundles** — fixed bundles (e.g. from the free **Shopify Bundles** app) render contents and add to cart normally via `components` (a bundle's items and quantities) and `groupedBy` (up to 10 bundles containing the current product). Disable with `pdp.bundles.enabled: false`.
+- **Related products** — Shopify's automatic recommendation API. On by default; disable with `pdp.relatedProducts.isEnabled: false` in `lib/config.ts`.
+- **Complementary products** — hand-curated in the Search & Discovery app. On by default; disable with `pdp.complementaryProducts.isEnabled: false`.
+- **Bundles** — fixed bundles (e.g. from the free **Shopify Bundles** app) render contents and add to cart normally via `components` (a bundle's items and quantities) and `groupedBy` (up to 10 bundles containing the current product). Disable with `pdp.bundles.isEnabled: false`.
 
 ## Common customizations
 

--- a/apps/docs/content/docs/skills/enable-analytics.mdx
+++ b/apps/docs/content/docs/skills/enable-analytics.mdx
@@ -43,8 +43,8 @@ If the storefront has `analytics` configuration in `lib/config.ts`, enable only 
 
 ```ts
 analytics: {
-  speedInsights: { enabled: false },
-  vercel: { enabled: false },
+  speedInsights: { isEnabled: false },
+  vercel: { isEnabled: false },
 },
 ```
 
@@ -112,8 +112,8 @@ export function AnalyticsComponents() {
 
   return (
     <>
-      {shopConfig.analytics.vercel.enabled ? <Analytics /> : null}
-      {shopConfig.analytics.speedInsights.enabled ? <SpeedInsights /> : null}
+      {shopConfig.analytics.vercel.isEnabled ? <Analytics /> : null}
+      {shopConfig.analytics.speedInsights.isEnabled ? <SpeedInsights /> : null}
       {gtmId ? <GoogleTagManager gtmId={gtmId} /> : null}
     </>
   );

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -199,11 +199,10 @@ These are agent-side conveniences. The template runs and deploys without them.
 
 ## Authentication
 
-Customer authentication uses Hydrogen's Shopify Customer Account OAuth/session helpers. It is **opt-in**: set `auth.enabled` to `true` in `lib/config.ts` to enable it. When enabled, `next.config.ts` requires the app-generated `CUSTOMER_ACCOUNT_SESSION_SECRET` for encrypted cookie storage and the Shopify-issued `SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID`. The flag is resolved in `lib/config.ts` and re-exported as `isAuthEnabled` from `lib/auth/index.ts`, keeping server and client feature gates aligned under cache components.
+Customer authentication uses Hydrogen's Shopify Customer Account OAuth/session helpers. It is **opt-in**: set `auth.isEnabled` to `true` in `lib/config.ts` to enable it. When enabled, `next.config.ts` requires the app-generated `CUSTOMER_ACCOUNT_SESSION_SECRET` for encrypted cookie storage and the Shopify-issued `SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID`. Read `shopConfig.auth.isEnabled` directly from `lib/config.ts` to gate auth surfaces in server and client code alike.
 
 Key files:
 
-- `lib/auth/index.ts` — universal `isAuthEnabled` flag
 - `lib/auth/server.ts` — encrypted HttpOnly cookie adapter plus read-only login/token helpers
 - `proxy.ts` — Hydrogen login, authorize, refresh, and logout handlers on the customer-account OAuth paths
 - `app/account/(authenticated)/` — auth-gated account pages

--- a/apps/template/app/account/(authenticated)/layout.tsx
+++ b/apps/template/app/account/(authenticated)/layout.tsx
@@ -10,8 +10,8 @@ import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
 import { Skeleton } from "@/components/ui/skeleton";
-import { isAuthEnabled } from "@/lib/auth";
 import { getCustomerAccessToken, requireCustomerSession } from "@/lib/auth/server";
+import { shopConfig } from "@/lib/config";
 import { getCustomerProfile } from "@/lib/shopify/operations/customer";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -60,13 +60,13 @@ export default function AccountLayout({ children }: { children: React.ReactNode 
 }
 
 async function AccountGate({ children }: { children: React.ReactNode }) {
-  if (!isAuthEnabled) notFound();
+  if (!shopConfig.auth.isEnabled) notFound();
   await requireCustomerSession();
   return <>{children}</>;
 }
 
 async function AccountLabel() {
-  if (!isAuthEnabled) notFound();
+  if (!shopConfig.auth.isEnabled) notFound();
   await requireCustomerSession();
 
   const accessToken = await getCustomerAccessToken();

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -9,14 +9,14 @@ import {
 import { checkBotId } from "botid/server";
 
 import { createAgent, type PageContext, type User, withAgentContext } from "@/lib/agent/server";
-import { BOTID_DENIED_CODE, botIdCheckOptions, isBotIdEnabled } from "@/lib/botid";
+import { BOTID_DENIED_CODE, botIdCheckOptions } from "@/lib/botid";
 import { buildCartIdSetCookieHeader, getCartIdFromCookie } from "@/lib/cart/server";
+import { shopConfig } from "@/lib/config";
 import { defaultLocale, type Locale } from "@/lib/i18n";
 import { withFallback } from "@/lib/shopify/errors";
 import { createCartWithoutCookie } from "@/lib/shopify/operations/cart";
 import { getCollection } from "@/lib/shopify/operations/collections";
 import { getProductWithVariants } from "@/lib/shopify/operations/products";
-import { shopConfig } from "@/lib/config";
 
 function parseReferer(referer: string | null): { locale: Locale; segments: string[] } {
   if (!referer) return { locale: defaultLocale, segments: [] };
@@ -56,10 +56,10 @@ async function resolvePageContext(
 }
 
 export async function POST(request: Request) {
-  if (!shopConfig.agent.enabled) return new Response(null, { status: 404 });
+  if (!shopConfig.agent.isEnabled) return new Response(null, { status: 404 });
 
   // Runs before body parsing and cart creation so rejected traffic costs no Shopify or gateway work.
-  if (isBotIdEnabled) {
+  if (shopConfig.botid.isEnabled) {
     const { isBot } = await checkBotId(botIdCheckOptions);
     if (isBot) return Response.json({ error: BOTID_DENIED_CODE }, { status: 403 });
   }

--- a/apps/template/app/cart/page.tsx
+++ b/apps/template/app/cart/page.tsx
@@ -14,11 +14,11 @@ import { RelatedProductsSection } from "@/components/product/related-products-se
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
+import { shopConfig } from "@/lib/config";
 import type { Locale } from "@/lib/i18n";
 import { getLocale } from "@/lib/params";
 import { withFallback } from "@/lib/shopify/errors";
 import { getCart } from "@/lib/shopify/operations/cart";
-import { shopConfig } from "@/lib/config";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("cart");
@@ -81,7 +81,7 @@ async function CartContent({ locale }: { locale: Locale }) {
                     </div>
                   </aside>
                 </div>
-                {shopConfig.pdp.relatedProducts.enabled &&
+                {shopConfig.pdp.relatedProducts.isEnabled &&
                 cart.lines[0]?.merchandise.product.handle ? (
                   <RelatedProductsSection
                     handle={cart.lines[0].merchandise.product.handle}

--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -15,9 +15,9 @@ import { Footer } from "@/components/footer";
 import { Nav } from "@/components/nav";
 import { SiteSchema } from "@/components/schema/site-schema";
 import { Toaster } from "@/components/ui/sonner";
+import { shopConfig } from "@/lib/config";
 import { getLocale } from "@/lib/params";
 import { buildAlternates } from "@/lib/seo";
-import { shopConfig } from "@/lib/config";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -66,7 +66,7 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
               />
             </Suspense>
             <Suspense>
-              <ActionBar>{shopConfig.agent.enabled && <AgentButton />}</ActionBar>
+              <ActionBar>{shopConfig.agent.isEnabled && <AgentButton />}</ActionBar>
             </Suspense>
           </CartProvider>
           <Toaster closeButton />

--- a/apps/template/app/page.tsx
+++ b/apps/template/app/page.tsx
@@ -5,9 +5,9 @@ import { ProductsGrid } from "@/components/product/products-grid";
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
+import { shopConfig } from "@/lib/config";
 import { getLocale } from "@/lib/params";
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
-import { shopConfig } from "@/lib/config";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("seo");

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -6,6 +6,7 @@ import { RelatedProductsSection } from "@/components/product/related-products-se
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
+import { shopConfig } from "@/lib/config";
 import { getLocale } from "@/lib/params";
 import {
   defaultSelectedOptions,
@@ -20,7 +21,6 @@ import {
   getProductVariant,
 } from "@/lib/shopify/operations/products";
 import type { ProductVariant } from "@/lib/types";
-import { shopConfig } from "@/lib/config";
 
 const PLACEHOLDER_HANDLE = "__placeholder__";
 
@@ -128,7 +128,7 @@ export default async function ProductPage({
             variantPromise={variantPromise}
             locale={locale}
           />
-          {shopConfig.pdp.relatedProducts.enabled ? (
+          {shopConfig.pdp.relatedProducts.isEnabled ? (
             <RelatedProductsSection handle={handle} limit={4} locale={locale} />
           ) : null}
         </Sections>

--- a/apps/template/app/sitemap.xml/route.ts
+++ b/apps/template/app/sitemap.xml/route.ts
@@ -1,5 +1,5 @@
-import { getShopifySitemapPagesCount } from "@/lib/shopify/operations/sitemap";
 import { shopConfig } from "@/lib/config";
+import { getShopifySitemapPagesCount } from "@/lib/shopify/operations/sitemap";
 
 function escapeXml(value: string): string {
   return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");

--- a/apps/template/app/sitemap/[shard]/route.ts
+++ b/apps/template/app/sitemap/[shard]/route.ts
@@ -1,8 +1,8 @@
 import { notFound } from "next/navigation";
 
+import { shopConfig } from "@/lib/config";
 import { getShopPolicies } from "@/lib/shopify/operations/policies";
 import { getShopifySitemapPage, type ShopifySitemapType } from "@/lib/shopify/operations/sitemap";
-import { shopConfig } from "@/lib/config";
 
 function escapeXml(value: string): string {
   return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");

--- a/apps/template/components/analytics.tsx
+++ b/apps/template/components/analytics.tsx
@@ -6,8 +6,8 @@ import { shopConfig } from "@/lib/config";
 export function AnalyticsComponents() {
   return (
     <>
-      {shopConfig.analytics.vercel.enabled ? <Analytics /> : null}
-      {shopConfig.analytics.speedInsights.enabled ? <SpeedInsights /> : null}
+      {shopConfig.analytics.vercel.isEnabled ? <Analytics /> : null}
+      {shopConfig.analytics.speedInsights.isEnabled ? <SpeedInsights /> : null}
     </>
   );
 }

--- a/apps/template/components/footer/index.tsx
+++ b/apps/template/components/footer/index.tsx
@@ -3,10 +3,10 @@ import Link from "next/link";
 
 import { Container } from "@/components/ui/container";
 import { Sections } from "@/components/ui/sections";
+import { shopConfig } from "@/lib/config";
 import { getShopPolicies } from "@/lib/shopify/operations/policies";
 import type { MenuItem } from "@/lib/shopify/types/menu";
 import { cn } from "@/lib/utils";
-import { shopConfig } from "@/lib/config";
 
 import { SocialLinks } from "./social-links";
 import type { SocialLink } from "./social-links";
@@ -22,7 +22,7 @@ export async function Footer({ locale }: { locale: string }) {
   return (
     <footer>
       {/* pb-22 clears the fixed agent ActionBar pill when it renders */}
-      <Container className={cn("pt-20 pb-10", shopConfig.agent.enabled && "pb-22")}>
+      <Container className={cn("pt-20 pb-10", shopConfig.agent.isEnabled && "pb-22")}>
         <Sections className="gap-10">
           {items.length > 0 && <FooterMenu items={items} />}
           <div className="flex flex-col sm:flex-row items-center justify-between gap-5">

--- a/apps/template/components/nav/index.tsx
+++ b/apps/template/components/nav/index.tsx
@@ -2,7 +2,6 @@ import Link from "next/link";
 import { Suspense } from "react";
 
 import { Container } from "@/components/ui/container";
-import { isAuthEnabled } from "@/lib/auth";
 import { shopConfig } from "@/lib/config";
 import type { MenuItem } from "@/lib/shopify/types/menu";
 
@@ -33,7 +32,7 @@ export async function Nav({ locale }: { locale: string }) {
 
         <div className="flex items-center gap-5 ml-auto">
           <SearchModal />
-          {isAuthEnabled && (
+          {shopConfig.auth.isEnabled && (
             <Suspense fallback={<NavAccountFallback />}>
               <NavAccount />
             </Suspense>

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -23,6 +23,7 @@ import { BreadcrumbSchema } from "@/components/schema/breadcrumb-schema";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { shopConfig } from "@/lib/config";
 import type { Locale } from "@/lib/i18n";
 import {
   defaultSelectedOptions,
@@ -34,7 +35,6 @@ import {
 import { getAvailableOptionValues } from "@/lib/shopify/encoded-variants";
 import type { ProductDetails, ProductVariant } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { shopConfig } from "@/lib/config";
 
 export function ProductDetailSection({
   product,
@@ -246,8 +246,8 @@ async function ProductInfoArea({
           handle={handle}
           featuredImage={featuredImage}
           availableForSale={availableForSale}
-          buyWithShop={shopConfig.pdp.buyWithShop.enabled}
-          quantityPicker={shopConfig.pdp.quantityPicker.enabled}
+          buyWithShop={shopConfig.pdp.buyWithShop.isEnabled}
+          quantityPicker={shopConfig.pdp.quantityPicker.isEnabled}
         />
       ) : (
         <Suspense fallback={<BuyButtonsFallback t={buyFallbackT} allInStock={allInStock} />}>
@@ -256,18 +256,18 @@ async function ProductInfoArea({
             handle={handle}
             featuredImage={featuredImage}
             availableForSale={availableForSale}
-            buyWithShop={shopConfig.pdp.buyWithShop.enabled}
-            quantityPicker={shopConfig.pdp.quantityPicker.enabled}
+            buyWithShop={shopConfig.pdp.buyWithShop.isEnabled}
+            quantityPicker={shopConfig.pdp.quantityPicker.isEnabled}
             variantPromise={variantPromise}
           />
         </Suspense>
       )}
 
-      {!product.isGiftCard && shopConfig.pdp.bundles.enabled ? (
+      {!product.isGiftCard && shopConfig.pdp.bundles.isEnabled ? (
         <BundleRelationships variant={product.defaultVariant} t={t} />
       ) : null}
 
-      {!product.isGiftCard && shopConfig.pdp.complementaryProducts.enabled ? (
+      {!product.isGiftCard && shopConfig.pdp.complementaryProducts.isEnabled ? (
         <ComplementaryProducts handle={handle} limit={4} locale={locale} title={t("pairsWith")} />
       ) : null}
 
@@ -460,12 +460,12 @@ function BuyButtonsFallback({
   return (
     <div className="grid gap-2.5">
       <div className="flex gap-2.5">
-        {shopConfig.pdp.quantityPicker.enabled ? <QuantityPickerFallback /> : null}
+        {shopConfig.pdp.quantityPicker.isEnabled ? <QuantityPickerFallback /> : null}
         <div className="flex h-12 min-w-0 flex-1 items-center justify-center rounded-lg bg-primary text-sm font-medium text-primary-foreground">
           {t ? (allInStock ? t("addToCart") : t("outOfStock")) : null}
         </div>
       </div>
-      {shopConfig.pdp.buyWithShop.enabled ? (
+      {shopConfig.pdp.buyWithShop.isEnabled ? (
         <div
           className={cn(
             "flex h-12 items-center justify-center rounded-lg bg-shop px-4 text-white",

--- a/apps/template/components/product-detail/schema.tsx
+++ b/apps/template/components/product-detail/schema.tsx
@@ -1,5 +1,5 @@
-import type { Image, Money } from "@/lib/types";
 import { shopConfig } from "@/lib/config";
+import type { Image, Money } from "@/lib/types";
 
 interface ProductSchemaData {
   id: string;

--- a/apps/template/instrumentation-client.ts
+++ b/apps/template/instrumentation-client.ts
@@ -1,7 +1,8 @@
 import { initBotId } from "botid/client/core";
 
-import { botIdProtectedRoutes, isBotIdEnabled } from "@/lib/botid";
+import { botIdProtectedRoutes } from "@/lib/botid";
+import { shopConfig } from "@/lib/config";
 
-if (isBotIdEnabled && botIdProtectedRoutes.length > 0) {
+if (shopConfig.botid.isEnabled && botIdProtectedRoutes.length > 0) {
   initBotId({ protect: botIdProtectedRoutes });
 }

--- a/apps/template/lib/auth/index.ts
+++ b/apps/template/lib/auth/index.ts
@@ -1,3 +1,0 @@
-import { shopConfig } from "@/lib/config";
-
-export const isAuthEnabled = shopConfig.auth.enabled;

--- a/apps/template/lib/auth/server.ts
+++ b/apps/template/lib/auth/server.ts
@@ -12,10 +12,9 @@ import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import { cache } from "react";
 
-import { isAuthEnabled } from "@/lib/auth";
+import { shopConfig } from "@/lib/config";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import { resolveShopId } from "@/lib/shopify/discovery";
-import { shopConfig } from "@/lib/config";
 
 const COOKIE_CHUNK_SIZE = 3_800;
 const COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
@@ -170,7 +169,7 @@ function createSessionManager(
 let customerSessionPromise: Promise<HydrogenCustomerSession> | undefined;
 
 export function getHydrogenCustomerSession(): Promise<HydrogenCustomerSession> {
-  if (!isAuthEnabled) notFound();
+  if (!shopConfig.auth.isEnabled) notFound();
 
   if (!customerSessionPromise) {
     customerSessionPromise = resolveShopId().then((shopId) =>
@@ -237,7 +236,7 @@ const getReadonlyRequestContext = cache(async (): Promise<ShopifyRequestContext>
 });
 
 export const isCustomerLoggedIn = cache(async (): Promise<boolean> => {
-  if (!isAuthEnabled) return false;
+  if (!shopConfig.auth.isEnabled) return false;
 
   const [customerSession, sessionManager, requestContext] = await Promise.all([
     getHydrogenCustomerSession(),
@@ -248,7 +247,7 @@ export const isCustomerLoggedIn = cache(async (): Promise<boolean> => {
 });
 
 export const getCustomerAccessToken = cache(async (): Promise<string | undefined> => {
-  if (!isAuthEnabled) return undefined;
+  if (!shopConfig.auth.isEnabled) return undefined;
 
   const [customerSession, sessionManager, requestContext] = await Promise.all([
     getHydrogenCustomerSession(),
@@ -259,12 +258,12 @@ export const getCustomerAccessToken = cache(async (): Promise<string | undefined
 });
 
 export async function requireCustomerSession(): Promise<void> {
-  if (!isAuthEnabled) notFound();
+  if (!shopConfig.auth.isEnabled) notFound();
   if (!(await isCustomerLoggedIn())) redirect("/account/login?return_to=/account");
 }
 
 export async function requireCustomerAccessToken(returnTo = "/account"): Promise<string> {
-  if (!isAuthEnabled) notFound();
+  if (!shopConfig.auth.isEnabled) notFound();
 
   const accessToken = await getCustomerAccessToken();
   if (accessToken) return accessToken;

--- a/apps/template/lib/botid/index.ts
+++ b/apps/template/lib/botid/index.ts
@@ -8,14 +8,12 @@ export interface BotIdProtectedRoute {
 
 export const BOTID_DENIED_CODE = "botid_denied";
 
-export const isBotIdEnabled = shopConfig.botid.enabled;
-
 // The client `protect` entry and the server `checkBotId()` call must declare the same checkLevel or verification fails.
 export const botIdCheckOptions = {
   advancedOptions: { checkLevel: shopConfig.botid.checkLevel },
 };
 
-export const botIdProtectedRoutes: BotIdProtectedRoute[] = shopConfig.agent.enabled
+export const botIdProtectedRoutes: BotIdProtectedRoute[] = shopConfig.agent.isEnabled
   ? [
       {
         advancedOptions: { checkLevel: shopConfig.botid.checkLevel },

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -2,38 +2,38 @@ export type BotIdCheckLevel = "basic" | "deepAnalysis";
 
 export interface ShopConfig {
   agent: {
-    enabled: boolean;
+    isEnabled: boolean;
   };
   analytics: {
     speedInsights: {
-      enabled: boolean;
+      isEnabled: boolean;
     };
     vercel: {
-      enabled: boolean;
+      isEnabled: boolean;
     };
   };
   auth: {
-    enabled: boolean;
+    isEnabled: boolean;
   };
   botid: {
     checkLevel: BotIdCheckLevel;
-    enabled: boolean;
+    isEnabled: boolean;
   };
   pdp: {
     bundles: {
-      enabled: boolean;
+      isEnabled: boolean;
     };
     buyWithShop: {
-      enabled: boolean;
+      isEnabled: boolean;
     };
     complementaryProducts: {
-      enabled: boolean;
+      isEnabled: boolean;
     };
     quantityPicker: {
-      enabled: boolean;
+      isEnabled: boolean;
     };
     relatedProducts: {
-      enabled: boolean;
+      isEnabled: boolean;
     };
   };
   site: {
@@ -55,38 +55,38 @@ const defaultUrl = bareHost ? `https://${bareHost}` : "http://localhost:3000";
 
 export const shopConfig = {
   agent: {
-    enabled: false,
+    isEnabled: false,
   },
   analytics: {
     speedInsights: {
-      enabled: false,
+      isEnabled: false,
     },
     vercel: {
-      enabled: false,
+      isEnabled: false,
     },
   },
   auth: {
-    enabled: false,
+    isEnabled: false,
   },
   botid: {
     checkLevel: "basic",
-    enabled: false,
+    isEnabled: false,
   },
   pdp: {
     bundles: {
-      enabled: true,
+      isEnabled: true,
     },
     buyWithShop: {
-      enabled: true,
+      isEnabled: true,
     },
     complementaryProducts: {
-      enabled: true,
+      isEnabled: true,
     },
     quantityPicker: {
-      enabled: true,
+      isEnabled: true,
     },
     relatedProducts: {
-      enabled: true,
+      isEnabled: true,
     },
   },
   site: {

--- a/apps/template/lib/markdown/llms.ts
+++ b/apps/template/lib/markdown/llms.ts
@@ -1,5 +1,5 @@
-import type { Collection } from "@/lib/types";
 import { shopConfig } from "@/lib/config";
+import type { Collection } from "@/lib/types";
 
 import { escapeMarkdown } from "./utils";
 

--- a/apps/template/lib/shopify/customer-account.ts
+++ b/apps/template/lib/shopify/customer-account.ts
@@ -7,8 +7,8 @@ import {
   gql,
 } from "@shopify/hydrogen/customer-account";
 
-import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import { shopConfig } from "@/lib/config";
+import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 
 import { resolveShopId } from "./discovery";
 

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -1,5 +1,6 @@
 import { cacheLife, cacheTag } from "next/cache";
 
+import { shopConfig } from "@/lib/config";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import type {
   Filter,
@@ -10,7 +11,6 @@ import type {
   ProductVariant,
   SelectedOption,
 } from "@/lib/types";
-import { shopConfig } from "@/lib/config";
 
 import { assertStorefrontOk } from "../errors";
 import {
@@ -106,7 +106,7 @@ export async function getProduct({
   const language = getLanguageCode(locale);
 
   const response = await storefront.request<{ productByHandle: ShopifyProduct }>(
-    shopConfig.pdp.bundles.enabled
+    shopConfig.pdp.bundles.isEnabled
       ? GET_PRODUCT_BY_HANDLE_WITH_BUNDLES_QUERY
       : GET_PRODUCT_BY_HANDLE_QUERY,
     {
@@ -168,7 +168,7 @@ export async function getProductVariant({
   const response = await storefront.request<{
     productByHandle: { selectedOrFirstAvailableVariant: ShopifyVariant | null } | null;
   }>(
-    shopConfig.pdp.bundles.enabled
+    shopConfig.pdp.bundles.isEnabled
       ? GET_PRODUCT_VARIANT_WITH_BUNDLES_QUERY
       : GET_PRODUCT_VARIANT_QUERY,
     {

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -20,7 +20,7 @@ function assertRequiredEnv() {
     );
   }
 
-  if (shopConfig.auth.enabled) {
+  if (shopConfig.auth.isEnabled) {
     const missing = [
       "CUSTOMER_ACCOUNT_SESSION_SECRET",
       "SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID",
@@ -29,7 +29,7 @@ function assertRequiredEnv() {
     if (missing.length > 0) {
       throw new Error(
         `Enabled auth requires: ${missing.join(", ")}. ` +
-          `Set the missing variables or disable auth via auth.enabled in lib/config.ts.`,
+          `Set the missing variables or disable auth via auth.isEnabled in lib/config.ts.`,
       );
     }
   }
@@ -85,7 +85,7 @@ const withNextIntl = createNextIntlPlugin({
 
 const intlConfig = withNextIntl(nextConfig);
 
-const config = shopConfig.botid.enabled ? withBotId(intlConfig) : intlConfig;
+const config = shopConfig.botid.isEnabled ? withBotId(intlConfig) : intlConfig;
 
 function getConfig(phase: string): NextConfig {
   // `next typegen` shares PHASE_PRODUCTION_BUILD but runs before any .env exists (create-next-app), so exclude it.

--- a/apps/template/proxy.ts
+++ b/apps/template/proxy.ts
@@ -8,13 +8,13 @@ import {
 } from "@shopify/hydrogen/customer-account";
 import { NextResponse, type NextRequest } from "next/server";
 
-import { isAuthEnabled } from "@/lib/auth";
 import {
   createCustomerRequestContext,
   createCustomerSessionManager,
   getCustomerRequestOrigin,
   getHydrogenCustomerSession,
 } from "@/lib/auth/server";
+import { shopConfig } from "@/lib/config";
 import { createRequestStorefrontClient } from "@/lib/shopify/storefront";
 
 const AUTH_PATHS = new Set<string>([
@@ -28,7 +28,7 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   const requestContext = createCustomerRequestContext(request);
 
   // Only pay for Hydrogen session/route work on the customer-account OAuth paths.
-  if (isAuthEnabled && AUTH_PATHS.has(request.nextUrl.pathname)) {
+  if (shopConfig.auth.isEnabled && AUTH_PATHS.has(request.nextUrl.pathname)) {
     const shopifyRoute = await handleShopifyRoutes({
       handlers: [
         createCustomerAccountServerHandlers({

--- a/packages/plugin/skills/enable-analytics/SKILL.md
+++ b/packages/plugin/skills/enable-analytics/SKILL.md
@@ -32,8 +32,8 @@ If the storefront has `analytics` configuration in `lib/config.ts`, enable only 
 
 ```ts
 analytics: {
-  speedInsights: { enabled: false },
-  vercel: { enabled: false },
+  speedInsights: { isEnabled: false },
+  vercel: { isEnabled: false },
 },
 ```
 
@@ -101,8 +101,8 @@ export function AnalyticsComponents() {
 
   return (
     <>
-      {shopConfig.analytics.vercel.enabled ? <Analytics /> : null}
-      {shopConfig.analytics.speedInsights.enabled ? <SpeedInsights /> : null}
+      {shopConfig.analytics.vercel.isEnabled ? <Analytics /> : null}
+      {shopConfig.analytics.speedInsights.isEnabled ? <SpeedInsights /> : null}
       {gtmId ? <GoogleTagManager gtmId={gtmId} /> : null}
     </>
   );


### PR DESCRIPTION
## What

Renames every `shopConfig` feature flag from `enabled` to `isEnabled`, and removes the two static alias re-exports that pointed at the config.

## Why

- `isEnabled` makes the boolean intent explicit at every read site (`shopConfig.auth.isEnabled` reads more clearly than `shopConfig.auth.enabled`).
- `isAuthEnabled` (`lib/auth/index.ts`) and `isBotIdEnabled` (`lib/botid/index.ts`) were trivial one-line re-exports of the config value. Now that feature flags live in `lib/config.ts`, the indirection adds nothing — consumers read the config directly and `lib/auth/index.ts` is deleted.

## Changes

- `lib/config.ts` — interface and defaults: `enabled` → `isEnabled` across agent, analytics (vercel/speedInsights), auth, botid, and all PDP flags
- Removed `isAuthEnabled` and `isBotIdEnabled`; consumers in `app/`, `components/`, `lib/auth/server.ts`, `proxy.ts`, `instrumentation-client.ts`, `next.config.ts` now use `shopConfig.*.isEnabled`
- Docs updated: shop-config reference, agent/authentication/pdp/env-vars anatomy pages
- `enable-analytics` skill updated and synced into the docs app

## Verification

- Template: `pnpm lint` ✅ (0 errors), `pnpm format` ✅, `pnpm build` ✅
- Docs: `pnpm build` ✅