### PR TITLE
fix(template): guard Hydrogen's randomUUID against the static shell

### DIFF
--- a/apps/template/lib/auth/server.ts
+++ b/apps/template/lib/auth/server.ts
@@ -8,6 +8,7 @@ import {
   type ReadonlyCustomerSessionManager,
   type WritableCustomerSessionManager,
 } from "@shopify/hydrogen/customer-account";
+import { io } from "next/cache";
 import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import { cache } from "react";
@@ -227,6 +228,8 @@ const getReadonlySessionManager = cache(async (): Promise<ReadonlyCustomerSessio
 });
 
 const getReadonlyRequestContext = cache(async (): Promise<ShopifyRequestContext> => {
+  // Hydrogen's createShopifyRequestContext calls crypto.randomUUID(); exclude it from the static shell.
+  await io();
   const requestHeaders = await headers();
   return createCustomerRequestContext(
     new Request(shopConfig.site.url, {

--- a/apps/template/lib/auth/server.ts
+++ b/apps/template/lib/auth/server.ts
@@ -228,7 +228,6 @@ const getReadonlySessionManager = cache(async (): Promise<ReadonlyCustomerSessio
 });
 
 const getReadonlyRequestContext = cache(async (): Promise<ShopifyRequestContext> => {
-  // Hydrogen's createShopifyRequestContext calls crypto.randomUUID(); exclude it from the static shell.
   await io();
   const requestHeaders = await headers();
   return createCustomerRequestContext(

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -76,7 +76,7 @@ export const shopConfig = {
     },
   },
   auth: {
-    isEnabled: false,
+    isEnabled: true,
   },
   botid: {
     checkLevel: "basic",

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -76,7 +76,7 @@ export const shopConfig = {
     },
   },
   auth: {
-    isEnabled: true,
+    isEnabled: false,
   },
   botid: {
     checkLevel: "basic",

--- a/apps/template/lib/shopify/storefront.ts
+++ b/apps/template/lib/shopify/storefront.ts
@@ -86,7 +86,6 @@ export const storefront = {
     const language =
       typeof variables?.language === "string" ? variables.language : getLanguageCode(defaultLocale);
 
-    // Hydrogen's createShopifyRequestContext calls crypto.randomUUID(); no-op inside "use cache".
     await io();
 
     // Brand runtime strings so Hydrogen does not infer `never` variables.

--- a/apps/template/lib/shopify/storefront.ts
+++ b/apps/template/lib/shopify/storefront.ts
@@ -6,6 +6,7 @@ import {
   type StorefrontClient,
   type StorefrontQueryString,
 } from "@shopify/hydrogen";
+import { io } from "next/cache";
 
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 
@@ -84,6 +85,9 @@ export const storefront = {
       typeof variables?.country === "string" ? variables.country : getCountryCode(defaultLocale);
     const language =
       typeof variables?.language === "string" ? variables.language : getLanguageCode(defaultLocale);
+
+    // Hydrogen's createShopifyRequestContext calls crypto.randomUUID(); no-op inside "use cache".
+    await io();
 
     // Brand runtime strings so Hydrogen does not infer `never` variables.
     const doc = query as StorefrontQueryString<T, Record<string, unknown>>;


### PR DESCRIPTION
## The problem

Hydrogen's `createShopifyRequestContext` mints three UUIDs when the corresponding request headers and cookies are absent — `@shopify/hydrogen/dist/core/headers.mjs`:

```js
requestGroupId: request.headers.get("Custom-Storefront-Request-Group-ID")
  ?? request.headers.get("x-request-id")
  ?? request.headers.get("request-id")
  ?? crypto.randomUUID(),
...
context.uniqueToken = legacyUniqueToken ?? headerUniqueToken ?? crypto.randomUUID();
context.visitToken  = legacyVisitToken  ?? headerVisitToken  ?? crypto.randomUUID();
```

Each is a fallback: a real request carrying those headers or the `_shopify_y` / `_shopify_s` cookies never mints a UUID. But during a **prerender** there are no headers and no cookies, so all three fall through to `crypto.randomUUID()`.

Under Cache Components that's an IO violation, and Next is right to reject it — the value would be baked into static HTML and then differ for every real visitor.

## The fix

Two call sites reach that constructor outside a `"use cache"` scope:

1. **`storefront.request()`** via `getClient()` (`lib/shopify/storefront.ts`) — every uncached Storefront read funnels through here. **This is the one that actually reproduced**, on `/search` and `/collections/all`, both of which read `searchParams` and so are legitimately request-time.
2. **`getReadonlyRequestContext()`** (`lib/auth/server.ts`) — the nav's read-only session check. Same latent bug; this is the path that surfaces on `demo/enterprise`, where auth is enabled.

Both now `await io()` before touching Hydrogen, matching the precedent already in `lib/cart/server.ts:75` and `lib/shopify/operations/cart.ts:29`, which carry the same one-line comment.

`io()` is a no-op inside `"use cache"` scopes, during requests, and in the browser — so cached reads still bake into the static shell, and only the genuinely per-request paths opt out. `next/dist/docs/.../io.md` names `crypto.randomUUID()` explicitly as the case for it.

**Net diff is 2 files, +7/−0.** `auth.isEnabled` was temporarily flipped on in the first commit to exercise the auth path, then restored to `false` in the follow-up, so it cancels out — a fresh clone still builds without the Customer Account env vars.

## Verification

Controlled A/B on `/search` and `/collections/all`, the two routes that reproduce:

| State | `randomUUID` prerender errors |
| --- | --- |
| Auth **on**, no fixes | **2** |
| Auth **on**, auth fix only | **2** |
| Auth **on**, both fixes | **0** |
| Auth **off**, no storefront fix | **2** |
| Auth **off**, both fixes (shipped state) | **0** |

Two rows carry the weight. *Auth on, auth fix only* still fails — proving `storefront.request()` is the decisive call site, not the auth path. *Auth off, no storefront fix* also fails — proving the fix is load-bearing in the shipped default configuration, not something masked by disabling auth.

Also checked in the shipped state (auth off, both fixes):

- `pnpm lint` (oxlint + oxfmt) — pass, 0 warnings / 0 errors
- `pnpm exec next build` with `CUSTOMER_ACCOUNT_SESSION_SECRET` and `SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID` **unset** — pass, TypeScript clean, 33/33 static pages
- Six routes (`/`, `/search`, `/collections`, `/collections/all`, a PDP, `/cart`) all return 200 with **zero** `randomUUID` errors
- **No caching regression** — `/search` and `/collections/all` still build as partial prerenders (`◐`), not forced dynamic
- **No data regression** — 40 product links on `/search`, 40 on `/collections/all`, 8 on `/`
