### PR TITLE
feat(template): complete Hydrogen cart integration

### DIFF
--- a/apps/docs/content/docs/anatomy/authentication.mdx
+++ b/apps/docs/content/docs/anatomy/authentication.mdx
@@ -59,6 +59,8 @@ Shopify does not support wildcard callback or logout URIs — register each prod
 
 **Token refresh happens out-of-band, not inline.** `isCustomerLoggedIn()` treats a refreshable session as logged in, so the nav doesn't flicker to signed-out when the access token expires. `requireCustomerAccessToken()` redirects through `/account/refresh` when only a refresh token remains, where Hydrogen rotates tokens and commits the updated cookie before returning to the account page. Logout mirrors this: the sign-out button POSTs to `/account/logout`, which clears the local session and redirects through Shopify's logout endpoint with `id_token_hint`, ending both the storefront session and the Shopify SSO session.
 
+**The cart follows the customer session.** When authentication is enabled, the cart and Customer Account handlers share the same Hydrogen customer session. New carts include the signed-in customer's buyer identity, login and token refresh attach an existing browser cart, and logout detaches it. Authenticated cart reads also mark the checkout URL so Shopify can carry the customer into checkout with their saved details instead of starting a guest flow. Cart synchronization is best-effort and never blocks an auth redirect; if Hydrogen cannot safely detach a cart during logout, it expires the cart cookie.
+
 ```ts
 import {
   isCustomerLoggedIn,
@@ -84,6 +86,7 @@ Use `isCustomerLoggedIn()` for read-only UI state, `requireCustomerSession()` fo
 ## Out of the box
 
 - **Auth routes** — `/account/login` (GET, starts PKCE and redirects to Shopify), `/account/authorize` (GET, validates the OAuth callback), `/account/refresh` (GET, rotates an expired access token), and `/account/logout` (POST, clears the session). All four are installed via Hydrogen's standard handlers through `handleShopifyRoutes` in the [proxy](/docs/anatomy/proxy), which intercepts the customer-account OAuth paths before routing.
+- **Cart session attribution** — the same Hydrogen customer session is passed to the cart and auth handlers, so buyer identity stays synchronized across cart creation, login, refresh, checkout, and logout.
 - **Account pages** — `/account` (redirects to profile), `/account/profile` (edit name, read-only email), `/account/orders` (paginated order history), `/account/orders/[id]` (order detail), and `/account/addresses` (address book with create, edit, delete, and default selection). The `(authenticated)` route group gates these without claiming the auth-handler paths.
 - **Customer Account API data** — profile, orders, and addresses come from the Customer Account API, which has its own GraphQL endpoint and schema, separate from the Storefront API. Every call resolves a usable access token first, routing through the refresh step when only a refresh token remains, so no operation runs with an expired token. Customer responses are personalized and never publicly cached.
 - **Rendering and mutations** — order and profile pages are Server Components wrapped in Suspense. Address and profile editing use client forms backed by server actions that validate input, surface Shopify `userErrors`, and revalidate the affected pages.

--- a/apps/docs/content/docs/anatomy/proxy.mdx
+++ b/apps/docs/content/docs/anatomy/proxy.mdx
@@ -14,16 +14,17 @@ The storefront ships a [proxy](https://nextjs.org/docs/app/getting-started/proxy
 
 **Every fallthrough request carries Shopify request context.** The proxy forwards Hydrogen's request-context headers to the application and applies its response headers on the way out. This supports Storefront API calls, analytics, and personalized-response cache safety without per-route setup.
 
-**Authentication setup stays lazy.** Customer account handlers and the writable session manager are created only on the four authentication paths. Ordinary storefront and API requests do not pay for customer-session discovery.
+**Authentication setup stays scoped.** When authentication is enabled, the proxy creates session-aware cart handlers only for `/api/cart` and the four Customer Account paths. The auth handlers receive that same cart handler set so login, refresh, and logout can synchronize buyer identity. Ordinary storefront and unrelated API requests keep the guest cart handlers and do not pay for customer-session discovery.
 
 ## Out of the box
 
-| Request | What the proxy does |
-| --- | --- |
-| Shopify-owned API or protocol route | Returns Hydrogen's response before App Router routing |
-| Customer account auth route | Lazily installs and runs Hydrogen's auth handler when authentication is enabled |
-| Matched storefront route | Lets Hydrogen decline it, forwards request-context headers, and continues to Next.js |
-| Other application `/api/*` route | Skips proxy and runs its App Router Route Handler directly |
+| Request                             | What the proxy does                                                                                   |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Shopify-owned API or protocol route | Returns Hydrogen's response before App Router routing                                                 |
+| Cart API route                      | Uses session-aware cart handlers when authentication is enabled, otherwise the guest handlers         |
+| Customer account auth route         | Runs Hydrogen's auth handler with the same session-aware cart handlers when authentication is enabled |
+| Matched storefront route            | Lets Hydrogen decline it, forwards request-context headers, and continues to Next.js                  |
+| Other application `/api/*` route    | Skips proxy and runs its App Router Route Handler directly                                            |
 
 No environment variables configure the proxy itself. Authentication behavior follows the feature flag described in [Environment Variables](/docs/reference/env-vars).
 

--- a/apps/template/lib/auth/server.ts
+++ b/apps/template/lib/auth/server.ts
@@ -4,7 +4,6 @@ import { createHash, randomBytes, createCipheriv, createDecipheriv } from "node:
 import { createShopifyRequestContext, type ShopifyRequestContext } from "@shopify/hydrogen";
 import {
   createCustomerSession,
-  type CustomerSession as HydrogenCustomerSession,
   type ReadonlyCustomerSessionManager,
   type WritableCustomerSessionManager,
 } from "@shopify/hydrogen/customer-account";
@@ -167,9 +166,9 @@ function createSessionManager(
   };
 }
 
-let customerSessionPromise: Promise<HydrogenCustomerSession> | undefined;
+let customerSessionPromise: Promise<ReturnType<typeof createCustomerSession>> | undefined;
 
-export function getHydrogenCustomerSession(): Promise<HydrogenCustomerSession> {
+export function getHydrogenCustomerSession() {
   if (!shopConfig.auth.isEnabled) notFound();
 
   if (!customerSessionPromise) {
@@ -222,10 +221,12 @@ export function createCustomerRequestContext(request: Request): ShopifyRequestCo
   });
 }
 
-const getReadonlySessionManager = cache(async (): Promise<ReadonlyCustomerSessionManager> => {
-  const requestHeaders = await headers();
-  return createSessionManager(requestHeaders.get("cookie"), shopConfig.site.url, false);
-});
+export const getReadonlyCustomerSessionManager = cache(
+  async (): Promise<ReadonlyCustomerSessionManager> => {
+    const requestHeaders = await headers();
+    return createSessionManager(requestHeaders.get("cookie"), shopConfig.site.url, false);
+  },
+);
 
 const getReadonlyRequestContext = cache(async (): Promise<ShopifyRequestContext> => {
   await io();
@@ -242,7 +243,7 @@ export const isCustomerLoggedIn = cache(async (): Promise<boolean> => {
 
   const [customerSession, sessionManager, requestContext] = await Promise.all([
     getHydrogenCustomerSession(),
-    getReadonlySessionManager(),
+    getReadonlyCustomerSessionManager(),
     getReadonlyRequestContext(),
   ]);
   return customerSession.isLoggedIn(sessionManager, requestContext);
@@ -253,7 +254,7 @@ export const getCustomerAccessToken = cache(async (): Promise<string | undefined
 
   const [customerSession, sessionManager, requestContext] = await Promise.all([
     getHydrogenCustomerSession(),
-    getReadonlySessionManager(),
+    getReadonlyCustomerSessionManager(),
     getReadonlyRequestContext(),
   ]);
   return customerSession.getAccessToken(sessionManager, requestContext);

--- a/apps/template/lib/cart/server.ts
+++ b/apps/template/lib/cart/server.ts
@@ -8,6 +8,8 @@ import {
 import { io } from "next/cache";
 import { cookies, headers } from "next/headers";
 
+import { getHydrogenCustomerSession, getReadonlyCustomerSessionManager } from "@/lib/auth/server";
+import { shopConfig } from "@/lib/config";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import { createRequestStorefrontClient } from "@/lib/shopify/storefront";
 
@@ -36,6 +38,15 @@ const CART_FRAGMENT = gql(/* GraphQL */ `
 `);
 
 export const cartHandlers = createCartServerHandlers({ fragment: CART_FRAGMENT });
