### PR TITLE
Add Hydrogen storefront analytics events

### DIFF
--- a/apps/docs/content/docs/skills/enable-analytics.mdx
+++ b/apps/docs/content/docs/skills/enable-analytics.mdx
@@ -150,11 +150,11 @@ The root component remains mounted as the extension point for current and future
 
 Only make changes here if the user asked about Shopify analytics.
 
-The storefront sends page views to Shopify analytics through Hydrogen's analytics bus. It is disabled by default and requires no credentials beyond the Storefront API variables the storefront already needs. To turn it on, set `analytics.shopify.isEnabled` to `true` in `lib/config.ts`.
+The storefront sends page, product, collection, search, cart-view, and confirmed cart-change events through Hydrogen's analytics bus. It is disabled by default and requires no credentials beyond the Storefront API variables the storefront already needs. To turn Shopify's built-in analytics destination on, set `analytics.shopify.isEnabled` to `true` in `lib/config.ts`.
 
 Consent mode is set by `analytics.shopify.consentMode` in `lib/config.ts` and defaults to `default-banner`, which renders Shopify's hosted privacy banner for visitors in regions that require consent. Use `custom-banner` when the storefront supplies its own consent UI. Do not ship `no-banner` in production unless consent is handled elsewhere, because visitors in those regions can never grant consent and their events are dropped.
 
-This integration covers page views only. Commerce events such as product views and cart activity are not wired up.
+Third-party analytics can subscribe through the same destination API, so consent gating and buffered replay remain centralized. Register destinations with `addAnalyticsDestination()` from `lib/analytics/client.ts`; do not publish cart-change events manually.
 
 ## Guardrails
 

--- a/apps/template/app/cart/page.tsx
+++ b/apps/template/app/cart/page.tsx
@@ -3,6 +3,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
+import { CartViewedTracker } from "@/components/analytics/trackers";
 import { CartItemsList } from "@/components/cart-page/cart-items-list";
 import { Empty } from "@/components/cart-page/empty-cart";
 import { Header } from "@/components/cart-page/header";
