### PR TITLE
refactor(template): remove cart seed shim

### DIFF
--- a/apps/template/components/cart/context.tsx
+++ b/apps/template/components/cart/context.tsx
@@ -363,8 +363,6 @@ export function useCart() {
   return context;
 }
 
-export function useSeedCart(_initialCart: Cart | null) {}
-
 type CartInitialData = ComponentProps<typeof HydrogenCartProvider>["initialData"];
 
 interface CartProviderWrapperProps {
@@ -389,7 +387,6 @@ interface CartContextSyncProps {
 
 export function CartContextSync({ cart, children }: CartContextSyncProps) {
   const { cartWithPending } = useCart();
-  useSeedCart(cart);
 
   // Fall back to the server-fetched cart until the provider is seeded — avoids a hydration flash.
   return (

--- a/apps/template/components/nav/cart-client.tsx
+++ b/apps/template/components/nav/cart-client.tsx
@@ -2,7 +2,7 @@
 
 import { HandbagIcon } from "lucide-react";
 
-import { useCart, useSeedCart } from "@/components/cart/context";
+import { useCart } from "@/components/cart/context";
 import type { Cart } from "@/lib/types";
 
 export function CartIconClient({
@@ -13,9 +13,6 @@ export function CartIconClient({
   initialCart: Cart | null;
 }) {
   const { cartWithPending, openOverlay } = useCart();
-
-  useSeedCart(initialCart);
-
   const displayCart = cartWithPending ?? initialCart;
   const quantity = displayCart?.totalQuantity ?? 0;
 


### PR DESCRIPTION
## Summary

- remove the no-op `useSeedCart()` compatibility shim
- remove its calls from the cart render context and navigation cart icon
- retain the existing server-cart fallbacks while Hydrogen's provider state initializes

## Verification

- `pnpm --dir apps/template exec tsc --noEmit`
- `pnpm --dir apps/template lint`
- confirmed `useSeedCart` has no remaining template references
- `git diff --check`
