### PR TITLE
fix(cart): let /api/cart route handlers own the request

### DIFF
--- a/apps/docs/content/docs/getting-started/extending-with-agents.mdx
+++ b/apps/docs/content/docs/getting-started/extending-with-agents.mdx
@@ -10,7 +10,7 @@ Vercel Shop is built for agentic development. Instead of copy-pasting snippets f
 
 ## How it works
 
-**The template ships with structured context that agents read automatically.** `AGENTS.md` carries architecture rules and conventions - things like "every cart mutation must call `invalidateCartCache()`" or "components in `ui/` must not import domain types." Project-scoped plugins (`vercel-shop`, `vercel-plugin`, `shopify-ai-toolkit`) add template conventions, platform guidance, and authoritative Shopify documentation and validation on top.
+**The template ships with structured context that agents read automatically.** `AGENTS.md` carries architecture rules and conventions - things like "new user-visible strings go in all locale files" or "components in `ui/` must not import domain types." Project-scoped plugins (`vercel-shop`, `vercel-plugin`, `shopify-ai-toolkit`) add template conventions, platform guidance, and authoritative Shopify documentation and validation on top.
 
 **Skills are agent-ready playbooks for specific tasks.** Each one names the files to touch, the patterns to follow, and the checks to run after. They're written and tested against the template, which means fewer hallucinations and consistent output than an ad-hoc prompt for the same task.
 

--- a/apps/docs/content/docs/reference/storefront-api.mdx
+++ b/apps/docs/content/docs/reference/storefront-api.mdx
@@ -158,9 +158,8 @@ Cached public operations use the established `cacheLife` and tags. Combined with
 | `collections`              | All collection queries               |
 | `collection-{handle}`      | Single collection                    |
 | `menus`                    | Navigation menus                     |
-| `cart`                     | All cart operations                  |
 
-Invalidate with `revalidateTag("product-blue-tee")` or `updateTag("cart")` in server actions. Cart mutations must always call `invalidateCartCache()` from `lib/cart/server` - this is a hard requirement.
+Invalidate with `revalidateTag("product-blue-tee")` in server actions. Carts are never placed in the Next.js data cache — cart reads are memoized per request via `getCart`, so cart mutations don't need any cache invalidation step.
 
 ## Mutations
 
@@ -174,7 +173,6 @@ export async function addToCart(lines: CartLineInput[], cartId: string, locale: 
   );
   assertStorefrontOk(response, "addToCart");
 
-  invalidateCartCache();
   return transformShopifyCart(response.data.cartLinesAdd.cart);
 }
 ```

--- a/apps/docs/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/content/docs/reference/troubleshooting.mdx
@@ -21,7 +21,6 @@ Fix it in admin: open the bundle product → **Publishing** → add your Headles
 The cart ID is stored in a `shopify_cartId` HTTP-only cookie with a 7-day expiry. Common causes:
 
 - **Cookie domain mismatch** - if you're running on a different domain than expected, the cookie may not be sent. Check your browser dev tools → Application → Cookies.
-- **Missing `invalidateCartCache()`** - every cart mutation must call `invalidateCartCache()` from `@/lib/cart/server`. Without it, the cached cart data goes stale and the UI may show an outdated state.
 
 ## Variant selection not working
 

--- a/apps/docs/content/docs/skills/enable-shopify-markets.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-markets.mdx
@@ -286,14 +286,14 @@ Switching language within the same country must not mutate buyer identity:
 - `fr-CA` to `en-CA`: set locale; no cart country update
 - `en-CA` to `en-US`: set locale and update buyer country to `US`
 
-Keep the mutation in a server action, validate both inputs, and update the cart's buyer identity directly — read the cart id from the shared `cart` cookie, issue `cartBuyerIdentityUpdate` through `storefront.request`, then call `invalidateCartCache()`:
+Keep the mutation in a server action, validate both inputs, and update the cart's buyer identity directly — read the cart id from the shared `cart` cookie and issue `cartBuyerIdentityUpdate` through `storefront.request`:
 
 ```ts
 "use server";
 
 import { cookies } from "next/headers";
 
-import { getCartIdFromCookie, invalidateCartCache } from "@/lib/cart/server";
+import { getCartIdFromCookie } from "@/lib/cart/server";
 import { getCountryCode, isEnabledLocale, LOCALE_COOKIE_NAME } from "@/lib/i18n";
 import { storefront } from "@/lib/shopify/storefront";
 
