### PR TITLE
Scope client translation messages

### DIFF
--- a/apps/docs/content/docs/anatomy/i18n.mdx
+++ b/apps/docs/content/docs/anatomy/i18n.mdx
@@ -1,0 +1,22 @@
+---
+title: Translations
+description: How the storefront keeps translation catalogs on the server and scopes client messages to interactive islands.
+---
+
+The storefront uses next-intl for translated copy and locale-aware formatting. Message catalogs load on the server. Server Components call `getTranslations()` and render translated text directly whenever the browser does not need to choose or format that text later.
+
+## Client message boundaries
+
+Interactive components sometimes need translations after hydration—for example, cart mutation errors, search results, collection filters, and product purchase controls. Give each cohesive interactive island a `NextIntlClientProvider` containing only the namespaces it uses. Do not pass the complete catalog from the root layout.
+
+Prefer a translated primitive prop when a client leaf needs only a few fixed labels. Keep `useTranslations()` when several related client components share a namespace or need dynamic messages, plurals, or interpolation. Place that provider in the nearest Server Component so unrelated routes and islands do not receive its messages.
+
+The root provider contains only shared error-boundary copy. Next.js route error boundaries are Client Components and cannot load request translations on the server, so this small namespace must remain available across the application. The active locale is also set there and is inherited by narrower providers.
+
+## Adding translated UI
+
+Add new user-visible copy to every locale catalog. In a Server Component, use `getTranslations()` and render the result or pass the required labels to a client leaf. If an interactive subtree needs a translator, select only its namespaces from `getMessages()` and pass those to a provider around that subtree.
+
+Avoid importing message JSON into Client Components. That bundles the catalog into client JavaScript instead of sending only the messages required by the rendered island.
+
+When adding a locale, preserve the same message shape across catalogs. The request configuration chooses the catalog for the active locale; the rendering boundaries determine which messages cross into the browser.

--- a/apps/docs/content/docs/anatomy/meta.json
+++ b/apps/docs/content/docs/anatomy/meta.json
@@ -8,6 +8,7 @@
     "product-card",
     "navigation",
     "footer",
+    "i18n",
     "proxy",
     "aeo-geo",
     "webmcp",

--- a/apps/docs/content/docs/skills/enable-analytics.mdx
+++ b/apps/docs/content/docs/skills/enable-analytics.mdx
@@ -127,7 +127,7 @@ Remove imports for integrations the storefront does not support.
 
 ### C2. Update `app/layout.tsx`
 
-Always render the root analytics component inside `<body>` after the `</NextIntlClientProvider>` closing tag:
+Render the root analytics component near the end of `<body>`, without changing the storefront's translation-provider boundaries:
 
 ```tsx
 import { AnalyticsComponents } from "@/components/analytics";
@@ -135,16 +135,14 @@ import { AnalyticsComponents } from "@/components/analytics";
 
 ```tsx
 <body ...>
