### PR TITLE
Register WebMCP tools with Chrome's use-webmcp-tool hook

### DIFF
--- a/apps/template/README.md
+++ b/apps/template/README.md
@@ -73,7 +73,7 @@ See [vercel.shop/docs/getting-started](https://vercel.shop/docs/getting-started)
 | `shop.get_cart`            | Read a reduced view of the browser's guest cart |
 | `shop.add_to_cart`         | Add one product variant and open the cart       |
 
-The example keeps the integration explicit: `components/webmcp-tools.tsx` contains the JSON Schemas, direct `registerTool()` calls, and `AbortSignal` cleanup. `lib/webmcp/action.ts` validates every input again on the server. Cart writes reuse the existing `/api/cart` path, including BotID checks when enabled, and tool results omit cart IDs, checkout URLs, payment data, and customer data.
+`components/webmcp-tools.tsx` holds the JSON Schemas and registers each tool through [`use-webmcp-tool`](https://github.com/GoogleChromeLabs/use-webmcp-tool), Chrome's React hook for `document.modelContext`. The hook ties each registration to the component lifecycle, keeps a changing `execute` closure from re-registering the tool, and normalizes whatever an action returns into an MCP tool result. `lib/webmcp/action.ts` validates every input again on the server. Cart writes reuse the existing `/api/cart` path, including BotID checks when enabled, and tool results omit cart IDs, checkout URLs, payment data, and customer data.
 
 ### Test locally in Chrome
 
@@ -94,13 +94,16 @@ codex mcp add chrome-devtools -- npx -y chrome-devtools-mcp@latest --auto-connec
 
 Remote debugging gives the connected agent access to the browser. Use a dedicated Chrome profile without sensitive tabs or personal data.
 
-For a public deployment during Chrome's origin trial, create a token for that exact origin and set the optional server environment variable:
+### Enable on a deployment
 
-```sh
-WEBMCP_ORIGIN_TRIAL_TOKEN=your-origin-bound-token
-```
+The Chrome flag above covers local testing only. A deployed origin also needs an origin-trial token, because WebMCP ships as a Chrome origin trial through Chrome 156.
 
-Origin-trial tokens are origin-bound and expire. A token from the canonical demo does not enable WebMCP on cloned deployments.
+1. Register the exact deployment origin — scheme, host, and port — for the WebMCP trial on [Chrome's origin trials site](https://developer.chrome.com/origintrials).
+2. Set the issued token as `WEBMCP_ORIGIN_TRIAL_TOKEN` in each environment that should expose the tools.
+
+`app/layout.tsx` emits `<meta http-equiv="origin-trial">` only when that variable is set, so leaving it unset is a clean no-op.
+
+Origin-trial tokens are origin-bound and expire, so a token issued for the canonical demo does not enable WebMCP on a cloned deployment, and each preview domain needs its own token. **No token is provisioned for this template's deployments yet**, so the tools currently register only in a flag-enabled browser.
 
 ## Skills
 

--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -31,6 +31,7 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+// TODO(gaojude): no origin-trial token is provisioned for the deployed origins yet, so WebMCP stays flag-only outside local testing.
 const webMCPOriginTrialToken = process.env.WEBMCP_ORIGIN_TRIAL_TOKEN;
 
 export default async function RootLayout({ children }: LayoutProps<"/">) {

--- a/apps/template/components/webmcp-tools.tsx
+++ b/apps/template/components/webmcp-tools.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useTranslations } from "next-intl";
 import { useEffect } from "react";
+import { useWebMCP } from "use-webmcp-tool";
 
 import { useCart } from "@/components/cart/context";
 import { addToCart } from "@/lib/cart/client";
@@ -12,19 +12,8 @@ import {
   searchWebMCPProductsAction,
 } from "@/lib/webmcp/action";
 
-// WebMCP is not in TypeScript's DOM library yet, so type only the capability used here.
-interface WebMCPTool {
-  annotations?: { readOnlyHint?: boolean; untrustedContentHint?: boolean };
-  description: string;
-  execute(input: object): Promise<unknown>;
-  inputSchema?: object;
-  name: string;
-  title?: string;
-}
-
-interface WebMCPModelContext {
-  registerTool(tool: WebMCPTool, options?: { signal?: AbortSignal }): Promise<void>;
-}
+const MUTATING_ANNOTATIONS = { readOnlyHint: false, untrustedContentHint: false } as const;
+const READ_ONLY_ANNOTATIONS = { readOnlyHint: true, untrustedContentHint: true } as const;
 
 const searchProductsInputSchema = {
   type: "object",
@@ -116,83 +105,69 @@ const addToCartInputSchema = {
   additionalProperties: false,
 } as const;
 
-export function WebMCPTools() {
-  const { openOverlay } = useCart();
-  const t = useTranslations("webmcp");
+// Tool actions report failures as `{ error }` payloads, which the hook would otherwise serialize as a successful result.
+function markToolErrors(result: unknown) {
+  if (result !== null && typeof result === "object" && "error" in result) {
+    return { content: [{ text: JSON.stringify(result.error), type: "text" }], isError: true };
+  }
+  return result;
+}
+
+type StorefrontToolOptions = Omit<Parameters<typeof useWebMCP>[0], "formatOutput">;
+
+function useStorefrontTool(options: StorefrontToolOptions) {
+  const { error } = useWebMCP({ ...options, formatOutput: markToolErrors });
 
   useEffect(() => {
-    const { modelContext } = document as unknown as {
-      readonly modelContext?: WebMCPModelContext;
-    };
-    if (typeof modelContext?.registerTool !== "function") return;
+    if (error) console.error(`WebMCP tool ${options.name} failed to register`, error);
+  }, [error, options.name]);
+}
 
-    // Aborting this signal unregisters every tool when the component unmounts.
-    const controller = new AbortController();
-    const options = { signal: controller.signal };
+export function WebMCPTools() {
+  const { openOverlay } = useCart();
 
-    void Promise.all([
-      modelContext.registerTool(
-        {
-          name: "shop.search_products",
-          title: t("searchProductsTitle"),
-          description:
-            "Search this store's catalog. Use a returned handle with shop.get_product_options.",
-          inputSchema: searchProductsInputSchema,
-          annotations: { readOnlyHint: true, untrustedContentHint: true },
-          execute: searchWebMCPProductsAction,
-        },
-        options,
-      ),
-      modelContext.registerTool(
-        {
-          name: "shop.get_product_options",
-          title: t("getProductOptionsTitle"),
-          description:
-            "List option name and value pairs for a product. Use nextOptionOffset to continue.",
-          inputSchema: getProductOptionsInputSchema,
-          annotations: { readOnlyHint: true, untrustedContentHint: true },
-          execute: getWebMCPProductOptionsAction,
-        },
-        options,
-      ),
-      modelContext.registerTool(
-        {
-          name: "shop.get_cart",
-          title: t("getCartTitle"),
-          description:
-            "Read a redacted page of the guest cart. Use variantId to verify an uncertain add.",
-          inputSchema: getCartInputSchema,
-          annotations: { readOnlyHint: true, untrustedContentHint: true },
-          execute: getWebMCPCartAction,
-        },
-        options,
-      ),
-      modelContext.registerTool(
-        {
-          name: "shop.add_to_cart",
-          title: t("addToCartTitle"),
-          description: "Add one available variant to the guest cart and open the cart for review.",
-          inputSchema: addToCartInputSchema,
-          annotations: { readOnlyHint: false, untrustedContentHint: false },
-          execute: async (input) => {
-            const prepared = await prepareWebMCPAddToCartAction(input);
-            if ("error" in prepared) return prepared;
+  // TODO(gaojude): pass localized `title` again once use-webmcp-tool forwards it to registerTool.
+  useStorefrontTool({
+    annotations: READ_ONLY_ANNOTATIONS,
+    description:
+      "Search this store's catalog. Use a returned handle with shop.get_product_options.",
+    execute: searchWebMCPProductsAction,
+    inputSchema: searchProductsInputSchema,
+    name: "shop.search_products",
+  });
 
-            const result = await addToCart(prepared.variantId, prepared.quantity);
-            if (result.applied === true) openOverlay();
-            return result.applied === false ? result : { ...result, variantId: prepared.variantId };
-          },
-        },
-        options,
-      ),
-    ]).catch((error: unknown) => {
-      if (controller.signal.aborted) return;
-      controller.abort();
-      console.error("WebMCP tool registration failed", error);
-    });
+  useStorefrontTool({
+    annotations: READ_ONLY_ANNOTATIONS,
+    description:
+      "List option name and value pairs for a product. Use nextOptionOffset to continue.",
+    execute: getWebMCPProductOptionsAction,
+    inputSchema: getProductOptionsInputSchema,
+    name: "shop.get_product_options",
+  });
 
-    return () => controller.abort();
-  }, [openOverlay, t]);
+  useStorefrontTool({
+    annotations: READ_ONLY_ANNOTATIONS,
+    description:
+      "Read a redacted page of the guest cart. Use variantId to verify an uncertain add.",
+    execute: getWebMCPCartAction,
+    inputSchema: getCartInputSchema,
+    name: "shop.get_cart",
+  });
+
+  useStorefrontTool({
+    annotations: MUTATING_ANNOTATIONS,
+    description: "Add one available variant to the guest cart and open the cart for review.",
+    execute: async (input) => {
+      const prepared = await prepareWebMCPAddToCartAction(input);
+      if ("error" in prepared) return prepared;
+
+      const result = await addToCart(prepared.variantId, prepared.quantity);
+      if (result.applied === true) openOverlay();
+      return result.applied === false ? result : { ...result, variantId: prepared.variantId };
+    },
+    inputSchema: addToCartInputSchema,
+    name: "shop.add_to_cart",
+  });
 
   return null;
 }

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -411,11 +411,5 @@
     "searchDescriptionQuery": "Find products matching \"{query}\"",
     "searchTitle": "Search",
     "searchTitleQuery": "Search results for \"{query}\""
-  },
-  "webmcp": {
-    "addToCartTitle": "Add to cart",
-    "getCartTitle": "Get cart",
-    "getProductOptionsTitle": "Get product options",
-    "searchProductsTitle": "Search products"
   }
 }

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -46,6 +46,7 @@
     "tailwindcss": "4.3.3",
     "tw-animate-css": "1.4.0",
     "typescript": "7.0.2",
+    "use-webmcp-tool": "0.2.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      use-webmcp-tool:
+        specifier: 0.2.0
+        version: 0.2.0(react@19.2.8)
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -6891,6 +6894,11 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  use-webmcp-tool@0.2.0:
+    resolution: {integrity: sha512-kYUpV1xFmX3Wnq68KOM1MbedpRc6mbgWEcVFtWpFPBTGEcuc7Sva4bHjRxM3k8mkGshkwxnLKn9/I4/NP2bTBw==}
+    peerDependencies:
+      react: '>=18'
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -14518,6 +14526,10 @@ snapshots:
       react: 19.2.8
 
   use-sync-external-store@1.6.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
+  use-webmcp-tool@0.2.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 


### PR DESCRIPTION
## What

- register the four storefront tools through [`use-webmcp-tool`](https://github.com/GoogleChromeLabs/use-webmcp-tool) instead of hand-rolled `document.modelContext` calls
- convert the `{ error }` payloads the tool actions already return into MCP `isError` results
- document origin-trial enablement as a deployment step and flag that no token is provisioned yet

## Why this library

`use-webmcp-tool` is published from `GoogleChromeLabs`, Apache-2.0, with zero runtime dependencies and a single `react >= 18` peer. Its README states it is maintained by Chrome and tracks spec changes, so the template no longer owns a local copy of the WebMCP interface shape. It is one of only two libraries listed in Google's own [`AWESOME_WEBMCP.md`](https://github.com/GoogleChromeLabs/webmcp-tools/blob/main/AWESOME_WEBMCP.md).

Worth being explicit that there is no *official* W3C or MCP React binding — the spec is a W3C Web Machine Learning Community Group draft, not on the standards track. This is the closest thing: first-party to the browser shipping the origin trial. The alternatives considered were the `@mcp-b/*` family and `webmcp-react`; both pull a polyfill or extra transitive dependencies, which sits badly with the template's progressive-enhancement story.

## Implementation notes

Beyond deleting the local `WebMCPTool` / `WebMCPModelContext` declarations and the `AbortController` effect, the hook closes three gaps in the previous implementation:

- **Failures now reach the agent as errors.** The tool actions return `{ error: { code, message } }`, which the hook would otherwise serialize as a *successful* result — an agent could not distinguish a failed lookup from a successful one. A small `formatOutput` shim converts those payloads into `{ content, isError: true }`, preserving the error code.
- **A changing `execute` closure no longer re-registers the tool.** The previous effect keyed on `[openOverlay, t]`, so any identity change unregistered and re-registered all four tools. The hook holds `execute` in a ref and only re-registers when `name`, `description`, `inputSchema`, or `annotations` change by content.
- **A late-injected `document.modelContext` is detected.** The previous effect ran once on mount, so an extension content script that landed afterwards registered nothing. This affects the Model Context Tool Inspector workflow the README documents.

Registration errors — for example `NotAllowedError` from a `tools` Permissions Policy — are now surfaced per tool through the hook's `error` state rather than a single combined `catch`.

The JSON Schemas, server-side revalidation in `lib/webmcp/action.ts`, the `/api/cart` write path with BotID checks, and the redaction of cart IDs, checkout URLs, payment data, and customer data are all unchanged.

## One tradeoff to confirm

The hook does not forward `title` to `registerTool`, so the four localized tool titles are dropped along with their `webmcp` block in `en.json`. Titles are cosmetic and agents dispatch on `name` and `description`, so this trades a small i18n surface for the correctness fixes above. A `TODO` marks the restore point.

If we would rather keep the titles, the alternative is a small upstream PR adding `title` pass-through to `GoogleChromeLabs/use-webmcp-tool`. Happy to send that instead.

## Origin trial

The `WEBMCP_ORIGIN_TRIAL_TOKEN` env var and the `<meta http-equiv="origin-trial">` tag already existed, but **no token is provisioned for any deployed origin**, so the tools currently register only in a flag-enabled browser. The README now spells out registering the exact origin and setting the token per environment, and a `TODO` sits at the env read in `app/layout.tsx`. The trial runs through Chrome 156.

## Testing

- `pnpm lint` (oxlint + oxfmt) clean
- `pnpm exec next typegen` and `pnpm exec tsc --noEmit` clean
- `pnpm exec next build` reports `✓ Compiled successfully`, confirming the ESM-only package bundles; prerender then fails only on placeholder Shopify credentials, as on `main`
- `pnpm install --frozen-lockfile` passes; the lockfile adds `use-webmcp-tool` with no transitive dependencies
- five focused checks against the real published `use-webmcp-tool@0.2.0` in jsdom: an `{ error }` payload becomes an `isError` result with its code intact, a success payload stays non-error, unmount unregisters every tool, three re-renders with a changing `execute` produce exactly one registration, and the agent calls the latest closure
- not verified in a live flag-enabled Chrome