+
+export function createCustomerCartHandlers(
+  customerSession: Awaited<ReturnType<typeof getHydrogenCustomerSession>>,
+) {
+  return createCartServerHandlers({
+    customerSession,
+    fragment: CART_FRAGMENT,
+  });
+}
 
 // Shared with the Hydrogen cart handlers, RSC cart reads, and the AI agent.
 const CART_ID_COOKIE = "cart";
@@ -82,8 +93,21 @@ export function seedCartData() {
       i18n,
       request: { headers: await headers() },
     });
-    const { data } = await cartHandlers.get({
-      storefrontClient: createRequestStorefrontClient(requestContext),
+    const storefrontClient = createRequestStorefrontClient(requestContext);
+    if (!shopConfig.auth.isEnabled) {
+      const { data } = await cartHandlers.get({ storefrontClient });
+      return data;
+    }
+
+    const [customerSession, sessionManager] = await Promise.all([
+      getHydrogenCustomerSession(),
+      getReadonlyCustomerSessionManager(),
+    ]);
+    const customerCartHandlers = createCustomerCartHandlers(customerSession);
+    const { data } = await customerCartHandlers.get({
+      requestContext,
+      sessionManager,
+      storefrontClient,
     });
     return data;
   })();

--- a/apps/template/proxy.ts
+++ b/apps/template/proxy.ts
@@ -14,7 +14,7 @@ import {
   getCustomerRequestOrigin,
   getHydrogenCustomerSession,
 } from "@/lib/auth/server";
