### PR TITLE
fix(cli): resolve the Windows skills junction against the link directory

### DIFF
--- a/.changeset/inline-skills-at-scaffold.md
+++ b/.changeset/inline-skills-at-scaffold.md
@@ -1,0 +1,5 @@
+---
+'create-vercel-shop': minor
+---
+
+Inline agent skills at scaffold time instead of shelling out to `npx plugins add`. The CLI already downloads the full repo tarball, so it now extracts `packages/plugin/skills` into `.agents/skills/` (with per-skill Claude Code symlinks in `.claude/skills/`, falling back to copies where symlinks are unavailable) and `packages/plugin/commands` into `.claude/commands/` from the same single fetch. This removes the three post-install `npx plugins add` subprocesses — which ran even after a failed dependency install — and makes the skills versioned with the scaffolded project. `--no-template` now inlines only the agent assets into an existing project and fails cleanly if the download fails. The optional companion plugins (`vercel/vercel-plugin`, `Shopify/shopify-ai-toolkit`) are no longer auto-installed; the CLI prints the install commands instead.

--- a/.changeset/refuse-non-empty-scaffold-target.md
+++ b/.changeset/refuse-non-empty-scaffold-target.md
@@ -1,0 +1,5 @@
+---
+'create-vercel-shop': minor
+---
+
+Refuse to scaffold the template into a directory that already contains files. Previously the CLI created the target with `mkdir({ recursive: true })` and copied the template straight in, so pointing it at an existing project silently overwrote same-named files before `install` and `git init` ran. The CLI now inspects the target first: an empty or missing directory proceeds as before, a non-empty one asks for confirmation on a TTY (defaulting to no) and exits with code 1 in non-interactive environments such as CI or a coding agent. Pass the new `--force` flag to scaffold into a non-empty directory anyway. `--no-template` is unaffected — adding agent assets to an existing project is its purpose. A target path that exists but is not a directory now reports a clear error instead of crashing.

--- a/.changeset/windows-skill-junction-target.md
+++ b/.changeset/windows-skill-junction-target.md
@@ -1,0 +1,5 @@
+---
+'create-vercel-shop': patch
+---
+
+Point the `.claude/skills/<name>` link at the right place on Windows. The link was created with a relative target (`../../.agents/skills/<name>`), but Node resolves a relative target for a junction against `process.cwd()` instead of the link's own directory — so scaffolding from anywhere other than the project's parent produced a junction aimed at a path that does not exist, without raising an error. The target is now resolved against the link's directory on Windows; POSIX symlinks stay relative so a scaffolded project remains movable.

