### PR TITLE
feat(template): make PDP variants instant

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -12,7 +12,7 @@ The Product Detail Page (PDP) is a single product page — title, price, media, 
 
 **Static-first rendering.** Product data is awaited at the top of the page and baked into the static shell, so the title, price, gallery, and description ship as one coherent copy. Freshness comes from cache invalidation — a Shopify webhook calling `revalidateTag`, plus the `cacheLife` window — not a per-request fetch, so the body never re-renders at request time.
 
-**Variant selection through URL searchParams.** Each option change is a navigation (`/products/tee?color=Blue&size=XS`), not client state. That gives you shareable URLs, working browser back/forward, and a fully server-rendered page with zero layout shift. The selected variant resolves from a second, per-selection Shopify query kept off the critical path, so the picker highlights at URL speed rather than waiting on the network.
+**Instant variant selection with shareable URLs.** The initial selection comes from URL search params (`/products/tee?color=Blue&size=XS`) and Shopify resolves the matching variant on the server. After hydration, Hydrogen derives existence, availability, and most selected variants locally from encoded option data plus a sparse set of adjacent variants, so price, options, and purchase controls update immediately instead of waiting for the route request. Each option remains a real link and replaces the URL, preserving refresh, sharing, and no-JavaScript behavior; selections outside the sparse local set resolve through the server route.
 
 ## Out of the box
 

--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -1,4 +1,3 @@
-import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 import type * as React from "react";
 
@@ -7,7 +6,10 @@ import { buildOptionUrl, type SelectedOptions } from "@/lib/product";
 import type { ProductOption } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-export type ProductTranslator = Awaited<ReturnType<typeof getTranslations<"product">>>;
