### PR TITLE
Add experimental WebMCP storefront tools

### DIFF
--- a/apps/template/.env.example
+++ b/apps/template/.env.example
@@ -11,3 +11,5 @@ NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN="your-access-token-here"
 # SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID="shp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 # SHOPIFY_WEBHOOK_SECRET="your-webhook-secret-here"
 # UCP_AGENT_PROFILE_URL="https://your-agent.example.com/.well-known/ucp"
+# Set this to an origin-bound Chrome trial token when testing WebMCP on a public deployment.
+# WEBMCP_ORIGIN_TRIAL_TOKEN="your-origin-bound-token-here"

--- a/apps/template/README.md
+++ b/apps/template/README.md
@@ -58,8 +58,49 @@ See [vercel.shop/docs/getting-started](https://vercel.shop/docs/getting-started)
 - **Tailwind CSS 4** and shadcn/ui components
 - **Internationalization-ready** with next-intl
 - **AI-ready** with Vercel AI SDK integration
+- **Experimental WebMCP tools** for browser agents
 - **Optimized cart** with server actions and instant cache invalidation
 - **SEO** with structured data and dynamic metadata
+
+## Experimental WebMCP tools
+
+[WebMCP](https://developer.chrome.com/docs/ai/webmcp) is a proposed browser API for exposing structured page tools to AI agents. This template progressively registers four tools when `document.modelContext` is available; unsupported browsers continue to get the normal storefront.
+
+| Tool                       | Capability                                      |
+| -------------------------- | ----------------------------------------------- |
+| `shop.search_products`     | Search the public product catalog               |
+| `shop.get_product_options` | Read product option names and values            |
+| `shop.get_cart`            | Read a reduced view of the browser's guest cart |
+| `shop.add_to_cart`         | Add one product variant and open the cart       |
+
+The example keeps the integration explicit: `components/webmcp-tools.tsx` contains the JSON Schemas, direct `registerTool()` calls, and `AbortSignal` cleanup. `lib/webmcp/action.ts` validates every input again on the server. Cart writes reuse the existing `/api/cart` path, including BotID checks when enabled, and tool results omit cart IDs, checkout URLs, payment data, and customer data.
+
+### Test locally in Chrome
+
+WebMCP is experimental. Use Chrome 150 or newer for local testing:
+
+1. Open `chrome://flags/#enable-webmcp-testing`.
+2. Enable **WebMCP for testing**, then relaunch Chrome.
+3. Install the [WebMCP – Model Context Tool Inspector](https://chromewebstore.google.com/detail/webmcp-model-context-tool/gbpdfapgefenggkahomfgkhfehlcenpd).
+4. Open the storefront and use the extension's side panel to inspect or manually execute the registered tools. For natural-language testing, select **Set Gemini API key** in the side panel first.
+
+The inspector is a development tool and does not provide production security boundaries. Only use it on pages you trust.
+
+To drive the same tools from Codex or another coding agent, connect [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) to the flag-enabled browser and enable its experimental WebMCP category. In that Chrome profile, open `chrome://inspect/#remote-debugging`, enable remote debugging, and keep Chrome open. Then, for Codex:
+
+```sh
+codex mcp add chrome-devtools -- npx -y chrome-devtools-mcp@latest --auto-connect --category-experimental-webmcp=true
+```
+
+Remote debugging gives the connected agent access to the browser. Use a dedicated Chrome profile without sensitive tabs or personal data.
+
+For a public deployment during Chrome's origin trial, create a token for that exact origin and set the optional server environment variable:
+
+```sh
+WEBMCP_ORIGIN_TRIAL_TOKEN=your-origin-bound-token
+```
+
+Origin-trial tokens are origin-bound and expire. A token from the canonical demo does not enable WebMCP on cloned deployments.
 
 ## Skills
 

--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -15,6 +15,7 @@ import { Footer } from "@/components/footer";
 import { Nav } from "@/components/nav";
 import { SiteSchema } from "@/components/schema/site-schema";
 import { Toaster } from "@/components/ui/sonner";
+import { WebMCPTools } from "@/components/webmcp-tools";
 import { seedCartData } from "@/lib/cart/server";
 import { shopConfig } from "@/lib/config";
 import { getLocale } from "@/lib/params";
@@ -30,6 +31,8 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const webMCPOriginTrialToken = process.env.WEBMCP_ORIGIN_TRIAL_TOKEN;
+
 export default async function RootLayout({ children }: LayoutProps<"/">) {
   const [locale, messages, t] = await Promise.all([
     getLocale(),
@@ -42,7 +45,11 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
 
   return (
     <html lang={locale}>
-      <head />
+      <head>
+        {webMCPOriginTrialToken ? (
+          <meta content={webMCPOriginTrialToken} httpEquiv="origin-trial" />
+        ) : null}
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} flex min-h-dvh flex-col font-sans antialiased`}
       >
@@ -62,6 +69,7 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
             <Footer locale={locale} />
             <CartNotifications />
             <CartOverlayBridge />
+            <WebMCPTools />
             <Suspense>
               <ActionBar>{shopConfig.agent.isEnabled && <AgentButton />}</ActionBar>
             </Suspense>

--- a/apps/template/components/cart/context.tsx
+++ b/apps/template/components/cart/context.tsx
@@ -263,7 +263,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
         setIsAddingToCart(true);
         setOverlayOpen(true);
       }
-      addToCart(variantId, quantity, productInfo);
+      void addToCart(variantId, quantity, productInfo);
     },
     [],
   );

--- a/apps/template/components/product-detail/gift-card-purchase-form.tsx
+++ b/apps/template/components/product-detail/gift-card-purchase-form.tsx
@@ -74,7 +74,7 @@ export function GiftCardPurchaseForm({ merchandiseId, productInfo }: GiftCardPur
     }
 
     setWarnings([]);
-    addToCart(
+    void addToCart(
       merchandiseId,
       1,
       productInfo,

--- a/apps/template/components/webmcp-tools.tsx
+++ b/apps/template/components/webmcp-tools.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect } from "react";
+
+import { useCart } from "@/components/cart/context";
+import { addToCart } from "@/lib/cart/client";
+import {
+  getWebMCPCartAction,
+  getWebMCPProductOptionsAction,
+  prepareWebMCPAddToCartAction,
+  searchWebMCPProductsAction,
+} from "@/lib/webmcp/action";
+
+// WebMCP is not in TypeScript's DOM library yet, so type only the capability used here.
+interface WebMCPTool {
+  annotations?: { readOnlyHint?: boolean; untrustedContentHint?: boolean };
+  description: string;
+  execute(input: object): Promise<unknown>;
+  inputSchema?: object;
+  name: string;
+  title?: string;
+}
+
+interface WebMCPModelContext {
+  registerTool(tool: WebMCPTool, options?: { signal?: AbortSignal }): Promise<void>;
+}
+
+const searchProductsInputSchema = {
+  type: "object",
+  properties: {
+    query: {
+      type: "string",
+      minLength: 1,
+      maxLength: 120,
+      description: "Words to search for in the catalog.",
+    },
+    cursor: {
+      type: "string",
+      maxLength: 512,
+      description: "The nextCursor from the previous search page.",
+    },
+  },
+  required: ["query"],
+  additionalProperties: false,
+} as const;
+
+const getProductOptionsInputSchema = {
+  type: "object",
+  properties: {
+    handle: {
+      type: "string",
+      minLength: 1,
+      maxLength: 255,
+      pattern: "^[A-Za-z0-9][A-Za-z0-9-]*$",
+      description: "A product handle returned by shop.search_products.",
+    },
+    optionOffset: {
+      type: "integer",
+      minimum: 0,
+      default: 0,
+      description: "The nextOptionOffset from the previous options page.",
+    },
+  },
+  required: ["handle"],
+  additionalProperties: false,
+} as const;
+
+const getCartInputSchema = {
+  type: "object",
+  properties: {
+    lineOffset: {
+      type: "integer",
+      minimum: 0,
+      maximum: 49,
+      default: 0,
+      description: "The nextLineOffset from the previous cart page.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const addToCartInputSchema = {
+  type: "object",
+  properties: {
+    productHandle: {
+      type: "string",
+      minLength: 1,
+      maxLength: 255,
+      pattern: "^[A-Za-z0-9][A-Za-z0-9-]*$",
+      description: "A product handle returned by shop.search_products.",
+    },
+    selectedOptions: {
+      type: "array",
+      maxItems: 3,
+      description: "One name and value from shop.get_product_options for every product option.",
+      items: {
+        type: "object",
+        properties: {
+          name: { type: "string", minLength: 1, maxLength: 255 },
+          value: { type: "string", minLength: 1, maxLength: 255 },
+        },
+        required: ["name", "value"],
+        additionalProperties: false,
+      },
+    },
+    quantity: {
+      type: "integer",
+      minimum: 1,
+      maximum: 99,
+      default: 1,
+      description: "Number of units to add.",
+    },
+  },
+  required: ["productHandle", "selectedOptions"],
+  additionalProperties: false,
+} as const;
+
+export function WebMCPTools() {
+  const { openOverlay } = useCart();
+  const t = useTranslations("webmcp");
+
+  useEffect(() => {
+    const { modelContext } = document as unknown as {
+      readonly modelContext?: WebMCPModelContext;
+    };
+    if (typeof modelContext?.registerTool !== "function") return;
+
+    // Aborting this signal unregisters every tool when the component unmounts.
+    const controller = new AbortController();
+    const options = { signal: controller.signal };
+
+    void Promise.all([
+      modelContext.registerTool(
+        {
+          name: "shop.search_products",
+          title: t("searchProductsTitle"),
+          description:
+            "Search this store's catalog. Use a returned handle with shop.get_product_options.",
+          inputSchema: searchProductsInputSchema,
+          annotations: { readOnlyHint: true, untrustedContentHint: true },
+          execute: searchWebMCPProductsAction,
+        },
+        options,
+      ),
+      modelContext.registerTool(
+        {
+          name: "shop.get_product_options",
+          title: t("getProductOptionsTitle"),
+          description:
+            "List option name and value pairs for a product. Use nextOptionOffset to continue.",
+          inputSchema: getProductOptionsInputSchema,
+          annotations: { readOnlyHint: true, untrustedContentHint: true },
+          execute: getWebMCPProductOptionsAction,
+        },
+        options,
+      ),
+      modelContext.registerTool(
+        {
+          name: "shop.get_cart",
+          title: t("getCartTitle"),
+          description:
+            "Read a redacted page of the guest cart. Use variantId to verify an uncertain add.",
+          inputSchema: getCartInputSchema,
+          annotations: { readOnlyHint: true, untrustedContentHint: true },
+          execute: getWebMCPCartAction,
+        },
+        options,
+      ),
+      modelContext.registerTool(
+        {
+          name: "shop.add_to_cart",
+          title: t("addToCartTitle"),
+          description: "Add one available variant to the guest cart and open the cart for review.",
+          inputSchema: addToCartInputSchema,
+          annotations: { readOnlyHint: false, untrustedContentHint: false },
+          execute: async (input) => {
+            const prepared = await prepareWebMCPAddToCartAction(input);
+            if ("error" in prepared) return prepared;
+
+            const result = await addToCart(prepared.variantId, prepared.quantity);
+            if (result.applied === true) openOverlay();
+            return result.applied === false ? result : { ...result, variantId: prepared.variantId };
+          },
+        },
+        options,
+      ),
+    ]).catch((error: unknown) => {
+      if (controller.signal.aborted) return;
+      controller.abort();
+      console.error("WebMCP tool registration failed", error);
+    });
+
+    return () => controller.abort();
+  }, [openOverlay, t]);
+
+  return null;
+}

--- a/apps/template/lib/cart/client.ts
+++ b/apps/template/lib/cart/client.ts
@@ -47,15 +47,36 @@ interface CartMutationResponse {
   warnings?: { code: string; message: string }[];
 }
 
-async function postCart(payload: Record<string, unknown>): Promise<CartMutationResponse> {
+class CartRequestError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    super(`Cart request failed: ${status}`);
+    this.status = status;
+  }
+}
+
+let cartMutationQueue: Promise<void> = Promise.resolve();
+
+async function sendCartRequest(payload: Record<string, unknown>): Promise<CartMutationResponse> {
   const response = await fetch(ENDPOINT, {
     body: JSON.stringify(payload),
     headers: { "content-type": "application/json" },
     method: "POST",
     signal: AbortSignal.timeout(TIMEOUT_MS),
   });
-  if (!response.ok) throw new Error(`Cart request failed: ${response.status}`);
+  if (!response.ok) throw new CartRequestError(response.status);
   return response.json() as Promise<CartMutationResponse>;
+}
+
+// Serialize browser cart writes so the cart cookie and visible state cannot resolve out of order.
+function postCart(payload: Record<string, unknown>): Promise<CartMutationResponse> {
+  const request = cartMutationQueue.then(() => sendCartRequest(payload));
+  cartMutationQueue = request.then(
+    () => undefined,
+    () => undefined,
+  );
+  return request;
 }
 
 // The standard event flattens cart.lines.nodes into cart.lines for the store.
@@ -111,6 +132,58 @@ function dispatchLinesUpdate(
   document.dispatchEvent(event);
 }
 
+// A lost response makes a non-idempotent cart write unsafe to retry blindly.
+export type CartMutationResult =
+  | { applied: true; warning?: string }
+  | {
+      applied: false;
+      error: { code: "MUTATION_FAILED" | "NOT_ALLOWED"; message: string };
+    }
+  | {
+      applied: "unknown";
+      error: { code: "OUTCOME_UNKNOWN"; message: string };
+      retrySafe: false;
+    };
+
+async function toCartMutationResult(
+  request: Promise<CartMutationResponse>,
+): Promise<CartMutationResult> {
+  try {
+    const result = await request;
+    if (!result.cart || result.userErrors?.length) {
+      return {
+        applied: false,
+        error: { code: "MUTATION_FAILED", message: "The store rejected this cart change." },
+      };
+    }
+
+    return result.warnings?.length
+      ? { applied: true, warning: "The cart was updated with a store warning." }
+      : { applied: true };
+  } catch (error) {
+    if (error instanceof CartRequestError && error.status === 403) {
+      return {
+        applied: false,
+        error: { code: "NOT_ALLOWED", message: "The store blocked this cart change." },
+      };
+    }
+    if (error instanceof CartRequestError && error.status >= 400 && error.status < 500) {
+      return {
+        applied: false,
+        error: { code: "MUTATION_FAILED", message: "The store rejected this cart change." },
+      };
+    }
+    return {
+      applied: "unknown",
+      error: {
+        code: "OUTCOME_UNKNOWN",
+        message: "The store may have applied this change. Read the cart before retrying.",
+      },
+      retrySafe: false,
+    };
+  }
+}
+
 // Bypasses the preview's broken standard-actions updateCart handler: POST to our
 // route and feed the standard lines-update event the store listens for.
 export function addToCart(
@@ -118,19 +191,25 @@ export function addToCart(
   quantity: number,
   productInfo?: OptimisticProductInfo,
   attributes?: { key: string; value: string }[],
-): void {
+): Promise<CartMutationResult> {
   const line: CartMutationLine = { merchandiseId, quantity, ...(attributes ? { attributes } : {}) };
-  const promise = postCart({ lines: [line] }).then((result) => ({
+  const request = postCart({ lines: [line] });
+  const eventPromise = request.then((result) => ({
     cart: result.cart ? toStandardCart(result.cart) : null,
   }));
-  dispatchLinesAdd([line], productInfo, promise);
+  dispatchLinesAdd([line], productInfo, eventPromise);
+  return toCartMutationResult(request);
 }
 
 export function updateCartLine(lineId: string, quantity: number): void {
-  const promise = postCart({ lines: [{ id: lineId, quantity }] }).then((result) => ({
+  const eventPromise = postCart({ lines: [{ id: lineId, quantity }] }).then((result) => ({
     cart: result.cart ? toStandardCart(result.cart) : null,
   }));
-  dispatchLinesUpdate(quantity === 0 ? "remove" : "update", [{ id: lineId, quantity }], promise);
+  dispatchLinesUpdate(
+    quantity === 0 ? "remove" : "update",
+    [{ id: lineId, quantity }],
+    eventPromise,
+  );
 }
 
 export interface ServerCartLine {

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -411,5 +411,11 @@
     "searchDescriptionQuery": "Find products matching \"{query}\"",
     "searchTitle": "Search",
     "searchTitleQuery": "Search results for \"{query}\""
+  },
+  "webmcp": {
+    "addToCartTitle": "Add to cart",
+    "getCartTitle": "Get cart",
+    "getProductOptionsTitle": "Get product options",
+    "searchProductsTitle": "Search products"
   }
 }

--- a/apps/template/lib/webmcp/action.ts
+++ b/apps/template/lib/webmcp/action.ts
@@ -1,0 +1,249 @@
+"use server";
+
+import { z } from "zod";
+
+import { getLocale } from "@/lib/params";
+import { getCart } from "@/lib/shopify/operations/cart";
+import {
+  getProduct,
+  getProductVariant,
+  searchIndexProducts,
+} from "@/lib/shopify/operations/products";
+import type { CartLine, ProductCard, SelectedOption } from "@/lib/types";
+
+const MAX_OUTPUT_CHARACTERS = 1_450;
+const OPTION_PAGE_SIZE = 4;
+const CART_PAGE_SIZE = 2;
+
+const productHandle = z
+  .string()
+  .trim()
+  .min(1)
+  .max(255)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9-]*$/);
+
+const searchProductsInput = z.strictObject({
+  query: z.string().trim().min(1).max(120),
+  cursor: z.string().max(512).optional(),
+});
+const getProductOptionsInput = z.strictObject({
+  handle: productHandle,
+  optionOffset: z.number().int().min(0).optional(),
+});
+const getCartInput = z.strictObject({
+  lineOffset: z.number().int().min(0).max(49).optional(),
+});
+const selectedOptionInput = z.strictObject({
+  name: z.string().trim().min(1).max(255),
+  value: z.string().trim().min(1).max(255),
+});
+const addToCartInput = z.strictObject({
+  productHandle,
+  selectedOptions: z.array(selectedOptionInput).max(3),
+  quantity: z.number().int().min(1).max(99).optional(),
+});
+
+type WebMCPErrorCode =
+  | "INVALID_INPUT"
+  | "NOT_ALLOWED"
+  | "NOT_AVAILABLE"
+  | "NOT_FOUND"
+  | "UPSTREAM_UNAVAILABLE";
+
+function toolError(code: WebMCPErrorCode, message: string) {
+  return { error: { code, message } };
+}
+
+function conciseText(value: string, maximumLength: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length > maximumLength
+    ? `${normalized.slice(0, maximumLength - 1)}…`
+    : normalized;
+}
+
+function conciseProduct(product: ProductCard) {
+  return {
+    available: product.availableForSale,
+    handle: product.handle,
+    price: product.price,
+    title: conciseText(product.title, 80),
+  };
+}
+
+function conciseCartLine(line: CartLine) {
+  return {
+    lineTotal: line.cost.totalAmount,
+    productHandle: line.merchandise.product.handle,
+    productTitle: conciseText(line.merchandise.product.title, 60),
+    quantity: line.quantity,
+    variantId: line.merchandise.id,
+    variantTitle: conciseText(line.merchandise.title, 48),
+  };
+}
+
+function fitItemsToOutputBudget<Item, Output>(
+  items: Item[],
+  buildOutput: (includedItems: Item[]) => Output,
+): Output {
+  const includedItems: Item[] = [];
+
+  for (const item of items) {
+    const candidate = buildOutput([...includedItems, item]);
+    if (JSON.stringify(candidate).length > MAX_OUTPUT_CHARACTERS) break;
+    includedItems.push(item);
+  }
+
+  return buildOutput(includedItems);
+}
+
+function sameText(left: string, right: string) {
+  return left.toLocaleLowerCase() === right.toLocaleLowerCase();
+}
+
+function sameOptions(left: SelectedOption[], right: SelectedOption[]) {
+  return (
+    left.length === right.length &&
+    left.every((option) =>
+      right.some(
+        (candidate) =>
+          sameText(option.name, candidate.name) && sameText(option.value, candidate.value),
+      ),
+    )
+  );
+}
+
+export async function searchWebMCPProductsAction(input: unknown) {
+  const parsed = searchProductsInput.safeParse(input);
+  if (!parsed.success) {
+    return toolError("INVALID_INPUT", "The input did not match the tool schema.");
+  }
+
+  try {
+    const locale = await getLocale();
+    const result = await searchIndexProducts({
+      cursor: parsed.data.cursor,
+      limit: 1,
+      locale,
+      query: parsed.data.query,
+      sortKey: "best-matches",
+    });
+
+    return {
+      nextCursor: result.pageInfo.hasNextPage ? result.pageInfo.endCursor : null,
+      products: result.products.map(conciseProduct),
+    };
+  } catch (error) {
+    console.error("WebMCP product search failed", error);
+    return toolError("UPSTREAM_UNAVAILABLE", "Product search is unavailable right now.");
+  }
+}
+
+export async function getWebMCPProductOptionsAction(input: unknown) {
+  const parsed = getProductOptionsInput.safeParse(input);
+  if (!parsed.success) {
+    return toolError("INVALID_INPUT", "The input did not match the tool schema.");
+  }
+
+  try {
+    const locale = await getLocale();
+    const product = await getProduct({ handle: parsed.data.handle, locale });
+    if (!product) return toolError("NOT_FOUND", "No product exists for that handle.");
+
+    const optionValues = product.options.flatMap((option) =>
+      option.values.map((value) => ({ name: option.name, value: value.name })),
+    );
+    const offset = parsed.data.optionOffset ?? 0;
+    const page = optionValues.slice(offset, offset + OPTION_PAGE_SIZE);
+
+    return fitItemsToOutputBudget(page, (includedOptionValues) => ({
+      handle: product.handle,
+      nextOptionOffset:
+        offset + includedOptionValues.length < optionValues.length
+          ? offset + includedOptionValues.length
+          : null,
+      optionValueCount: optionValues.length,
+      optionValues: includedOptionValues,
+    }));
+  } catch (error) {
+    console.error("WebMCP product options failed", error);
+    return toolError("UPSTREAM_UNAVAILABLE", "Product options are unavailable right now.");
+  }
+}
+
+export async function prepareWebMCPAddToCartAction(input: unknown) {
+  const parsed = addToCartInput.safeParse(input);
+  if (!parsed.success) {
+    return toolError("INVALID_INPUT", "The input did not match the tool schema.");
+  }
+
+  try {
+    const locale = await getLocale();
+    const product = await getProduct({ handle: parsed.data.productHandle, locale });
+    if (!product) return toolError("NOT_FOUND", "No product exists for that handle.");
+    if (parsed.data.selectedOptions.length !== product.options.length) {
+      return toolError("INVALID_INPUT", "Select one value for every product option.");
+    }
+
+    const selectedOptions: SelectedOption[] = [];
+    for (const option of product.options) {
+      const requested = parsed.data.selectedOptions.find(({ name }) => sameText(name, option.name));
+      const value = requested
+        ? option.values.find((candidate) => sameText(candidate.name, requested.value))
+        : undefined;
+      if (!value) {
+        return toolError(
+          "INVALID_INPUT",
+          "Choose option names and values returned by get_product_options.",
+        );
+      }
+      selectedOptions.push({ name: option.name, value: value.name });
+    }
+
+    const variant = await getProductVariant({
+      handle: product.handle,
+      locale,
+      selectedOptions,
+    });
+    if (!variant || !sameOptions(selectedOptions, variant.selectedOptions)) {
+      return toolError("NOT_FOUND", "No variant matches those product options.");
+    }
+    if (!variant.availableForSale) {
+      return toolError("NOT_AVAILABLE", "That product variant is not available.");
+    }
+    if (variant.requiresComponents) {
+      return toolError("NOT_ALLOWED", "Bundle variants are not supported by this tool.");
+    }
+
+    return { quantity: parsed.data.quantity ?? 1, variantId: variant.id };
+  } catch (error) {
+    console.error("WebMCP add-to-cart preparation failed", error);
+    return toolError("UPSTREAM_UNAVAILABLE", "The product variant is unavailable right now.");
+  }
+}
+
+export async function getWebMCPCartAction(input: unknown) {
+  const parsed = getCartInput.safeParse(input);
+  if (!parsed.success) {
+    return toolError("INVALID_INPUT", "The input did not match the tool schema.");
+  }
+
+  try {
+    const cart = await getCart();
+    const lines = (cart?.lines ?? []).map(conciseCartLine);
+    const offset = parsed.data.lineOffset ?? 0;
+    const page = lines.slice(offset, offset + CART_PAGE_SIZE);
+
+    return fitItemsToOutputBudget(page, (includedLines) => ({
+      empty: lines.length === 0,
+      lines: includedLines,
+      moreLinesMayExist: (cart?.lines.length ?? 0) === 50,
+      nextLineOffset:
+        offset + includedLines.length < lines.length ? offset + includedLines.length : null,
+      total: cart?.cost.totalAmount ?? null,
+      totalQuantity: cart?.totalQuantity ?? 0,
+    }));
+  } catch (error) {
+    console.error("WebMCP cart read failed", error);
+    return toolError("UPSTREAM_UNAVAILABLE", "The cart is unavailable right now.");
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,8 @@
     "VERCEL_BRANCH_URL",
     "VERCEL_ENV",
     "VERCEL_PROJECT_PRODUCTION_URL",
-    "VERCEL_URL"
+    "VERCEL_URL",
+    "WEBMCP_ORIGIN_TRIAL_TOKEN"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## What

- progressively register four storefront tools through the native `document.modelContext` API
- expose product search, product options, guest-cart reads, and an explicit add-to-cart capability
- document Chrome's testing flag, the Model Context Tool Inspector, Chrome DevTools MCP, and optional origin-trial setup

## Implementation notes

- keeps the WebMCP integration in one null-rendering Client Component with direct `registerTool` calls and `AbortSignal` cleanup
- validates tool arguments again in Server Actions and resolves exact, available, non-bundle variants before mutation
- keeps cart writes on the existing `/api/cart` path, including BotID checks when enabled, and serializes browser cart writes
- returns reduced, bounded tool results without cart IDs, checkout URLs, payment data, customer data, or upstream error text
- reports ambiguous mutation outcomes as unsafe to retry

WebMCP remains experimental, so unsupported browsers keep the normal storefront experience.

## Testing

- `pnpm --filter template lint`
- `pnpm --filter template exec next typegen`
- `pnpm --filter template exec tsc --noEmit`
- focused mocked checks for output budgets, exact option resolution, mutation serialization, redaction, and ambiguous outcomes
- native Chrome lifecycle smoke: four tools registered, abort cleanup removed them, remount registered them again without duplicates, and cleanup removed them again
- `pnpm --filter template build` completed GraphQL codegen, then stopped because the required Shopify storefront environment variables are not available locally