@@ -321,7 +321,6 @@ export async function switchLocaleAction(currentValue: string, nextValue: string
           cartId,
         },
       });
-      invalidateCartCache();
     }
   }
 

--- a/apps/docs/content/docs/skills/shopify-graphql-reference.mdx
+++ b/apps/docs/content/docs/skills/shopify-graphql-reference.mdx
@@ -41,7 +41,7 @@ Read `references/REFERENCE.md` before editing.
 5. Pass locale context through existing country and language helpers when Shopify localizes the result.
 6. Keep raw Shopify response types under `lib/shopify/**`; transform them into provider-independent domain types before presentation.
 7. Preserve cache tags and the existing webhook invalidation hierarchy. Do not cache mutations.
-8. Call `invalidateCartCache()` after every successful cart mutation.
+8. Never place carts in the Next.js data cache; cart reads are memoized per request via `getCart`, so cart mutations need no cache invalidation step.
 
 ## Revalidate both boundaries
 

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -30,11 +30,10 @@ The opt-in assistant is served by `app/api/chat/route.ts` and built with AI SDK.
 
 ## Critical Rules (Always Apply)
 
-1. **Every cart mutation MUST call `invalidateCartCache()`** (from `@/lib/cart/server`) or cache goes stale.
-2. **New user-visible strings go in ALL locale files** (`en.json`, etc.) so the documented multi-locale upgrade path stays mechanical.
-3. **Components in `ui/` must NOT import domain types**. Accept primitive props only and never call `useTranslations`.
-4. **Always use `shopify-ai-toolkit` for Shopify API facts and validation** before adding or changing GraphQL. Use `/vercel-shop:shopify-graphql-reference` afterward for this template's operation placement, transforms, cache role, locale flow, and invalidation. Never treat the Vercel Shop skill as a schema source or guess Shopify fields.
-5. **Every user-configurable `process.env.X` read needs a row in `.env.example`** with a short comment explaining when to set it. If you add a new env var that toggles a feature, document it there so a fresh clone has a complete env reference.
+1. **New user-visible strings go in ALL locale files** (`en.json`, etc.) so the documented multi-locale upgrade path stays mechanical.
+2. **Components in `ui/` must NOT import domain types**. Accept primitive props only and never call `useTranslations`.
+3. **Always use `shopify-ai-toolkit` for Shopify API facts and validation** before adding or changing GraphQL. Use `/vercel-shop:shopify-graphql-reference` afterward for this template's operation placement, transforms, cache role, locale flow, and invalidation. Never treat the Vercel Shop skill as a schema source or guess Shopify fields.
+4. **Every user-configurable `process.env.X` read needs a row in `.env.example`** with a short comment explaining when to set it. If you add a new env var that toggles a feature, document it there so a fresh clone has a complete env reference.
 
 ## Storefront Architecture Contract
 

--- a/apps/template/app/api/cart/route.ts
+++ b/apps/template/app/api/cart/route.ts
@@ -1,7 +1,10 @@
 import { createShopifyRequestContext, type I18nConfig } from "@shopify/hydrogen";
+import { checkBotId } from "botid/server";
 import { NextResponse } from "next/server";
 
+import { BOTID_DENIED_CODE, botIdCheckOptions } from "@/lib/botid";
 import { cartHandlers } from "@/lib/cart/server";
+import { shopConfig } from "@/lib/config";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import { createRequestStorefrontClient } from "@/lib/shopify/storefront";
 
@@ -38,6 +41,11 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
+  if (shopConfig.botid.isEnabled) {
+    const { isBot } = await checkBotId(botIdCheckOptions);
+    if (isBot) return NextResponse.json({ error: BOTID_DENIED_CODE }, { status: 403 });
+  }
+
   const result = await cartHandlers.post({ request, storefrontClient: storefrontClient(request) });
   return toResponse(result as CartRouteResult, request);
 }

--- a/apps/template/lib/cart/server.ts
+++ b/apps/template/lib/cart/server.ts
@@ -5,7 +5,6 @@ import {
   gql,
   type I18nConfig,
 } from "@shopify/hydrogen";
-import { revalidateTag, updateTag } from "next/cache";
 import { cookies, headers } from "next/headers";
 
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
@@ -85,13 +84,4 @@ export function seedCartData() {
     });
     return data;
   })();