-  <a href="#main-content" ...>...</a>
-  <SiteSchema locale={locale} />
-  <NextIntlClientProvider locale={locale} messages={messages}>
-    {/* ... existing layout content ... */}
-  </NextIntlClientProvider>
-  <AnalyticsComponents />
+  {/* ... existing layout content and scoped providers ... */}
+  <Suspense>
+    <AnalyticsComponents locale={locale} />
+  </Suspense>
 </body>
 ```
 
-The root component remains mounted as the extension point for current and future analytics providers. Provider gates stay inside it so disabled integrations are not mounted.
+Do not pass the complete message catalog to a root `NextIntlClientProvider` for analytics. The root component remains mounted as the extension point for current and future analytics providers. Provider gates stay inside it so disabled integrations are not mounted.
 
 ## Part D: Shopify storefront analytics
 

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -31,9 +31,10 @@ The opt-in assistant is served by `app/api/chat/route.ts` and built with AI SDK.
 ## Critical Rules (Always Apply)
 
 1. **New user-visible strings go in ALL locale files** (`en.json`, etc.) so the documented multi-locale upgrade path stays mechanical.
-2. **Components in `ui/` must NOT import domain types**. Accept primitive props only and never call `useTranslations`.
-3. **Always use `shopify-ai-toolkit` for Shopify API facts and validation** before adding or changing GraphQL. Use `/vercel-shop:shopify-graphql-reference` afterward for this template's operation placement, transforms, cache role, locale flow, and invalidation. Never treat the Vercel Shop skill as a schema source or guess Shopify fields.
-4. **Every user-configurable `process.env.X` read needs a row in `.env.example`** with a short comment explaining when to set it. If you add a new env var that toggles a feature, document it there so a fresh clone has a complete env reference.
+2. **Keep translations server-first.** Server Components use `getTranslations()` and pass primitive labels to client leaves. When an interactive island needs `useTranslations()`, wrap it in the nearest Server Component with a `NextIntlClientProvider` containing only the namespaces it uses; never pass the full catalog from the root layout.
+3. **Components in `ui/` must NOT import domain types**. Accept primitive props only and never call `useTranslations`.
+4. **Always use `shopify-ai-toolkit` for Shopify API facts and validation** before adding or changing GraphQL. Use `/vercel-shop:shopify-graphql-reference` afterward for this template's operation placement, transforms, cache role, locale flow, and invalidation. Never treat the Vercel Shop skill as a schema source or guess Shopify fields.
+5. **Every user-configurable `process.env.X` read needs a row in `.env.example`** with a short comment explaining when to set it. If you add a new env var that toggles a feature, document it there so a fresh clone has a complete env reference.
 
 ## Storefront Architecture Contract
 

--- a/apps/template/app/account/(authenticated)/addresses/page.tsx
+++ b/apps/template/app/account/(authenticated)/addresses/page.tsx
@@ -1,4 +1,5 @@
-import { getTranslations } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages, getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
 import { AddressBook } from "@/components/account/address-book";
@@ -20,8 +21,12 @@ export default async function AddressesPage() {
 }
 
 async function AddressesContent() {
-  const addresses = await getCustomerAddresses();
-  return <AddressBook addresses={addresses} />;
+  const [addresses, messages] = await Promise.all([getCustomerAddresses(), getMessages()]);
+  return (
+    <NextIntlClientProvider messages={{ account: messages.account }}>
+      <AddressBook addresses={addresses} />
+    </NextIntlClientProvider>
+  );
 }
 
 function AddressesSkeleton() {

--- a/apps/template/app/layout.tsx
+++ b/apps/template/app/layout.tsx
@@ -8,9 +8,8 @@ import { Suspense } from "react";
 import { ActionBar } from "@/components/action-bar";
 import { AgentButton } from "@/components/agent/agent-button";
 import { AnalyticsComponents } from "@/components/analytics";
+import { CartUI } from "@/components/cart/cart-ui";
 import { CartProviderWrapper } from "@/components/cart/context";
-import { CartNotifications } from "@/components/cart/notifications";
-import { CartOverlayBridge } from "@/components/cart/overlay-bridge";
 import { Footer } from "@/components/footer";
 import { Nav } from "@/components/nav";
 import { SiteSchema } from "@/components/schema/site-schema";
@@ -36,6 +35,11 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
     getMessages(),
     getTranslations("accessibility"),
   ]);
+  const agentMessages = {
+    agent: messages.agent,
+    cart: messages.cart,
+    product: messages.product,
+  };
 
   // Un-awaited: the promise streams to the client provider; never block the shell on it.
   const cartData = seedCartData();
@@ -53,17 +57,22 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
           {t("skipToContent")}
         </a>
         <SiteSchema locale={locale} />
-        <NextIntlClientProvider locale={locale} messages={messages}>
+        <NextIntlClientProvider locale={locale} messages={{ common: messages.common }}>
           <CartProviderWrapper cartData={cartData}>
             <Nav locale={locale} />
             <main id="main-content" className="flex flex-1 flex-col min-w-0">
               {children}
             </main>
             <Footer locale={locale} />
-            <CartNotifications />
-            <CartOverlayBridge />
+            <CartUI />
             <Suspense>
-              <ActionBar>{shopConfig.agent.isEnabled && <AgentButton />}</ActionBar>
+              <ActionBar>
+                {shopConfig.agent.isEnabled && (
+                  <NextIntlClientProvider messages={agentMessages}>
+                    <AgentButton />
+                  </NextIntlClientProvider>
+                )}
+              </ActionBar>
             </Suspense>
             <Suspense>
               <AnalyticsComponents locale={locale} />

--- a/apps/template/components/cart/cart-ui.tsx
+++ b/apps/template/components/cart/cart-ui.tsx
@@ -1,0 +1,16 @@
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages } from "next-intl/server";
+
+import { CartNotifications } from "./notifications";
+import { CartOverlayBridge } from "./overlay-bridge";
+
+export async function CartUI() {
+  const messages = await getMessages();
+
+  return (
+    <NextIntlClientProvider messages={{ cart: messages.cart }}>
+      <CartNotifications />
+      <CartOverlayBridge />
+    </NextIntlClientProvider>
+  );
+}

--- a/apps/template/components/collections/collection-page.tsx
+++ b/apps/template/components/collections/collection-page.tsx
@@ -1,5 +1,6 @@
 import { SlidersHorizontalIcon } from "lucide-react";
-import { getTranslations } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages, getTranslations } from "next-intl/server";
 import Link from "next/link";
 import { Suspense } from "react";
 
@@ -41,7 +42,8 @@ export async function CollectionDetailPage({
   searchStatePromise: Promise<CollectionSearchState>;
   sortExclude?: string[];
 }) {
-  const [tSearch, tBreadcrumb] = await Promise.all([
+  const [messages, tSearch, tBreadcrumb] = await Promise.all([
+    getMessages(),
     getTranslations("search"),
     getTranslations("collections.breadcrumb"),
   ]);
@@ -67,39 +69,43 @@ export async function CollectionDetailPage({
                 <CollectionBrowseFallback filtersLabel={filtersLabel} sortByLabel={sortByLabel} />
               }
             >
-              <CollectionBrowseProvider handle={handle} searchStatePromise={searchStatePromise}>
-                <CollectionToolbar
-                  filterSheet={
-                    <FilterSidebarSheet
-                      label={filtersLabel}
-                      trigger={
-                        <button
-                          type="button"
-                          className="flex items-center gap-2 text-sm font-medium"
-                        >
-                          <SlidersHorizontalIcon className="size-4" />
-                          <span>{filtersLabel}</span>
-                          <CollectionActiveFilterCountBadge />
-                        </button>
-                      }
-                    >
-                      <FilterPendingScope>
-                        <CollectionFilters
-                          collectionResultsDataPromise={collectionResultsDataPromise}
-                        />
-                      </FilterPendingScope>
-                    </FilterSidebarSheet>
-                  }
-                  sortSelect={<CollectionsSortSelect collection exclude={sortExclude} />}
-                />
-
-                <FilterPendingScope>
-                  <CollectionResultsGrid
-                    locale={locale}
-                    collectionResultsDataPromise={collectionResultsDataPromise}
+              <NextIntlClientProvider
+                messages={{ category: messages.category, search: messages.search }}
+              >
+                <CollectionBrowseProvider handle={handle} searchStatePromise={searchStatePromise}>
+                  <CollectionToolbar
+                    filterSheet={
+                      <FilterSidebarSheet
+                        label={filtersLabel}
+                        trigger={
+                          <button
+                            type="button"
+                            className="flex items-center gap-2 text-sm font-medium"
+                          >
+                            <SlidersHorizontalIcon className="size-4" />
+                            <span>{filtersLabel}</span>
+                            <CollectionActiveFilterCountBadge />
+                          </button>
+                        }
+                      >
+                        <FilterPendingScope>
+                          <CollectionFilters
+                            collectionResultsDataPromise={collectionResultsDataPromise}
+                          />
+                        </FilterPendingScope>
+                      </FilterSidebarSheet>
+                    }
+                    sortSelect={<CollectionsSortSelect collection exclude={sortExclude} />}
                   />
-                </FilterPendingScope>
-              </CollectionBrowseProvider>
+
+                  <FilterPendingScope>
+                    <CollectionResultsGrid
+                      locale={locale}
+                      collectionResultsDataPromise={collectionResultsDataPromise}
+                    />
+                  </FilterPendingScope>
+                </CollectionBrowseProvider>
+              </NextIntlClientProvider>
             </Suspense>
           </Sections>
         </Container>

--- a/apps/template/components/nav/index.tsx
+++ b/apps/template/components/nav/index.tsx
@@ -1,4 +1,6 @@
 import { PredictiveSearchProvider } from "@shopify/hydrogen/react";
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages } from "next-intl/server";
 import Link from "next/link";
 import { Suspense } from "react";
 
@@ -13,6 +15,7 @@ import { QuickLinks } from "./quick-links";
 import { SearchModal } from "./search-modal";
 
 export async function Nav({ locale }: { locale: string }) {
+  const messages = await getMessages();
   const items: MenuItem[] = [
     { id: "default-nav-shop", title: "Shop", url: "/collections/all", type: "HTTP", items: [] },
   ];
@@ -22,33 +25,35 @@ export async function Nav({ locale }: { locale: string }) {
       className="sticky top-0 z-30 w-full bg-background pt-[env(safe-area-inset-top,0px)] transition-shadow duration-250"
       id="nav-outer"
     >
-      <Container className="flex h-16 items-center gap-2.5 md:gap-5">
-        <MobileMenu items={items} />
+      <NextIntlClientProvider messages={{ nav: messages.nav }}>
+        <Container className="flex h-16 items-center gap-2.5 md:gap-5">
+          <MobileMenu items={items} />
 
-        <Link className="flex items-center shrink-0" href="/">
-          <span className="text-xl leading-4">{shopConfig.site.name}</span>
-        </Link>
+          <Link className="flex items-center shrink-0" href="/">
+            <span className="text-xl leading-4">{shopConfig.site.name}</span>
+          </Link>
 
-        <QuickLinks items={items} />
+          <QuickLinks items={items} />
 
-        <div className="flex items-center gap-5 ml-auto">
-          <PredictiveSearchProvider
-            debounceInMs={300}
-            limit={3}
-            types={["PRODUCT", "COLLECTION", "QUERY"]}
-          >
-            <SearchModal />
-          </PredictiveSearchProvider>
-          {shopConfig.auth.isEnabled && (
-            <Suspense fallback={<NavAccountFallback />}>
-              <NavAccount />
+          <div className="flex items-center gap-5 ml-auto">
+            <PredictiveSearchProvider
+              debounceInMs={300}
+              limit={3}
+              types={["PRODUCT", "COLLECTION", "QUERY"]}
+            >
+              <SearchModal />
+            </PredictiveSearchProvider>
+            {shopConfig.auth.isEnabled && (
+              <Suspense fallback={<NavAccountFallback />}>
+                <NavAccount />
+              </Suspense>
+            )}
+            <Suspense fallback={<CartIconFallback />}>
+              <CartIcon />
             </Suspense>
-          )}
-          <Suspense fallback={<CartIconFallback />}>
-            <CartIcon />
-          </Suspense>
-        </div>
-      </Container>
+          </div>
+        </Container>
+      </NextIntlClientProvider>
     </nav>
   );
 }

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -1,5 +1,6 @@
 import { MinusIcon, PlusIcon } from "lucide-react";
-import { getTranslations } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages, getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
 import { BundleComponents, BundleParents } from "@/components/product-detail/bundle-components";
@@ -37,7 +38,7 @@ import { getAvailableOptionValues } from "@/lib/shopify/encoded-variants";
 import type { ProductDetails, ProductVariant } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-export function ProductDetailSection({
+export async function ProductDetailSection({
   product,
   selectedOptionsPromise,
   variantPromise,
@@ -48,8 +49,10 @@ export function ProductDetailSection({
   variantPromise: Promise<ProductVariant | undefined>;
   locale: Locale;
 }) {
+  const messages = await getMessages();
+
   return (
-    <>
+    <NextIntlClientProvider messages={{ cart: messages.cart, product: messages.product }}>
       <ProductSchema
         product={{
           id: product.id,
@@ -83,7 +86,7 @@ export function ProductDetailSection({
           locale={locale}
         />
       </div>
-    </>
+    </NextIntlClientProvider>
   );
 }
 

--- a/packages/plugin/skills/enable-analytics/SKILL.md
+++ b/packages/plugin/skills/enable-analytics/SKILL.md
@@ -116,7 +116,7 @@ Remove imports for integrations the storefront does not support.
 
 ### C2. Update `app/layout.tsx`
 
-Always render the root analytics component inside `<body>` after the `</NextIntlClientProvider>` closing tag:
+Render the root analytics component near the end of `<body>`, without changing the storefront's translation-provider boundaries:
 
 ```tsx
 import { AnalyticsComponents } from "@/components/analytics";
