### PR TITLE
Adopt Hydrogen storefront logging

### DIFF
--- a/apps/docs/content/docs/reference/env-vars.mdx
+++ b/apps/docs/content/docs/reference/env-vars.mdx
@@ -26,7 +26,7 @@ The template stores Hydrogen's OAuth session data in encrypted HttpOnly cookies.
 
 | Variable                            | Description                                                                                                                                                                  |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DEBUG_SHOPIFY`                     | Set to `true` to log every Shopify Storefront API request and response in the server console.                                                                                |
+| `DEBUG_SHOPIFY`                     | Set to `true` to include structured Storefront and Customer Account API operation timings in Hydrogen's server logs.                                                        |
 | `NEXT_PUBLIC_BASE_URL`              | Bare domain (no protocol) used to build the canonical base URL for sitemap entries, OG tags, and auth callbacks. Defaults to `VERCEL_PROJECT_PRODUCTION_URL` on Vercel.      |
 | `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ID` | Numeric storefront ID from the Headless channel. Hydrogen sends it as a trusted Storefront API header for cart attribution and includes it in Shopify runtime configuration. |
 | `SHOPIFY_API_VERSION`               | Override the Shopify Storefront API version. Defaults to `unstable`; Hydrogen selects its dated Customer Account API version.                                                |

--- a/apps/docs/content/docs/reference/storefront-api.mdx
+++ b/apps/docs/content/docs/reference/storefront-api.mdx
@@ -32,7 +32,7 @@ const { data } = response;
 
 ## Request details
 
-The client `POST`s to `https://{NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN}/api/{SHOPIFY_API_VERSION}/graphql.json` with the `X-Shopify-Storefront-Access-Token` header (mapped from the `publicAccessToken` passed at init). A `customFetchApi` wrapper in `lib/shopify/storefront.ts` preserves three behaviors the SDK doesn't provide on its own: the `?operation=<name>` URL annotation for network logs, `Accept-Encoding: gzip, br`, and `DEBUG_SHOPIFY` timing logs. Cache isolation between different variables comes from the `"use cache"` wrappers in `lib/shopify/operations/`, which key on function arguments.
+The client `POST`s to `https://{NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN}/api/{SHOPIFY_API_VERSION}/graphql.json` with the `X-Shopify-Storefront-Access-Token` header (mapped from the `publicAccessToken` passed at init). A `customFetchApi` wrapper in `lib/shopify/storefront.ts` preserves three intentionally app-specific behaviors: the `?operation=<name>` URL annotation for network logs, `Accept-Encoding: gzip, br`, and operation timing. Cache isolation between different variables comes from the `"use cache"` wrappers in `lib/shopify/operations/`, which key on function arguments.
 
 ## Writing a query
 
@@ -183,9 +183,9 @@ Shopify returns the full updated cart in every mutation response, so there's no 
 
 The Hydrogen client resolves to `{ data, errors? }` for GraphQL-level errors, but **throws** on transport failures — `StorefrontApiError` for non-OK HTTP responses and malformed payloads, `StorefrontTimeoutError` when the default 30s timeout elapses. The template applies its contract through `assertStorefrontOk(response, operation)` in `lib/shopify/errors.ts`:
 
-**GraphQL failure** - if `errors` is present and there's no `data`, it throws with the operation name and error detail.
+**GraphQL failure** - if `errors` is present and there's no `data`, it throws Hydrogen's `StorefrontApiError` with the operation name plus Shopify's locations, path, extensions, and any additional errors.
 
-**Partial success** - if there are `errors` but `data` is also present, it logs a warning and lets the operation use the partial data.
+**Partial success** - if there are `errors` but `data` is also present, it sends a structured warning through the configured Hydrogen logger and lets the operation use the partial data.
 
 **Narrowing** - on success it narrows `response.data` to non-null, so the operation can read it without optional chaining on the top level.
 
@@ -193,12 +193,14 @@ Individual operations follow a consistent contract on top of this: they **throw*
 
 ## Debug logging
 
-Set `DEBUG_SHOPIFY=true` to log every request with its operation name and timing (emitted from the `customFetchApi` wrapper):
+Hydrogen logging is configured once when the Next.js server starts. Set `DEBUG_SHOPIFY=true` to include structured Storefront and Customer Account API timings alongside Hydrogen's own runtime logs:
 
 ```
-[shopify] getProductByHandle 45ms
-[shopify] searchProducts 120ms
+[shopify:debug:storefront] Storefront API request { durationMs: 45, operation: "getProductByHandle" }
+[shopify:debug:customer-account] Customer Account API request { durationMs: 120, operation: "getCustomerProfile" }
 ```
+
+Warnings and errors remain enabled without the debug flag. Customer Account API failures retain that client's error contract; `StorefrontApiError` and `StorefrontTimeoutError` apply specifically to Storefront API requests.
 
 ## Transforms
 

--- a/apps/template/.env.example
+++ b/apps/template/.env.example
@@ -1,14 +1,14 @@
 # Required
 NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN="your-store.myshopify.com"
-NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN="your-access-token-here"
+NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 # Optional
 # AI_GATEWAY_API_KEY="your-ai-gateway-api-key-here"
-# CUSTOMER_ACCOUNT_SESSION_SECRET="your-session-secret-here"
-# DEBUG_SHOPIFY="1"
+# CUSTOMER_ACCOUNT_SESSION_SECRET="your-customer-account-session-secret-here"
+# DEBUG_SHOPIFY="1" # Log structured Shopify API operation timings.
 # NEXT_PUBLIC_BASE_URL="your-domain.com"
 # NEXT_PUBLIC_SHOPIFY_STOREFRONT_ID="123456789"
 # SHOPIFY_API_VERSION="unstable"
 # SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID="shp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-# SHOPIFY_WEBHOOK_SECRET="your-webhook-secret-here"
+# SHOPIFY_WEBHOOK_SECRET="your-shopify-webhook-secret-here"
 # UCP_AGENT_PROFILE_URL="https://your-agent.example.com/.well-known/ucp"

--- a/apps/template/instrumentation.ts
+++ b/apps/template/instrumentation.ts
@@ -1,0 +1,5 @@
+import { configureShopifyLogging } from "@/lib/shopify/logging";
+
+export function register() {
+  configureShopifyLogging();
+}

--- a/apps/template/lib/shopify/customer-account.ts
+++ b/apps/template/lib/shopify/customer-account.ts
@@ -11,8 +11,7 @@ import { shopConfig } from "@/lib/config";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 
 import { resolveShopId } from "./discovery";
-
-const DEBUG = process.env.DEBUG_SHOPIFY === "1";
+import { logShopifyDebug, shopifyLogger } from "./logging";
 
 export async function customerAccountFetch<T>({
   accessToken,
@@ -37,24 +36,29 @@ export async function customerAccountFetch<T>({
     }),
   });
 
-  const start = DEBUG ? performance.now() : 0;
+  const start = performance.now();
   // Brand runtime strings so Hydrogen does not infer `never` variables.
   const doc = gql(query) as CustomerAccountDocument<T, Record<string, unknown>>;
-  const { data, errors } = await client.graphql(doc, { accessToken, variables });
+  try {
+    const { data, errors } = await client.graphql(doc, { accessToken, variables });
 
-  if (DEBUG) {
-    const duration = performance.now() - start;
-    console.log(`[shopify:customer] ${operation} ${duration.toFixed(0)}ms`);
-  }
-
-  if (errors) {
-    if (!data) {
-      throw new Error(`GraphQL errors: ${JSON.stringify(errors)}`);
+    if (errors) {
+      if (!data) {
+        throw new Error(`GraphQL errors: ${JSON.stringify(errors)}`);
+      }
+      shopifyLogger.warn("Customer Account API returned partial errors", {
+        errors,
+        operation,
+        scope: "customer-account",
+      });
     }
-    console.warn(
-      `[shopify:customer] ${operation} returned partial errors: ${JSON.stringify(errors)}`,
-    );
-  }
 
-  return data as T;
+    return data as T;
+  } finally {
+    logShopifyDebug("Customer Account API request", {
+      durationMs: Math.round(performance.now() - start),
+      operation,
+      scope: "customer-account",
+    });
+  }
 }

--- a/apps/template/lib/shopify/errors.ts
+++ b/apps/template/lib/shopify/errors.ts
@@ -1,6 +1,8 @@
-import type { GraphQLFormattedError } from "@shopify/hydrogen";
+import { StorefrontApiError, type GraphQLFormattedError } from "@shopify/hydrogen";
 
 import type { CartWarning } from "@/lib/types";
