### PR TITLE
docs: remove environment variables from template README

### DIFF
--- a/apps/template/README.md
+++ b/apps/template/README.md
@@ -4,9 +4,7 @@ A Next.js storefront template and reference architecture for Shopify, built with
 
 See [vercel.shop](https://vercel.shop) for full documentation.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fshop&project-name=shop&repository-name=shop&root-directory=apps%2Ftemplate&demo-title=Vercel+Shop&demo-url=https%3A%2F%2Fshop-template.vercel.app&env=NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN%2CNEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN&envDescription=Required%20Shopify%20Storefront%20API%20credentials&envLink=https%3A%2F%2Fvercel.shop%2Fdocs%2Freference%2Fenv-vars)
-
-Vercel prompts for the two required Shopify credentials before the first deployment.
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fshop&project-name=shop&repository-name=shop&root-directory=apps%2Ftemplate&demo-title=Vercel+Shop&demo-url=https%3A%2F%2Fshop-template.vercel.app)
 
 ## Getting Started
 
@@ -28,18 +26,7 @@ To install only the agent plugins into an existing project, run this from that p
 npx create-vercel-shop@latest --no-template
 ```
 
-2. In Shopify admin, create a storefront token in **Settings → Apps and sales channels → Headless**, enable the required Storefront API permissions, then add your Shopify credentials:
-
-```sh
-cp .env.example .env.local
-```
-
-```
-NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN=your-store.myshopify.com
-NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN=your-token
-```
-
-3. Start the development server with the same package manager you used to scaffold the project:
+2. Start the development server with the same package manager you used to scaffold the project:
 
 ```sh
 pnpm dev
@@ -94,13 +81,7 @@ codex mcp add chrome-devtools -- npx -y chrome-devtools-mcp@latest --auto-connec
 
 Remote debugging gives the connected agent access to the browser. Use a dedicated Chrome profile without sensitive tabs or personal data.
 
-For a public deployment during Chrome's origin trial, create a token for that exact origin and set the optional server environment variable:
-
-```sh
-WEBMCP_ORIGIN_TRIAL_TOKEN=your-origin-bound-token
-```
-
-Origin-trial tokens are origin-bound and expire. A token from the canonical demo does not enable WebMCP on cloned deployments.
+For a public deployment during Chrome's origin trial, create a token for that exact origin. Origin-trial tokens are origin-bound and expire. A token from the canonical demo does not enable WebMCP on cloned deployments.
 
 ## Skills
 


### PR DESCRIPTION
Removes environment variables and their setup instructions from the README.

The repo root `README.md` contains no environment variables, so the change applies to `apps/template/README.md` — the only README in the repo that documents them.

## Changes

- Dropped the `env`, `envDescription`, and `envLink` params from the "Deploy with Vercel" button URL, plus the line about Vercel prompting for Shopify credentials.
- Removed Getting Started step 2 (Shopify storefront token creation, `cp .env.example .env.local`, and the `NEXT_PUBLIC_SHOPIFY_*` values) and renumbered the dev-server step to 2.
- Removed the `WEBMCP_ORIGIN_TRIAL_TOKEN` snippet, keeping the surrounding note that origin-trial tokens are origin-bound and expire.

The existing links to [vercel.shop/docs/getting-started](https://vercel.shop/docs/getting-started) and the Storefront API permissions reference are unchanged, so setup guidance is still reachable from the README.

Note: removing the `env` params means the Vercel clone flow will no longer prompt for the two required Shopify credentials at deploy time — worth confirming that's intended before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)