-import { cartHandlers } from "@/lib/cart/server";
+import { cartHandlers, createCustomerCartHandlers } from "@/lib/cart/server";
 import { shopConfig } from "@/lib/config";
 import { createRequestStorefrontClient } from "@/lib/shopify/storefront";
 
@@ -37,19 +37,30 @@ export async function proxy(request: NextRequest): Promise<Response> {
   const pathname = request.nextUrl.pathname;
 
   const isAuthPath = shopConfig.auth.isEnabled && AUTH_PATHS.has(pathname);
-  const authHandlers = isAuthPath
-    ? createCustomerAccountServerHandlers({
-        customerSession: await getHydrogenCustomerSession(),
-        defaultPostLoginRedirectPathname: "/account",
-        origin: getCustomerRequestOrigin,
-        postLogoutRedirectUri: "/",
-      })
+  const usesCustomerCart = shopConfig.auth.isEnabled && (isAuthPath || pathname === "/api/cart");
+  const customerSession = usesCustomerCart ? await getHydrogenCustomerSession() : undefined;
+  const customerCartHandlers = customerSession
+    ? createCustomerCartHandlers(customerSession)
     : undefined;
+  const authHandlers =
+    isAuthPath && customerSession && customerCartHandlers
+      ? createCustomerAccountServerHandlers({
+          cartServerHandlers: customerCartHandlers,
+          customerSession,
+          defaultPostLoginRedirectPathname: "/account",
+          origin: getCustomerRequestOrigin,
+          postLogoutRedirectUri: "/",
+        })
+      : undefined;
+  const handlers =
+    authHandlers && customerCartHandlers
+      ? [authHandlers, customerCartHandlers]
+      : [customerCartHandlers ?? cartHandlers];
   const shopifyRoute = handleShopifyRoutes({
-    handlers: authHandlers ? [authHandlers, cartHandlers] : [cartHandlers],
+    handlers,
     request,
     requestContext,
-    sessionManager: isAuthPath ? createCustomerSessionManager(request) : NOOP_SESSION_MANAGER,
+    sessionManager: usesCustomerCart ? createCustomerSessionManager(request) : NOOP_SESSION_MANAGER,
     storefrontClient: createRequestStorefrontClient(requestContext),
   });
   if (shopifyRoute) return shopifyRoute;


### PR DESCRIPTION
## Summary

This stack completes the Hydrogen cart integration:

- Share the customer session with cart handlers. Attach buyer identity after sign-in and remove it after sign-out.
- Keep optimistic lines responsive during concurrent mutations. Show settled totals and block checkout while cart state is pending.
- Send the storefront ID with cart requests and Shopify analytics.
- Preserve line attributes in optimistic events. Gift cards with different recipient data remain separate lines.
- Document the session, cart state, storefront ID, and gift card behavior.

## Stack

1. #509 — Customer session attribution
2. #510 — Concurrent cart state
3. #512 — Storefront attribution and line identity

## Verification

- `pnpm --dir apps/template exec tsc --noEmit`
- `pnpm --dir apps/template lint`
- `pnpm --dir apps/template build`
- Focused docs formatting
- `git diff --check`