--- a/apps/cli/index.mjs
+++ b/apps/cli/index.mjs
@@ -1,8 +1,18 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 import { realpathSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { get } from 'node:https';
+import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { pathToFileURL } from 'node:url';
@@ -12,6 +22,8 @@ export const DEFAULT_PROJECT_NAME = 'my-shop';
 export const TEMPLATE_TARBALL_URL =
   'https://codeload.github.com/vercel/shop/tar.gz/refs/heads/main';
 export const TEMPLATE_TARBALL_PREFIX = 'shop-main/apps/template';
+export const SKILLS_TARBALL_PREFIX = 'shop-main/packages/plugin/skills';
+export const COMMANDS_TARBALL_PREFIX = 'shop-main/packages/plugin/commands';
 
 const PACKAGE_MANAGER_FLAGS = {
   '--use-bun': 'bun',
@@ -20,12 +32,6 @@ const PACKAGE_MANAGER_FLAGS = {
   '--use-yarn': 'yarn',
 };
 const INTERNAL_FLAGS = new Set([NO_TEMPLATE_FLAG, ...Object.keys(PACKAGE_MANAGER_FLAGS)]);
-
-const pluginInstalls = [
-  ['vercel/shop', '--scope', 'project', '--yes'],
-  ['vercel/vercel-plugin', '--scope', 'project', '--yes'],
-  ['Shopify/shopify-ai-toolkit', '--scope', 'project', '--yes'],
-];
 
 export function explicitPackageManager(args) {
   for (const arg of args) {
@@ -134,28 +140,84 @@ function fetchResponse(url, depth = 0) {
   });
 }
 
+export async function inlineAgentAssets(projectDir, stagingDir) {
+  const skillsSrc = join(stagingDir, SKILLS_TARBALL_PREFIX);
+  const commandsSrc = join(stagingDir, COMMANDS_TARBALL_PREFIX);
+
+  const agentSkillsDir = join(projectDir, '.agents', 'skills');
+  const claudeSkillsDir = join(projectDir, '.claude', 'skills');
+  const claudeCommandsDir = join(projectDir, '.claude', 'commands');
+
+  await mkdir(agentSkillsDir, { recursive: true });
+  await mkdir(claudeSkillsDir, { recursive: true });
+  await mkdir(claudeCommandsDir, { recursive: true });
+
+  const skillNames = (await readdir(skillsSrc, { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+
+  for (const name of skillNames) {
+    const canonical = join(agentSkillsDir, name);
+    await rm(canonical, { force: true, recursive: true });
+    await cp(join(skillsSrc, name), canonical, { recursive: true });
+
+    // Claude Code discovers project skills in .claude/skills. Link to the
+    // canonical .agents/skills copy (same layout `npx skills add` produces);
+    // fall back to a copy where symlinks are unavailable (e.g. Windows
+    // without Developer Mode).
+    const link = join(claudeSkillsDir, name);
+    await rm(link, { force: true, recursive: true });
+    try {
+      await symlink(join('..', '..', '.agents', 'skills', name), link, 'junction');
+    } catch {
+      await cp(join(skillsSrc, name), link, { recursive: true });
+    }
+  }
+
+  await cp(commandsSrc, claudeCommandsDir, { recursive: true });
+
+  return skillNames;
+}
+
 export async function fetchTemplate(
   projectDir,
-  { url = TEMPLATE_TARBALL_URL, prefix = TEMPLATE_TARBALL_PREFIX } = {},
+  {
+    includeTemplate = true,
+    prefix = TEMPLATE_TARBALL_PREFIX,
+    url = TEMPLATE_TARBALL_URL,
+  } = {},
 ) {
-  const stripComponents = prefix.split('/').length;
-  const tar = spawn(
-    'tar',
-    ['-xz', `--strip-components=${stripComponents}`, '-C', projectDir, prefix],
-    { stdio: ['pipe', 'inherit', 'inherit'] },
-  );
+  const stagingDir = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
 
-  const tarClosed = new Promise((resolveTar, rejectTar) => {
-    tar.on('error', rejectTar);
-    tar.on('close', (code) => {
-      if (code === 0) resolveTar();
-      else rejectTar(new Error(`tar exited with code ${code}`));
+  try {
+    const extractPaths = [SKILLS_TARBALL_PREFIX, COMMANDS_TARBALL_PREFIX];
+    if (includeTemplate) extractPaths.unshift(prefix);
+
+    const tar = spawn('tar', ['-xz', '-C', stagingDir, ...extractPaths], {
+      stdio: ['pipe', 'inherit', 'inherit'],
     });
-  });
 
-  const response = await fetchResponse(url);
-  response.pipe(tar.stdin);
-  await tarClosed;
+    const tarClosed = new Promise((resolveTar, rejectTar) => {
+      tar.on('error', rejectTar);
+      tar.on('close', (code) => {
+        if (code === 0) resolveTar();
+        else rejectTar(new Error(`tar exited with code ${code}`));
+      });
+    });
+
+    const response = await fetchResponse(url);
+    response.pipe(tar.stdin);
+    await tarClosed;
+
+    if (includeTemplate) {
+      await cp(join(stagingDir, prefix), projectDir, { recursive: true });
+    }
+
+    await inlineAgentAssets(projectDir, stagingDir);
+  } finally {
+    await rm(stagingDir, { force: true, recursive: true });
+  }
 }
 
 export async function ensureProjectDir(projectDir) {
@@ -186,33 +248,13 @@ export function initGit(projectDir, run = runCommand) {
   return run('git', ['init', '--quiet'], { cwd: projectDir });
 }
 
-export async function installProjectPlugins(projectDir, run = runCommand) {
-  const failures = [];
-
-  for (const args of pluginInstalls) {
-    const code = await run('npx', ['plugins', 'add', ...args], {
-      cwd: projectDir,
-    });
-
-    if (code !== 0) {
-      failures.push(args[0]);
-    }
-  }
-
-  return failures;
-}
-
-export function printRetryCommands(projectDir, { scaffolded = true } = {}) {
-  if (scaffolded) {
-    console.warn('\nVercel Shop scaffolded successfully, but one or more plugin installs failed.');
-  } else {
-    console.warn('\nProject plugin installation failed.');
-  }
-
-  console.warn(`Retry from ${projectDir}:`);
-  console.warn('  npx plugins add vercel/shop --scope project --yes');
-  console.warn('  npx plugins add vercel/vercel-plugin --scope project --yes');
-  console.warn('  npx plugins add Shopify/shopify-ai-toolkit --scope project --yes');
+export function printAgentSetupSummary() {
+  console.log(
+    '\nAgent skills installed to .agents/skills (Claude Code links in .claude/skills, commands in .claude/commands).',
+  );
+  console.log('\nRecommended companion plugins (optional, run from the project root):');
+  console.log('  npx plugins add vercel/vercel-plugin --scope project --yes');
+  console.log('  npx plugins add Shopify/shopify-ai-toolkit --scope project --yes');
 }
 
 export async function main({
@@ -243,39 +285,45 @@ export async function main({
 
   await ensureProjectDir(projectDir);
 
-  if (!plan.noTemplate) {
+  if (plan.noTemplate) {
     try {
-      await scaffold(projectDir);
+      await scaffold(projectDir, { includeTemplate: false });
     } catch (error) {
-      console.error('\nFailed to download the Vercel Shop template.');
+      console.error('\nFailed to download the Vercel Shop agent skills.');
       console.error(error instanceof Error ? error.message : String(error));
       return 1;
     }
 
-    try {
-      const templateVersion = await readTemplateVersion(importMetaUrl);
-      await writeBootstrapMetadata(projectDir, templateVersion);
-    } catch (error) {
-      console.warn('\nScaffold completed, but bootstrap metadata could not be written.');
-      console.warn(error instanceof Error ? error.message : String(error));
-    }
-
-    const installCode = await installDependencies(projectDir, plan.packageManager, run);
-    if (installCode !== 0) {
-      console.warn(
-        `\n${plan.packageManager} install failed. Re-run it from ${projectDir} once resolved.`,
-      );
-    }
-
-    await initGit(projectDir, run);
+    printAgentSetupSummary();
+    return 0;
   }
 
-  const failedPlugins = await installProjectPlugins(projectDir, run);
-
-  if (failedPlugins.length > 0) {
-    printRetryCommands(projectDir, { scaffolded: !plan.noTemplate });
+  try {
+    await scaffold(projectDir);
+  } catch (error) {
+    console.error('\nFailed to download the Vercel Shop template.');
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
   }
 
+  try {
+    const templateVersion = await readTemplateVersion(importMetaUrl);
+    await writeBootstrapMetadata(projectDir, templateVersion);
+  } catch (error) {
+    console.warn('\nScaffold completed, but bootstrap metadata could not be written.');
+    console.warn(error instanceof Error ? error.message : String(error));
+  }
+
+  const installCode = await installDependencies(projectDir, plan.packageManager, run);
+  if (installCode !== 0) {
+    console.warn(
+      `\n${plan.packageManager} install failed. Re-run it from ${projectDir} once resolved.`,
+    );
+  }
+
+  await initGit(projectDir, run);
+
+  printAgentSetupSummary();
   return 0;
 }
 

--- a/apps/cli/index.mjs
+++ b/apps/cli/index.mjs
@@ -18,6 +18,7 @@ import { createInterface } from 'node:readline/promises';
 import { pathToFileURL } from 'node:url';
 
 export const NO_TEMPLATE_FLAG = '--no-template';
+export const FORCE_FLAG = '--force';
 export const DEFAULT_PROJECT_NAME = 'my-shop';
 export const TEMPLATE_TARBALL_URL =
   'https://codeload.github.com/vercel/shop/tar.gz/refs/heads/main';
@@ -31,7 +32,11 @@ const PACKAGE_MANAGER_FLAGS = {
   '--use-pnpm': 'pnpm',
   '--use-yarn': 'yarn',
 };
-const INTERNAL_FLAGS = new Set([NO_TEMPLATE_FLAG, ...Object.keys(PACKAGE_MANAGER_FLAGS)]);
+const INTERNAL_FLAGS = new Set([
+  FORCE_FLAG,
+  NO_TEMPLATE_FLAG,
+  ...Object.keys(PACKAGE_MANAGER_FLAGS),
+]);
 
 export function explicitPackageManager(args) {
   for (const arg of args) {
@@ -75,12 +80,30 @@ export async function promptProjectName({
   }
 }
 
+export async function promptOverwrite({
+  entries = [],
+  input = process.stdin,
+  output = process.stdout,
+  projectDir,
+} = {}) {
+  const rl = createInterface({ input, output });
+  try {
+    const answer = await rl.question(
+      `${projectDir} already contains ${describeEntries(entries)}. Scaffolding may overwrite existing files. Continue? (y/N) `,
+    );
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
+}
+
 export function createExecutionPlan({
   cliArgs,
   cwd = process.cwd(),
   execPath = process.env.npm_execpath ?? '',
   userAgent = process.env.npm_config_user_agent ?? '',
 } = {}) {
+  const force = cliArgs.includes(FORCE_FLAG);
   const noTemplate = cliArgs.includes(NO_TEMPLATE_FLAG);
   const packageManager =
     explicitPackageManager(cliArgs) ??
@@ -90,7 +113,7 @@ export function createExecutionPlan({
     cliArgs.filter((arg) => !INTERNAL_FLAGS.has(arg)),
   );
 
-  return { cwd, noTemplate, packageManager, positionalName };
+  return { cwd, force, noTemplate, packageManager, positionalName };
 }
 
 export async function readTemplateVersion(importMetaUrl = import.meta.url) {
@@ -220,6 +243,25 @@ export async function fetchTemplate(
   }
 }
 
+// Missing target is the happy path — it becomes an empty directory below.
+// Anything else (a file at that path, EACCES, …) is surfaced to the caller so
+// the CLI stops instead of copying the template on top of it.
+export async function readTargetEntries(projectDir) {
+  try {
+    return await readdir(projectDir);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+function describeEntries(entries) {
+  const shown = [...entries].sort().slice(0, 5);
+  const remaining = entries.length - shown.length;
+  const listed = shown.join(', ');
+  return remaining > 0 ? `${listed}, and ${remaining} more` : listed;
+}
+
 export async function ensureProjectDir(projectDir) {
   await mkdir(projectDir, { recursive: true });
 }
@@ -259,6 +301,7 @@ export function printAgentSetupSummary() {
 
 export async function main({
   cliArgs = process.argv.slice(2),
+  confirmOverwrite = promptOverwrite,
   cwd = process.cwd(),
   execPath = process.env.npm_execpath ?? '',
   importMetaUrl = import.meta.url,
@@ -282,6 +325,41 @@ export async function main({
   }
 
   const projectDir = projectName ? resolve(plan.cwd, projectName) : plan.cwd;
+
+  // A full scaffold copies the template over whatever is already there, so it
+  // has to run against an empty (or newly created) directory. `--no-template`
+  // is exempt: it only adds agent assets, and existing projects are its whole
+  // point.
+  if (!plan.noTemplate) {
+    let entries;
+    try {
+      entries = await readTargetEntries(projectDir);
+    } catch (error) {
+      console.error(`\nCannot scaffold into ${projectDir}.`);
+      console.error(error instanceof Error ? error.message : String(error));
+      return 1;
+    }
+
+    if (entries.length > 0) {
+      if (plan.force) {
+        console.warn(
+          `\nScaffolding into non-empty ${projectDir} because ${FORCE_FLAG} was passed. Existing files may be overwritten.`,
+        );
+      } else if (!isTTY) {
+        console.error(`\n${projectDir} is not empty (${describeEntries(entries)}).`);
+        console.error(
+          `Scaffolding would overwrite files that are already there. Pick an empty target directory, or pass ${FORCE_FLAG} to scaffold into this one anyway.`,
+        );
+        return 1;
+      } else {
+        const proceed = await confirmOverwrite({ entries, projectDir });
+        if (!proceed) {
+          console.error('\nAborted. No files were written.');
+          return 1;
+        }
+      }
+    }
+  }
 
   await ensureProjectDir(projectDir);
 

--- a/apps/cli/index.mjs
+++ b/apps/cli/index.mjs
@@ -13,7 +13,7 @@ import {
 } from 'node:fs/promises';
 import { get } from 'node:https';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { pathToFileURL } from 'node:url';
 
@@ -163,6 +163,19 @@ function fetchResponse(url, depth = 0) {
   });
 }
 
+// Target for the .claude/skills/<name> link pointing at .agents/skills/<name>.
+//
+// POSIX symlinks resolve against the link's own directory, so a relative target
+// keeps the scaffolded project movable. Windows junctions are always absolute,
+// and Node resolves a relative target against `process.cwd()` rather than the
+// link's directory — running the CLI from anywhere but the project's parent
+// produced a junction pointing at a path that does not exist, with no error.
+// Resolve it against the link's directory instead.
+export function skillLinkTarget(link, canonical, platform = process.platform) {
+  const relativeTarget = relative(dirname(link), canonical);
+  return platform === 'win32' ? resolve(dirname(link), relativeTarget) : relativeTarget;
+}
+
 export async function inlineAgentAssets(projectDir, stagingDir) {
   const skillsSrc = join(stagingDir, SKILLS_TARBALL_PREFIX);
   const commandsSrc = join(stagingDir, COMMANDS_TARBALL_PREFIX);
@@ -192,7 +205,7 @@ export async function inlineAgentAssets(projectDir, stagingDir) {
     const link = join(claudeSkillsDir, name);
     await rm(link, { force: true, recursive: true });
     try {
-      await symlink(join('..', '..', '.agents', 'skills', name), link, 'junction');
+      await symlink(skillLinkTarget(link, canonical), link, 'junction');
     } catch {
       await cp(join(skillsSrc, name), link, { recursive: true });
     }

--- a/apps/cli/index.test.mjs
+++ b/apps/cli/index.test.mjs
@@ -1,13 +1,16 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
 import {
+  COMMANDS_TARBALL_PREFIX,
   createExecutionPlan,
+  inlineAgentAssets,
   main,
   readTemplateVersion,
+  SKILLS_TARBALL_PREFIX,
 } from './index.mjs';
 
 test('createExecutionPlan parses --no-template and an explicit package manager', () => {
@@ -45,11 +48,39 @@ test('createExecutionPlan falls back to npm when nothing is detected', () => {
   assert.equal(plan.positionalName, null);
 });
 
-test('main skips scaffolding and only installs plugins with --no-template', async () => {
+test('main only inlines agent assets with --no-template and runs no subprocesses', async () => {
   const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
   const projectDir = join(tempRoot, 'existing-project');
   const calls = [];
-  let scaffoldCalls = 0;
+  const scaffoldCalls = [];
+
+  try {
+    const exitCode = await main({
+      cliArgs: ['--no-template', projectDir],
+      cwd: tempRoot,
+      run: async (command, args, options = {}) => {
+        calls.push({ args, command, options });
+        return 0;
+      },
+      scaffold: async (dir, options) => {
+        scaffoldCalls.push({ dir, options });
+      },
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(scaffoldCalls, [
+      { dir: projectDir, options: { includeTemplate: false } },
+    ]);
+    assert.equal(calls.length, 0);
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('main returns 1 when the --no-template asset download fails', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const projectDir = join(tempRoot, 'existing-project');
+  const calls = [];
 
   try {
     const exitCode = await main({
@@ -60,16 +91,12 @@ test('main skips scaffolding and only installs plugins with --no-template', asyn
         return 0;
       },
       scaffold: async () => {
-        scaffoldCalls += 1;
+        throw new Error('download failed');
       },
     });
 
-    assert.equal(exitCode, 0);
-    assert.equal(scaffoldCalls, 0);
-    assert.equal(calls.length, 3);
-    assert.ok(calls.every(({ command }) => command === 'npx'));
-    assert.ok(calls.every(({ args }) => args[0] === 'plugins' && args[1] === 'add'));
-    assert.ok(calls.every(({ options }) => options.cwd === projectDir));
+    assert.equal(exitCode, 1);
+    assert.equal(calls.length, 0);
   } finally {
     await rm(tempRoot, { force: true, recursive: true });
   }
@@ -104,10 +131,11 @@ test('main prompts for a project name when none is given and stdin is a TTY', as
     assert.equal(exitCode, 0);
     assert.equal(promptCalls, 1);
     assert.deepEqual(scaffoldDirs, [projectDir]);
-
-    const pluginCalls = calls.filter(({ args }) => args[0] === 'plugins');
-    assert.equal(pluginCalls.length, 3);
-    assert.ok(pluginCalls.every(({ options }) => options.cwd === projectDir));
+    assert.deepEqual(
+      calls.map(({ command }) => command),
+      ['npm', 'git'],
+    );
+    assert.ok(calls.every(({ options }) => options.cwd === projectDir));
   } finally {
     await rm(tempRoot, { force: true, recursive: true });
   }
@@ -174,15 +202,74 @@ test('main scaffolds, installs deps, inits git, and writes bootstrap metadata', 
     assert.deepEqual(gitCall.args, ['init', '--quiet']);
     assert.equal(gitCall.options.cwd, projectDir);
 
-    const pluginCalls = calls.filter(({ args }) => args[0] === 'plugins');
-    assert.equal(pluginCalls.length, 3);
-    assert.ok(pluginCalls.every(({ options }) => options.cwd === projectDir));
+    assert.equal(
+      calls.filter(({ command }) => command === 'npx').length,
+      0,
+      'expected no npx subprocesses',
+    );
 
     const bootstrapMetadata = JSON.parse(
       await readFile(join(projectDir, '.vercel-shop', 'bootstrap.json'), 'utf8'),
     );
     assert.equal(bootstrapMetadata.templateVersion, await readTemplateVersion());
     assert.ok(Number.isFinite(Date.parse(bootstrapMetadata.scaffoldedAt)));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('inlineAgentAssets copies skills to .agents/skills, links .claude/skills, and copies commands', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const stagingDir = join(tempRoot, 'staging');
+  const projectDir = join(tempRoot, 'project');
+
+  try {
+    const skillsSrc = join(stagingDir, SKILLS_TARBALL_PREFIX);
+    const commandsSrc = join(stagingDir, COMMANDS_TARBALL_PREFIX);
+    await mkdir(join(skillsSrc, 'enable-analytics'), { recursive: true });
+    await writeFile(
+      join(skillsSrc, 'enable-analytics', 'SKILL.md'),
+      '# enable-analytics\n',
+      'utf8',
+    );
+    await mkdir(join(skillsSrc, 'build-shop', 'references'), { recursive: true });
+    await writeFile(join(skillsSrc, 'build-shop', 'SKILL.md'), '# build-shop\n', 'utf8');
+    await writeFile(join(skillsSrc, 'build-shop', 'references', 'a.md'), 'ref\n', 'utf8');
+    await mkdir(commandsSrc, { recursive: true });
+    await writeFile(join(commandsSrc, 'vercel-shop-bootstrap.md'), '# bootstrap\n', 'utf8');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillNames = await inlineAgentAssets(projectDir, stagingDir);
+
+    assert.deepEqual(skillNames, ['build-shop', 'enable-analytics']);
+
+    assert.equal(
+      await readFile(join(projectDir, '.agents', 'skills', 'build-shop', 'SKILL.md'), 'utf8'),
+      '# build-shop\n',
+    );
+    assert.equal(
+      await readFile(
+        join(projectDir, '.agents', 'skills', 'build-shop', 'references', 'a.md'),
+        'utf8',
+      ),
+      'ref\n',
+    );
+
+    // .claude/skills entries resolve to the same content (symlink or copy fallback).
+    const claudeSkill = join(projectDir, '.claude', 'skills', 'enable-analytics');
+    assert.equal(await readFile(join(claudeSkill, 'SKILL.md'), 'utf8'), '# enable-analytics\n');
+    const stats = await lstat(claudeSkill);
+    if (stats.isSymbolicLink()) {
+      assert.equal(
+        await realpath(claudeSkill),
+        await realpath(join(projectDir, '.agents', 'skills', 'enable-analytics')),
+      );
+    }
+
+    assert.equal(
+      await readFile(join(projectDir, '.claude', 'commands', 'vercel-shop-bootstrap.md'), 'utf8'),
+      '# bootstrap\n',
+    );
   } finally {
     await rm(tempRoot, { force: true, recursive: true });
   }

--- a/apps/cli/index.test.mjs
+++ b/apps/cli/index.test.mjs
@@ -1,7 +1,16 @@
 import assert from 'node:assert/strict';
-import { lstat, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  realpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import test from 'node:test';
 
 import {
@@ -12,6 +21,7 @@ import {
   main,
   readTargetEntries,
   readTemplateVersion,
+  skillLinkTarget,
   SKILLS_TARBALL_PREFIX,
 } from './index.mjs';
 
@@ -526,5 +536,78 @@ test('inlineAgentAssets copies skills to .agents/skills, links .claude/skills, a
     );
   } finally {
     await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('skillLinkTarget keeps the POSIX link target relative to the link', () => {
+  const projectDir = join(tmpdir(), 'project');
+  const link = join(projectDir, '.claude', 'skills', 'build-shop');
+  const canonical = join(projectDir, '.agents', 'skills', 'build-shop');
+
+  assert.equal(
+    skillLinkTarget(link, canonical, 'linux'),
+    join('..', '..', '.agents', 'skills', 'build-shop'),
+  );
+});
+
+test('skillLinkTarget resolves the Windows junction target against the link directory', () => {
+  const projectDir = join(tmpdir(), 'project');
+  const link = join(projectDir, '.claude', 'skills', 'build-shop');
+  const canonical = join(projectDir, '.agents', 'skills', 'build-shop');
+
+  const target = skillLinkTarget(link, canonical, 'win32');
+
+  // Node resolves a relative junction target against process.cwd(), so it has to
+  // be absolute — otherwise the junction silently points outside the project.
+  assert.ok(isAbsolute(target), `expected an absolute junction target, got ${target}`);
+  assert.equal(target, canonical);
+});
+
+test('inlineAgentAssets links .claude/skills to .agents/skills from an unrelated cwd', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const unrelatedCwd = await mkdtemp(join(tmpdir(), 'create-vercel-shop-cwd-'));
+  const originalCwd = process.cwd();
+
+  try {
+    const stagingDir = join(tempRoot, 'staging');
+    const projectDir = join(tempRoot, 'project');
+    const skillsSrc = join(stagingDir, SKILLS_TARBALL_PREFIX);
+    const commandsSrc = join(stagingDir, COMMANDS_TARBALL_PREFIX);
+    await mkdir(join(skillsSrc, 'enable-analytics'), { recursive: true });
+    await writeFile(
+      join(skillsSrc, 'enable-analytics', 'SKILL.md'),
+      '# enable-analytics\n',
+      'utf8',
+    );
+    await mkdir(commandsSrc, { recursive: true });
+    await writeFile(join(commandsSrc, 'vercel-shop-bootstrap.md'), '# bootstrap\n', 'utf8');
+    await mkdir(projectDir, { recursive: true });
+
+    // The CLI is normally run from somewhere other than the project's parent —
+    // the link target must not depend on the working directory.
+    process.chdir(unrelatedCwd);
+    await inlineAgentAssets(projectDir, stagingDir);
+    process.chdir(originalCwd);
+
+    const claudeSkill = join(projectDir, '.claude', 'skills', 'enable-analytics');
+    const canonical = join(projectDir, '.agents', 'skills', 'enable-analytics');
+
+    assert.equal(await readFile(join(claudeSkill, 'SKILL.md'), 'utf8'), '# enable-analytics\n');
+
+    const stats = await lstat(claudeSkill);
+    if (stats.isSymbolicLink()) {
+      assert.equal(await realpath(claudeSkill), await realpath(canonical));
+
+      const target = await readlink(claudeSkill);
+      assert.equal(
+        await realpath(resolve(dirname(claudeSkill), target)),
+        await realpath(canonical),
+        'link target must resolve to the canonical skill from the link directory',
+      );
+    }
+  } finally {
+    process.chdir(originalCwd);
+    await rm(tempRoot, { force: true, recursive: true });
+    await rm(unrelatedCwd, { force: true, recursive: true });
   }
 });

--- a/apps/cli/index.test.mjs
+++ b/apps/cli/index.test.mjs
@@ -7,8 +7,10 @@ import test from 'node:test';
 import {
   COMMANDS_TARBALL_PREFIX,
   createExecutionPlan,
+  FORCE_FLAG,
   inlineAgentAssets,
   main,
+  readTargetEntries,
   readTemplateVersion,
   SKILLS_TARBALL_PREFIX,
 } from './index.mjs';
@@ -34,6 +36,22 @@ test('createExecutionPlan finds the positional project name and ignores internal
   assert.equal(plan.positionalName, 'my-store');
   assert.equal(plan.noTemplate, true);
   assert.equal(plan.packageManager, 'bun');
+});
+
+test('createExecutionPlan parses --force without treating it as the project name', () => {
+  const plan = createExecutionPlan({
+    cliArgs: [FORCE_FLAG, 'my-store'],
+    cwd: '/tmp/workspace',
+  });
+
+  assert.equal(plan.force, true);
+  assert.equal(plan.positionalName, 'my-store');
+});
+
+test('createExecutionPlan defaults force to false', () => {
+  const plan = createExecutionPlan({ cliArgs: ['my-store'], cwd: '/tmp/workspace' });
+
+  assert.equal(plan.force, false);
 });
 
 test('createExecutionPlan falls back to npm when nothing is detected', () => {
@@ -213,6 +231,242 @@ test('main scaffolds, installs deps, inits git, and writes bootstrap metadata', 
     );
     assert.equal(bootstrapMetadata.templateVersion, await readTemplateVersion());
     assert.ok(Number.isFinite(Date.parse(bootstrapMetadata.scaffoldedAt)));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('readTargetEntries reports an absent directory as empty', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+
+  try {
+    assert.deepEqual(await readTargetEntries(join(tempRoot, 'nope')), []);
+    assert.deepEqual(await readTargetEntries(tempRoot), []);
+
+    await writeFile(join(tempRoot, 'file.txt'), 'hi\n', 'utf8');
+    assert.deepEqual(await readTargetEntries(tempRoot), ['file.txt']);
+
+    await assert.rejects(() => readTargetEntries(join(tempRoot, 'file.txt')));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('main refuses to scaffold into a non-empty directory when not a TTY', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const projectDir = join(tempRoot, 'existing-project');
+  const existingFile = join(projectDir, 'package.json');
+  const calls = [];
+  const scaffoldDirs = [];
+
+  try {
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(existingFile, '{ "name": "mine" }\n', 'utf8');
+
+    const exitCode = await main({
+      cliArgs: ['existing-project'],
+      confirmOverwrite: async () => {
+        throw new Error('should not prompt without a TTY');
+      },
+      cwd: tempRoot,
+      isTTY: false,
+      run: async (command, args, options = {}) => {
+        calls.push({ args, command, options });
+        return 0;
+      },
+      scaffold: async (dir) => {
+        scaffoldDirs.push(dir);
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(scaffoldDirs, [], 'expected no scaffold into a non-empty directory');
+    assert.deepEqual(calls, [], 'expected no install or git subprocesses');
+    assert.equal(await readFile(existingFile, 'utf8'), '{ "name": "mine" }\n');
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('main treats a directory holding only dotfiles as non-empty', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const projectDir = join(tempRoot, 'existing-project');
+  const scaffoldDirs = [];
+
+  try {
+    await mkdir(join(projectDir, '.git'), { recursive: true });
+
+    const exitCode = await main({
+      cliArgs: ['existing-project'],
+      cwd: tempRoot,
+      isTTY: false,
+      run: async () => 0,
+      scaffold: async (dir) => {
+        scaffoldDirs.push(dir);
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(scaffoldDirs, []);
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('main scaffolds into an existing but empty directory without confirmation', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const projectDir = join(tempRoot, 'existing-project');
+  const scaffoldDirs = [];
+
+  try {
+    await mkdir(projectDir, { recursive: true });
+
+    const exitCode = await main({
+      cliArgs: ['existing-project'],
+      confirmOverwrite: async () => {
+        throw new Error('should not prompt for an empty directory');
+      },
+      cwd: tempRoot,
+      isTTY: true,
+      run: async () => 0,
+      scaffold: async (dir) => {
+        scaffoldDirs.push(dir);
+      },
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(scaffoldDirs, [projectDir]);
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('main aborts a non-empty scaffold when the TTY confirmation is declined', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const projectDir = join(tempRoot, 'existing-project');
+  const confirmCalls = [];
+  const scaffoldDirs = [];
+  const calls = [];
+
+  try {
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(join(projectDir, 'package.json'), '{}\n', 'utf8');
+
+    const exitCode = await main({
+      cliArgs: ['existing-project'],
+      confirmOverwrite: async (options) => {
+        confirmCalls.push(options);
+        return false;
+      },
+      cwd: tempRoot,
+      isTTY: true,
+      run: async (command, args, options = {}) => {
+        calls.push({ args, command, options });
+        return 0;
+      },
+      scaffold: async (dir) => {
+        scaffoldDirs.push(dir);
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.equal(confirmCalls.length, 1);
+    assert.equal(confirmCalls[0].projectDir, projectDir);
+    assert.deepEqual(confirmCalls[0].entries, ['package.json']);
+    assert.deepEqual(scaffoldDirs, []);
+    assert.deepEqual(calls, []);
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('main scaffolds a non-empty directory when the TTY confirmation is accepted', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const projectDir = join(tempRoot, 'existing-project');
+  const scaffoldDirs = [];
+  let confirmCalls = 0;
+
+  try {
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(join(projectDir, 'package.json'), '{}\n', 'utf8');
+
+    const exitCode = await main({
+      cliArgs: ['existing-project'],
+      confirmOverwrite: async () => {
+        confirmCalls += 1;
+        return true;
+      },
+      cwd: tempRoot,
+      isTTY: true,
+      run: async () => 0,
+      scaffold: async (dir) => {
+        scaffoldDirs.push(dir);
+      },
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(confirmCalls, 1);
+    assert.deepEqual(scaffoldDirs, [projectDir]);
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('main scaffolds a non-empty directory with --force and never prompts', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const projectDir = join(tempRoot, 'existing-project');
+  const scaffoldDirs = [];
+
+  try {
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(join(projectDir, 'package.json'), '{}\n', 'utf8');
+
+    const exitCode = await main({
+      cliArgs: ['existing-project', FORCE_FLAG],
+      confirmOverwrite: async () => {
+        throw new Error('should not prompt with --force');
+      },
+      cwd: tempRoot,
+      isTTY: true,
+      run: async () => 0,
+      scaffold: async (dir) => {
+        scaffoldDirs.push(dir);
+      },
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(scaffoldDirs, [projectDir]);
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('main allows --no-template against a non-empty existing project', async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'create-vercel-shop-'));
+  const projectDir = join(tempRoot, 'existing-project');
+  const scaffoldCalls = [];
+
+  try {
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(join(projectDir, 'package.json'), '{}\n', 'utf8');
+
+    const exitCode = await main({
+      cliArgs: ['--no-template', 'existing-project'],
+      confirmOverwrite: async () => {
+        throw new Error('should not prompt for --no-template');
+      },
+      cwd: tempRoot,
+      isTTY: false,
+      run: async () => 0,
+      scaffold: async (dir, options) => {
+        scaffoldCalls.push({ dir, options });
+      },
+    });
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(scaffoldCalls, [
+      { dir: projectDir, options: { includeTemplate: false } },
+    ]);
   } finally {
     await rm(tempRoot, { force: true, recursive: true });
   }

--- a/apps/docs/content/docs/anatomy/navigation.mdx
+++ b/apps/docs/content/docs/anatomy/navigation.mdx
@@ -4,7 +4,7 @@ description: The storefront navigation system - navbar, quick links, mobile bott
 type: guide
 ---
 
-The navigation system is split into a sticky top navbar for desktop and a fixed bottom bar for mobile. By default, navigation links are hardcoded. Use [`/vercel-shop:enable-shopify-menus`](/docs/skills/enable-shopify-menus) to fetch menus from Shopify.
+The navigation system is split into a sticky top navbar for desktop and a fixed bottom bar for mobile. By default, navigation links are hardcoded. Use the [`enable-shopify-menus` skill](/docs/skills/enable-shopify-menus) to fetch menus from Shopify.
 
 ## How it works
 

--- a/apps/docs/content/docs/getting-started/extending-with-agents.mdx
+++ b/apps/docs/content/docs/getting-started/extending-with-agents.mdx
@@ -10,35 +10,39 @@ Vercel Shop is built for agentic development. Instead of copy-pasting snippets f
 
 ## How it works
 
-**The template ships with structured context that agents read automatically.** `AGENTS.md` carries architecture rules and conventions - things like "new user-visible strings go in all locale files" or "components in `ui/` must not import domain types." Project-scoped plugins (`vercel-shop`, `vercel-plugin`, `shopify-ai-toolkit`) add template conventions, platform guidance, and authoritative Shopify documentation and validation on top.
+**The template ships with structured context that agents read automatically.** `AGENTS.md` carries architecture rules and conventions - things like "new user-visible strings go in all locale files" or "components in `ui/` must not import domain types." Storefront skills are inlined into the project at `.agents/skills/`, and optional project-scoped plugins (`vercel-plugin`, `shopify-ai-toolkit`) add platform guidance and authoritative Shopify documentation and validation on top.
 
 **Skills are agent-ready playbooks for specific tasks.** Each one names the files to touch, the patterns to follow, and the checks to run after. They're written and tested against the template, which means fewer hallucinations and consistent output than an ad-hoc prompt for the same task.
 
-**Not every agent integrates equally.** For best results, use an agent that reads `AGENTS.md` and supports skills and project-scoped plugins - for example [Claude Code](https://claude.ai/code), [Cursor](https://cursor.sh), or [Codex](https://openai.com/index/introducing-codex/). Claude Code has the deepest integration via the plugin install flow; Cursor and Codex lean more on the repo context and docs.
+**Not every agent integrates equally.** For best results, use an agent that reads `AGENTS.md` and supports skills - for example [Claude Code](https://claude.ai/code), [Cursor](https://cursor.sh), or [Codex](https://openai.com/index/introducing-codex/). Claude Code additionally picks up the inlined slash commands and supports the optional companion plugins; Cursor and Codex lean more on the repo context and docs.
 
 ## Setting up
 
-After [creating your project](/docs/getting-started), `create-vercel-shop` installs the project plugins:
+When you [create your project](/docs/getting-started), `create-vercel-shop` inlines the storefront skills directly into the project:
 
-- `vercel-shop` for initialization and storefront skills plus drift and upgrade-planning commands
-- `vercel-plugin` for generic Vercel and Next.js guidance
-- `shopify-ai-toolkit` for current Shopify documentation, schemas, operation validation, and store execution
+- `.agents/skills/` holds the skills (initialization, storefront extensions, drift and upgrade planning) - versioned with your repo
+- `.claude/skills/` links to them so Claude Code discovers them automatically
+- `.claude/commands/` carries the `vercel-shop-*` slash commands
 
-If you already have a project and only want the agent setup:
+Because the skills are ordinary files in your project, there is no plugin install step that can fail, and they travel with the repo for every collaborator.
+
+If you already have a project (or the skills are missing), run this from the project root:
 
 ```bash
 npx create-vercel-shop@latest --no-template
 ```
 
-If any plugins are missing, rerun:
+Two optional companion plugins are recommended for agents that support them:
+
+- `vercel-plugin` for generic Vercel and Next.js guidance
+- `shopify-ai-toolkit` for current Shopify documentation, schemas, operation validation, and store execution
 
 ```bash
-npx plugins add vercel/shop --scope project --yes
 npx plugins add vercel/vercel-plugin --scope project --yes
 npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 ```
 
-For upgrade work, use the [`update-shop` skill](/docs/skills/update-shop). The `vercel-shop` plugin carries a template rollout log so agents can reason about change-level updates instead of guessing from a single scaffold version. New scaffolds record bootstrap metadata so agents can compare rollout entries against when a project was created.
+For upgrade work, use the [`update-shop` skill](/docs/skills/update-shop). It fetches the upstream template rollout log so agents can reason about change-level updates instead of guessing from a single scaffold version. New scaffolds record bootstrap metadata so agents can compare rollout entries against when a project was created.
 
 To initialize a storefront from an agent, use the `init-vercel-shop` skill and provide an explicit target directory. The skill delegates filesystem changes to `create-vercel-shop`, verifies the generated project, and can use Shopify CLI to connect an existing store or fall back to the Headless channel.
 
@@ -69,16 +73,16 @@ Everything outside these markers is yours. Add team conventions or domain constr
 
 ## Skills
 
-To run a storefront skill in Claude Code:
+In Claude Code, ask for the task or invoke the skill by name:
 
 ```bash
-/vercel-shop:enable-shopify-markets
+/enable-shopify-markets
 ```
 
 For a new project:
 
 ```bash
-/vercel-shop:init-vercel-shop
+/init-vercel-shop
 ```
 
 In Cursor or Codex, describe the task and reference the matching skill doc when helpful:

--- a/apps/docs/content/docs/reference/storefront-api.mdx
+++ b/apps/docs/content/docs/reference/storefront-api.mdx
@@ -72,7 +72,7 @@ Output lands in `lib/shopify/types/generated/`, which is **gitignored**. Nothing
 
 Because codegen resolves interpolations of other `#graphql` consts by name, every fragment in `lib/shopify/fragments.ts` is also tagged `#graphql ... as const`. A raw selection snippet that isn't a valid standalone document (it can't be `#graphql`-tagged) must be inlined into each operation rather than interpolated.
 
-Always use Shopify AI Toolkit to search current Shopify documentation and validate the final operation. Then use [`/vercel-shop:shopify-graphql-reference`](/docs/skills/shopify-graphql-reference) for Vercel Shop integration conventions. The Vercel Shop skill is not a schema source.
+Always use Shopify AI Toolkit to search current Shopify documentation and validate the final operation. Then use the [`shopify-graphql-reference` skill](/docs/skills/shopify-graphql-reference) for Vercel Shop integration conventions. The Vercel Shop skill is not a schema source.
 
 ## Fragments
 

--- a/apps/docs/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/content/docs/reference/troubleshooting.mdx
@@ -60,25 +60,24 @@ To get near-instant updates, set up Shopify webhooks pointed at `/api/webhooks/s
 
 ## Locale or currency not changing
 
-Multi-locale commerce requires Shopify Markets to be enabled. The template ships as single-locale by default. Run [`/vercel-shop:enable-shopify-markets`](/docs/skills/enable-shopify-markets) to add regional locale routing and propagate Shopify's localized country, language, and currency context. The skill supports locale-prefixed, invisible cookie-based, and per-domain routing.
+Multi-locale commerce requires Shopify Markets to be enabled. The template ships as single-locale by default. Run the [`enable-shopify-markets` skill](/docs/skills/enable-shopify-markets) to add regional locale routing and propagate Shopify's localized country, language, and currency context. The skill supports locale-prefixed, invisible cookie-based, and per-domain routing.
 
 ## Agent can't find context files
 
-Coding agents rely on `AGENTS.md` in the project root plus the expected project-scoped plugins. If an agent is missing context or commands:
+Coding agents rely on `AGENTS.md` in the project root plus the inlined storefront skills. If an agent is missing context or skills:
 
 - Verify you cloned from the correct template (`vercel/shop`, `apps/template` path)
 - The `AGENTS.md` file should be at the project root, not nested in a subdirectory
-- Check that `.claude/settings.json` exists and that the project plugins are enabled
-- Rerun the project plugin setup from the project root if needed:
+- Check that `.agents/skills/` exists and that `.claude/skills/` links to it (Claude Code also reads slash commands from `.claude/commands/`)
+- Restore the inlined skills from the project root if needed:
 
 ```bash
 npx create-vercel-shop@latest --no-template
 ```
 
-If that still fails, rerun the plugin installs individually:
+For the optional companion plugins, install them individually:
 
 ```bash
-npx plugins add vercel/shop --scope project --yes
 npx plugins add vercel/vercel-plugin --scope project --yes
 npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 ```

--- a/apps/docs/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/content/docs/reference/troubleshooting.mdx
@@ -62,6 +62,24 @@ To get near-instant updates, set up Shopify webhooks pointed at `/api/webhooks/s
 
 Multi-locale commerce requires Shopify Markets to be enabled. The template ships as single-locale by default. Run the [`enable-shopify-markets` skill](/docs/skills/enable-shopify-markets) to add regional locale routing and propagate Shopify's localized country, language, and currency context. The skill supports locale-prefixed, invisible cookie-based, and per-domain routing.
 
+## Scaffold stops with "is not empty"
+
+`create-vercel-shop` copies the template over the target directory, so it refuses to run against a directory that already contains files rather than overwriting them. On a terminal it asks for confirmation first; in CI or from a coding agent it exits with code 1.
+
+Scaffold into a new or empty directory:
+
+```bash
+npx create-vercel-shop@latest my-store
+```
+
+If you meant to write into the existing directory, opt in explicitly:
+
+```bash
+npx create-vercel-shop@latest my-store --force
+```
+
+To add only the agent skills to a project you already have, use `--no-template` instead — it never overwrites application code.
+
 ## Agent can't find context files
 
 Coding agents rely on `AGENTS.md` in the project root plus the inlined storefront skills. If an agent is missing context or skills:

--- a/apps/docs/content/docs/shopify/index.mdx
+++ b/apps/docs/content/docs/shopify/index.mdx
@@ -30,5 +30,5 @@ The template connects to Shopify through the Storefront API. This page is an ori
 
 ## Common customizations
 
-- **Shopify-powered menus** — run [`/vercel-shop:enable-shopify-menus`](/docs/skills/enable-shopify-menus) to fetch `main-menu` and `footer` menus from Shopify instead of the hardcoded defaults.
+- **Shopify-powered menus** — run the [`enable-shopify-menus` skill](/docs/skills/enable-shopify-menus) to fetch `main-menu` and `footer` menus from Shopify instead of the hardcoded defaults.
 - **Near-instant cache invalidation** — configure Shopify webhooks pointed at `/api/webhooks/shopify` so Admin edits invalidate cache tags immediately. See [Webhooks](/docs/anatomy/webhooks) for the endpoint, supported topics, and setup steps.

--- a/apps/docs/content/docs/skills/build-shop.mdx
+++ b/apps/docs/content/docs/skills/build-shop.mdx
@@ -7,7 +7,7 @@ type: guide
 ## How to use
 
 ```bash
-/vercel-shop:build-shop
+/build-shop
 ```
 
 The skill includes source-backed references for the shared rendering architecture, home pages, collection and search pages, product pages, cart-provider bootstrap and reconciliation, and account pages.
@@ -72,7 +72,7 @@ For each layer's full ownership boundary, see the responsibility table in `refer
 
 Use the installed Shopify AI Toolkit for Shopify API documentation, schema facts, operation design, and validation. Invoke its API-specific skill before adding or changing Storefront or Customer Account GraphQL. For metafields or metaobjects, use its custom-data skill first.
 
-Use `/vercel-shop:shopify-graphql-reference` only after Shopify validation to apply Vercel Shop conventions: operation placement, domain transforms, cache role, locale flow, invalidation, and route integration. Never treat this architecture skill as a substitute for authoritative Shopify validation.
+Use the `shopify-graphql-reference` skill only after Shopify validation to apply Vercel Shop conventions: operation placement, domain transforms, cache role, locale flow, invalidation, and route integration. Never treat this architecture skill as a substitute for authoritative Shopify validation.
 
 ## Prevent blocking
 

--- a/apps/docs/content/docs/skills/enable-analytics.mdx
+++ b/apps/docs/content/docs/skills/enable-analytics.mdx
@@ -7,7 +7,7 @@ type: guide
 ## How to use
 
 ```bash
-/vercel-shop:enable-analytics
+/enable-analytics
 ```
 
 <div className="pb-6" />

--- a/apps/docs/content/docs/skills/enable-i18n.mdx
+++ b/apps/docs/content/docs/skills/enable-i18n.mdx
@@ -7,7 +7,7 @@ type: guide
 ## How to use
 
 ```bash
-/vercel-shop:enable-i18n
+/enable-i18n
 ```
 
 <div className="pb-6" />

--- a/apps/docs/content/docs/skills/enable-shopify-markets.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-markets.mdx
@@ -7,7 +7,7 @@ type: guide
 ## How to use
 
 ```bash
-/vercel-shop:enable-shopify-markets
+/enable-shopify-markets
 ```
 
 <div className="pb-6" />

--- a/apps/docs/content/docs/skills/enable-shopify-menus.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-menus.mdx
@@ -7,7 +7,7 @@ type: guide
 ## How to use
 
 ```bash
-/vercel-shop:enable-shopify-menus
+/enable-shopify-menus
 ```
 
 <div className="pb-6" />

--- a/apps/docs/content/docs/skills/shopify-graphql-reference.mdx
+++ b/apps/docs/content/docs/skills/shopify-graphql-reference.mdx
@@ -9,7 +9,7 @@ type: guide
 Use Shopify AI Toolkit's API-specific skill first, then run:
 
 ```bash
-/vercel-shop:shopify-graphql-reference
+/shopify-graphql-reference
 ```
 
 <div className="pb-6" />

--- a/apps/docs/content/docs/skills/update-shop.mdx
+++ b/apps/docs/content/docs/skills/update-shop.mdx
@@ -7,7 +7,7 @@ type: guide
 ## How to use
 
 ```bash
-/vercel-shop:update-shop
+/update-shop
 ```
 
 The skill audits how far a storefront has drifted from the current template, plans an upgrade from the template rollout log entry by entry, and — when asked to apply — carries selected changes into the project with per-entry validation, recording decisions so future runs stay incremental.
@@ -58,8 +58,7 @@ Compare the scaffold metadata against the current recommended template version a
 
 - missing `.vercel-shop/bootstrap.json`
 - missing `AGENTS.md`
-- missing project-scoped plugin config in `.claude/settings.json`
-- legacy local skill files such as `.agents/skills/` or a legacy `.claude/skills` symlink
+- missing inlined agent skills in `.agents/skills/` (current scaffolds inline them there, with Claude Code links in `.claude/skills/`; older scaffolds used the `vercel-shop` plugin via `.claude/settings.json` instead — either layout counts as present)
 - obvious divergence from the expected Vercel Shop structure such as missing `lib/shopify/` or `components/`
 
 Report the original scaffold version, the scaffold timestamp, the current recommended template version, and a short note on overall drift. If the scaffold version matches the current version, say so explicitly. In audit mode, stop here.

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -2,17 +2,21 @@
 
 This file provides guidance for agents working in the template.
 
-## Recommended Project Plugins
+## Agent Skills & Recommended Plugins
+
+Storefront skills ship inlined with the project in `.agents/skills/` (Claude Code discovers them via `.claude/skills/`, with commands in `.claude/commands/`). They are versioned with your repo — no plugin install is required for them. If they are missing (e.g. the project was cloned instead of scaffolded), restore them from the project root with:
+
+```bash
+npx create-vercel-shop@latest --no-template
+```
 
 These project-scoped plugins are not required to run the template, but they make agent work in this codebase substantially better. If you're working with an agent that supports them, install with:
 
 ```bash
-npx plugins add vercel/shop --scope project --yes
 npx plugins add vercel/vercel-plugin --scope project --yes
 npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 ```
 
-- `vercel-shop` provides storefront-specific skills and commands such as `/vercel-shop:enable-shopify-markets`.
 - `vercel-plugin` provides generic Vercel and Next.js skills.
 - `shopify-ai-toolkit` is authoritative for current Shopify documentation, API schemas, operation validation, and store execution.
 
@@ -32,7 +36,7 @@ The opt-in assistant is served by `app/api/chat/route.ts` and built with AI SDK.
 
 1. **New user-visible strings go in ALL locale files** (`en.json`, etc.) so the documented multi-locale upgrade path stays mechanical.
 2. **Components in `ui/` must NOT import domain types**. Accept primitive props only and never call `useTranslations`.
-3. **Always use `shopify-ai-toolkit` for Shopify API facts and validation** before adding or changing GraphQL. Use `/vercel-shop:shopify-graphql-reference` afterward for this template's operation placement, transforms, cache role, locale flow, and invalidation. Never treat the Vercel Shop skill as a schema source or guess Shopify fields.
+3. **Always use `shopify-ai-toolkit` for Shopify API facts and validation** before adding or changing GraphQL. Use the `shopify-graphql-reference` skill afterward for this template's operation placement, transforms, cache role, locale flow, and invalidation. Never treat the Vercel Shop skill as a schema source or guess Shopify fields.
 4. **Every user-configurable `process.env.X` read needs a row in `.env.example`** with a short comment explaining when to set it. If you add a new env var that toggles a feature, document it there so a fresh clone has a complete env reference.
 
 ## Storefront Architecture Contract
@@ -46,7 +50,7 @@ The opt-in assistant is served by `app/api/chat/route.ts` and built with AI SDK.
 - Use `next/image` with reserved dimensions and truthful `sizes`. Preload only the actual LCP image; keep product grids lazy by default.
 - Treat prefetching as a production-measured traffic-versus-latency choice, especially for high-fanout product grids.
 
-Use `/vercel-shop:build-shop` when the project plugin is installed for the full route-specific workflow and audit guidance.
+Use the `build-shop` skill for the full route-specific workflow and audit guidance.
 
 <!-- BEGIN:vercel-shop-style -->
 
@@ -182,17 +186,17 @@ pnpm format
 Request → Page → Operation → storefront.request → Shopify API → Transform → Domain type → Component
 ```
 
-## Storefront Skills (Optional Plugin)
+## Storefront Skills (Inlined)
 
-If the `vercel-shop` plugin is installed (see "Recommended Project Plugins" above), agents have access to slash commands that walk through common storefront extensions:
+The skills in `.agents/skills/` walk through common storefront extensions:
 
-- Integrating Shopify-validated GraphQL into the template: `/vercel-shop:shopify-graphql-reference`
-- Shopify Markets and multi-locale support: `/vercel-shop:enable-shopify-markets`
-- Locale-prefixed routing + i18n (no Markets): `/vercel-shop:enable-i18n`
-- Navigation menus: `/vercel-shop:enable-shopify-menus`
-- Analytics: `/vercel-shop:enable-analytics`
-- Storefront architecture, commerce behavior, and rendering performance: `/vercel-shop:build-shop`
-- Keeping the storefront current with template changes: `/vercel-shop:update-shop`
+- Integrating Shopify-validated GraphQL into the template: `shopify-graphql-reference`
+- Shopify Markets and multi-locale support: `enable-shopify-markets`
+- Locale-prefixed routing + i18n (no Markets): `enable-i18n`
+- Navigation menus: `enable-shopify-menus`
+- Analytics: `enable-analytics`
+- Storefront architecture, commerce behavior, and rendering performance: `build-shop`
+- Keeping the storefront current with template changes: `update-shop`
 
 These are agent-side conveniences. The template runs and deploys without them.
 
@@ -216,14 +220,14 @@ The nav reserves a fixed `size-5` icon container to avoid layout shift. The `(au
 
 - Use the API-specific Shopify AI Toolkit skill first: Storefront GraphQL for catalog/cart/public storefront operations, Customer for authenticated customer data, and custom-data first for metafields or metaobjects.
 - Let Shopify AI Toolkit search current documentation and validate the complete operation. If it is unavailable, use official Shopify documentation and validation tooling; never guess.
-- Use `/vercel-shop:shopify-graphql-reference` afterward for template-specific operation placement, fragments, locale flow, cache role, transforms, invalidation, and route composition.
+- Use the `shopify-graphql-reference` skill afterward for template-specific operation placement, fragments, locale flow, cache role, transforms, invalidation, and route composition.
 - Do not add repo-local schema snapshots or agent-specific folders to the template.
 
 ## Key Patterns
 
 - Routes live under `app/` and use clean URLs like `/products/handle`.
 - `getLocale()` resolves the active deployment locale; the template defaults to `en-US`.
-- Multi-locale URL routing is documented in `/vercel-shop:enable-i18n` and is intentionally not enabled by default.
+- Multi-locale URL routing is documented in the `enable-i18n` skill and is intentionally not enabled by default.
 - Components import domain types from `@/lib/types`, not Shopify response types.
 - Prefer Tailwind data-attribute selectors over conditional class assembly.
 - Follow the `ui/` → `product/` wrapper pattern when adding reusable product UI.

--- a/apps/template/README.md
+++ b/apps/template/README.md
@@ -16,16 +16,17 @@ Vercel prompts for the two required Shopify credentials before the first deploym
 npx create-vercel-shop@latest my-store
 ```
 
-The scaffold also installs these project-scoped agent plugins:
-
-- `vercel-shop`
-- `vercel-plugin`
-- `shopify-ai-toolkit`
-
-To install only the agent plugins into an existing project, run this from that project's root:
+The scaffold also inlines the Vercel Shop agent skills into `.agents/skills/` (with Claude Code links in `.claude/skills/` and commands in `.claude/commands/`), so they are versioned with your project. To add only the agent skills to an existing project, run this from that project's root:
 
 ```sh
 npx create-vercel-shop@latest --no-template
+```
+
+Two optional companion plugins are recommended for agents that support them:
+
+```sh
+npx plugins add vercel/vercel-plugin --scope project --yes
+npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 ```
 
 2. In Shopify admin, create a storefront token in **Settings → Apps and sales channels → Headless**, enable the required Storefront API permissions, then add your Shopify credentials:
@@ -63,7 +64,7 @@ See [vercel.shop/docs/getting-started](https://vercel.shop/docs/getting-started)
 
 ## Skills
 
-Vercel Shop includes a `vercel-shop` plugin with skills for extending the storefront with common commerce patterns. In Claude Code, these are exposed as `/vercel-shop:<skill>` commands:
+Vercel Shop inlines agent skills for extending the storefront with common commerce patterns. They live in `.agents/skills/` and are picked up automatically by agents that support skills (Claude Code reads them via `.claude/skills/`):
 
 | Skill                    | Description                                                                |
 | ------------------------ | -------------------------------------------------------------------------- |

--- a/packages/plugin/skills/build-shop/SKILL.md
+++ b/packages/plugin/skills/build-shop/SKILL.md
@@ -59,7 +59,7 @@ For each layer's full ownership boundary, see the responsibility table in `refer
 
 Use the installed Shopify AI Toolkit for Shopify API documentation, schema facts, operation design, and validation. Invoke its API-specific skill before adding or changing Storefront or Customer Account GraphQL. For metafields or metaobjects, use its custom-data skill first.
 
-Use `/vercel-shop:shopify-graphql-reference` only after Shopify validation to apply Vercel Shop conventions: operation placement, domain transforms, cache role, locale flow, invalidation, and route integration. Never treat this architecture skill as a substitute for authoritative Shopify validation.
+Use the `shopify-graphql-reference` skill only after Shopify validation to apply Vercel Shop conventions: operation placement, domain transforms, cache role, locale flow, invalidation, and route integration. Never treat this architecture skill as a substitute for authoritative Shopify validation.
 
 ## Prevent blocking
 

--- a/packages/plugin/skills/init-vercel-shop/SKILL.md
+++ b/packages/plugin/skills/init-vercel-shop/SKILL.md
@@ -15,12 +15,17 @@ Ask for the target directory if the user did not provide one. Always pass it exp
    ```
 
    Preserve an explicitly requested package manager with `--use-pnpm`, `--use-npm`, `--use-yarn`, or `--use-bun`.
-3. Confirm the generated project contains `.vercel-shop/bootstrap.json`, `AGENTS.md`, `app/`, `components/`, `lib/shopify/`, and `package.json`.
+3. Confirm the generated project contains `.vercel-shop/bootstrap.json`, `.agents/skills/`, `AGENTS.md`, `app/`, `components/`, `lib/shopify/`, and `package.json`.
 4. Read the generated `AGENTS.md` before making further changes.
-5. If the CLI reports a plugin installation failure, keep the generated project and show the matching retry command:
+5. If `.agents/skills/` is missing, keep the generated project and restore the inlined agent skills from the project root:
 
    ```bash
-   npx plugins add vercel/shop --scope project --yes
+   npx create-vercel-shop@latest --no-template
+   ```
+
+   Optionally offer the recommended companion plugins if the user's agent supports them:
+
+   ```bash
    npx plugins add vercel/vercel-plugin --scope project --yes
    npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
    ```
@@ -31,4 +36,4 @@ Ask for the target directory if the user did not provide one. Always pass it exp
 
    If no, finish with the normal environment setup as the next step.
 
-Return the generated project path, whether a Shopify store was connected, and whether plugin installation needs a retry.
+Return the generated project path, whether a Shopify store was connected, and whether the inlined agent skills needed a retry.

--- a/packages/plugin/skills/init-vercel-shop/SKILL.md
+++ b/packages/plugin/skills/init-vercel-shop/SKILL.md
@@ -15,6 +15,8 @@ Ask for the target directory if the user did not provide one. Always pass it exp
    ```
 
    Preserve an explicitly requested package manager with `--use-pnpm`, `--use-npm`, `--use-yarn`, or `--use-bun`.
+
+   The CLI enforces step 1: it exits with code 1 when the target is non-empty, because agents run it non-interactively. Treat that as a stop, report the conflicting files, and ask the user for a different target. Only add `--force` when the user has explicitly confirmed that overwriting the existing files is what they want.
 3. Confirm the generated project contains `.vercel-shop/bootstrap.json`, `.agents/skills/`, `AGENTS.md`, `app/`, `components/`, `lib/shopify/`, and `package.json`.
 4. Read the generated `AGENTS.md` before making further changes.
 5. If `.agents/skills/` is missing, keep the generated project and restore the inlined agent skills from the project root:

--- a/packages/plugin/skills/update-shop/SKILL.md
+++ b/packages/plugin/skills/update-shop/SKILL.md
@@ -45,8 +45,7 @@ Compare the scaffold metadata against the current recommended template version a
 
 - missing `.vercel-shop/bootstrap.json`
 - missing `AGENTS.md`
-- missing project-scoped plugin config in `.claude/settings.json`
-- legacy local skill files such as `.agents/skills/` or a legacy `.claude/skills` symlink
+- missing inlined agent skills in `.agents/skills/` (current scaffolds inline them there, with Claude Code links in `.claude/skills/`; older scaffolds used the `vercel-shop` plugin via `.claude/settings.json` instead — either layout counts as present)
 - obvious divergence from the expected Vercel Shop structure such as missing `lib/shopify/` or `components/`
 
 Report the original scaffold version, the scaffold timestamp, the current recommended template version, and a short note on overall drift. If the scaffold version matches the current version, say so explicitly. In audit mode, stop here.


### PR DESCRIPTION
Follow-up to @boris's review of #492 after #493 merged into that branch. Targets `blurra/inline-skills-scaffold` so the fix ships with #492 — that branch is where the junction is created (`apps/cli/index.mjs`).

## Problem

`inlineAgentAssets` linked `.claude/skills/<name>` to the canonical copy with a bare relative target:

```js
await symlink(join('..', '..', '.agents', 'skills', name), link, 'junction');
```

POSIX symlinks resolve that against the link's own directory, so it works. Windows junctions are always absolute, and Node resolves a relative `target` with `path.resolve(target)` — against `process.cwd()`, not the link's directory. Scaffolding from anywhere other than the project's parent therefore produced a junction pointing somewhere else entirely, and `fs.symlink` still succeeded, so nothing surfaced the problem: Claude Code just found no project skills.

Simulating Node's junction handling with `path.win32`, cwd `C:\Users\me`, project `D:\work\my-shop`:

```
canonical      : D:\work\my-shop\.agents\skills\build-shop
old -> junction: C:\.agents\skills\build-shop      <- dangling, no error
new -> junction: D:\work\my-shop\.agents\skills\build-shop
```

## Solution

New exported `skillLinkTarget(link, canonical, platform)` computes the target from the link's own directory:

- **Windows** — resolves to an absolute path against `dirname(link)`, so the junction is correct regardless of the working directory.
- **POSIX** — stays relative, so a scaffolded project remains movable (copy or rename the directory and the symlink still resolves).

The `catch` fallback to a plain copy (Windows without Developer Mode) is unchanged.

## Tests

`apps/cli/index.test.mjs` grows 3 cases (22 total, all passing):

- `skillLinkTarget` returns `../../.agents/skills/<name>` on POSIX.
- `skillLinkTarget` returns an absolute, link-relative path on `win32` — this is the regression guard; it fails against the pre-fix behavior (verified by reverting the platform branch locally: `not ok 21`, 21 pass / 1 fail).
- `inlineAgentAssets` run with `process.chdir()` set to an unrelated directory still produces a link whose target resolves to `.agents/skills/<name>` from the link's directory.

## Docs

No change needed — the troubleshooting entry only says `.claude/skills/` should link to `.agents/skills/`, which is now true on Windows too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)