### PR TITLE
fix(docs): drop env vars from the deploy button URL

### DIFF
--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -20,9 +20,11 @@ npx create-vercel-shop@latest my-store
 
 Or deploy the template directly to Vercel:
 
-<a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fshop%2Ftree%2Fmain%2Fapps%2Ftemplate&env=NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN,NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN&envDescription=Required%20values%20to%20work%20with%20Shopify&envLink=https%3A%2F%2Fvercel.shop%2Fdocs%2Freference%2Fenv-vars&products=%5B%7B%22type%22%3A%22integration%22%2C%22integrationSlug%22%3A%22shopify%22%2C%22productSlug%22%3A%22shopify%22%2C%22protocol%22%3A%22other%22%7D%5D">
+<a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fshop%2Ftree%2Fmain%2Fapps%2Ftemplate&products=%5B%7B%22type%22%3A%22integration%22%2C%22integrationSlug%22%3A%22shopify%22%2C%22productSlug%22%3A%22shopify%22%2C%22protocol%22%3A%22other%22%7D%5D">
   <img src="https://vercel.com/button" alt="Deploy with Vercel" />
 </a>
+
+The deploy flow installs the Shopify integration, which connects a new or existing store and configures the required Shopify credentials on the project.
 
 ## Add your credentials
 


### PR DESCRIPTION
## Summary

Removes the required environment variables from the Deploy Button URL on [`/docs/getting-started`](https://vercel.shop/docs/getting-started), following the thread feedback.

The URL already installs the Shopify integration via `products`. That integration [connects a new *or existing* store](https://vercel.com/marketplace/shopify) and auto-configures the Shopify credentials on the project. Keeping `env` alongside it made the project creation flow demand `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN` and `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN` up front — values the user can't have yet at the moment they're about to connect a store through the integration — so the deploy-button flow was effectively blocked.

`envDescription` and `envLink` go with it: [per the docs](https://vercel.com/docs/deploy-button/environment-variables), both only render when required env vars are set, so they're dead params once `env` is gone.

Added one line under the button saying where the credentials come from in the deploy path, since the page no longer implies Vercel will prompt for them.

**Before**

```
?repository-url=…&env=NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN,NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN
&envDescription=Required%20values%20to%20work%20with%20Shopify
&envLink=…%2Fdocs%2Freference%2Fenv-vars&products=…
```

**After**

```
?repository-url=…&products=[{"type":"integration","integrationSlug":"shopify","productSlug":"shopify","protocol":"other"}]
```

## Testing

- `pnpm build` (apps/docs) — passes, 118 static pages
- `pnpm typecheck` — passes
- Served the build and confirmed the rendered page + the AI-readable `/docs/getting-started.md` route emit the trimmed URL, with no `env` / `envDescription` / `envLink` anywhere in the output
- Confirmed the `products` JSON still decodes and the deploy URL returns 200
- Pre-existing on `main`, untouched here: `pnpm lint` reports an `oxfmt` issue in `app/[lang]/(home)/components/one-two-section.tsx`, and `pnpm typecheck` fails before a build has generated the Next.js `LayoutProps`/`RouteContext` globals

## Note for the reviewer

`apps/template/README.md` has a second deploy button that still carries `env`. I left it alone: that URL has no `products` param, so nothing would supply the credentials if the prompt were removed. Unifying it with this one (add the integration, then drop `env`) is a separate call — happy to fold it in if you want them consistent.

No changeset — `docs` is in the `ignore` list in `.changeset/config.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)