@@ -124,16 +124,14 @@ import { AnalyticsComponents } from "@/components/analytics";
 
 ```tsx
 <body ...>
-  <a href="#main-content" ...>...</a>
-  <SiteSchema locale={locale} />
-  <NextIntlClientProvider locale={locale} messages={messages}>
-    {/* ... existing layout content ... */}
-  </NextIntlClientProvider>
-  <AnalyticsComponents />
+  {/* ... existing layout content and scoped providers ... */}
+  <Suspense>
+    <AnalyticsComponents locale={locale} />
+  </Suspense>
 </body>
 ```
 
-The root component remains mounted as the extension point for current and future analytics providers. Provider gates stay inside it so disabled integrations are not mounted.
+Do not pass the complete message catalog to a root `NextIntlClientProvider` for analytics. The root component remains mounted as the extension point for current and future analytics providers. Provider gates stay inside it so disabled integrations are not mounted.
 
 ## Part D: Shopify storefront analytics
 


### PR DESCRIPTION
## Summary

- keep translations server-first and stop serializing the complete message catalog from the root layout
- scope client messages to the nav/search, cart, agent, collection, product, and address-management islands that use them
- retain only shared error-boundary copy at the root, where Next.js client error boundaries require it
- document the translation boundary pattern and make it a template agent rule
- update and sync the analytics skill so it does not restore the old full-catalog provider

## Payload shape

The English catalog is about 15.5 KB on disk. The previous root provider sent all 359 messages to every route. The new base shell sends only `common`, `nav`, and `cart`; route-specific and opt-in namespaces are serialized only when their interactive islands render.

## Verification

- `cd apps/template && pnpm lint` — passed, 0 warnings and 0 errors
- `cd apps/template && pnpm build` — passed; 32/32 static pages generated
- `cd apps/docs && pnpm typecheck` — passed
- changed docs `oxfmt --check` — passed
- docs `oxlint .` — 0 errors; one pre-existing Satori `<img>` warning
- `npx tsx apps/docs/scripts/sync-skills.ts` — one expected page updated, 0 errors
- `git diff --check` — passed