+export interface ProductOptionLabels {
+  selectVariant: Record<string, Record<string, string>>;
+  unavailableVariant: Record<string, Record<string, string>>;
+}
 
 interface ColorPickerProps extends React.ComponentProps<"div"> {
   available: Set<string> | undefined;
@@ -15,10 +17,10 @@ interface ColorPickerProps extends React.ComponentProps<"div"> {
   handle: string;
   hideImages?: boolean;
   onOptionSelect?: (name: string, value: string) => void;
+  labels: ProductOptionLabels;
   option: ProductOption;
   selectedOptions: SelectedOptions;
   selectedValue: string;
-  t: ProductTranslator;
 }
 
 export function ColorPicker({
@@ -27,10 +29,10 @@ export function ColorPicker({
   handle,
   hideImages,
   onOptionSelect,
+  labels,
   option,
   selectedOptions,
   selectedValue,
-  t,
   className,
   ...props
 }: ColorPickerProps) {
@@ -63,7 +65,7 @@ export function ColorPicker({
               <span
                 key={value.id}
                 className="block cursor-not-allowed opacity-40"
-                aria-label={t("unavailableVariantLabel", { name: option.name, value: value.name })}
+                aria-label={labels.unavailableVariant[option.name]?.[value.name]}
               >
                 {swatch}
               </span>
@@ -77,7 +79,7 @@ export function ColorPicker({
               replace
               scroll={false}
               className={cn("block cursor-pointer", !isAvailable && "opacity-40")}
-              aria-label={t("selectVariantLabel", { name: option.name, value: value.name })}
+              aria-label={labels.selectVariant[option.name]?.[value.name]}
               onClick={onOptionSelect ? () => onOptionSelect(option.name, value.name) : undefined}
             >
               {swatch}

--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -10,23 +10,27 @@ import { cn } from "@/lib/utils";
 export type ProductTranslator = Awaited<ReturnType<typeof getTranslations<"product">>>;
 
 interface ColorPickerProps extends React.ComponentProps<"div"> {
-  option: ProductOption;
-  selectedValue: string;
   available: Set<string> | undefined;
+  existing?: Set<string>;
   handle: string;
-  selectedOptions: SelectedOptions;
-  t: ProductTranslator;
   hideImages?: boolean;
+  onOptionSelect?: (name: string, value: string) => void;
+  option: ProductOption;
+  selectedOptions: SelectedOptions;
+  selectedValue: string;
+  t: ProductTranslator;
 }
 
 export function ColorPicker({
-  option,
-  selectedValue,
   available,
+  existing,
   handle,
-  selectedOptions,
-  t,
   hideImages,
+  onOptionSelect,
+  option,
+  selectedOptions,
+  selectedValue,
+  t,
   className,
   ...props
 }: ColorPickerProps) {
@@ -38,6 +42,7 @@ export function ColorPicker({
       <div className="flex flex-wrap gap-2.5">
         {option.values.map((value) => {
           const isSelected = selectedValue === value.name;
+          const exists = !existing || existing.has(value.name);
           const isAvailable = !available || available.has(value.name);
           const imageUrl = hideImages
             ? undefined
@@ -53,7 +58,7 @@ export function ColorPicker({
             />
           );
 
-          if (!isAvailable) {
+          if (!exists) {
             return (
               <span
                 key={value.id}
@@ -69,9 +74,11 @@ export function ColorPicker({
             <Link
               key={value.id}
               href={href}
+              replace
               scroll={false}
-              className="block cursor-pointer"
+              className={cn("block cursor-pointer", !isAvailable && "opacity-40")}
               aria-label={t("selectVariantLabel", { name: option.name, value: value.name })}
+              onClick={onOptionSelect ? () => onOptionSelect(option.name, value.name) : undefined}
             >
               {swatch}
             </Link>

--- a/apps/template/components/product-detail/option-picker.tsx
+++ b/apps/template/components/product-detail/option-picker.tsx
@@ -6,19 +6,23 @@ import type { ProductOption } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 interface OptionPickerProps extends React.ComponentProps<"div"> {
-  option: ProductOption;
-  selectedValue: string;
   available: Set<string> | undefined;
+  existing?: Set<string>;
   handle: string;
+  onOptionSelect?: (name: string, value: string) => void;
+  option: ProductOption;
   selectedOptions: SelectedOptions;
+  selectedValue: string;
 }
 
 export function OptionPicker({
-  option,
-  selectedValue,
   available,
+  existing,
   handle,
+  onOptionSelect,
+  option,
   selectedOptions,
+  selectedValue,
   className,
   ...props
 }: OptionPickerProps) {
@@ -29,17 +33,19 @@ export function OptionPicker({
         {option.values.map((value) => {
           const isSelected = selectedValue === value.name;
 
+          const exists = !existing || existing.has(value.name);
           const isAvailable = !available || available.has(value.name);
 
           const href = buildOptionUrl(handle, selectedOptions, option.name, value.name);
 
           const classes = cn(
             "grid px-5 py-2 text-center text-sm rounded-lg transition-all border",
-            !isAvailable
+            !exists
               ? "font-normal border-dashed border-border text-muted-foreground/50 line-through cursor-not-allowed"
               : isSelected
                 ? "font-medium border-foreground text-foreground starting:border-border starting:text-muted-foreground"
                 : "font-normal border-border text-muted-foreground hover:border-foreground hover:text-foreground",
+            !isAvailable && exists && "opacity-50",
           );
 
           // Invisible medium-weight twin reserves the bold width so pills don't shift on selection.
@@ -52,7 +58,7 @@ export function OptionPicker({
             </>
           );
 
-          if (!isAvailable) {
+          if (!exists) {
             return (
               <span key={value.id} className={classes}>
                 {label}
@@ -61,7 +67,14 @@ export function OptionPicker({
           }
 
           return (
-            <Link key={value.id} href={href} scroll={false} className={classes}>
+            <Link
+              key={value.id}
+              href={href}
+              replace
+              scroll={false}
+              className={classes}
+              onClick={onOptionSelect ? () => onOptionSelect(option.name, value.name) : undefined}
+            >
               {label}
             </Link>
           );

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -5,6 +5,7 @@ import { Suspense } from "react";
 import { BundleComponents, BundleParents } from "@/components/product-detail/bundle-components";
 import { BuyButtons, type BuyButtonVariant } from "@/components/product-detail/buy-buttons";
 import { BuyWithShopLogo } from "@/components/product-detail/buy-with-shop-logo";
+import type { ProductOptionLabels } from "@/components/product-detail/color-picker";
 import { ComplementaryProducts } from "@/components/product-detail/complementary-products";
 import { GiftCardPurchaseForm } from "@/components/product-detail/gift-card-purchase-form";
 import { ProductOpenGraph } from "@/components/product-detail/open-graph";
@@ -179,6 +180,7 @@ async function ProductInfoArea({
     ? { selectedOptions: defaultSelectedOptions(product), selectedVariant: product.defaultVariant }
     : null;
   const t = await getTranslations("product");
+  const optionLabels = buildProductOptionLabels(options, t);
 
   return (
     <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
@@ -205,20 +207,20 @@ async function ProductInfoArea({
       {eagerSelection ? (
         <ProductInfoOptions
           availableValues={availableValues}
+          labels={optionLabels}
           options={options}
           selectedOptions={eagerSelection.selectedOptions}
           handle={handle}
-          t={t}
         />
       ) : product.isGiftCard ? (
         <Suspense
           fallback={
             <ProductInfoOptions
               availableValues={availableValues}
+              labels={optionLabels}
               options={options}
               selectedOptions={{}}
               handle={handle}
-              t={t}
               hideImages
             />
           }
@@ -227,8 +229,8 @@ async function ProductInfoArea({
             availableValues={availableValues}
             options={options}
             handle={handle}
+            labels={optionLabels}
             selectedOptionsPromise={selectedOptionsPromise}
-            t={t}
           />
         </Suspense>
       ) : null}
@@ -252,8 +254,13 @@ async function ProductInfoArea({
           quantityPicker={shopConfig.pdp.quantityPicker.isEnabled}
         />
       ) : (
-        <Suspense fallback={<ProductPurchaseControlsFallback product={product} t={t} />}>
+        <Suspense
+          fallback={
+            <ProductPurchaseControlsFallback labels={optionLabels} product={product} t={t} />
+          }
+        >
           <ResolvedProductPurchaseControls
+            labels={optionLabels}
             locale={locale}
             product={product}
             variantPromise={variantPromise}
@@ -313,25 +320,25 @@ async function ResolvedProductPrice({
 
 async function ResolvedProductInfoOptions({
   availableValues,
-  options,
   handle,
+  labels,
+  options,
   selectedOptionsPromise,
-  t,
 }: {
   availableValues: Map<string, Set<string>>;
-  options: ProductDetails["options"];
   handle: string;
+  labels: ProductOptionLabels;
+  options: ProductDetails["options"];
   selectedOptionsPromise: Promise<SelectedOptions>;
-  t: Awaited<ReturnType<typeof getTranslations<"product">>>;
 }) {
   const selectedOptions = await selectedOptionsPromise;
   return (
     <ProductInfoOptions
       availableValues={availableValues}
+      labels={labels}
       options={options}
       selectedOptions={selectedOptions}
       handle={handle}
-      t={t}
     />
   );
 }
@@ -351,10 +358,12 @@ function toBuyButtonVariant(variant: ProductVariant | undefined): BuyButtonVaria
 }
 
 async function ResolvedProductPurchaseControls({
+  labels,
   locale,
   product,
   variantPromise,
 }: {
+  labels: ProductOptionLabels;
   locale: Locale;
   product: ProductDetails;
   variantPromise: Promise<ProductVariant | undefined>;
@@ -362,6 +371,7 @@ async function ResolvedProductPurchaseControls({
   return (
     <ProductPurchaseControls
       buyWithShop={shopConfig.pdp.buyWithShop.isEnabled}
+      labels={labels}
       locale={locale}
       product={product}
       quantityPicker={shopConfig.pdp.quantityPicker.isEnabled}
@@ -370,10 +380,42 @@ async function ResolvedProductPurchaseControls({
   );
 }
 
+function buildProductOptionLabels(
+  options: ProductDetails["options"],
+  t: Awaited<ReturnType<typeof getTranslations<"product">>>,
+): ProductOptionLabels {
+  return {
+    selectVariant: Object.fromEntries(
+      options.map((option) => [
+        option.name,
+        Object.fromEntries(
+          option.values.map((value) => [
+            value.name,
+            t("selectVariantLabel", { name: option.name, value: value.name }),
+          ]),
+        ),
+      ]),
+    ),
+    unavailableVariant: Object.fromEntries(
+      options.map((option) => [
+        option.name,
+        Object.fromEntries(
+          option.values.map((value) => [
+            value.name,
+            t("unavailableVariantLabel", { name: option.name, value: value.name }),
+          ]),
+        ),
+      ]),
+    ),
+  };
+}
+
 function ProductPurchaseControlsFallback({
+  labels,
   product,
   t,
 }: {
+  labels: ProductOptionLabels;
   product: ProductDetails;
   t: Awaited<ReturnType<typeof getTranslations<"product">>>;
 }) {
@@ -390,9 +432,9 @@ function ProductPurchaseControlsFallback({
         )}
         handle={product.handle}
         hideImages
+        labels={labels}
         options={product.options}
         selectedOptions={{}}
-        t={t}
       />
       <BuyButtonsFallback
         allInStock={product.defaultVariant?.availableForSale ?? product.availableForSale}

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -256,7 +256,6 @@ async function ProductInfoArea({
           <ResolvedProductPurchaseControls
             locale={locale}
             product={product}
-            t={t}
             variantPromise={variantPromise}
           />
         </Suspense>
@@ -354,12 +353,10 @@ function toBuyButtonVariant(variant: ProductVariant | undefined): BuyButtonVaria
 async function ResolvedProductPurchaseControls({
   locale,
   product,
-  t,
   variantPromise,
 }: {
   locale: Locale;
   product: ProductDetails;
-  t: Awaited<ReturnType<typeof getTranslations<"product">>>;
   variantPromise: Promise<ProductVariant | undefined>;
 }) {
   return (
@@ -369,7 +366,6 @@ async function ResolvedProductPurchaseControls({
       product={product}
       quantityPicker={shopConfig.pdp.quantityPicker.isEnabled}
       selectedVariant={await variantPromise}
-      t={t}
     />
   );
 }

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -18,6 +18,7 @@ import {
   ProductMedia,
 } from "@/components/product-detail/product-media";
 import { ProductPrice } from "@/components/product-detail/product-price";
+import { ProductPurchaseControls } from "@/components/product-detail/product-purchase-controls-client";
 import { ProductSchema } from "@/components/product-detail/schema";
 import { BreadcrumbSchema } from "@/components/schema/breadcrumb-schema";
 import { Input } from "@/components/ui/input";
@@ -172,35 +173,34 @@ async function ProductInfoArea({
   locale: Locale;
 }) {
   const { options, handle, title, featuredImage, descriptionHtml, availableForSale } = product;
-  const uniformPrice = product.hasUniformPricing;
-  const uniformStock = product.allVariantsInStock;
   const singleVariant = product.variantsCount === 1;
   const availableValues = getAvailableOptionValues(options, product.encodedVariantAvailability);
   const eagerSelection = singleVariant
     ? { selectedOptions: defaultSelectedOptions(product), selectedVariant: product.defaultVariant }
     : null;
   const t = await getTranslations("product");
-  const buyFallbackT = uniformStock && !singleVariant ? t : null;
-  const allInStock = product.defaultVariant?.availableForSale ?? availableForSale;
 
   return (
     <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
-      <div data-slot="product-info-header">
-        <h1 className="text-foreground text-3xl">{title}</h1>
-        {uniformPrice ? (
-          <ProductPrice
-            amount={product.priceRange.minVariantPrice.amount}
-            currencyCode={product.priceRange.minVariantPrice.currencyCode}
-            compareAtAmount={product.compareAtPriceRange?.minVariantPrice.amount}
-            locale={locale}
-          />
-        ) : (
-          // h-7 matches the resolved price's text-xl line-height (1.75rem) — keep in sync to avoid CLS
-          <Suspense fallback={<div className="h-7" aria-hidden />}>
-            <ResolvedProductPrice variantPromise={variantPromise} locale={locale} />
-          </Suspense>
-        )}
-      </div>
+      {eagerSelection || product.isGiftCard ? (
+        <div data-slot="product-info-header">
+          <h1 className="text-foreground text-3xl">{title}</h1>
+          {eagerSelection ? (
+            <ProductPrice
+              amount={eagerSelection.selectedVariant?.price.amount ?? product.price.amount}
+              currencyCode={
+                eagerSelection.selectedVariant?.price.currencyCode ?? product.price.currencyCode
+              }
+              compareAtAmount={eagerSelection.selectedVariant?.compareAtPrice?.amount}
+              locale={locale}
+            />
+          ) : (
+            <Suspense fallback={<div className="h-7" aria-hidden />}>
+              <ResolvedProductPrice variantPromise={variantPromise} locale={locale} />
+            </Suspense>
+          )}
+        </div>
+      ) : null}
 
       {eagerSelection ? (
         <ProductInfoOptions
@@ -210,7 +210,7 @@ async function ProductInfoArea({
           handle={handle}
           t={t}
         />
-      ) : (
+      ) : product.isGiftCard ? (
         <Suspense
           fallback={
             <ProductInfoOptions
@@ -231,7 +231,7 @@ async function ProductInfoArea({
             t={t}
           />
         </Suspense>
-      )}
+      ) : null}
 
       {product.isGiftCard ? (
         <Suspense fallback={<GiftCardPurchaseFormFallback t={t} />}>
@@ -252,14 +252,11 @@ async function ProductInfoArea({
           quantityPicker={shopConfig.pdp.quantityPicker.isEnabled}
         />
       ) : (
-        <Suspense fallback={<BuyButtonsFallback t={buyFallbackT} allInStock={allInStock} />}>
-          <ResolvedBuyButtons
-            title={title}
-            handle={handle}
-            featuredImage={featuredImage}
-            availableForSale={availableForSale}
-            buyWithShop={shopConfig.pdp.buyWithShop.isEnabled}
-            quantityPicker={shopConfig.pdp.quantityPicker.isEnabled}
+        <Suspense fallback={<ProductPurchaseControlsFallback product={product} t={t} />}>
+          <ResolvedProductPurchaseControls
+            locale={locale}
+            product={product}
+            t={t}
             variantPromise={variantPromise}
           />
         </Suspense>
@@ -297,11 +294,11 @@ function BundleRelationships({
 }
 
 async function ResolvedProductPrice({
-  variantPromise,
   locale,
+  variantPromise,
 }: {
-  variantPromise: Promise<ProductVariant | undefined>;
   locale: Locale;
+  variantPromise: Promise<ProductVariant | undefined>;
 }) {
   const selectedVariant = await variantPromise;
   if (!selectedVariant) return null;
@@ -354,34 +351,58 @@ function toBuyButtonVariant(variant: ProductVariant | undefined): BuyButtonVaria
   };
 }
 
-async function ResolvedBuyButtons({
-  availableForSale,
-  buyWithShop,
-  featuredImage,
-  handle,
-  quantityPicker,
-  title,
+async function ResolvedProductPurchaseControls({
+  locale,
+  product,
+  t,
   variantPromise,
 }: {
-  availableForSale: boolean;
-  buyWithShop: boolean;
-  featuredImage: ProductDetails["featuredImage"];
-  handle: string;
-  quantityPicker: boolean;
-  title: string;
+  locale: Locale;
+  product: ProductDetails;
+  t: Awaited<ReturnType<typeof getTranslations<"product">>>;
   variantPromise: Promise<ProductVariant | undefined>;
 }) {
-  const selectedVariant = await variantPromise;
   return (
-    <BuyButtons
-      selectedVariant={toBuyButtonVariant(selectedVariant)}
-      title={title}
-      handle={handle}
-      featuredImage={featuredImage}
-      availableForSale={availableForSale}
-      buyWithShop={buyWithShop}
-      quantityPicker={quantityPicker}
+    <ProductPurchaseControls
+      buyWithShop={shopConfig.pdp.buyWithShop.isEnabled}
+      locale={locale}
+      product={product}
+      quantityPicker={shopConfig.pdp.quantityPicker.isEnabled}
+      selectedVariant={await variantPromise}
+      t={t}
     />
+  );
+}
+
+function ProductPurchaseControlsFallback({
+  product,
+  t,
+}: {
+  product: ProductDetails;
+  t: Awaited<ReturnType<typeof getTranslations<"product">>>;
+}) {
+  return (
+    <>
+      <div data-slot="product-info-header">
+        <h1 className="text-foreground text-3xl">{product.title}</h1>
+        <div className="h-7" aria-hidden />
+      </div>
+      <ProductInfoOptions
+        availableValues={getAvailableOptionValues(
+          product.options,
+          product.encodedVariantAvailability,
+        )}
+        handle={product.handle}
+        hideImages
+        options={product.options}
+        selectedOptions={{}}
+        t={t}
+      />
+      <BuyButtonsFallback
+        allInStock={product.defaultVariant?.availableForSale ?? product.availableForSale}
+        t={product.allVariantsInStock ? t : null}
+      />
+    </>
   );
 }
 

--- a/apps/template/components/product-detail/product-info.tsx
+++ b/apps/template/components/product-detail/product-info.tsx
@@ -40,20 +40,24 @@ function ProductInfoHeader({
 
 interface ProductInfoOptionsProps extends React.ComponentProps<"div"> {
   availableValues: Map<string, Set<string>>;
+  existingValues?: Map<string, Set<string>>;
+  handle: string;
+  hideImages?: boolean;
+  onOptionSelect?: (name: string, value: string) => void;
   options: ProductOption[];
   selectedOptions: SelectedOptions;
-  handle: string;
   t: ProductTranslator;
-  hideImages?: boolean;
 }
 
 function ProductInfoOptions({
   availableValues,
+  existingValues,
+  handle,
+  hideImages,
+  onOptionSelect,
   options,
   selectedOptions,
-  handle,
   t,
-  hideImages,
   className,
   ...props
 }: ProductInfoOptionsProps) {
@@ -88,7 +92,9 @@ function ProductInfoOptions({
             option={colorOption}
             selectedValue={selectedOptions[colorOption.name] ?? ""}
             available={availableValues.get(colorOption.name)}
+            existing={existingValues?.get(colorOption.name)}
             handle={handle}
+            onOptionSelect={onOptionSelect}
             selectedOptions={selectedOptions}
             t={t}
             hideImages={hideImages}
@@ -101,7 +107,9 @@ function ProductInfoOptions({
             option={option}
             selectedValue={selectedOptions[option.name] ?? ""}
             available={availableValues.get(option.name)}
+            existing={existingValues?.get(option.name)}
             handle={handle}
+            onOptionSelect={onOptionSelect}
             selectedOptions={selectedOptions}
           />
         ))}

--- a/apps/template/components/product-detail/product-info.tsx
+++ b/apps/template/components/product-detail/product-info.tsx
@@ -5,7 +5,7 @@ import type { ProductOption, ProductVariant } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 import { AboutItem } from "./about-item";
-import { ColorPicker, type ProductTranslator } from "./color-picker";
+import { ColorPicker, type ProductOptionLabels } from "./color-picker";
 import { OptionPicker } from "./option-picker";
 import { ProductPrice } from "./product-price";
 
@@ -43,10 +43,10 @@ interface ProductInfoOptionsProps extends React.ComponentProps<"div"> {
   existingValues?: Map<string, Set<string>>;
   handle: string;
   hideImages?: boolean;
+  labels: ProductOptionLabels;
   onOptionSelect?: (name: string, value: string) => void;
   options: ProductOption[];
   selectedOptions: SelectedOptions;
-  t: ProductTranslator;
 }
 
 function ProductInfoOptions({
@@ -54,10 +54,10 @@ function ProductInfoOptions({
   existingValues,
   handle,
   hideImages,
+  labels,
   onOptionSelect,
   options,
   selectedOptions,
-  t,
   className,
   ...props
 }: ProductInfoOptionsProps) {
@@ -94,9 +94,9 @@ function ProductInfoOptions({
             available={availableValues.get(colorOption.name)}
             existing={existingValues?.get(colorOption.name)}
             handle={handle}
+            labels={labels}
             onOptionSelect={onOptionSelect}
             selectedOptions={selectedOptions}
-            t={t}
             hideImages={hideImages}
           />
         ))}

--- a/apps/template/components/product-detail/product-purchase-controls-client.tsx
+++ b/apps/template/components/product-detail/product-purchase-controls-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { createProductComponents } from "@shopify/hydrogen/react";
-import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 
@@ -12,6 +11,7 @@ import type { SelectedOptions } from "@/lib/product";
 import type { ProductDetails, ProductVariant } from "@/lib/types";
 
 import { BuyButtons } from "./buy-buttons";
+import type { ProductOptionLabels } from "./color-picker";
 
 interface ProductFormProduct {
   adjacentVariants: ProductVariant[];
@@ -35,6 +35,7 @@ const { ProductProvider, useProduct } = createProductComponents<ProductFormProdu
 
 interface ProductPurchaseControlsProps {
   buyWithShop: boolean;
+  labels: ProductOptionLabels;
   locale: Locale;
   product: ProductDetails;
   quantityPicker: boolean;
@@ -43,6 +44,7 @@ interface ProductPurchaseControlsProps {
 
 export function ProductPurchaseControls({
   buyWithShop,
+  labels,
   locale,
   product,
   quantityPicker,
@@ -88,6 +90,7 @@ export function ProductPurchaseControls({
     >
       <ProductPurchaseControlsContent
         buyWithShop={buyWithShop}
+        labels={labels}
         locale={locale}
         product={product}
         quantityPicker={quantityPicker}
@@ -98,12 +101,12 @@ export function ProductPurchaseControls({
 
 function ProductPurchaseControlsContent({
   buyWithShop,
+  labels,
   locale,
   product,
   quantityPicker,
 }: Omit<ProductPurchaseControlsProps, "selectedVariant">) {
   const { options, selectedVariant, selectOption } = useProduct();
-  const t = useTranslations("product");
   const selectedOptions: SelectedOptions = Object.fromEntries(
     options.flatMap((option) =>
       option.values.filter((value) => value.selected).map((value) => [option.name, value.name]),
@@ -141,10 +144,10 @@ function ProductPurchaseControlsContent({
         availableValues={availableValues}
         existingValues={existingValues}
         handle={product.handle}
+        labels={labels}
         onOptionSelect={selectOption}
         options={product.options}
         selectedOptions={selectedOptions}
-        t={t}
       />
       <BuyButtons
         selectedVariant={

--- a/apps/template/components/product-detail/product-purchase-controls-client.tsx
+++ b/apps/template/components/product-detail/product-purchase-controls-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createProductComponents } from "@shopify/hydrogen/react";
+import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 
@@ -11,7 +12,6 @@ import type { SelectedOptions } from "@/lib/product";
 import type { ProductDetails, ProductVariant } from "@/lib/types";
 
 import { BuyButtons } from "./buy-buttons";
-import type { ProductTranslator } from "./color-picker";
 
 interface ProductFormProduct {
   adjacentVariants: ProductVariant[];
@@ -39,7 +39,6 @@ interface ProductPurchaseControlsProps {
   product: ProductDetails;
   quantityPicker: boolean;
   selectedVariant: ProductVariant | undefined;
-  t: ProductTranslator;
 }
 
 export function ProductPurchaseControls({
@@ -48,7 +47,6 @@ export function ProductPurchaseControls({
   product,
   quantityPicker,
   selectedVariant,
-  t,
 }: ProductPurchaseControlsProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -93,7 +91,6 @@ export function ProductPurchaseControls({
         locale={locale}
         product={product}
         quantityPicker={quantityPicker}
-        t={t}
       />
     </ProductProvider>
   );
@@ -104,9 +101,9 @@ function ProductPurchaseControlsContent({
   locale,
   product,
   quantityPicker,
-  t,
 }: Omit<ProductPurchaseControlsProps, "selectedVariant">) {
   const { options, selectedVariant, selectOption } = useProduct();
+  const t = useTranslations("product");
   const selectedOptions: SelectedOptions = Object.fromEntries(
     options.flatMap((option) =>
       option.values.filter((value) => value.selected).map((value) => [option.name, value.name]),

--- a/apps/template/components/product-detail/product-purchase-controls-client.tsx
+++ b/apps/template/components/product-detail/product-purchase-controls-client.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { createProductComponents } from "@shopify/hydrogen/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+
+import { ProductInfoOptions } from "@/components/product-detail/product-info";
+import { ProductPrice } from "@/components/product-detail/product-price";
+import type { Locale } from "@/lib/i18n";
+import type { SelectedOptions } from "@/lib/product";
+import type { ProductDetails, ProductVariant } from "@/lib/types";
+
+import { BuyButtons } from "./buy-buttons";
+import type { ProductTranslator } from "./color-picker";
+
+interface ProductFormProduct {
+  adjacentVariants: ProductVariant[];
+  encodedVariantAvailability?: string;
+  encodedVariantExistence?: string;
+  handle: string;
+  id: string;
+  options: Array<{
+    name: string;
+    optionValues: Array<{
+      firstSelectableVariant?: ProductVariant;
+      name: string;
+      swatch?: ProductDetails["options"][number]["values"][number]["swatch"];
+    }>;
+  }>;
+  selectedOrFirstAvailableVariant: ProductVariant | null;
+  title: string;
+}
+
+const { ProductProvider, useProduct } = createProductComponents<ProductFormProduct>();
+
+interface ProductPurchaseControlsProps {
+  buyWithShop: boolean;
+  locale: Locale;
+  product: ProductDetails;
+  quantityPicker: boolean;
+  selectedVariant: ProductVariant | undefined;
+  t: ProductTranslator;
+}
+
+export function ProductPurchaseControls({
+  buyWithShop,
+  locale,
+  product,
+  quantityPicker,
+  selectedVariant,
+  t,
+}: ProductPurchaseControlsProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const productFormProduct = useMemo(
+    (): ProductFormProduct => ({
+      adjacentVariants: product.adjacentVariants,
+      encodedVariantAvailability: product.encodedVariantAvailability,
+      encodedVariantExistence: product.encodedVariantExistence,
+      handle: product.handle,
+      id: product.id,
+      options: product.options.map((option) => ({
+        name: option.name,
+        optionValues: option.values.map((value) => ({
+          firstSelectableVariant: value.firstSelectableVariant,
+          name: value.name,
+          swatch: value.swatch,
+        })),
+      })),
+      selectedOrFirstAvailableVariant: selectedVariant ?? null,
+      title: product.title,
+    }),
+    [product, selectedVariant],
+  );
+
+  return (
+    <ProductProvider
+      product={productFormProduct}
+      onSelect={(result) => {
+        const next = new URLSearchParams(searchParams);
+        for (const option of product.options) next.delete(option.name.toLowerCase());
+        for (const option of result.selectedOptions) {
+          next.set(option.name.toLowerCase(), option.value);
+        }
+        const query = next.toString();
+        router.replace(`/products/${product.handle}${query ? `?${query}` : ""}`, {
+          scroll: false,
+        });
+      }}
+    >
+      <ProductPurchaseControlsContent
+        buyWithShop={buyWithShop}
+        locale={locale}
+        product={product}
+        quantityPicker={quantityPicker}
+        t={t}
+      />
+    </ProductProvider>
+  );
+}
+
+function ProductPurchaseControlsContent({
+  buyWithShop,
+  locale,
+  product,
+  quantityPicker,
+  t,
+}: Omit<ProductPurchaseControlsProps, "selectedVariant">) {
+  const { options, selectedVariant, selectOption } = useProduct();
+  const selectedOptions: SelectedOptions = Object.fromEntries(
+    options.flatMap((option) =>
+      option.values.filter((value) => value.selected).map((value) => [option.name, value.name]),
+    ),
+  );
+  const availableValues = new Map(
+    options.map((option) => [
+      option.name,
+      new Set(option.values.filter((value) => value.available).map((value) => value.name)),
+    ]),
+  );
+  const existingValues = new Map(
+    options.map((option) => [
+      option.name,
+      new Set(option.values.filter((value) => value.exists).map((value) => value.name)),
+    ]),
+  );
+
+  return (
+    <>
+      <div data-slot="product-info-header">
+        <h1 className="text-foreground text-3xl">{product.title}</h1>
+        {selectedVariant ? (
+          <ProductPrice
+            amount={selectedVariant.price.amount}
+            currencyCode={selectedVariant.price.currencyCode}
+            compareAtAmount={selectedVariant.compareAtPrice?.amount}
+            locale={locale}
+          />
+        ) : (
+          <div className="h-7" aria-hidden />
+        )}
+      </div>
+      <ProductInfoOptions
+        availableValues={availableValues}
+        existingValues={existingValues}
+        handle={product.handle}
+        onOptionSelect={selectOption}
+        options={product.options}
+        selectedOptions={selectedOptions}
+        t={t}
+      />
+      <BuyButtons
+        selectedVariant={
+          selectedVariant
+            ? {
+                availableForSale: selectedVariant.availableForSale,
+                id: selectedVariant.id,
+                image: selectedVariant.image,
+                price: selectedVariant.price,
+                requiresBundleConfiguration:
+                  selectedVariant.requiresComponents && selectedVariant.components.length === 0,
+                selectedOptions: selectedVariant.selectedOptions,
+                title: selectedVariant.title,
+              }
+            : undefined
+        }
+        title={product.title}
+        handle={product.handle}
+        featuredImage={product.featuredImage}
+        availableForSale={product.availableForSale}
+        buyWithShop={buyWithShop}
+        quantityPicker={quantityPicker}
+      />
+    </>
+  );
+}

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -354,6 +354,9 @@ export const PRODUCT_FRAGMENT = `#graphql
     selectedOrFirstAvailableVariant {
       ...ProductVariantFields
     }
+    adjacentVariants {
+      ...ProductVariantFields
+    }
     options {
       id
       name
@@ -370,9 +373,7 @@ export const PRODUCT_FRAGMENT = `#graphql
           }
         }
         firstSelectableVariant {
-          image {
-            ...ImageFields
-          }
+          ...ProductVariantFields
         }
       }
     }

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -87,6 +87,16 @@ const GET_PRODUCT_BY_HANDLE_WITH_BUNDLES_QUERY = `#graphql
   query getProductByHandleWithBundles($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     productByHandle(handle: $handle) {
       ...ProductFields
+      adjacentVariants {
+        ...BundleRelationshipFields
+      }
+      options {
+        optionValues {
+          firstSelectableVariant {
+            ...BundleRelationshipFields
+          }
+        }
+      }
       selectedOrFirstAvailableVariant {
         ...BundleRelationshipFields
       }

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -59,10 +59,10 @@ interface ShopifyOptionValueSwatch {
 }
 
 interface ShopifyOptionValue {
+  firstSelectableVariant?: ShopifyVariant | null;
   id: string;
   name: string;
   swatch: ShopifyOptionValueSwatch | null;
-  firstSelectableVariant?: { image: ShopifyImage | null } | null;
 }
 
 interface ShopifyOption {
@@ -125,6 +125,7 @@ export interface ShopifyProduct {
     minVariantPrice: ShopifyMoney;
     maxVariantPrice: ShopifyMoney;
   } | null;
+  adjacentVariants?: ShopifyVariant[];
   encodedVariantAvailability?: string | null;
   encodedVariantExistence?: string | null;
   variantsCount: { count: number };
@@ -279,26 +280,23 @@ function transformSwatch(swatch: ShopifyOptionValueSwatch | null): OptionValueSw
 }
 
 function transformOption(option: ShopifyOption): ProductOption {
-  const swatchLookup = new Map<string, OptionValueSwatch | undefined>();
-  const imageLookup = new Map<string, string | undefined>();
-  if (option.optionValues) {
-    for (const ov of option.optionValues) {
-      swatchLookup.set(ov.name, transformSwatch(ov.swatch));
-      imageLookup.set(ov.name, ov.firstSelectableVariant?.image?.url);
-    }
-  }
+  const optionValueLookup = new Map(option.optionValues?.map((value) => [value.name, value]));
 
   return {
     id: option.id,
     name: option.name,
-    values: option.values.map(
-      (value): OptionValue => ({
+    values: option.values.map((value): OptionValue => {
+      const optionValue = optionValueLookup.get(value);
+      return {
+        firstSelectableVariant: optionValue?.firstSelectableVariant
+          ? transformVariant(optionValue.firstSelectableVariant)
+          : undefined,
         id: value,
-        image: imageLookup.get(value),
+        image: optionValue?.firstSelectableVariant?.image?.url,
         name: value,
-        swatch: swatchLookup.get(value),
-      }),
-    ),
+        swatch: transformSwatch(optionValue?.swatch ?? null),
+      };
+    }),
   };
 }
 
@@ -351,6 +349,7 @@ export function transformShopifyProductDetails(product: ShopifyProduct): Product
     vendor: product.vendor || undefined,
     availableForSale: product.availableForSale,
     isGiftCard: product.isGiftCard,
+    adjacentVariants: product.adjacentVariants?.map(transformVariant) ?? [],
     allVariantsInStock:
       !product.encodedVariantExistence ||
       product.encodedVariantExistence === product.encodedVariantAvailability,

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -53,6 +53,7 @@ export interface ProductCard {
 }
 
 export interface ProductDetails extends ProductCard {
+  adjacentVariants: ProductVariant[];
   allVariantsInStock: boolean;
   category?: Category | null;
   categoryId?: string;
@@ -126,6 +127,7 @@ export interface OptionValueSwatch {
 }
 
 export interface OptionValue {
+  firstSelectableVariant?: ProductVariant;
   id: string;
   image?: string;
   name: string;


### PR DESCRIPTION
## Summary

- keep the PDP's coherent cached route shell and server-resolved initial variant
- use Hydrogen's product form store to resolve same-product option selections immediately from encoded availability plus sparse adjacent variants
- keep option controls as real links while replacing the URL after client selection, preserving refresh and no-JavaScript behavior
- document the hybrid server/client variant model

## Why

The PDP intentionally remains a blocking, coherent product route rather than exposing a generic loading shell. Once the product is loaded, however, variant interaction should not be paced by a route round trip when Shopify already provides enough encoded and sparse variant data to resolve it locally.

## Verification

- `pnpm --dir apps/template format` — passed
- `pnpm --dir apps/template codegen` — passed
- `pnpm --dir apps/template exec next typegen` — passed
- `pnpm --dir apps/template exec tsc --noEmit` — passed
- `pnpm --dir apps/template lint` — passed
- `pnpm --dir apps/template build` — passed

`pnpm --dir apps/template exec hydrogen gql check --fail-on-warn` is currently blocked by Hydrogen/gql.tada under the workspace's TypeScript 7: `TypeError: a.parseConfigFileTextToJson is not a function`. The repository GraphQL codegen validated and generated the changed documents successfully.

The session's tracked `apps/template/lib/shopify/transforms/image-placeholders.test.ts` does not exist on `main`; it belonged to the earlier demo branch and could not be run here.