+
+import { shopifyLogger } from "./logging";
 
 interface StorefrontResponse<T> {
   data?: T | null;
@@ -12,15 +14,28 @@ export function assertStorefrontOk<T>(
   operation: string,
 ): asserts response is { data: T; errors?: GraphQLFormattedError[] } {
   if (response.errors?.length && !response.data) {
-    const detail = response.errors.map((error) => error.message).join("; ");
-    throw new Error(`Shopify ${operation} failed: ${detail}`);
+    const [firstError, ...additionalErrors] = response.errors;
+    throw new StorefrontApiError(`Shopify ${operation} failed: ${firstError.message}`, {
+      extensions: {
+        ...firstError.extensions,
+        additionalErrors,
+        operation,
+      },
+      locations: firstError.locations,
+      path: firstError.path,
+    });
   }
   if (response.errors?.length) {
-    const detail = JSON.stringify(response.errors);
-    console.warn(`[shopify] ${operation} returned partial errors: ${detail}`);
+    shopifyLogger.warn("Storefront API returned partial errors", {
+      errors: response.errors,
+      operation,
+      scope: "storefront",
+    });
   }
   if (!response.data) {
-    throw new Error(`Shopify ${operation}: no data returned`);
+    throw new StorefrontApiError(`Shopify ${operation}: no data returned`, {
+      extensions: { operation },
+    });
   }
 }
 

--- a/apps/template/lib/shopify/logging.ts
+++ b/apps/template/lib/shopify/logging.ts
@@ -1,0 +1,47 @@
+import {
+  configureLogging,
+  type HydrogenLogger,
+  type LogContext,
+  type LogLevel,
+} from "@shopify/hydrogen";
+
+const DEBUG_SHOPIFY = ["1", "true"].includes(process.env.DEBUG_SHOPIFY?.toLowerCase() ?? "");
+
+const CONSOLE_METHODS = {
+  debug: "debug",
+  error: "error",
+  fatal: "error",
+  info: "info",
+  trace: "debug",
+  warn: "warn",
+} as const;
+
+type WritableLogLevel = Exclude<LogLevel, "silent">;
+
+function writeLog(level: WritableLogLevel, message: string, context?: LogContext) {
+  const { error, scope = "shopify", ...details } = context ?? {};
+  const args: unknown[] = [`[shopify:${level}:${scope}] ${message}`];
+  if (error !== undefined) args.push(error);
+  if (Object.keys(details).length > 0) args.push(details);
+  console[CONSOLE_METHODS[level]](...args);
+}
+
+export const shopifyLogger: HydrogenLogger = {
+  debug: (message, context) => writeLog("debug", message, context),
+  error: (message, context) => writeLog("error", message, context),
+  fatal: (message, context) => writeLog("fatal", message, context),
+  info: (message, context) => writeLog("info", message, context),
+  trace: (message, context) => writeLog("trace", message, context),
+  warn: (message, context) => writeLog("warn", message, context),
+};
+
+export function configureShopifyLogging() {
+  configureLogging({
+    level: DEBUG_SHOPIFY ? "debug" : "info",
+    logger: shopifyLogger,
+  });
+}
+
+export function logShopifyDebug(message: string, context: LogContext) {
+  if (DEBUG_SHOPIFY) shopifyLogger.debug(message, context);
+}

--- a/apps/template/lib/shopify/storefront.ts
+++ b/apps/template/lib/shopify/storefront.ts
@@ -10,12 +10,12 @@ import { io } from "next/cache";
 
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 
+import { logShopifyDebug } from "./logging";
+
 const SHOPIFY_STORE_DOMAIN = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN as string;
 const SHOPIFY_ACCESS_TOKEN = process.env.NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN as string;
 const SHOPIFY_API_VERSION = process.env.SHOPIFY_API_VERSION ?? "unstable";
 const SHOPIFY_STOREFRONT_ID = process.env.NEXT_PUBLIC_SHOPIFY_STOREFRONT_ID;
-const DEBUG = process.env.DEBUG_SHOPIFY === "1";
-
 function operationName(body: RequestInit["body"]): string {
   if (typeof body !== "string") return "anonymous";
   try {
@@ -34,12 +34,16 @@ const customFetchApi: typeof fetch = async (input, init) => {
   const headers = new Headers(init?.headers);
   headers.set("Accept-Encoding", "gzip, br");
 
-  const start = DEBUG ? performance.now() : 0;
-  const response = await fetch(annotated, { ...init, headers });
-  if (DEBUG) {
-    console.log(`[shopify] ${operation} ${(performance.now() - start).toFixed(0)}ms`);
+  const start = performance.now();
+  try {
+    return await fetch(annotated, { ...init, headers });
+  } finally {
+    logShopifyDebug("Storefront API request", {
+      durationMs: Math.round(performance.now() - start),
+      operation,
+      scope: "storefront",
+    });
   }
-  return response;
 };
 
 // Hydrogen overrides locale variables from client config, requiring a client per locale pair.


### PR DESCRIPTION
## Summary

- configure Hydrogen logging once through Next.js server instrumentation
- add a shared structured `HydrogenLogger` for Hydrogen runtime entries and app-specific Shopify annotations
- emit Storefront and Customer Account operation timings at debug level when `DEBUG_SHOPIFY` is enabled
- normalize Storefront GraphQL failures to Hydrogen's `StorefrontApiError`
- preserve GraphQL locations, path, extensions, operation name, and additional errors
- send partial GraphQL failures through structured warning context instead of bespoke console output
- update Storefront API and environment-variable documentation

## Intentional boundary

The custom Storefront fetch wrapper remains for behavior Hydrogen does not own:

- `?operation=<name>` URL annotations used in network logs
- `Accept-Encoding: gzip, br`
- operation-level timing annotations

Hydrogen already owns transport normalization, including `StorefrontApiError` for HTTP/network/response failures and `StorefrontTimeoutError` for its default timeout. Customer Account API uses a separate client and retains its existing failure contract, while sharing the logger for timing and partial-error output.

## Verification

- focused `oxfmt` and `oxlint` — passed, 0 warnings/errors
- `./node_modules/.bin/tsc --noEmit` — passed
- `pnpm build` — passed; Next.js compiled successfully and generated 32/32 pages
- `DEBUG_SHOPIFY=true pnpm dev` — passed
- runtime smoke test — HTTP 200 for `/collections`
- confirmed structured Storefront operation timing output from the real Next.js startup path
- `git diff --check` — passed