@@ -36,6 +37,7 @@ export default async function CartPage() {
 
   return (
     <main>
+      <CartViewedTracker />
       <Suspense fallback={<PageSkeleton />}>
         <CartContent locale={locale} />
       </Suspense>

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 
+import { ProductViewedTracker } from "@/components/analytics/trackers";
 import { ProductDetailSection } from "@/components/product-detail/product-detail-section";
 import { RelatedProductsSection } from "@/components/product/related-products-section";
 import { Container } from "@/components/ui/container";
@@ -121,20 +123,25 @@ export default async function ProductPage({
   );
 
   return (
-    <Page className="pt-0">
-      <Container className="bg-background">
-        <Sections>
-          <ProductDetailSection
-            product={product}
-            selectedOptionsPromise={selectedOptionsPromise}
-            variantPromise={variantPromise}
-            locale={locale}
-          />
-          {shopConfig.pdp.relatedProducts.isEnabled ? (
-            <RelatedProductsSection handle={handle} limit={4} locale={locale} />
-          ) : null}
-        </Sections>
-      </Container>
-    </Page>
+    <>
+      <Suspense fallback={null}>
+        <ProductViewedTracker product={product} variantPromise={variantPromise} />
+      </Suspense>
+      <Page className="pt-0">
+        <Container className="bg-background">
+          <Sections>
+            <ProductDetailSection
+              product={product}
+              selectedOptionsPromise={selectedOptionsPromise}
+              variantPromise={variantPromise}
+              locale={locale}
+            />
+            {shopConfig.pdp.relatedProducts.isEnabled ? (
+              <RelatedProductsSection handle={handle} limit={4} locale={locale} />
+            ) : null}
+          </Sections>
+        </Container>
+      </Page>
+    </>
   );
 }

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 import { Suspense } from "react";
 
+import { SearchViewedTracker } from "@/components/analytics/trackers";
 import {
   FilterPendingScope,
   FilterTransitionProvider,
@@ -86,6 +87,9 @@ export default async function SearchPage({ searchParams }: PageProps<"/search">)
       <Container>
         <FilterTransitionProvider>
           <Sections className="gap-5">
+            <Suspense fallback={null}>
+              <SearchAnalyticsTracker searchParamsPromise={searchParams} />
+            </Suspense>
             <div>
               <h1 className="text-3xl sm:text-4xl md:text-5xl">
                 <Link href="/search">{t("title")}</Link>
@@ -146,6 +150,16 @@ export default async function SearchPage({ searchParams }: PageProps<"/search">)
       </Container>
     </Page>
   );
+}
+
+async function SearchAnalyticsTracker({
+  searchParamsPromise,
+}: {
+  searchParamsPromise: PageProps<"/search">["searchParams"];
+}) {
+  const searchParams = await searchParamsPromise;
+  const query = Array.isArray(searchParams.q) ? searchParams.q[0] : searchParams.q;
+  return <SearchViewedTracker searchTerm={query ?? ""} />;
 }
 
 async function SearchQueryLabel({

--- a/apps/template/components/analytics/shopify-client.tsx
+++ b/apps/template/components/analytics/shopify-client.tsx
@@ -1,15 +1,23 @@
 "use client";
 
-import type { I18nConfig } from "@shopify/hydrogen";
+import type { ShopifyScriptsI18n, ShopifyScriptsShop } from "@shopify/hydrogen";
 import { ShopifyScripts, useCartAnalytics } from "@shopify/hydrogen/react";
 import { useRouter } from "next/navigation";
+import { type ReactNode, useEffect, useState } from "react";
 
+import { PageViewedTracker } from "@/components/analytics/trackers";
 import { shopConfig } from "@/lib/config";
 import type { ShopAnalyticsData } from "@/lib/types";
 
 interface ShopifyScriptsTrackerProps {
   shop: ShopAnalyticsData;
   storefrontId: string;
+}
+
+function AnalyticsReady({ children }: { children: ReactNode }) {
+  const [isReady, setIsReady] = useState(false);
+  useEffect(() => setIsReady(true), []);
+  return isReady ? children : null;
 }
 
 function CartAnalyticsTracker() {
@@ -19,6 +27,16 @@ function CartAnalyticsTracker() {
 
 export function ShopifyScriptsTracker({ shop, storefrontId }: ShopifyScriptsTrackerProps) {
   const router = useRouter();
+  const i18n: ShopifyScriptsI18n = {
+    country: shop.country,
+    currency: shop.currency,
+    language: shop.acceptedLanguage,
+  };
+  const shopifyShop: ShopifyScriptsShop = {
+    myshopifyDomain: shop.storeDomain,
+    shopId: shop.shopId,
+    storefrontId,
+  };
 
   return (
     <>
@@ -31,23 +49,16 @@ export function ShopifyScriptsTracker({ shop, storefrontId }: ShopifyScriptsTrac
       <ShopifyScripts
         analytics={{ channel: "headless" }}
         consent={{ mode: shopConfig.analytics.shopify.consentMode }}
-        i18n={
-          {
-            country: shop.country,
-            currency: shop.currency,
-            language: shop.acceptedLanguage,
-          } as I18nConfig & { currency: string }
-        }
+        i18n={i18n}
         navigate={(url) => router.push(url)}
-        shop={{
-          shopId: shop.shopId,
-          myshopifyDomain: shop.storeDomain,
-          storefrontId,
-        }}
+        shop={shopifyShop}
         shopifyAnalytics={shopConfig.analytics.shopify.isEnabled}
         webMcp={shopConfig.webmcp.isEnabled}
       />
-      <CartAnalyticsTracker />
+      <AnalyticsReady>
+        <PageViewedTracker />
+        <CartAnalyticsTracker />
+      </AnalyticsReady>
     </>
   );
 }

--- a/apps/template/components/analytics/trackers.tsx
+++ b/apps/template/components/analytics/trackers.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import type { AnalyticsCart, CollectionViewPayload, ProductPayload } from "@shopify/hydrogen";
+import { useCart } from "@shopify/hydrogen/react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { use, useEffect, useRef } from "react";
+
+import { AnalyticsEvent, getAnalytics } from "@/lib/analytics/client";
+import type { ProductDetails, ProductVariant } from "@/lib/types";
+
+export function CartViewedTracker() {
+  const cartState = useCart((state) => state);
+  const trackedRef = useRef(false);
+
+  useEffect(() => {
+    if (cartState.loading || trackedRef.current) return;
+    const cart = isAnalyticsCart(cartState.data) ? cartState.data : null;
+    getAnalytics()?.publish(AnalyticsEvent.CART_VIEWED, { cart });
+    trackedRef.current = true;
+  }, [cartState.data, cartState.loading]);
+  return null;
+}
+
+export function CollectionViewedTracker({
+  collection,
+}: {
+  collection: CollectionViewPayload["collection"];
+}) {
+  const { handle, id } = collection;
+  useEffect(() => {
+    getAnalytics()?.publish(AnalyticsEvent.COLLECTION_VIEWED, { collection: { handle, id } });
+  }, [handle, id]);
+  return null;
+}
+
+export function PageViewedTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const pageKey = `${pathname}?${searchParams.toString()}`;
+
+  useEffect(() => {
+    getAnalytics()?.publish(AnalyticsEvent.PAGE_VIEWED);
+  }, [pageKey]);
+  return null;
+}
+
+export function ProductViewedTracker({
+  product,
+  variantPromise,
+}: {
+  product: ProductDetails;
+  variantPromise: Promise<ProductVariant | undefined>;
+}) {
+  const variant = use(variantPromise);
+  const trackedHandleRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!variant || trackedHandleRef.current === product.handle) return;
+    const payload: ProductPayload = {
+      id: product.id,
+      price: variant.price.amount,
+      quantity: 1,
+      title: product.title,
+      variantId: variant.id,
+      variantTitle: variant.title,
+      vendor: product.manufacturerName,
+    };
+    getAnalytics()?.publish(AnalyticsEvent.PRODUCT_VIEWED, { products: [payload] });
+    trackedHandleRef.current = product.handle;
+  }, [product, variant]);
+  return null;
+}
+
+export function SearchViewedTracker({ searchTerm }: { searchTerm: string }) {
+  useEffect(() => {
+    getAnalytics()?.publish(AnalyticsEvent.SEARCH_VIEWED, { searchTerm });
+  }, [searchTerm]);
+  return null;
+}
+
+function isAnalyticsCart(cart: Record<string, unknown>): cart is AnalyticsCart {
+  return Boolean(cart.id && cart.updatedAt && cart.lines);
+}

--- a/apps/template/components/collections/collection-page.tsx
+++ b/apps/template/components/collections/collection-page.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 import { Suspense } from "react";
 
+import { CollectionViewedTracker } from "@/components/analytics/trackers";
 import { FilterSidebarSheet } from "@/components/collections/filter-sidebar-sheet";
 import { CollectionFilters } from "@/components/collections/filters";
 import { CollectionResultsGrid } from "@/components/collections/results-grid";
@@ -43,54 +44,59 @@ export async function CollectionDetailPage({
   const sortByLabel = tSearch("sortBy");
 
   return (
-    <FilterTransitionProvider>
-      <Page className="pt-2.5 md:pt-10">
-        <Container>
-          <Sections className="gap-5">
-            <CollectionHeader
-              collection={collection}
-              handle={handle}
-              homeLabel={tBreadcrumb("home")}
-            />
-
-            <CollectionToolbar
-              filterSheet={
-                <FilterSidebarSheet
-                  label={filtersLabel}
-                  trigger={
-                    <button type="button" className="flex items-center gap-2 text-sm font-medium">
-                      <SlidersHorizontalIcon className="size-4" />
-                      <span>{filtersLabel}</span>
-                      <Suspense fallback={null}>
-                        <CollectionFilterCountBadge searchStatePromise={searchStatePromise} />
-                      </Suspense>
-                    </button>
-                  }
-                >
-                  <FilterPendingScope>
-                    <CollectionFilters
-                      collectionResultsDataPromise={collectionResultsDataPromise}
-                    />
-                  </FilterPendingScope>
-                </FilterSidebarSheet>
-              }
-              sortSelect={
-                <Suspense fallback={<SortSelectFallback label={sortByLabel} />}>
-                  <CollectionsSortSelect exclude={sortExclude} />
-                </Suspense>
-              }
-            />
-
-            <FilterPendingScope>
-              <CollectionResultsGrid
-                locale={locale}
-                collectionResultsDataPromise={collectionResultsDataPromise}
+    <>
+      {collection.id ? (
+        <CollectionViewedTracker collection={{ handle: collection.handle, id: collection.id }} />
+      ) : null}
+      <FilterTransitionProvider>
+        <Page className="pt-2.5 md:pt-10">
+          <Container>
+            <Sections className="gap-5">
+              <CollectionHeader
+                collection={collection}
+                handle={handle}
+                homeLabel={tBreadcrumb("home")}
               />
-            </FilterPendingScope>
-          </Sections>
-        </Container>
-      </Page>
-    </FilterTransitionProvider>
+
+              <CollectionToolbar
+                filterSheet={
+                  <FilterSidebarSheet
+                    label={filtersLabel}
+                    trigger={
+                      <button type="button" className="flex items-center gap-2 text-sm font-medium">
+                        <SlidersHorizontalIcon className="size-4" />
+                        <span>{filtersLabel}</span>
+                        <Suspense fallback={null}>
+                          <CollectionFilterCountBadge searchStatePromise={searchStatePromise} />
+                        </Suspense>
+                      </button>
+                    }
+                  >
+                    <FilterPendingScope>
+                      <CollectionFilters
+                        collectionResultsDataPromise={collectionResultsDataPromise}
+                      />
+                    </FilterPendingScope>
+                  </FilterSidebarSheet>
+                }
+                sortSelect={
+                  <Suspense fallback={<SortSelectFallback label={sortByLabel} />}>
+                    <CollectionsSortSelect exclude={sortExclude} />
+                  </Suspense>
+                }
+              />
+
+              <FilterPendingScope>
+                <CollectionResultsGrid
+                  locale={locale}
+                  collectionResultsDataPromise={collectionResultsDataPromise}
+                />
+              </FilterPendingScope>
+            </Sections>
+          </Container>
+        </Page>
+      </FilterTransitionProvider>
+    </>
   );
 }
 

--- a/apps/template/lib/analytics/client.ts
+++ b/apps/template/lib/analytics/client.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import {
+  AnalyticsEvent,
+  type StorefrontAnalytics,
+  type StorefrontAnalyticsDestination,
+} from "@shopify/hydrogen";
+
+export { AnalyticsEvent };
+
+let analytics: StorefrontAnalytics | null = null;
+
+export function addAnalyticsDestination(destination: StorefrontAnalyticsDestination): () => void {
+  return getAnalytics()?.addDestination(destination) ?? (() => {});
+}
+
+export function getAnalytics(): StorefrontAnalytics | null {
+  if (typeof window === "undefined") return null;
+  if (analytics) return analytics;
+  analytics = window.Shopify?.analytics ?? null;
+  return analytics;
+}

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -275,6 +275,7 @@ export const CART_FRAGMENT = `#graphql
 export const COLLECTION_FIELDS_FRAGMENT = `#graphql
   ${IMAGE_FRAGMENT}
   fragment CollectionFields on Collection {
+    id
     handle
     title
     description

--- a/apps/template/lib/shopify/operations/shop.ts
+++ b/apps/template/lib/shopify/operations/shop.ts
@@ -1,3 +1,4 @@
+import type { I18nConfig } from "@shopify/hydrogen";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
@@ -49,8 +50,8 @@ export async function getShopAnalytics({
   assertStorefrontOk(response, "getShopAnalytics");
 
   return {
-    acceptedLanguage: language,
-    country,
+    acceptedLanguage: language as I18nConfig["language"],
+    country: country as I18nConfig["country"],
     currency: response.data.localization.country.currency.isoCode,
     shopId: response.data.shop.id,
     storeDomain: process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN as string,

--- a/apps/template/lib/shopify/transforms/collection.ts
+++ b/apps/template/lib/shopify/transforms/collection.ts
@@ -2,6 +2,7 @@ import type { Collection } from "@/lib/types";
 
 interface ShopifyCollection {
   handle: string;
+  id: string;
   title: string;
   description: string;
   image: {
@@ -20,6 +21,7 @@ interface ShopifyCollection {
 export function transformShopifyCollection(collection: ShopifyCollection): Collection {
   return {
     handle: collection.handle,
+    id: collection.id,
     title: collection.title,
     description: collection.description,
     image: collection.image

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -1,3 +1,5 @@
+import type { I18nConfig } from "@shopify/hydrogen";
+
 import type { Locale } from "@/lib/i18n";
 
 export type SearchParamsPromise = Promise<Record<string, string | string[] | undefined>>;
@@ -214,6 +216,7 @@ export interface CartProduct {
 export interface Collection {
   description: string;
   handle: string;
+  id?: string;
   image?: Image | null;
   path: string;
   seo: SEO;
@@ -322,8 +325,8 @@ export interface SearchSuggestion {
 }
 
 export interface ShopAnalyticsData {
-  acceptedLanguage: string;
-  country: string;
+  acceptedLanguage: I18nConfig["language"];
+  country: I18nConfig["country"];
   currency: string;
   shopId: string;
   storeDomain: string;

--- a/packages/plugin/skills/enable-analytics/SKILL.md
+++ b/packages/plugin/skills/enable-analytics/SKILL.md
@@ -139,11 +139,11 @@ The root component remains mounted as the extension point for current and future
 
 Only make changes here if the user asked about Shopify analytics.
 
-The storefront sends page views to Shopify analytics through Hydrogen's analytics bus. It is disabled by default and requires no credentials beyond the Storefront API variables the storefront already needs. To turn it on, set `analytics.shopify.isEnabled` to `true` in `lib/config.ts`.
+The storefront sends page, product, collection, search, cart-view, and confirmed cart-change events through Hydrogen's analytics bus. It is disabled by default and requires no credentials beyond the Storefront API variables the storefront already needs. To turn Shopify's built-in analytics destination on, set `analytics.shopify.isEnabled` to `true` in `lib/config.ts`.
 
 Consent mode is set by `analytics.shopify.consentMode` in `lib/config.ts` and defaults to `default-banner`, which renders Shopify's hosted privacy banner for visitors in regions that require consent. Use `custom-banner` when the storefront supplies its own consent UI. Do not ship `no-banner` in production unless consent is handled elsewhere, because visitors in those regions can never grant consent and their events are dropped.
 
-This integration covers page views only. Commerce events such as product views and cart activity are not wired up.
+Third-party analytics can subscribe through the same destination API, so consent gating and buffered replay remain centralized. Register destinations with `addAnalyticsDestination()` from `lib/analytics/client.ts`; do not publish cart-change events manually.
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary

- publish Shopify page, product, collection, search, and cart-view events through Hydrogen's shared analytics bus
- keep confirmed cart-change events on Hydrogen's cart tracker
- expose consent-gated destination registration for third-party analytics
- pass server-resolved product, collection, locale, and shop data into thin client trackers
- update and synchronize the analytics skill documentation

## Behavior

Shopify analytics now receives route-specific commerce context instead of page views alone. Product events use the resolved selected variant, collection events use the Shopify collection GID, search events include the query, and cart views wait for the cart store to settle. The local `/collections/all` route remains a page view because it is not a Shopify collection.

Third-party integrations can register with `addAnalyticsDestination()` and inherit Shopify Customer Privacy gating and buffered replay. Confirmed cart additions, removals, and updates continue to come from `useCartAnalytics()` rather than manual event publication.

The installed Hydrogen release does not support custom event names, so this change does not add a parallel custom-event channel outside Hydrogen's consent model.

## Verification

- focused `oxlint` — passed, 0 warnings/errors
- `./node_modules/.bin/tsc --noEmit` — passed
- `pnpm build` — passed; Next.js compiled successfully and generated 32/32 pages
- runtime route smoke tests — HTTP 200 for product, collection, search, and cart pages
- confirmed Shopify analytics bootstrap and server-fed route payloads in rendered responses