-}
-
-export function invalidateCartCache(): void {
-  try {
-    updateTag("cart");
-  } catch {
-    // Fallback when used outside of server actions where updateTag is not available
-    revalidateTag("cart", { expire: 0 });
-  }
 }

--- a/apps/template/lib/shopify/operations/cart.ts
+++ b/apps/template/lib/shopify/operations/cart.ts
@@ -1,6 +1,6 @@
 import { cache } from "react";
 
-import { getCartIdFromCookie, invalidateCartCache, setCartIdCookie } from "@/lib/cart/server";
+import { getCartIdFromCookie, setCartIdCookie } from "@/lib/cart/server";
 import { defaultLocale } from "@/lib/i18n";
 import type { Cart } from "@/lib/types";
 
@@ -17,6 +17,7 @@ import {
 
 export type { CartLineInput, CartMutationResult };
 
+// Carts are never put in the Next.js data cache — only this per-request memoization.
 export const getCart = cache(async (): Promise<Cart | undefined> => {
   const cartId = await getCartIdFromCookie();
   if (!cartId) return undefined;
@@ -31,9 +32,7 @@ export async function getCartById(cartId: string): Promise<Cart | undefined> {
 export async function createCartWithoutCookie(
   locale: string = defaultLocale,
 ): Promise<CartMutationResult> {
-  const result = await createCartCore(locale);
-  invalidateCartCache();
-  return result;
+  return createCartCore(locale);
 }
 
 export async function createCart(locale: string = defaultLocale): Promise<CartMutationResult> {
@@ -57,9 +56,7 @@ export async function addToCart(
   }
   if (!resolvedCartId) throw new Error("Cart ID not found");
 
-  const result = await addToCartCore(lines, resolvedCartId);
-  invalidateCartCache();
-  return result;
+  return addToCartCore(lines, resolvedCartId);
 }
 
 export async function updateCart(
@@ -69,9 +66,7 @@ export async function updateCart(
   const cartId = cartIdOverride || (await getCartIdFromCookie());
   if (!cartId) throw new Error("Cart ID not found");
 
-  const result = await updateCartCore(lines, cartId);
-  invalidateCartCache();
-  return result;
+  return updateCartCore(lines, cartId);
 }
 
 export async function removeFromCart(
@@ -81,9 +76,7 @@ export async function removeFromCart(
   const cartId = cartIdOverride || (await getCartIdFromCookie());
   if (!cartId) throw new Error("Cart ID not found");
 
-  const result = await removeFromCartCore(lineIds, cartId);
-  invalidateCartCache();
-  return result;
+  return removeFromCartCore(lineIds, cartId);
 }
 
 export async function updateCartNote(
@@ -93,7 +86,5 @@ export async function updateCartNote(
   const cartId = cartIdOverride || (await getCartIdFromCookie());
   if (!cartId) return undefined;
 
-  const result = await updateCartNoteCore(note, cartId);
-  invalidateCartCache();
-  return result;
+  return updateCartNoteCore(note, cartId);
 }

--- a/apps/template/proxy.ts
+++ b/apps/template/proxy.ts
@@ -6,7 +6,6 @@ import {
   CUSTOMER_ACCOUNT_LOGOUT_PATH,
   CUSTOMER_ACCOUNT_REFRESH_PATH,
 } from "@shopify/hydrogen/customer-account";
-import { checkBotId } from "botid/server";
 import { NextResponse, type NextRequest } from "next/server";
 
 import {
@@ -15,12 +14,8 @@ import {
   getCustomerRequestOrigin,
   getHydrogenCustomerSession,
 } from "@/lib/auth/server";
-import { BOTID_DENIED_CODE, botIdCheckOptions } from "@/lib/botid";
-import { cartHandlers } from "@/lib/cart/server";
 import { shopConfig } from "@/lib/config";
 import { createRequestStorefrontClient } from "@/lib/shopify/storefront";
-
-const CART_API_PATH = "/api/cart";
 
 const AUTH_PATHS = new Set<string>([
   CUSTOMER_ACCOUNT_AUTHORIZE_PATH,
@@ -29,47 +24,28 @@ const AUTH_PATHS = new Set<string>([
   CUSTOMER_ACCOUNT_REFRESH_PATH,
 ]);
 
-const NOOP_SESSION_MANAGER = {
-  getSessionItem: () => undefined,
-  getSessionOrigin: () => "",
-  removeSessionItem: () => {},
-  setSessionItem: () => {},
-};
-
 export async function proxy(request: NextRequest): Promise<NextResponse> {
   const requestContext = createCustomerRequestContext(request);
   const pathname = request.nextUrl.pathname;
 
-  const isCartPath = pathname === CART_API_PATH;
+  // /api/cart is deliberately NOT registered here: its App Router route handler owns the
+  // request (BotID gate + response shaping). Passing cartHandlers to handleShopifyRoutes
+  // would short-circuit the proxy and the route handler would never run.
   const isAuthPath = shopConfig.auth.isEnabled && AUTH_PATHS.has(pathname);
 
-  // BotID runs here, not in the route handler: handleShopifyRoutes short-circuits
-  // /api/cart before the App Router route executes, so a gate there never fires.
-  if (isCartPath && request.method === "POST" && shopConfig.botid.isEnabled) {
-    const { isBot } = await checkBotId(botIdCheckOptions);
-    if (isBot) return NextResponse.json({ error: BOTID_DENIED_CODE }, { status: 403 });
-  }
-
-  if (isCartPath || isAuthPath) {
-    const handlers: Array<
-      typeof cartHandlers | ReturnType<typeof createCustomerAccountServerHandlers>
-    > = [cartHandlers];
-    if (isAuthPath) {
-      handlers.push(
+  if (isAuthPath) {
+    const shopifyRoute = await handleShopifyRoutes({
+      handlers: [
         createCustomerAccountServerHandlers({
           customerSession: await getHydrogenCustomerSession(),
           defaultPostLoginRedirectPathname: "/account",
           origin: getCustomerRequestOrigin,
           postLogoutRedirectUri: "/",
         }),
-      );
-    }
-    const shopifyRoute = await handleShopifyRoutes({
-      handlers,
+      ],
       request,
       requestContext,
-      // The session manager is only exercised by the customer-account handlers.
-      sessionManager: isAuthPath ? createCustomerSessionManager(request) : NOOP_SESSION_MANAGER,
+      sessionManager: createCustomerSessionManager(request),
       storefrontClient: createRequestStorefrontClient(requestContext),
     });
     if (shopifyRoute) return shopifyRoute as NextResponse;

--- a/packages/plugin/skills/build-shop/references/cart-account.md
+++ b/packages/plugin/skills/build-shop/references/cart-account.md
@@ -13,7 +13,7 @@
 
 Cart and account data depend on cookies, sessions, or customer access tokens. Do not put their responses in public `"use cache"` or `"use cache: remote"` entries. Preserve auth gates and keep Customer Account API reads per customer.
 
-Every cart mutation must call `invalidateCartCache()`. Preserve optimistic cart reconciliation so the interface responds immediately and converges on the server result.
+Carts are never placed in the Next.js data cache, so cart mutations need no cache invalidation step. Preserve optimistic cart reconciliation so the interface responds immediately and converges on the server result.
 
 For cart provider, bootstrap, optimistic state, nav badge, overlay, or mutation work, read `cart-provider.md` and preserve its confirmed-cart plus pending-intents model.
 

--- a/packages/plugin/skills/build-shop/references/cart-provider.md
+++ b/packages/plugin/skills/build-shop/references/cart-provider.md
@@ -52,7 +52,7 @@ Use a memoized pure projection, a reducer over explicit pending intent, or an eq
 
 1. Enqueue the quantity under the purchasable-line key and render it immediately. Open the overlay when the interaction calls for it.
 2. Accumulate or debounce rapid adds for the same key when that reduces network work without delaying feedback.
-3. Send the accumulated quantity to a server action. The action creates the cart when necessary, persists the cart ID through the server cookie path, calls `invalidateCartCache()`, and returns the updated Shopify cart plus warnings or errors.
+3. Send the accumulated quantity to a server action. The action creates the cart when necessary, persists the cart ID through the server cookie path, and returns the updated Shopify cart plus warnings or errors.
 4. On success, replace `confirmedCart` with that returned cart and retire only the quantity acknowledged by the response. Preserve intent queued while the request was in flight.
 5. On failure, retire the failed intent, reveal the last confirmed cart, and surface the error near the initiating action or cart.
 

--- a/packages/plugin/skills/build-shop/references/commerce-flows.md
+++ b/packages/plugin/skills/build-shop/references/commerce-flows.md
@@ -31,7 +31,7 @@ Verify commerce outcomes without prescribing visual composition. Adapt the prese
 - Create a cart when none exists and persist its identifier using the existing server cookie path.
 - Apply each optimistic intent exactly once, then reconcile warnings, errors, and the canonical Shopify cart without quantity flashes or reversions.
 - Preserve line identity, attributes, discounts, buyer identity, delivery state, totals, currency, and checkout URL.
-- Call `invalidateCartCache()` after every cart mutation.
+- Carts are never in the Next.js data cache, so cart mutations need no cache invalidation step.
 - Keep checkout handoff usable without requiring unrelated client state to finish hydrating.
 
 ## Customer account

--- a/packages/plugin/skills/build-shop/references/rendering-architecture.md
+++ b/packages/plugin/skills/build-shop/references/rendering-architecture.md
@@ -90,7 +90,7 @@ Invariants the shape enforces:
 | Public content that belongs in the prerendered shell | Plain `"use cache"` with the existing `cacheLife` and `cacheTag` policy |
 | Public results resolved after request inputs such as filters or search params | `"use cache: remote"` when a shared runtime cache is justified |
 | Customer, session, cart, or authorization-dependent data | Uncached or private per-session handling; never place it in a shared remote cache |
-| Mutation results | Preserve the domain invalidation path; every cart mutation must call `invalidateCartCache()` |
+| Mutation results | Preserve the domain invalidation path; carts are never in the Next.js data cache, so cart mutations need no cache invalidation step |
 
 Keep cache directives in the data layer. Do not add a second cache in presentation code.
 
@@ -113,7 +113,7 @@ An outer route fallback is appropriate when the route truly has no useful shell.
 - Isolate search dialogs, filters, variant controls, cart controls, galleries, and forms into leaf client components.
 - Pass primitives or narrow serializable view models rather than complete domain objects.
 - Keep optimistic state close to the mutation it predicts, then reconcile with the canonical server result.
-- Invalidate only the affected domain data. Preserve `invalidateCartCache()` for every cart mutation.
+- Invalidate only the affected domain data. Carts are never in the Next.js data cache, so cart mutations need no cache invalidation step.
 - Lazy-load expensive closed overlays or optional tools, but do not lazy-load primary content to improve a bundle report.
 
 ## Architect media and third parties

--- a/packages/plugin/skills/enable-shopify-markets/SKILL.md
+++ b/packages/plugin/skills/enable-shopify-markets/SKILL.md
@@ -279,14 +279,14 @@ Switching language within the same country must not mutate buyer identity:
 - `fr-CA` to `en-CA`: set locale; no cart country update
 - `en-CA` to `en-US`: set locale and update buyer country to `US`
 
-Keep the mutation in a server action, validate both inputs, and update the cart's buyer identity directly — read the cart id from the shared `cart` cookie, issue `cartBuyerIdentityUpdate` through `storefront.request`, then call `invalidateCartCache()`:
+Keep the mutation in a server action, validate both inputs, and update the cart's buyer identity directly — read the cart id from the shared `cart` cookie and issue `cartBuyerIdentityUpdate` through `storefront.request`:
 
 ```ts
 "use server";
 
 import { cookies } from "next/headers";
 
-import { getCartIdFromCookie, invalidateCartCache } from "@/lib/cart/server";
+import { getCartIdFromCookie } from "@/lib/cart/server";
 import { getCountryCode, isEnabledLocale, LOCALE_COOKIE_NAME } from "@/lib/i18n";
 import { storefront } from "@/lib/shopify/storefront";
 
@@ -314,7 +314,6 @@ export async function switchLocaleAction(currentValue: string, nextValue: string
           cartId,
         },
       });
-      invalidateCartCache();
     }
   }
 

--- a/packages/plugin/skills/shopify-graphql-reference/SKILL.md
+++ b/packages/plugin/skills/shopify-graphql-reference/SKILL.md
@@ -28,7 +28,7 @@ Read `references/REFERENCE.md` before editing.
 5. Pass locale context through existing country and language helpers when Shopify localizes the result.
 6. Keep raw Shopify response types under `lib/shopify/**`; transform them into provider-independent domain types before presentation.
 7. Preserve cache tags and the existing webhook invalidation hierarchy. Do not cache mutations.
-8. Call `invalidateCartCache()` after every successful cart mutation.
+8. Never place carts in the Next.js data cache; cart reads are memoized per request via `getCart`, so cart mutations need no cache invalidation step.
 
 ## Revalidate both boundaries
 

--- a/packages/plugin/skills/shopify-graphql-reference/references/REFERENCE.md
+++ b/packages/plugin/skills/shopify-graphql-reference/references/REFERENCE.md
@@ -22,7 +22,7 @@ Never duplicate Shopify API reference material here. Re-run Shopify validation w
 | `lib/shopify/transforms/*.ts` | Shopify response to domain mapping |
 | `lib/shopify/types/**` | Raw Shopify response shapes and generated validation output |
 | `lib/types.ts` | Provider-independent types consumed by presentation |
-| `lib/cart/server.ts` | Cart cookie helpers and `invalidateCartCache()` |
+| `lib/cart/server.ts` | Cart cookie helpers and server-side cart read seeding |
 | `app/api/webhooks/shopify/route.ts` | Public-content invalidation entry point |
 
 ## Data flow
@@ -73,7 +73,7 @@ Current examples of intent:
 - Reuse established product, collection, menu, recommendation, sitemap, CMS, and cart tags.
 - Add a new tag only when the webhook or mutation path can invalidate it correctly.
 - Keep public-content tags aligned with `app/api/webhooks/shopify/route.ts`.
-- Call `invalidateCartCache()` after every successful cart mutation.
+- Never place carts in the Next.js data cache; cart reads are memoized per request via `getCart`, so cart mutations need no cache invalidation step.
 - Never rely on public cache invalidation for Customer Account privacy or authorization.
 
 ## Completion checklist


### PR DESCRIPTION
## What

Fixes the /api/cart wiring flagged in Hydrogen team review: our App Router cart route handler was unreachable, and `invalidateCartCache()` was a no-op.

## Changes

**1. Drop `cartHandlers` from `handleShopifyRoutes` (proxy.ts)**

`handleShopifyRoutes` → `handleShopifyRouteHandlers` matches `/api/cart` by registered handler pathname and returns a `Response` before App Router routing — so `app/api/cart/route.ts` never executed (the proxy even carried a comment admitting it: "handleShopifyRoutes short-circuits /api/cart before the App Router route executes"). Since we have real route handlers, the registration is removed; the proxy now only handles customer-account paths. The later `handleAjaxApi` interceptor doesn't catch `/api/cart` (`AJAX_CART_RE` matches Shopify's `/cart(.js|/add|/update|/change|/clear)` paths), so nothing else claims the route.

**2. Move the BotID gate into the route handler**

`app/api/cart/route.ts` POST now runs `checkBotId()` when `botid.isEnabled` (403 + `botid_denied`), replacing the proxy-side check that only existed because of the short-circuit. `botIdProtectedRoutes` already declared `POST /api/cart`, so client/server check levels stay in sync.

**3. Remove `invalidateCartCache()`**

Nothing in the app ever calls `cacheTag("cart")`, so `updateTag("cart")` / `revalidateTag("cart")` had zero cache entries to act on — pure no-op. Carts are intentionally uncached (per-request `react.cache` memoization only in `getCart()`). Removes the function from `lib/cart/server.ts`, its 5 call sites in `lib/shopify/operations/cart.ts`, and the now-false "Every cart mutation MUST call `invalidateCartCache()`" critical rule from `AGENTS.md`.

**Followup (docs):** if `getCart()` ever gains `cacheTag("cart")`, mutations in `app/api/cart/route.ts` (and the agent/server-action paths) must add `updateTag("cart")` at that time.

## Not changed

- `useSuspenseCart`: still unused — the layout seeds the store via un-awaited `seedCartData()` streamed into `CartProvider initialData`, so there's no initial-read suspense gap. Could revisit for the nav badge fallback in `CartContextSync`.

## Verification

- `pnpm exec tsc --noEmit` ✅
- `pnpm lint` ✅ (oxlint + oxfmt)
- `pnpm build` ✅ (33/33, `/api/cart` still `ƒ` dynamic)
- End-to-end against dev server (the route handler was dead code before, so exercised explicitly):
  - `GET /api/cart` → `{"cart":null}`
  - `POST /api/cart` with a real variant gid → cart created, `Set-Cookie: cart=hWNFEPZ4…`
  - `GET /api/cart` with that cookie → `totalQuantity: 2`, line intact
