### PR TITLE
Rewrite docs around essential user outcomes

### DIFF
--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -60,7 +60,13 @@ npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 - Use MDX frontmatter with at least `title` and `description`; the schema (from `@vercel/geistdocs/source-config`) also supports `type`, `prerequisites`, `related`, `summary`, `tags`, and `excludeFrom`.
 - Add each new page to the relevant `meta.json` so it appears in the sidebar.
 - Plain markdown copied into MDX must have `{`, `}`, and bare `<` escaped outside code blocks.
-- Do not add `Key files`, file inventory, or file-to-purpose table sections. Mention a path inline only when it directly supports the surrounding instruction or explanation.
+- Give each page one audience and one purpose. Lead with the outcome, then state the default, required action, important limits, and a way to verify the result when the page is procedural.
+- Apply an essentiality test to implementation detail. Keep a technical detail only when the reader needs it to complete a task, make a decision, avoid a security or data problem, understand a real limitation, or verify the result.
+- Prefer observable behavior and merchant or shopper language. Treat function names, component names, internal fields, file paths, request choreography, and cache mechanics as warning signs in reader-facing guides.
+- Use short sentences, active voice, consistent terms, one instruction per step, and one main idea per paragraph. Define uncommon abbreviations before using them.
+- Exact commands, settings, environment variables, Admin paths, callback URLs, permissions, and security requirements are appropriate when the reader must act on them.
+- Generated skill pages are procedural instructions for coding agents and may remain technical. Never hand-edit their embedded skill content.
+- Do not add `Key files`, file inventory, or file-to-purpose table sections. Mention a path inline only when it directly supports a required action.
 - Keep customization suggestions concise and user-facing: say what can be changed and why someone might change it. Avoid implementation steps, code symbols, and file paths unless they are necessary to complete the customization or the reader asks for them.
 - Keep slugs stable unless the task explicitly includes redirects or link updates.
 

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -60,14 +60,14 @@ npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 - Use MDX frontmatter with at least `title` and `description`; the schema (from `@vercel/geistdocs/source-config`) also supports `type`, `prerequisites`, `related`, `summary`, `tags`, and `excludeFrom`.
 - Add each new page to the relevant `meta.json` so it appears in the sidebar.
 - Plain markdown copied into MDX must have `{`, `}`, and bare `<` escaped outside code blocks.
-- Give each page one audience and one purpose. Lead with the outcome, then state the default, required action, important limits, and a way to verify the result when the page is procedural.
+- Give each page one audience and one purpose. Lead with the outcome, then state the default, required action, and important limits. In procedural guides, place essential confirmation beside the action it validates rather than adding a standard closing verification section.
 - Apply an essentiality test to implementation detail. Keep a technical detail only when the reader needs it to complete a task, make a decision, avoid a security or data problem, understand a real limitation, or verify the result.
 - Prefer observable behavior and merchant or shopper language. Treat function names, component names, internal fields, file paths, request choreography, and cache mechanics as warning signs in reader-facing guides.
 - Use short sentences, active voice, consistent terms, one instruction per step, and one main idea per paragraph. Define uncommon abbreviations before using them.
 - Exact commands, settings, environment variables, Admin paths, callback URLs, permissions, and security requirements are appropriate when the reader must act on them.
 - Generated skill pages are procedural instructions for coding agents and may remain technical. Never hand-edit their embedded skill content.
 - Do not add `Key files`, file inventory, or file-to-purpose table sections. Mention a path inline only when it directly supports a required action.
-- Keep customization suggestions concise and user-facing: say what can be changed and why someone might change it. Avoid implementation steps, code symbols, and file paths unless they are necessary to complete the customization or the reader asks for them.
+- End feature guides with a concise `What’s next` section describing common ways teams extend or adapt the feature. Keep those suggestions user-facing: say what can be changed and why someone might change it. Avoid implementation steps, code symbols, and file paths unless they are necessary to complete the customization or the reader asks for them.
 - Keep slugs stable unless the task explicitly includes redirects or link updates.
 
 ## Commands

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -60,14 +60,17 @@ npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 - Use MDX frontmatter with at least `title` and `description`; the schema (from `@vercel/geistdocs/source-config`) also supports `type`, `prerequisites`, `related`, `summary`, `tags`, and `excludeFrom`.
 - Add each new page to the relevant `meta.json` so it appears in the sidebar.
 - Plain markdown copied into MDX must have `{`, `}`, and bare `<` escaped outside code blocks.
-- Give each page one audience and one purpose. Lead with the outcome, then state the default, required action, and important limits. In procedural guides, place essential confirmation beside the action it validates rather than adding a standard closing verification section.
+- Give each page one audience and one purpose. Lead with the outcome, then state the default, required action, and important limits.
 - Apply an essentiality test to implementation detail. Keep a technical detail only when the reader needs it to complete a task, make a decision, avoid a security or data problem, understand a real limitation, or verify the result.
 - Prefer observable behavior and merchant or shopper language. Treat function names, component names, internal fields, file paths, request choreography, and cache mechanics as warning signs in reader-facing guides.
 - Use short sentences, active voice, consistent terms, one instruction per step, and one main idea per paragraph. Define uncommon abbreviations before using them.
 - Exact commands, settings, environment variables, Admin paths, callback URLs, permissions, and security requirements are appropriate when the reader must act on them.
 - Generated skill pages are procedural instructions for coding agents and may remain technical. Never hand-edit their embedded skill content.
+- Do not put material in a reader-facing guide solely for a coding agent. Put repository instructions in `AGENTS.md` and reusable agent procedures in a skill.
 - Do not add `Key files`, file inventory, or file-to-purpose table sections. Mention a path inline only when it directly supports a required action.
-- End feature guides with a concise `What’s next` section describing common ways teams extend or adapt the feature. Keep those suggestions user-facing: say what can be changed and why someone might change it. Avoid implementation steps, code symbols, and file paths unless they are necessary to complete the customization or the reader asks for them.
+- Do not add a routine closing `Verify`, `Test`, or `Validation` section to reader-facing docs. In a procedural guide, place an essential confirmation immediately after the action it validates and describe the observable result. Agent-facing skills may keep explicit verification checklists.
+- End feature guides with a concise `What’s next` section. Suggest common ways teams extend or adapt the feature, explain what each change enables, and mention important tradeoffs. Keep the suggestions user-facing rather than turning them into implementation inventories.
+- Do not force `What’s next` onto reference pages, index pages, or setup flows that already end with a natural next action or navigation cards. Avoid repeating ideas already covered in the body.
 - Keep slugs stable unless the task explicitly includes redirects or link updates.
 
 ## Commands

--- a/apps/docs/content/docs/anatomy/aeo-geo.mdx
+++ b/apps/docs/content/docs/anatomy/aeo-geo.mdx
@@ -4,68 +4,47 @@ description: How the storefront makes itself legible to AI answer engines and ge
 type: guide
 ---
 
-**Answer Engine Optimization (AEO)** and **Generative Engine Optimization (GEO)** are the practices of making a site legible to the AI surfaces that increasingly mediate commerce — ChatGPT, Claude, Perplexity, Google AI Overviews, and the long tail of agent-driven shopping. Where classical SEO optimizes for crawlers that build a search index, AEO/GEO optimizes for models that read a page once and synthesize an answer. The legibility bar is higher: noisy markup, hydration-only data, and content trapped behind interaction all degrade an LLM's ability to recover the underlying facts.
+**Answer Engine Optimization (AEO)** and **Generative Engine Optimization (GEO)** help AI services understand and cite your storefront. The template provides machine-readable product and collection content without changing the pages shoppers visit.
 
-The template ships with several built-in surfaces that contribute to AEO/GEO. The largest of them is **content negotiation** — serving structured markdown to clients that ask for it — but the supporting cast (JSON-LD schema, sitemaps, OpenGraph metadata) is what makes a page consistently parseable across surfaces.
+## Make storefront content readable to AI
 
-## How it works
+Product, collection, and search URLs return structured Markdown when a client requests `text/markdown`. Normal browser requests continue to receive HTML from the same URLs. No setup is required.
 
-**Content negotiation swaps response format, not routes.** Product, collection, and search pages serve structured markdown when a client sends `Accept: text/markdown`; browsers that don't send it are unaffected and keep getting HTML from the same URL. A `next.config.ts` rewrite intercepts the matching request and routes it to a markdown handler under `app/md/` instead of the page route:
+The storefront also publishes `/llms.txt`, a concise index for AI agents. It links to search, collections, the sitemap, and crawl guidance rather than duplicating the full catalog. The [sitemap](/docs/anatomy/sitemap) remains the complete URL inventory.
 
-```
-GET /products/speaker        (Accept: text/markdown)
-GET /collections/speakers    (Accept: text/markdown)
-GET /search?q=speaker        (Accept: text/markdown)
-    ↓
-next.config.ts rewrite
-    ↓
-/md/products/[handle]
-/md/collections/[handle]
-/md/search
-    ↓
-Route handler response: text/markdown
-```
+If you enable Shopify Markets, add a `locale` query parameter to request locale-specific prices and catalog context.
 
-Every markdown route lives under this single top-level `app/md/` directory so all content-negotiation handlers are co-located and easy to find, and the `Vary: Accept` header ensures CDNs cache the markdown and HTML responses separately. This is built in and requires no configuration.
+## Included discovery surfaces
 
-**`llms.txt` is a curated index, not a full dump.** `/llms.txt` is a machine-readable index of the storefront — an [emerging convention](https://llmstxt.org) that is to AI agents what `robots.txt` is to crawlers. It links to the search entry point, the collection catalog, and the sitemap/robots discovery surfaces, and tells agents that those pages also serve clean Markdown via the content negotiation above. The route is dynamic: collections are pulled live from Shopify and capped so the file stays a concise index rather than an exhaustive dump — the full URL set lives in the [sitemap](/docs/anatomy/sitemap) instead. Because the links honor content negotiation, the virtual `/collections/all` catalog page is served as Markdown too, not just HTML.
+| Surface                          | Outcome                                                                        |
+| -------------------------------- | ------------------------------------------------------------------------------ |
+| Markdown responses               | Gives AI clients clean product, collection, and search content                 |
+| Schema.org data                  | Describes products, breadcrumbs, and the organization                          |
+| [Sitemap](/docs/anatomy/sitemap) | Lists storefront content for crawlers                                          |
+| Crawl guidance                   | Points crawlers to the sitemap and blocks faceted collection URLs              |
+| `/llms.txt`                      | Gives AI agents a concise storefront index                                     |
+| Social metadata                  | Supplies route-specific titles, descriptions, images, prices, and availability |
 
-**If you've enabled Shopify Markets, locale routing composes with content negotiation for free.** The content-negotiation rewrite fires before locale routing, so no additional configuration is needed — pass a `?locale=` query parameter to the markdown endpoint for locale-specific pricing and collection/search context.
+Markdown responses include the facts needed to interpret each page:
 
-## Out of the box
+- **Products** — brand, category, prices, options, variants, specifications, images, tags, and SEO metadata.
+- **Collections** — description, active and available filters, products, pagination, image, and SEO metadata.
+- **Search** — query, collection scope, filters, products, and pagination.
 
-| Surface                          | What it does                                                                                           |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| **Content negotiation**          | Serves clean markdown to AI clients via `Accept: text/markdown`                                        |
-| **Schema.org JSON-LD**           | Embeds structured `Product`, `BreadcrumbList`, and `Organization` data                                 |
-| **Sitemap**                      | [Sitemap index + paged children](/docs/anatomy/sitemap) for products and collections                   |
-| **Robots**                       | Declares crawl policy and blocks faceted (sort/filter) collection URLs                                 |
-| **`llms.txt`**                   | Curated `/llms.txt` index of collections and discovery links for AI agents                             |
-| **OpenGraph & Twitter metadata** | Per-route title/description/image previews, plus `product` OG tags (type, price, availability) on PDPs |
-
-Markdown coverage by page type:
-
-- **Product pages** — handle, brand, category, pricing, options, variants, specs, images, tags, and SEO metadata
-- **Collection pages** — collection metadata, description, applied filters, available filters, products, pagination, image, and SEO metadata
-- **Search pages** — query metadata, active collection filter, applied filters, available filters, products, and pagination state
-
-Verify it directly:
+## Verify the responses
 
 ```bash
-# Returns structured markdown
+# Structured Markdown
 curl -H "Accept: text/markdown" http://localhost:3000/products/speaker
-
-# Returns collection markdown with products, filters, and pagination
 curl -H "Accept: text/markdown" http://localhost:3000/collections/speakers
-
-# Returns search markdown with query, filters, and result summaries
 curl -H "Accept: text/markdown" "http://localhost:3000/search?q=speaker&sort=price-low-to-high"
 
-# Returns the normal HTML page
+# Normal HTML
 curl http://localhost:3000/products/speaker
 ```
 
-## Common customizations
+Check that the Markdown contains accurate catalog data and that the final command still returns the shopper-facing page.
 
-- **Extending markdown coverage to a new route** — add a handler under `app/md/`, wire the matching `next.config.ts` rewrite for its `Accept: text/markdown` variant, and decide what fields belong in the markdown output for that content type.
-- **Tuning the `llms.txt` index** — adjust the collection cap or linked discovery surfaces if your catalog size or navigation structure calls for a different balance between a concise index and a fuller listing.
+## Important choices
+
+Keep `/llms.txt` concise. Use the sitemap for exhaustive discovery. If you add Markdown support to another page type, include only facts an agent needs to identify, compare, or link to that content.

--- a/apps/docs/content/docs/anatomy/aeo-geo.mdx
+++ b/apps/docs/content/docs/anatomy/aeo-geo.mdx
@@ -31,20 +31,6 @@ Markdown responses include the facts needed to interpret each page:
 - **Collections** — description, active and available filters, products, pagination, image, and SEO metadata.
 - **Search** — query, collection scope, filters, products, and pagination.
 
-## Verify the responses
+## What’s next
 
-```bash
-# Structured Markdown
-curl -H "Accept: text/markdown" http://localhost:3000/products/speaker
-curl -H "Accept: text/markdown" http://localhost:3000/collections/speakers
-curl -H "Accept: text/markdown" "http://localhost:3000/search?q=speaker&sort=price-low-to-high"
-
-# Normal HTML
-curl http://localhost:3000/products/speaker
-```
-
-Check that the Markdown contains accurate catalog data and that the final command still returns the shopper-facing page.
-
-## Important choices
-
-Keep `/llms.txt` concise. Use the sitemap for exhaustive discovery. If you add Markdown support to another page type, include only facts an agent needs to identify, compare, or link to that content.
+Keep `/llms.txt` concise and use the sitemap for exhaustive discovery. Common extensions include Markdown responses for additional page types, localized discovery content, and public metaobject content. Include only facts an agent needs to identify, compare, or link to that content.

--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -35,15 +35,7 @@ Cart changes made in chat update the same cart used by the rest of the storefron
 
 The current conversation and draft are stored only in the shopper's browser. They survive navigation and reloads, but not clearing site data or moving to another device. Clearing the chat removes that browser-local history.
 
-## Verify the setup
-
-1. Confirm the assistant control is visible.
-2. Ask for a product with a known option and check the result against Shopify Admin.
-3. Add that product from the conversation and confirm the cart badge, cart view, and chat summary agree.
-4. Ask a policy question and confirm the answer matches the store's published policy.
-5. Reload the page and confirm the conversation remains available.
-
-## Customize the experience
+## What’s next
 
 You can change the model, response instructions, available actions, and rendered shopping experiences. Keep product facts grounded in Shopify, preserve one shared cart, and validate any new action before exposing it to shoppers.
 

--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -6,50 +6,45 @@ prerequisites:
   - /docs/getting-started
 ---
 
-The storefront includes an opt-in AI shopping assistant built with [AI SDK](https://ai-sdk.dev). It can search products, browse collections, manage the cart, answer store-policy questions, and render interactive product and cart UI through natural conversation. The default model is OpenAI GPT-5.6 Luna through the Vercel AI Gateway.
+The storefront includes an opt-in AI shopping assistant built with [AI SDK](https://ai-sdk.dev). It helps shoppers discover products, browse collections, answer store-policy questions, manage their cart, and navigate the storefront through conversation.
 
-## How it works
+The assistant is disabled by default. When disabled, the chat control is hidden and `POST /api/chat` returns `404`.
 
-**Feature-flagged, single-file runtime.** The assistant defaults to disabled through `agent.isEnabled` in `lib/config.ts`. When disabled, the button is hidden and `POST /api/chat` returns `404` before reading the request body or creating a cart. The model, loop limit, prompts, and tool registry all live together in `lib/agent/server.ts`, since they form one runtime implementation rather than a storefront configuration API: `AgentPanel` (`useChat`) posts to `/api/chat`, which runs a request-scoped `ToolLoopAgent` against the Shopify tools and streams the result back.
+## Enable the assistant
 
-**Bot protection is on by default.** The chat endpoint is anonymous and every message costs model tokens, so it is a natural target for automated abuse. Enabling the assistant also enables [Vercel BotID](https://vercel.com/docs/botid), an invisible CAPTCHA that turns away automated traffic before it can reach the model or touch a cart. See [Shop Configuration](/docs/reference/shop-config) to change the detection level or turn it off.
+Set `agent.isEnabled` to `true` in `lib/config.ts`, then deploy with access to the Vercel AI Gateway. The included assistant uses OpenAI GPT-5.6 Luna by default.
 
-**Trusted page context, not client-supplied state.** The route derives context from the same-origin `Referer` header rather than trusting a client-supplied product or collection object. It passes only the handle of the current product or collection into the system prompt, so the assistant understands phrases like "this product" while every price, variant, and availability fact still comes from a tool call. A request-scoped `AsyncLocalStorage` exposes the current locale, cart ID, and page context to every tool during that request.
+The chat endpoint is public and each message can incur model usage. Bot protection is configured separately and is also disabled by default. Before production traffic, review [Shop Configuration](/docs/reference/shop-config) and add rate limits or spending controls that match your risk tolerance.
 
-**The model chooses layout; the storefront owns the data.** Responses stream through json-render's `pipeJsonRender`, which adds structured UI data parts to the normal AI SDK stream, and `useJsonRenderMessage` reconstructs the spec on the client for `<Renderer>`. Generated components reference products by handle rather than restating their fields, and the client resolves each handle against the tool results from that turn. A model cannot invent a price, and cards render only after the turn settles, so a partial spec never flashes an incorrect card.
+Set `UCP_AGENT_PROFILE_URL` only if your store requires an agent profile for Shopify's hosted [Storefront MCP](https://shopify.dev/docs/apps/build/storefront-mcp). See [Environment Variables](/docs/reference/env-vars) for the full variable reference.
 
-**One cart, one source of truth.** Cart tools mutate through `lib/shopify/operations/cart.ts`, and `AgentCartBridge` applies the resulting cart to the client cart store through the same standard event the rest of the storefront uses. The assistant's cart summary, the cart overlay, and the nav badge therefore read identical state, and the assistant never narrates cart contents as text it could get wrong.
+## Shopper experience
 
-## Out of the box
+Out of the box, shoppers can:
 
-**Product discovery**
+- Search the catalog, including required options such as color or size
+- Browse collections and request related or complementary products
+- View current product details, prices, variants, images, and availability
+- Add products, change quantities, remove lines, and add a cart note
+- Ask about shipping, returns, payments, warranty, sizing, care, and other store policies
+- Open product, collection, search, cart, checkout, account, and order destinations
 
-| Tool                        | Purpose                                                                                                                                   |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `searchProducts`            | One search tool with a semantic mode (Shopify's catalog search) and a keyword mode with sorting, plus enforced product-option constraints |
-| `getProductDetails`         | Full product info: description, prices, options, variants, availability, and images                                                       |
-| `getProductRecommendations` | Complementary and related products                                                                                                        |
-| `listCollections`           | All store collections and categories                                                                                                      |
-| `browseCollection`          | Products within a collection with sorting                                                                                                 |
+Product, availability, and policy answers come from Shopify data rather than the model's memory. Searches with a required option can return fewer results, or none, instead of showing near matches.
 
-Semantic search calls Shopify's hosted [Storefront MCP](https://shopify.dev/docs/apps/build/storefront-mcp) endpoint, which returns product IDs only; those IDs are always resolved back through the Storefront API so results carry the same canonical fields as the rest of the storefront. A semantic miss falls back to the keyword index automatically rather than asking the model to retry. Set `UCP_AGENT_PROFILE_URL` only when the store requires an agent profile.
+Cart changes made in chat update the same cart used by the rest of the storefront. Product cards, variant choices, and cart summaries can appear directly in the conversation.
 
-When a shopper states a hard requirement such as a colour or size, the model passes it as a product option rather than leaving it in the query text. Shopify ranks matches first but pads results out to the requested count, and its `productFilters` argument narrows facet counts rather than results, so the tool checks each candidate against the product's real option values and keeps only genuine matches. A constrained search therefore returns fewer results than the usual six, and returns none at all when nothing matches, so the assistant can say a colour is unavailable instead of presenting near misses as matches.
+The current conversation and draft are stored only in the shopper's browser. They survive navigation and reloads, but not clearing site data or moving to another device. Clearing the chat removes that browser-local history.
 
-**Cart management** — `getCart`, `addToCart`, `updateCartItem` (quantity `0` removes the line), and `addCartNote`, all funneled through `lib/shopify/operations/cart.ts` so existing cache invalidation applies. The route creates a cart before streaming when needed and returns its httpOnly cookie in the response headers.
+## Verify the setup
 
-**Store knowledge** — `searchShopPolicies` answers policy, shipping, returns, payment, warranty, sizing, and care questions from Shopify's own content, so the model never guesses them.
+1. Confirm the assistant control is visible.
+2. Ask for a product with a known option and check the result against Shopify Admin.
+3. Add that product from the conversation and confirm the cart badge, cart view, and chat summary agree.
+4. Ask a policy question and confirm the answer matches the store's published policy.
+5. Reload the page and confirm the conversation remains available.
 
-**Navigation** — `navigateUser` builds links to product pages, collections, search, cart, checkout, account, and orders from the same route map the tool and page-context parser share.
+## Customize the experience
 
-**Generative UI components** — `AgentProductCard`, `AgentProductGrid`, `AgentCartSummary`, and `AgentVariantPicker`, registered in the json-render catalog in `lib/agent/index.ts`. The cart summary and variant picker are interactive: shoppers step quantities, remove lines, pick a variant, and add to cart directly from the conversation, reusing the storefront's own cart mutation path.
+You can change the model, response instructions, available actions, and rendered shopping experiences. Keep product facts grounded in Shopify, preserve one shared cart, and validate any new action before exposing it to shoppers.
 
-**Chat UI and persistence** — a compact-to-capped panel with a per-tool streaming status, bottom pinning, click-outside behavior, a working stop button, and clear/minimize controls. The panel stays mounted while browsing, so a conversation survives navigation. Draft input and UI messages persist to `localStorage` under `template-agent-chat`, so a conversation also survives reloads until cleared — persistence is browser-local; there is no durable server-side session.
-
-## Common customizations
-
-The agent doesn't ship these, but they're worth adding before real traffic or production use.
-
-- **Rate limiting and spend caps** — BotID turns away automated traffic, but it does not bound what a real browser can spend. Per-request rate limiting and a cap on model output bound worst-case gateway cost.
-- **Durable chat sessions** — conversation history is browser-local only today; swapping in a server-durable store (a database, or a Workflow session) would let a conversation survive a device switch or a cleared cache.
-- **Additional tools** — new capabilities are added the same way as the shipped ones: an AI SDK `tool()` under `lib/agent/tools/` that calls the normal Shopify operation layer, then registered in `lib/agent/server.ts`.
+For production, consider durable chat history if shoppers need conversations across devices. Add rate limits and spending caps independently of bot detection.

--- a/apps/docs/content/docs/anatomy/authentication.mdx
+++ b/apps/docs/content/docs/anatomy/authentication.mdx
@@ -70,17 +70,9 @@ Customer Account API data is personalized and is not publicly cached.
 
 > **Security requirements:** Never expose access, refresh, or ID tokens to browser-readable storage. Keep logout as a same-origin `POST`. Register callback and logout URIs exactly, and rotate `CUSTOMER_ACCOUNT_SESSION_SECRET` only when you intend to invalidate all sessions.
 
-## Verify the setup
+If sign-in redirects fail, compare the deployed origin, callback URI, logout URI, store domain, and client ID character for character.
 
-1. Open `/account/login` from the public HTTPS origin.
-2. Sign in through Shopify and confirm the storefront returns to an account page.
-3. Check profile, order, and address data against the same customer in Shopify Admin.
-4. Add an item before signing in and confirm it remains in the cart afterward.
-5. Sign out and confirm protected account pages require a new sign-in.
-
-If the redirect fails, first compare the deployed origin, callback URI, logout URI, store domain, and client ID character for character.
-
-## Customize customer accounts
+## What’s next
 
 You can change the account navigation, add a dashboard, or expose more Customer Account API data such as store credit or subscriptions. Validate additions against the Customer Account API schema, which differs from the Storefront API, and keep private customer data behind authentication.
 

--- a/apps/docs/content/docs/anatomy/authentication.mdx
+++ b/apps/docs/content/docs/anatomy/authentication.mdx
@@ -4,13 +4,13 @@ description: Built-in customer authentication with Hydrogen and Shopify Customer
 type: guide
 ---
 
-The template includes opt-in customer authentication using the framework-neutral session and OAuth helpers from `@shopify/hydrogen/customer-account`. Customers can sign in through Shopify, view their profile, order history, and address book, refresh expired access tokens, and sign out of both the storefront and Shopify identity provider.
+The template includes opt-in customer authentication through Shopify Customer Accounts. Signed-in customers can manage their profile and addresses, review orders, and continue to checkout with their customer identity.
 
-Authentication is disabled by default. The canonical default lives in `lib/config.ts` as `auth.isEnabled`. When disabled, the storefront works as a guest-only experience and no auth UI is rendered.
+Authentication is disabled by default. The storefront remains guest-only until you enable `auth.isEnabled` in `lib/config.ts` and complete the Shopify setup below.
 
-## Configuration
+## Configure customer accounts
 
-Enable the feature in `lib/config.ts`:
+Enable authentication:
 
 ```ts
 export const shopConfig = {
@@ -22,76 +22,66 @@ export const shopConfig = {
 };
 ```
 
-Then set the Customer Account API client ID, session secret, and public base URL:
+Set these environment variables:
 
 ```bash
-CUSTOMER_ACCOUNT_SESSION_SECRET="[redacted]"
-SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID="your-customer-account-client-id"
+CUSTOMER_ACCOUNT_SESSION_SECRET="your-session-secret-here"
+SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID="shp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 NEXT_PUBLIC_BASE_URL="your-domain.com"
 ```
 
-Shopify provides `SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID`. It does not provide `CUSTOMER_ACCOUNT_SESSION_SECRET` — that one is app-owned, so generate it yourself:
+Shopify provides the client ID. Generate the session secret yourself:
 
 ```bash
 openssl rand -base64 32
 ```
 
-The template derives its cookie encryption key from that secret. Keep it server-only and identical across every instance of a deployment, and treat rotation as deliberate: it invalidates every existing customer session. Enabling auth without both values fails the build.
+Keep the session secret server-only and identical across every instance of a deployment. Rotating it signs out all customers. A build with authentication enabled fails when the session secret or client ID is missing.
 
-Customer Account OAuth requires a public HTTPS origin. Use a tunnel for local OAuth testing and set `NEXT_PUBLIC_BASE_URL` to that tunnel's bare domain (no protocol).
+Customer Account OAuth requires a public HTTPS origin. For local testing, use a tunnel and set `NEXT_PUBLIC_BASE_URL` to its domain without the protocol.
 
-To enable it in Shopify Admin:
+In Shopify Admin:
 
-1. Enable customer accounts: **Settings → Customer accounts → Edit**, choose **Customer accounts**, and Save
-2. Install the **Headless** sales channel from the Shopify App Store
-3. Go to **Sales channels → Headless → (your storefront) → Customer Account API**
-4. Use a public Customer Account API client; Hydrogen performs authorization code + PKCE without a client secret
-5. Set the callback URI to `{YOUR_DOMAIN}/account/authorize` and the logout URI to `{YOUR_DOMAIN}/`
-6. Copy the client ID to `SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID`, and confirm the store domain matches `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN`
+1. Go to **Settings → Customer accounts → Edit**.
+2. Choose **Customer accounts**, then save.
+3. Install the **Headless** sales channel.
+4. Go to **Sales channels → Headless → your storefront → Customer Account API**.
+5. Use a public Customer Account API client.
+6. Add `https://YOUR_DOMAIN/account/authorize` as the callback URI.
+7. Add `https://YOUR_DOMAIN/` as the logout URI.
+8. Copy the client ID into `SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID`.
+9. Confirm `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN` identifies the same store.
 
-Shopify does not support wildcard callback or logout URIs — register each production, preview, or tunnel origin that needs authentication. See [Environment Variables](/docs/reference/env-vars) for the full variable reference.
+Shopify does not support wildcard callback or logout URIs. Register every production, preview, and tunnel origin that needs authentication. See [Environment Variables](/docs/reference/env-vars) for the full variable reference.
 
-## How it works
+## Customer experience
 
-**No client-side auth SDK.** Sign-in is a normal GET navigation to `/account/login`; sign-out is a same-origin POST form to `/account/logout`. The `shopConfig.auth.isEnabled` flag (`lib/config.ts`) gates every auth surface and is safe to read from server and client code alike. When it's false: the account icon disappears from the nav, the Hydrogen auth routes and protected account pages return `404`, and the shared session/access-token helpers in `lib/auth/server.ts` fail before initializing Hydrogen — no auth-related code runs at request time.
+Customers sign in at `/account/login` and sign out through `/account/logout`. The storefront provides:
 
-**The session lives in an encrypted cookie, not a server store.** `/account/login` asks Hydrogen to generate state, nonce, and PKCE values, which the app encrypts into chunked AES-256-GCM HttpOnly cookies. Shopify redirects to `/account/authorize`, where Hydrogen validates state, nonce, issuer, audience, and ID-token expiry before exchanging the authorization code — access, refresh, and ID tokens then replace the pending-login state in that same cookie. Server Components only perform read-only login and token checks; they never mutate cookies.
+- `/account/profile` for name and email details
+- `/account/orders` and `/account/orders/[id]` for order history and details
+- `/account/addresses` for creating, editing, deleting, and choosing a default address
 
-**Token refresh happens out-of-band, not inline.** `isCustomerLoggedIn()` treats a refreshable session as logged in, so the nav doesn't flicker to signed-out when the access token expires. `requireCustomerAccessToken()` redirects through `/account/refresh` when only a refresh token remains, where Hydrogen rotates tokens and commits the updated cookie before returning to the account page. Logout mirrors this: the sign-out button POSTs to `/account/logout`, which clears the local session and redirects through Shopify's logout endpoint with `id_token_hint`, ending both the storefront session and the Shopify SSO session.
+Sessions use encrypted, HttpOnly cookies rather than browser-readable storage. Expired access tokens refresh through `/account/refresh`. Logout ends both the storefront session and the Shopify sign-in session.
 
-**The cart follows the customer session.** When authentication is enabled, the cart and Customer Account handlers share the same Hydrogen customer session. New carts include the signed-in customer's buyer identity, login and token refresh attach an existing browser cart, and logout detaches it. Authenticated cart reads also mark the checkout URL so Shopify can carry the customer into checkout with their saved details instead of starting a guest flow. Cart synchronization is best-effort and never blocks an auth redirect; if Hydrogen cannot safely detach a cart during logout, it expires the cart cookie.
+When authentication is enabled, the cart follows the customer session. Signing in attaches the browser cart when possible, and checkout can carry the customer's saved details. Cart synchronization is best-effort; an authentication redirect still completes if cart synchronization fails.
 
-```ts
-import {
-  isCustomerLoggedIn,
-  requireCustomerAccessToken,
-  requireCustomerSession,
-} from "@/lib/auth/server";
+Customer Account API data is personalized and is not publicly cached.
 
-const loggedIn = await isCustomerLoggedIn();
-await requireCustomerSession();
-const accessToken = await requireCustomerAccessToken("/account/orders");
-```
+> **Security requirements:** Never expose access, refresh, or ID tokens to browser-readable storage. Keep logout as a same-origin `POST`. Register callback and logout URIs exactly, and rotate `CUSTOMER_ACCOUNT_SESSION_SECRET` only when you intend to invalidate all sessions.
 
-Use `isCustomerLoggedIn()` for read-only UI state, `requireCustomerSession()` for account-page gates, and `requireCustomerAccessToken()` immediately before private Customer Account API work.
+## Verify the setup
 
-> **Guardrails.**
->
-> - Never expose access, refresh, or ID tokens to Client Components or browser-readable storage.
-> - Keep Server Components on the read-only session path. Token refresh belongs in `/account/refresh`.
-> - Keep login as GET and logout as same-origin POST, and register the callback and logout URIs in Shopify exactly.
-> - Rotate `CUSTOMER_ACCOUNT_SESSION_SECRET` deliberately — rotation invalidates every existing session.
-> - `auth.isEnabled` lives in `lib/config.ts` (not an env var), so the server and client feature gates read one shared value and stay in agreement under cache components.
+1. Open `/account/login` from the public HTTPS origin.
+2. Sign in through Shopify and confirm the storefront returns to an account page.
+3. Check profile, order, and address data against the same customer in Shopify Admin.
+4. Add an item before signing in and confirm it remains in the cart afterward.
+5. Sign out and confirm protected account pages require a new sign-in.
 
-## Out of the box
+If the redirect fails, first compare the deployed origin, callback URI, logout URI, store domain, and client ID character for character.
 
-- **Auth routes** — `/account/login` (GET, starts PKCE and redirects to Shopify), `/account/authorize` (GET, validates the OAuth callback), `/account/refresh` (GET, rotates an expired access token), and `/account/logout` (POST, clears the session). All four are installed via Hydrogen's standard handlers through `handleShopifyRoutes` in the [proxy](/docs/anatomy/proxy), which intercepts the customer-account OAuth paths before routing.
-- **Cart session attribution** — the same Hydrogen customer session is passed to the cart and auth handlers, so buyer identity stays synchronized across cart creation, login, refresh, checkout, and logout.
-- **Account pages** — `/account` (redirects to profile), `/account/profile` (edit name, read-only email), `/account/orders` (paginated order history), `/account/orders/[id]` (order detail), and `/account/addresses` (address book with create, edit, delete, and default selection). The `(authenticated)` route group gates these without claiming the auth-handler paths.
-- **Customer Account API data** — profile, orders, and addresses come from the Customer Account API, which has its own GraphQL endpoint and schema, separate from the Storefront API. Every call resolves a usable access token first, routing through the refresh step when only a refresh token remains, so no operation runs with an expired token. Customer responses are personalized and never publicly cached.
-- **Rendering and mutations** — order and profile pages are Server Components wrapped in Suspense. Address and profile editing use client forms backed by server actions that validate input, surface Shopify `userErrors`, and revalidate the affected pages.
+## Customize customer accounts
 
-## Common customizations
+You can change the account navigation, add a dashboard, or expose more Customer Account API data such as store credit or subscriptions. Validate additions against the Customer Account API schema, which differs from the Storefront API, and keep private customer data behind authentication.
 
-- **Additional account data** — store credit, subscriptions, draft orders, or richer order fields all follow the same path as the shipped account data: a Customer Account API operation, a transform to a domain type, and a server action for anything that mutates. Validate new fields against the live Customer Account API schema, since it differs from the Storefront API.
-- **Account page composition** — the shipped profile, orders, and addresses pages are a starting point. Reordering them, adding a landing dashboard, or splitting order history into its own section is presentation work that leaves the auth flow untouched.
+See [Proxy](/docs/anatomy/proxy) for the storefront's request-routing role in customer account URLs.

--- a/apps/docs/content/docs/anatomy/cart.mdx
+++ b/apps/docs/content/docs/anatomy/cart.mdx
@@ -31,15 +31,6 @@ If `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ID` is set, server-side cart activity is attr
 - Cart updates can fail because of availability, quantity, discount, or checkout restrictions.
 - Gift cards and bundles can carry information that ordinary product lines do not; preserve that data when extending cart behavior.
 
-## Verify the cart
-
-1. Add an available variant and confirm the cart badge and overlay update.
-2. Change its quantity, then reload `/cart` and confirm the quantity and totals persist.
-3. Apply one valid and one invalid discount code and confirm each result is clear.
-4. Remove the line and confirm the empty-cart state appears.
-5. If authentication or the assistant is enabled, change the cart through that experience and confirm every cart surface agrees.
-6. Start checkout and confirm the products, quantities, discounts, currency, and customer state are correct.
-
-## Customize the cart
+## What’s next
 
 You can adjust the cart lifetime, expose order-level attributes, support personalized products, or add custom bundle purchase flows. Keep the cookie lifetime aligned with Shopify's cart handling, preserve all line attributes needed at checkout, and continue treating Shopify's confirmed cart as the source of truth.

--- a/apps/docs/content/docs/anatomy/cart.mdx
+++ b/apps/docs/content/docs/anatomy/cart.mdx
@@ -6,36 +6,40 @@ type: guide
 
 <CartBrowser />
 
-> **Note:** The cart ID is stored in a `cart` cookie (the same cookie Hydrogen's cart handlers use) with a 14-day expiry. Sessions longer than that start a fresh cart.
+The storefront ships with a shared Shopify cart across product pages, the cart overlay, the full cart page, checkout, and the optional shopping assistant. Shoppers see changes immediately while Shopify confirms prices, discounts, and availability.
 
-The cart system spans the entire storefront, not just the cart page. It is built on `@shopify/hydrogen`'s first-party cart stack rather than a hand-rolled one: a server handler owns the `/api/cart` endpoint and cart cookie, a client cart store holds optimistic state, and a provider in `layout.tsx` gives every component access to cart state.
+No additional setup is required for the standard cart. The cart ID is stored in an HttpOnly `cart` cookie for 14 days. After that cookie expires, the shopper starts a new cart.
 
-## How it works
+## Shopper experience
 
-**Hydrogen's cart server handlers own `/api/cart` and the cart cookie.** `lib/cart/server.ts` creates them with `createCartServerHandlers()` and `proxy.ts` registers them through `handleShopifyRoutes`, so `GET`/`POST /api/cart` is answered by Hydrogen before app routing. The handler reads and writes the `cart` cookie and returns the full cart envelope (`{ cart, errors }`). The template's RSC cart reads and AI-agent mutations use the same `cart` cookie (see `lib/cart/server.ts`), so server components, the agent, and the endpoint all operate on one cart id. When `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ID` is set, Hydrogen sends it as a trusted Storefront API header so Shopify attributes server-side cart activity to the correct Headless storefront.
+Shoppers can add products, change quantities, remove lines, apply discount codes, and proceed to checkout. The cart overlay is available throughout the storefront, and `/cart` provides the full cart with product recommendations.
 
-**The cart streams into the app as a promise.** The root layout is a static shell. An async `AppShell` inside `<Suspense>` calls `await connection()`, starts the full-cart read via `seedCartData()` in `lib/cart/server.ts`, and passes the unresolved promise to a client `CartProvider` as `initialData`. The store tracks the in-flight load, so the shell stays CDN-cacheable while cart content can suspend behind its own fallback with `useSuspenseCart`.
+Updates are optimistic: quantities and badges change immediately, then reconcile with Shopify. If Shopify rejects a change, the cart returns to its confirmed state and shows the relevant error. Checkout remains unavailable while totals are still being confirmed.
 
-**Optimistic state lives in Hydrogen's cart store.** The store applies an optimistic update on each mutation, tracks in-flight entities in `pending` (per line, discount code, note, attributes, and cost), reconciles with the server response, and rolls back to a baseline on failure. One transaction per mutation makes rapid overlapping changes safe — a superseded response cannot leave stale totals behind. The template's `components/cart/context.tsx` adapter exposes `cartWithPending` for immediate quantities and badges while `cart` keeps the last cost-settled snapshot during `pending.cost` or background `revalidating`. Summaries therefore hold steady and checkout remains disabled until the authoritative cart cost settles.
+The cart displays confirmed discounts and sale pricing. Shopify bundles remain grouped so shoppers can understand which products belong together. Quantity and remove controls follow Shopify's rules for each line, so some bundle lines may not be editable individually.
 
-**Confirmed cart changes publish Shopify analytics events.** `useCartAnalytics()` subscribes once to the Hydrogen cart store and emits cart-updated, product-added, and product-removed events only after pending work settles. The custom cart fragment includes Shopify's `updatedAt` timestamp so repeated renders and concurrent responses do not duplicate events.
+When customer authentication is enabled, sign-in can attach the existing browser cart to the customer. Checkout can then use the customer's saved details. See [Authentication](/docs/anatomy/authentication).
 
-**Mutations reconcile through Hydrogen's cart store.** Quantity, remove, and discount controls use Hydrogen's typed `useCartForm()` registrations, so native form intents own optimistic state, pending work, reconciliation, scoped errors, quantity sanitization, and editable quantity-input attachment. Add-to-cart keeps a narrow compatibility bridge because this Hydrogen preview's form parser cannot carry gift-card line attributes or the product detail used to render a complete optimistic line. Discount forms read loading state from `pending.discountCodes` and errors from `errors.discountCodes`; newly submitted codes remain visually pending until Shopify confirms whether they apply, so the optimistic placeholder does not flash as invalid.
+The optional shopping assistant uses the same cart, so changes made in chat appear in the cart overlay and on `/cart`.
 
-**Bundles nest as domain cart lines, not flattened rows.** The cart store preserves each bundle parent's `lineComponents` as nested lines (`CartLine.components`), so fixed and transformed bundles render as one parent line listing its included products. The controls in `overlay-item.tsx` honor Shopify's `canUpdateQuantity` and `canRemove` instructions rather than assuming every line is editable.
+If `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ID` is set, server-side cart activity is attributed to the corresponding Headless storefront. See [Environment Variables](/docs/reference/env-vars).
 
-**The cart cookie's `SameSite` attribute adapts to the deployment.** It's derived from `VERCEL_ENV`: `Strict` in production, `Lax` on preview and every other environment. Preview deployments sit behind Vercel Authentication, whose SSO flow bounces the browser cross-site and redirects back — a `Strict` cookie would be withheld on that return navigation, dropping the cart id. `Lax` still rides top-level GET navigations back into the site (the SSO return, and the return from Shopify's checkout domain) while staying off cross-site subrequests, which is the right level for a cart identifier. The production custom domain is public, so it keeps `Strict`.
+## Important limits
 
-## Out of the box
+- The cart lasts only as long as its 14-day cookie.
+- Shopify remains authoritative for inventory, prices, discounts, and line-editing rules.
+- Cart updates can fail because of availability, quantity, discount, or checkout restrictions.
+- Gift cards and bundles can carry information that ordinary product lines do not; preserve that data when extending cart behavior.
 
-- **Server actions** (`lib/cart/action.ts`, `"use server"`) — handle the checkout-URL flows: `buyNowAction()` (checkout URL for a new item) and `prepareCheckoutAction()` (checkout URL for an existing cart). Cart forms submit line and discount mutations through `/api/cart`; add flows use the compatibility bridge described above. Locale and currency are set at cart creation through the `I18nConfig` (country/language) that `seedCartData()` passes to `createShopifyRequestContext()`; Hydrogen applies it via `@inContext`.
-- **Cart overlay** — a right-side `Sheet` on every viewport (`w-[calc(100%-2.5rem)] max-w-md`, the same width rule as the mobile menu and collection filter sidebar). `overlay-content.tsx` composes an empty state, a scrollable line-item list, and a summary with subtotal, checkout button, and a link to the full cart page. Each line item (`overlay-item.tsx`) top-aligns its image and renders the title, variant options, bundle components, quantity controls, a remove button, and the unit price. The price cell follows Dawn's model: a line with a Shopify discount allocation shows the final unit price first and strikes the regular selling price without repeating the discount code on every item. Otherwise it strikes only a genuine `compareAtPrice` sale price. Quantity still feeds the cart subtotal rather than changing the displayed unit-price basis.
-- **Cart page** (`/cart`) — a 12-column grid on large screens (9 for items, 3 for a sticky summary), wrapped in `Suspense` with a skeleton fallback. Components live in `components/cart-page/`: `Header`, `CartItemsList` (reuses `OverlayItem`), `Summary`, and `Empty`. A `RelatedProductsSection` shows recommendations based on the first cart item; `Empty` replaces the whole grid when the cart has none.
-- **AI agent cart tools** — the agent's add/update/remove/note tools still run through `lib/shopify/operations/cart.ts` server-side and share the `cart` cookie, so agent-driven changes and storefront interactions target the same cart.
+## Verify the cart
 
-## Common customizations
+1. Add an available variant and confirm the cart badge and overlay update.
+2. Change its quantity, then reload `/cart` and confirm the quantity and totals persist.
+3. Apply one valid and one invalid discount code and confirm each result is clear.
+4. Remove the line and confirm the empty-cart state appears.
+5. If authentication or the assistant is enabled, change the cart through that experience and confirm every cart surface agrees.
+6. Start checkout and confirm the products, quantities, discounts, currency, and customer state are correct.
 
-- **Custom cart fields** — pass a `fragment` named `CartFragment` to `createCartServerHandlers({ fragment })` in `lib/cart/server.ts` to add fields the default Hydrogen fragment omits (for example `quantityAvailable` for inventory clamping, or extra merchandise fields). The template already extends it this way to select the catalog unit price and `compareAtPrice` for the overlay's strikethrough. The React bindings in `lib/cart/client.ts` stay typed from the handlers.
-- **Cart attributes** — Hydrogen supports optimistic cart-level attribute updates, but the template does not expose a generic editor. Add one with a concrete use case such as order-level personalization; the existing gift card flow uses line attributes instead.
-- **Cart lifetime** — the 14-day cookie expiry is a constant in `lib/cart/server.ts` and in Hydrogen's own cookie; extending or shortening session length means aligning both.
-- **Custom bundle flows** — `addToCart()` in `lib/shopify/operations/cart.ts` accepts Shopify's optional `CartLineInput.parent` relationship, available as a foundation for app-specific customized-bundle UX beyond the fixed and transformed bundles rendered out of the box.
+## Customize the cart
+
+You can adjust the cart lifetime, expose order-level attributes, support personalized products, or add custom bundle purchase flows. Keep the cookie lifetime aligned with Shopify's cart handling, preserve all line attributes needed at checkout, and continue treating Shopify's confirmed cart as the source of truth.

--- a/apps/docs/content/docs/anatomy/footer.mdx
+++ b/apps/docs/content/docs/anatomy/footer.mdx
@@ -4,32 +4,22 @@ description: The storefront footer - copyright, Shopify policy links, social lin
 type: guide
 ---
 
-The footer renders at the bottom of every page. By default it displays a copyright notice, every configured Shopify store policy, and optional social media links.
+The footer appears on every page. By default, it shows your store name and links to every policy configured in Shopify. Social links and menu columns are optional.
 
-## How it works
+## Publish store policies
 
-**Policy links come from Shopify, not a hardcoded list.** The footer links to every policy configured in Shopify Admin, using the active locale, and each link disappears individually when that policy isn't configured — there's no separate allowlist to maintain. They render at `/policies/[handle]` and share the `policies` cache tag with the policy pages and static sitemap shard, so a policy edit in Shopify invalidates all three surfaces together.
+Add and maintain policies in Shopify Admin. The footer automatically links each configured policy in the shopper's active locale. Policies without content do not appear, so there is no separate list to maintain.
 
-**Social links are hidden by default.** The `socialLinks` array in `components/footer/index.tsx` takes `{ platform, url }` entries — `platform` is one of `facebook`, `instagram`, `x`, `youtube`, `tiktok`, `pinterest`, `linkedin`, or `github`. The default is an empty array, which hides the section entirely; a non-empty array renders icons on the right side of the footer opposite the copyright.
+Supported policy pages include contact information, legal notice, privacy, refunds, shipping, terms of sale, and terms of service.
 
-```ts
-// components/footer/index.tsx
-const socialLinks: SocialLink[] = [
-  { platform: "x", url: "https://x.com/mystore" },
-  { platform: "instagram", url: "https://instagram.com/mystore" },
-];
-```
+## Choose what else to show
 
-**The copyright line has no year by design.** It uses the `footer.copyright` i18n key with `shopConfig.site.name` interpolated in (edited in `lib/config.ts`, defaulting to `"Vercel Shop"`). Reading `new Date()` for a year would force every page dynamic under Next.js 16 Cache Components, so the template omits it rather than trading that away by default.
+- **Copyright** — uses the configured store name and omits the year by default.
+- **Social profiles** — hidden until you add profile URLs. Supported services are Facebook, Instagram, X, YouTube, TikTok, Pinterest, LinkedIn, and GitHub.
+- **Menu columns** — use the [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) skill to add links from a Shopify footer menu.
 
-## Out of the box
+A dynamic year is not included because reading the current date can change how pages are cached. Add one only if that tradeoff is acceptable for your storefront.
 
-- **Copyright** — "© \{shopConfig.site.name\}. All rights reserved.", editable via `footer.copyright` in `lib/i18n/messages/en.json`.
-- **Policy links** — one link per Shopify-configured store policy, locale-aware.
-- **Social links** — icons for any configured `socialLinks` entry, hidden when the array is empty.
+## Verify the footer
 
-## Common customizations
-
-- **Shopify menu columns** — the [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) skill adds link columns sourced from a Shopify `"footer"` menu above the copyright.
-- **Branding** — edit `site.name` in `lib/config.ts` to change the name; edit `lib/i18n/messages/en.json` to change the copyright wording itself.
-- **A dynamic year** — add one only inside a `Suspense` boundary, since an unwrapped `new Date()` read would force the whole page dynamic under Cache Components.
+Preview the storefront in each supported locale. Confirm that configured policies open successfully, unconfigured policies are absent, and each social link points to the intended profile.

--- a/apps/docs/content/docs/anatomy/footer.mdx
+++ b/apps/docs/content/docs/anatomy/footer.mdx
@@ -20,6 +20,6 @@ Supported policy pages include contact information, legal notice, privacy, refun
 
 A dynamic year is not included because reading the current date can change how pages are cached. Add one only if that tradeoff is acceptable for your storefront.
 
-## Verify the footer
+## What’s next
 
-Preview the storefront in each supported locale. Confirm that configured policies open successfully, unconfigured policies are absent, and each social link points to the intended profile.
+Common additions include a Shopify-managed link menu, a newsletter signup, payment or trust marks, and market or language controls. Keep the footer focused on destinations shoppers may need from any page.

--- a/apps/docs/content/docs/anatomy/i18n.mdx
+++ b/apps/docs/content/docs/anatomy/i18n.mdx
@@ -19,6 +19,6 @@ Pass a few translated labels directly when an interactive element needs only fix
 
 Do not import complete translation catalogs into browser code. This increases the JavaScript sent to every shopper and can expose messages that the current page never uses.
 
-## Verify a locale
+## What’s next
 
-Open each changed page in every supported locale. Check fixed copy, interactive states, plurals, currency and number formatting, and error messages. Missing messages should be fixed before adding the locale to storefront navigation.
+Common additions include a locale selector, Shopify Markets for localized catalogs and currencies, and a translation workflow for larger teams. Add a locale to storefront navigation only after its fixed copy, interactive states, plurals, formatting, and error messages are complete.

--- a/apps/docs/content/docs/anatomy/i18n.mdx
+++ b/apps/docs/content/docs/anatomy/i18n.mdx
@@ -1,22 +1,24 @@
 ---
 title: Translations
-description: How the storefront keeps translation catalogs on the server and scopes client messages to interactive islands.
+description: How the storefront keeps translation catalogs on the server and sends the browser only the messages needed for interactive UI.
 ---
 
-The storefront uses next-intl for translated copy and locale-aware formatting. Message catalogs load on the server. Server Components call `getTranslations()` and render translated text directly whenever the browser does not need to choose or format that text later.
+The storefront uses next-intl for translated copy and locale-aware formatting. Translation catalogs stay on the server by default, which keeps unnecessary messages out of browser JavaScript.
 
-## Client message boundaries
+## Add translated copy
 
-Interactive components sometimes need translations after hydration—for example, cart mutation errors, search results, collection filters, and product purchase controls. Give each cohesive interactive island a `NextIntlClientProvider` containing only the namespaces it uses. Do not pass the complete catalog from the root layout.
+Add every new shopper-facing message to every locale catalog. Keep the same message structure across locales.
 
-Prefer a translated primitive prop when a client leaf needs only a few fixed labels. Keep `useTranslations()` when several related client components share a namespace or need dynamic messages, plurals, or interpolation. Place that provider in the nearest Server Component so unrelated routes and islands do not receive its messages.
+Render fixed text on the server whenever possible. If an interactive area needs translations after the page loads, provide only the messages used by that area. Examples include cart errors, search results, collection filters, and product purchase controls.
 
-The root provider contains only shared error-boundary copy. Next.js route error boundaries are Client Components and cannot load request translations on the server, so this small namespace must remain available across the application. The active locale is also set there and is inherited by narrower providers.
+A small set of shared error messages must remain available throughout the application because route error screens run in the browser.
 
-## Adding translated UI
+## Keep browser messages small
 
-Add new user-visible copy to every locale catalog. In a Server Component, use `getTranslations()` and render the result or pass the required labels to a client leaf. If an interactive subtree needs a translator, select only its namespaces from `getMessages()` and pass those to a provider around that subtree.
+Pass a few translated labels directly when an interactive element needs only fixed text. Provide a translation namespace when related controls need dynamic messages, plurals, or interpolation.
 
-Avoid importing message JSON into Client Components. That bundles the catalog into client JavaScript instead of sending only the messages required by the rendered island.
+Do not import complete translation catalogs into browser code. This increases the JavaScript sent to every shopper and can expose messages that the current page never uses.
 
-When adding a locale, preserve the same message shape across catalogs. The request configuration chooses the catalog for the active locale; the rendering boundaries determine which messages cross into the browser.
+## Verify a locale
+
+Open each changed page in every supported locale. Check fixed copy, interactive states, plurals, currency and number formatting, and error messages. Missing messages should be fixed before adding the locale to storefront navigation.

--- a/apps/docs/content/docs/anatomy/navigation.mdx
+++ b/apps/docs/content/docs/anatomy/navigation.mdx
@@ -22,6 +22,6 @@ Use the [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) skill to let
 
 An optional mobile bottom bar appears only when you add an action, such as an agent button.
 
-## Verify navigation
+## What’s next
 
-Check desktop and mobile layouts. Confirm that every menu item opens the expected destination, search returns relevant suggestions, the full results link preserves the query, and the cart badge matches the cart contents.
+Common additions include Shopify-managed menus, a customer-account link, promotional bars, and richer desktop navigation for large catalogs. Keep search and cart access easy to reach on every screen size.

--- a/apps/docs/content/docs/anatomy/navigation.mdx
+++ b/apps/docs/content/docs/anatomy/navigation.mdx
@@ -1,32 +1,27 @@
 ---
 title: Navigation
-description: The storefront navigation system - navbar, quick links, mobile bottom bar, and responsive layout.
+description: The storefront navigation system - desktop and mobile menus, search, cart access, and optional Shopify-managed links.
 type: guide
 ---
 
-The navigation system is split into a sticky top navbar for desktop and a fixed bottom bar for mobile. By default, navigation links are hardcoded. Use [`/vercel-shop:enable-shopify-menus`](/docs/skills/enable-shopify-menus) to fetch menus from Shopify.
+The storefront provides desktop and mobile navigation, predictive search, and cart access. Links are static by default. Use [`/vercel-shop:enable-shopify-menus`](/docs/skills/enable-shopify-menus) when merchants need to manage them in Shopify.
 
-## How it works
+## Help shoppers move through the store
 
-**Desktop and mobile split at the `md` breakpoint, not just visually.** Desktop gets a full sticky navbar (`z-30`) with the logo, quick links, and cart icon. Below `md`, quick links hide and a hamburger to the left of the logo opens a left-sliding `Sheet` with the same links, rendered as padded touch targets with breathing room below the close button; the cart and search icons stay in the top bar, and an optional agent button lives in a separate fixed bottom bar that only renders when it has children.
+On desktop, a sticky header shows the logo, primary links, search, and cart. On mobile, primary links move into a menu while search and cart remain in the header. The mobile menu closes after a shopper selects a link.
 
-**Links are hardcoded but already Shopify-shaped.** The quick-links component accepts a Shopify-shaped `MenuItem[]` and renders up to three levels via an inline hover panel, even though the default data is a single hardcoded `Shop` link. The mobile sheet reuses the same link data. Because the shape already matches Shopify Navigation, the `enable-shopify-menus` skill only needs to swap the data source — desktop, mobile, and footer links all switch over together.
+Search opens as a dialog. It shows suggestions and matching products as the shopper types, links directly to products, and offers a full results page. It closes after navigation, Escape, or an outside click.
 
-**Search is a self-contained modal, not a page.** A search icon opens a centered dialog backed by Hydrogen's predictive-search store and `/api/predictive-search` handler. Hydrogen debounces input, cancels stale requests, and queries Shopify's `predictiveSearch` API after hydration, so the navbar remains part of the static shell rather than varying by search text. Suggestion chips and matching products appear as the user types; clicking a product navigates directly to its page, while "View all" opens the full search results page. The modal closes on navigation, Escape, or an outside click.
+The cart badge shows the current item count and opens the cart.
 
-**The cart icon is a server/client pair.** The server half reads the `shopify_cartId` cookie and fetches the initial cart so the count is correct on first paint; the client half renders the quantity badge, animates pending additions, and opens the cart overlay on click.
+## Choose how links are managed
 
-## Out of the box
+The default storefront includes a single Shop link. This is suitable for a small catalog or a navigation structure managed in code.
 
-- **Navbar** — sticky header composing the logo, quick links, and cart icon.
-- **Quick links** — horizontal link bar, hidden on mobile (`md:flex`).
-- **Mobile menu** — hamburger-triggered `Sheet` with the same links as quick links; closes automatically on tap.
-- **Search modal** — predictive search dialog, described above.
-- **Cart icon** — server-rendered initial count, client-rendered badge and overlay trigger.
-- **Footer** — renders a copyright notice by default; see [Footer](/docs/anatomy/footer) for its full composition, including the `enable-shopify-menus` menu columns.
-- **Mobile bottom bar** — fixed bar reserved for optional children such as the agent button.
+Use the [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) skill to let merchants manage desktop links, mobile links, and footer columns through Shopify Navigation. Menus can contain up to three levels.
 
-## Common customizations
+An optional mobile bottom bar appears only when you add an action, such as an agent button.
 
-- **Shopify-powered menus** — the [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) skill replaces the hardcoded quick links, mobile menu links, and footer columns with a Shopify Navigation menu in one pass.
-- **Additional bottom-bar actions** — the mobile bottom bar only renders when it has children, so adding another mobile-only action (beyond the agent button) is a matter of passing it another child rather than restructuring the bar.
+## Verify navigation
+
+Check desktop and mobile layouts. Confirm that every menu item opens the expected destination, search returns relevant suggestions, the full results link preserves the query, and the cart badge matches the cart contents.

--- a/apps/docs/content/docs/anatomy/pages/content.mdx
+++ b/apps/docs/content/docs/anatomy/pages/content.mdx
@@ -6,30 +6,28 @@ type: guide
 
 <ContentBrowser />
 
-The template renders Shopify's built-in editorial content — Pages, policies, blogs, and articles — as storefront routes, without requiring a separate CMS.
+Use Shopify's built-in content tools to publish editorial and policy pages without adding another content management system.
 
-- Shopify Pages render at `/pages/[handle]`.
-- Configured store policies render at `/policies/[handle]`.
-- Shopify blogs render at `/blogs/[blogHandle]`, with articles at `/blogs/[blogHandle]/[articleHandle]`.
+- Shopify Pages appear at `/pages/[handle]`.
+- Store policies appear at `/policies/[handle]`.
+- Blogs appear at `/blogs/[blogHandle]`, with articles at `/blogs/[blogHandle]/[articleHandle]`.
 
-All route types use the active locale as Storefront API context and return `404` for unknown handles. There is intentionally no `/blogs` index route; storefront navigation links to individual blogs such as `/blogs/news`.
+Unknown handles return a not-found page. There is no combined `/blogs` page, so navigation should link to a specific blog such as `/blogs/news`.
 
-## How it works
+## Publish content in Shopify
 
-**Shopify's editorial content, not a separate CMS model.** Pages, policies, blogs, and articles come straight from Shopify's native content types (Admin → Online Store → Pages, Settings → Policies, Content → Blog posts) and render through the shared prose layout. There's no additional content schema to maintain — anything editable in Shopify Admin is editable here.
+Manage Pages and blog posts in Shopify Admin, and manage store policies in Shopify settings. The storefront uses the active locale when requesting this content.
 
-**Long-lived cache, manual invalidation.** Every read uses plain `"use cache"` with `cacheLife("max")`, tagged by content type (`pages`, `policies`, `blogs`, `articles`) and by handle. Unlike products and collections, Shopify exposes no webhook topics for this content (see [Webhooks](/docs/anatomy/webhooks)), so a `cacheLife("max")` read has no automatic invalidation signal — it stays cached until purged manually or by a redeploy.
+Shopify Pages include a title, rich-text body, and SEO fields. Blogs list recent articles with dates, excerpts, and optional images. Articles include the title, author, date, image, and body. Policy URLs exist only when the corresponding policy has content, and the [footer](/docs/anatomy/footer) links to every configured policy.
 
-> **Temporary workaround.** Until Shopify ships content webhooks (or you add a poller), force an edit to surface by calling `revalidateTag` for the affected tag yourself — `revalidateTag("pages", { expire: 0 })`, `revalidateTag("policies", { expire: 0 })`, `revalidateTag("blogs", { expire: 0 })`, or `revalidateTag("articles", { expire: 0 })` — from a route handler or server action you trigger after editing. A redeploy also starts from a cold cache.
+Search and social metadata use Shopify's SEO fields when available. Sitemaps include Pages, blogs, articles, and configured policies. See [Sitemap](/docs/anatomy/sitemap).
 
-## Out of the box
+## Plan for delayed updates
 
-- **Shopify Pages** — title, sanitized rich-text HTML body, and SEO fields, falling back to the page title and body summary when SEO fields are absent.
-- **Store policies** — contact information, legal notice, privacy, refund, shipping, terms of sale, and terms of service; only policies with content are returned, so unconfigured policy URLs `404` instead of rendering empty. The footer automatically links every configured policy.
-- **Blogs and articles** — each blog lists its latest articles with date, excerpt, and optional image; articles render title, author, date, image, and body.
-- **Localization** — every read passes the locale's country and language through Shopify's `@inContext` directive; the Markets and i18n skills can move these routes under locale-aware routing without changing their data contract.
-- **SEO and discovery** — canonical and Open Graph metadata from Shopify's SEO fields, plus paginated `pages-{n}`, `blogs-{n}`, and `articles-{n}` sitemap shards from Shopify's native sitemap query. Policies have no sitemap resource type of their own, so the template adds configured policy URLs to the static shard instead.
+Shopify does not provide webhook topics for Pages, policies, blogs, or articles. An edit may remain cached until you manually purge the affected content cache or redeploy. Product and collection webhook behavior does not apply to these content types; see [Webhooks](/docs/anatomy/webhooks).
 
-## Common customizations
+Verify every published or edited page in the storefront, including its active locale, metadata, navigation link, and sitemap entry.
 
-The template's content routes assume Shopify Admin as the source of truth. If a project needs richer authoring than Shopify Pages and blogs offer — structured layouts, custom fields, editor previews — the natural extension is swapping in a headless CMS (Sanity, Contentful, Builder.io, etc.) behind the same route contracts, fetching from the CMS instead of `getPage` / `getBlog` while keeping the caching, SEO, and sitemap patterns above. This isn't wired up today, but the route boundaries are built to make that swap contained rather than a rewrite.
+## Know when Shopify content is enough
+
+Shopify Pages and blogs work well for standard rich text, policy content, and news. Consider a dedicated content management system only when editors need structured layouts, custom fields, or preview workflows that Shopify does not provide.

--- a/apps/docs/content/docs/anatomy/pages/home.mdx
+++ b/apps/docs/content/docs/anatomy/pages/home.mdx
@@ -1,30 +1,25 @@
 ---
 title: Home
-description: The storefront landing page - a headline and a products grid.
+description: The storefront landing page with an introductory message and a product grid.
 type: guide
 ---
 
 <HomeBrowser />
 
-The home page is a server component: a headline section followed by a grid of the storefront's top products. It's the simplest route in the template and the one most teams customize first.
+The home page introduces the store and gives shoppers a direct path into the catalog. By default, it shows a translated headline followed by eight products.
 
-## How it works
+## Choose the opening message
 
-**Static headline, live-fetched grid.** The headline and description are static strings from the `home` translation namespace, rendered with no data dependency, so they ship as part of the static shell with zero layout shift. The products grid is a separate `Suspense` boundary below it, so a slow catalog fetch never blocks the headline from painting.
+The headline and description are fixed storefront copy. Keep them short and use them to explain what the store sells or why a shopper should continue.
 
-**The grid mirrors `/collections/all`, not a curated list.** Products come from `searchIndexProducts()` — the same relevance-ranked Storefront `search` path (wildcard `*` query) that backs the all-products collection page — so the home grid shows exactly the first 8 products a shopper would see there, rather than a separate best-selling or hand-picked list.
+The message appears before catalog data finishes loading, so shoppers can understand the page even when product loading is slow.
 
-## Out of the box
+## Choose the products to feature
 
-- **Headline section** — a centered `h1` and description above the grid, with a `4/1` aspect-ratio spacer on desktop and compact padding on mobile.
-- **Products grid** — the top 8 products via `searchIndexProducts({ limit: 8, locale })`, cached with `cacheLife("max")` and product-level cache tags for granular revalidation.
-- **"View all" link** — the grid's section heading links to `/collections/all` by default, set via the `title` and `collectionUrl` props on `ProductsGrid` in `app/page.tsx`.
-- **Responsive columns** — 2 columns on mobile, 4 on desktop, using the standard [product card](/docs/anatomy/product-card).
+The default grid shows the first eight products from the same relevance-ranked catalog used by `/collections/all`. It is not a hand-picked or best-selling list. The section links to `/collections/all` and uses the standard [product card](/docs/anatomy/product-card), with two columns on mobile and four on desktop.
 
-## Common customizations
+Use a specific Shopify collection when merchants need direct control over featured products. Additional sections can highlight new arrivals, best sellers, or promotions, but keep the page focused on the next action you want shoppers to take.
 
-The home page doesn't ship these, but they're common additions teams layer on top.
+## Verify the home page
 
-- **Hero banner** — an image or video banner above the headline, for a merchandising-led landing page instead of a plain text intro.
-- **Curated or best-selling sections** — additional `ProductsGrid` instances backed by a specific collection instead of the search index, for "New Arrivals" or "Best Sellers" rows.
-- **Promotional content** — editorial blocks and banners between sections. The template ships a `ProductsSlider` component for a horizontally scrollable row of the same [product card](/docs/anatomy/product-card), though it isn't wired into any page by default.
+Check the translated introduction, the order and availability of products, the View all destination, and the grid at mobile and desktop sizes. Confirm that the opening message remains visible while products load.

--- a/apps/docs/content/docs/anatomy/pages/home.mdx
+++ b/apps/docs/content/docs/anatomy/pages/home.mdx
@@ -20,6 +20,6 @@ The default grid shows the first eight products from the same relevance-ranked c
 
 Use a specific Shopify collection when merchants need direct control over featured products. Additional sections can highlight new arrivals, best sellers, or promotions, but keep the page focused on the next action you want shoppers to take.
 
-## Verify the home page
+## What’s next
 
-Check the translated introduction, the order and availability of products, the View all destination, and the grid at mobile and desktop sizes. Confirm that the opening message remains visible while products load.
+Common additions include a hero image or video, merchant-curated collections, new-arrival or best-selling sections, and promotional content between product groups. Keep each section focused on a clear next action for shoppers.

--- a/apps/docs/content/docs/anatomy/pages/index.mdx
+++ b/apps/docs/content/docs/anatomy/pages/index.mdx
@@ -4,19 +4,19 @@ description: The core page types that make up your storefront.
 type: overview
 ---
 
-Each storefront is built from a small set of core page types. These guides cover the architecture, data fetching, and customization patterns for each.
+These guides explain the shopper outcome, default behavior, important choices, and limits for each core storefront page.
 
 <Cards>
   <Card title="Home" href="/docs/anatomy/pages/home">
-    The storefront landing page - hero, featured collections, and promotional content.
+    Introduce the store and direct shoppers into the catalog.
   </Card>
   <Card title="Product Detail Page (PDP)" href="/docs/anatomy/pages/pdp">
-    Individual product pages with variants, media, and add-to-cart.
+    Help shoppers choose a variant and complete a purchase.
   </Card>
   <Card title="Product Listing Page (PLP)" href="/docs/anatomy/pages/plp">
-    Collection and search results pages with filtering, sorting, and pagination.
+    Help shoppers browse, filter, sort, and search the catalog.
   </Card>
   <Card title="Content Pages" href="/docs/anatomy/pages/content">
-    Shopify Pages and store policies with localized rich text, metadata, and discovery.
+    Publish localized Pages, policies, blogs, and articles from Shopify.
   </Card>
 </Cards>

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -30,10 +30,6 @@ Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/do
 
 Quantity, Buy with Shop, bundles, complementary products, and related products are enabled by default. Disable sections that do not fit the catalog or purchase journey.
 
-## Common additions
+## What’s next
 
-Reviews, detailed material or care information, virtual try-on, and restock waitlists require another data source or service. Add them only when they help shoppers make a purchase decision that the default product data cannot support.
-
-## Verify a product page
-
-Test products with multiple options, unavailable variants, distinct color images, gift-card recipients, bundles, and recommendations. Confirm that the URL preserves the chosen variant and that the cart receives the correct variant, quantity, and gift-card details.
+Common additions include reviews, detailed material or care information, size guides, virtual try-on, and restock waitlists. These features require another data source or service. Add them only when they help shoppers make a purchase decision that the default product data cannot support.

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -1,39 +1,39 @@
 ---
 title: Product Detail Page (PDP)
-description: A single product page with variants, media, and add-to-cart.
+description: A single product page with variants, media, purchase controls, and product recommendations.
 type: guide
 ---
 
 <PDPBrowser />
 
-The Product Detail Page (PDP) is a single product page — title, price, media, variant selection, and add-to-cart. It's the smallest unit of commerce in the storefront.
+The Product Detail Page (PDP) gives shoppers the information and controls needed to choose a product variant and purchase it.
 
-## How it works
+## Help shoppers choose the right variant
 
-**Static-first rendering.** Product data is awaited at the top of the page and baked into the static shell, so the title, price, gallery, and description ship as one coherent copy. Freshness comes from cache invalidation — a Shopify webhook calling `revalidateTag`, plus the `cacheLife` window — not a per-request fetch, so the body never re-renders at request time.
+Product pages show the title, price, media, description, and available options. Option choices update the page URL, so shoppers can share a selected color, size, or other variant and use browser back and forward controls.
 
-**Variant selection through URL searchParams.** Each option change is a navigation (`/products/tee?color=Blue&size=XS`), not client state. That gives you shareable URLs, working browser back/forward, and a fully server-rendered page with zero layout shift. The selected variant resolves from a second, per-selection Shopify query kept off the critical path, so the picker highlights at URL speed rather than waiting on the network.
+When colors have distinct media, the gallery leads with the selected color's image. Desktop shoppers get a grid and lightbox; mobile shoppers get a swipeable gallery.
 
-## Out of the box
+Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/docs/anatomy/webhooks).
 
-- **Variant picker** — color, size, and other options rendered as links, with swatch availability decoded from Shopify's encoded variant data.
-- **Color-aware image gallery** — a desktop grid with lightbox and a mobile snap carousel, leading with the selected color's image when color options have distinct media.
-- **Add to cart** — optimistic add of the selected variant.
-- **Gift cards** — a recipient form replaces the buy buttons for gift card products. Recipient details are sent as Shopify line attributes, so gift cards for the same variant remain distinct when their recipients or messages differ.
-- **Quantity picker** — a 1–99 picker beside the cart action.
-- **Buy with Shop** — Shopify's official lock-up that creates a checkout and redirects to it.
-- **Bundles** — "includes" and "available in" bundle relationships below the buy buttons.
-- **Complementary products** — merchant-curated "Pairs Well With" add-ons.
-- **Related products** — algorithmic "you might also like" set below the product details.
-- **Structured data** — Product and Breadcrumb JSON-LD for search and social.
+## Included purchase features
 
-The quantity picker, Buy with Shop, bundles, complementary products, and related products are on by default and toggled under `pdp` in `lib/config.ts`.
+- **Variant picker** — shows available colors, sizes, and other options.
+- **Add to cart** — adds the selected variant without waiting for the full cart response.
+- **Quantity** — accepts values from 1 through 99.
+- **Gift cards** — collects recipient details and keeps gifts for different recipients separate in the cart.
+- **Buy with Shop** — starts Shopify checkout.
+- **Bundles** — shows included items and other bundles containing the product.
+- **Complementary products** — presents merchant-curated add-ons.
+- **Related products** — presents algorithmic recommendations.
+- **Structured data** — describes the product and breadcrumbs to search engines.
 
-## Common customizations
+Quantity, Buy with Shop, bundles, complementary products, and related products are enabled by default. Disable sections that do not fit the catalog or purchase journey.
 
-The PDP doesn't ship these, but they're common additions teams layer on top. Each is your own data source and component, wired in alongside the other sections in `product-detail-section.tsx`.
+## Common additions
 
-- **Reviews** — a ratings summary near the price and a review list below the details, usually backed by a reviews app or Shopify metafields.
-- **Virtual try-on** — an AR or camera overlay launched from the gallery, typically a modal wrapping a partner SDK.
-- **Metafield accordion** — an accordion below the description surfacing metafields (materials, care, sizing) that aren't part of the default fields.
-- **Waitlist** — a restock signup that replaces Add to Cart when the selected variant is unavailable.
+Reviews, detailed material or care information, virtual try-on, and restock waitlists require another data source or service. Add them only when they help shoppers make a purchase decision that the default product data cannot support.
+
+## Verify a product page
+
+Test products with multiple options, unavailable variants, distinct color images, gift-card recipients, bundles, and recommendations. Confirm that the URL preserves the chosen variant and that the cart receives the correct variant, quantity, and gift-card details.

--- a/apps/docs/content/docs/anatomy/pages/plp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/plp.mdx
@@ -26,6 +26,6 @@ Filters, sorting, and pagination state are reflected in the URL. Shoppers can sh
 
 These features are enabled for every storefront; there are no configuration toggles for them.
 
-## Verify catalog browsing
+## What’s next
 
-Test collections and search with multiple filters, every supported sort, no results, and enough products for several pages. Confirm that the URL preserves the selected state, results do not repeat during scrolling, and unsupported search sorts are not offered.
+Common additions include merchant-curated collection ordering, promotional tiles within the grid, saved filters, and catalog-specific filter groups. Keep filter and sort choices in the URL so refined views remain shareable.

--- a/apps/docs/content/docs/anatomy/pages/plp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/plp.mdx
@@ -6,22 +6,26 @@ type: guide
 
 <PLPBrowser />
 
-The Product Listing Page (PLP) covers two routes — `/collections/[handle]` for browsing a collection and `/search` for query-based results. Both share the same grid, filtering, sorting, and infinite scroll.
+The Product Listing Page (PLP) helps shoppers narrow a catalog. Collection pages use `/collections/[handle]`; query results use `/search`. Both provide the same product grid, filters, sorting, and continuous loading.
 
-## How it works
+## Help shoppers refine results
 
-**Static header, live grid.** Collection metadata (title, description, image) is awaited at the top of the page and baked into the static shell, the same pattern as the [PDP](/docs/anatomy/pages/pdp). The product grid is the opposite: it's read live from Shopify on every request, deliberately uncached. Caching it produced duplicate products at page boundaries, because two cached cursor pages could be snapshotted at different times and drift out of order. Reading every page live keeps a scroll session's cursors consistent. `/search` has no cacheable header at all — its body is entirely query-driven — so it skips the static-shell step altogether.
+Collection pages show the collection title, description, and image. Search pages focus on the shopper's query. Product results remain live rather than cached so pagination stays consistent while the catalog or ranking changes.
 
-**Filter, sort, and cursor state live in the URL.** Collection pages use Hydrogen's collection store for optimistic browse intent and Liquid-compatible `filter.*` / `sort_by` URLs. The store never owns product or facet data: each navigation still resolves through the live Server Component request, and Hydrogen keeps the controls pending until that response confirms the exact URL snapshot. This makes rapid filter changes feel immediate without letting optimistic state become authoritative. Search results retain their separate `sort` URL model because Shopify search supports a narrower set of sort keys.
+Filters, sorting, and pagination state are reflected in the URL. Shoppers can share a refined view, use browser history, and return to the same selection.
 
-## Out of the box
+## Included browsing tools
 
-- **Faceted filtering** — checkbox filters for size, color, vendor, type, and tags, plus a price range slider with presets.
-- **Swatch filters** — color (or other swatch-enabled) filters render as a color/image grid instead of a text list, driven by Shopify's filter presentation data.
-- **Sorting** — all eight Shopify sort keys on collections; search excludes name and date, which Shopify's search sort doesn't support.
-- **Infinite scroll** — cursor-based pagination that loads more products as the user scrolls, with duplicate protection against a live ranking shift mid-scroll.
-- **Toolbar** — filter trigger, result count, and sort dropdown above the grid.
-- **Predictive search** — suggestion chips and product results as the user types, from the nav search modal.
-- **Structured data** — Collection JSON-LD on collection pages.
+- **Faceted filters** — size, color, vendor, product type, tags, and price.
+- **Swatches** — color or image choices when Shopify provides swatch presentation data.
+- **Sorting** — Shopify's supported collection sorts. Search omits name and date because Shopify search does not support them.
+- **Infinite scroll** — loads additional products as the shopper moves down the page and guards against duplicates when rankings change.
+- **Toolbar** — provides filter access, result count, and sorting.
+- **Predictive search** — shows suggestions and products from the navigation search dialog.
+- **Structured data** — describes collection pages to search engines.
 
-None of the PLP's features are toggled in `lib/config.ts` today — they ship on for every storefront.
+These features are enabled for every storefront; there are no configuration toggles for them.
+
+## Verify catalog browsing
+
+Test collections and search with multiple filters, every supported sort, no results, and enough products for several pages. Confirm that the URL preserves the selected state, results do not repeat during scrolling, and unsupported search sorts are not offered.

--- a/apps/docs/content/docs/anatomy/product-card.mdx
+++ b/apps/docs/content/docs/anatomy/product-card.mdx
@@ -20,6 +20,6 @@ The default card is for discovery. Shoppers open the product page to choose vari
 
 Common additions include alternate image proportions, a second image on hover, variant swatches, and quick add. Add purchasing controls only when shoppers can make a safe choice from the information on the card. Products with required options usually need the full product page.
 
-## Verify product cards
+## What’s next
 
-Review cards with one price, a price range, a discount, no image, and no available inventory. Confirm that every card opens the correct product and that grid spacing remains stable while images load.
+Common additions include alternate image proportions, a second image on hover, review summaries, variant swatches, and quick add. Keep cards easy to scan, and add purchasing controls only when shoppers have enough information to choose safely without opening the product page.

--- a/apps/docs/content/docs/anatomy/product-card.mdx
+++ b/apps/docs/content/docs/anatomy/product-card.mdx
@@ -1,30 +1,25 @@
 ---
 title: Product Card
-description: The shared tile that displays a product's image, title, and price in grids and sliders.
+description: The shared tile that displays a product's image, title, price, and availability across the storefront.
 type: guide
 ---
 
-Used in the home featured grid, collection (PLP) and search grids, the related-products slider on the PDP, and the AI agent's results. It's the same component everywhere a product is shown as a tile, so a change to the card is a change everywhere at once.
+Product cards give shoppers a consistent way to recognize and compare products. They appear on the home page, collection and search pages, related-product sections, and agent results. A visual change affects every use.
 
-## How it works
+## Information shoppers see
 
-**Compound component with stable styling hooks.** `ProductCard` is a server component that wraps the product in a `Link` to `/products/[handle]` — the bare product URL, which renders the first-available (default) variant. Each part — image container, image, content, title, price, optional badge — exposes a `data-slot` attribute (`product-card`, `product-card-image`, etc.), so the pieces can be composed or restyled independently without touching the underlying markup.
+Each card links to the product and shows its image, title, and price. Products with a price range show both bounds. A single discounted price can show the original price and a discount badge; ranges do not show a discount because discounts may differ by variant.
 
-**Loading, empty, and out-of-stock states share one footprint.** The skeleton, the no-image placeholder, and the loaded image all render inside the same square box using the same `ImagePlaceholder` element, so grids never shift as cards move between states. An out-of-stock overlay draws on top of the image rather than replacing it, keeping that same footprint.
+Unavailable products keep their image visible under an out-of-stock label. Products without an image show a placeholder instead of a broken image. Loading, empty, and loaded states reserve the same square space so grids remain stable.
 
-## Out of the box
+The featured style adds a Featured badge and stronger image treatment. Standard grids use the default style.
 
-- **Two variants** — `default` for standard grids and sliders, and `featured`, which adds a "Featured" badge and a top-down gradient behind the image for highlighting hero products.
-- **Price ranges** — when a product's variants span a price range, the card shows both bounds (_$48.00 – $96.00_) instead of a single price; compare-at strike-through and the discount badge only appear for a single price, since per-variant discounts differ across a range.
-- **Square media** — loaded images, no-image placeholders, and skeletons use the same square footprint by default.
-- **Image fallback** — products with no featured image render a placeholder icon instead of a broken image, so grids stay visually aligned.
-- **Out-of-stock overlay** — a darkened image with a localized "out of stock" label when the product is unavailable.
+## Decide whether cards should support purchasing
 
-## Common customizations
+The default card is for discovery. Shoppers open the product page to choose variants and add an item to the cart.
 
-The card doesn't ship these, but they're common additions teams layer on top.
+Common additions include alternate image proportions, a second image on hover, variant swatches, and quick add. Add purchasing controls only when shoppers can make a safe choice from the information on the card. Products with required options usually need the full product page.
 
-- **Image aspect ratio** — change the aspect ratio of product images to fit your storefront.
-- **Hover image carousel** — reveal additional product images on desktop hover instead of showing only the featured image.
-- **Variant selection from the grid** — swatches on the card itself (usually color) so shoppers can preview or add a specific variant without opening the PDP.
-- **Quick add** — an add-to-cart action on the card that skips the PDP for simple, single-variant products.
+## Verify product cards
+
+Review cards with one price, a price range, a discount, no image, and no available inventory. Confirm that every card opens the correct product and that grid spacing remains stable while images load.

--- a/apps/docs/content/docs/anatomy/proxy.mdx
+++ b/apps/docs/content/docs/anatomy/proxy.mdx
@@ -1,42 +1,34 @@
 ---
 title: Proxy
-description: How the root proxy composes Shopify-owned routes, request context, and application routing.
+description: How the storefront assigns Shopify-owned routes while leaving application routes available to Next.js.
 type: guide
 ---
 
-The storefront ships a [proxy](https://nextjs.org/docs/app/getting-started/proxy) — frequently called middleware — that runs before filesystem routing. It gives Shopify's reserved routes to Hydrogen, adds Shopify request context to storefront requests, and lets everything else continue to the Next.js application.
+The storefront uses a [Next.js proxy](https://nextjs.org/docs/app/getting-started/proxy), often called middleware, to direct requests before page routing. It protects Shopify-owned endpoints while leaving ordinary storefront and application routes available to Next.js.
 
-## How it works
+## Route ownership
 
-**The matcher defines route ownership.** Shopify-owned API and protocol routes are listed explicitly, including `/api/cart`, the Storefront API proxy, Shopify MCP, Ajax cart endpoints, and agent or customer-account handoff routes. The general storefront matcher excludes `/api`, so application Route Handlers such as `/api/chat`, `/api/webhooks`, or a custom `/api/search` remain owned by Next.js unless they are intentionally added to the matcher.
+Shopify handles its cart, Storefront API, Model Context Protocol (MCP), Ajax cart, agent, and customer-account endpoints. Storefront pages continue to Next.js with the Shopify request context needed for Storefront API calls, analytics, and safe caching.
 
-**Hydrogen gets the first opportunity to handle matched requests.** `handleShopifyRoutes()` checks its standard interceptors and registered handlers. It returns `null` synchronously when no Shopify route matches, or a response promise when Hydrogen owns the request. The proxy returns that promise directly instead of awaiting it; a `null` result falls through to later proxy behavior and then Next.js routing.
+Other application API routes bypass the proxy unless you explicitly assign them to an integration. This avoids collisions between Shopify endpoints and your own APIs.
 
-**Every fallthrough request carries Shopify request context.** The proxy forwards Hydrogen's request-context headers to the application and applies its response headers on the way out. This supports Storefront API calls, analytics, and personalized-response cache safety without per-route setup.
+Authentication changes only cart and customer-account handling. When authentication is enabled, those requests can synchronize the shopper's identity with the cart. Other requests keep the guest-cart behavior. See [Environment Variables](/docs/reference/env-vars) for the authentication setting.
 
-**Authentication setup stays scoped.** When authentication is enabled, the proxy creates session-aware cart handlers only for `/api/cart` and the four Customer Account paths. The auth handlers receive that same cart handler set so login, refresh, and logout can synchronize buyer identity. Ordinary storefront and unrelated API requests keep the guest cart handlers and do not pay for customer-session discovery.
+## Add routing without creating conflicts
 
-## Out of the box
+Assign only the exact route families an integration owns. Do not claim every API route for Shopify or locale handling, because that can intercept unrelated application APIs.
 
-| Request                             | What the proxy does                                                                                   |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Shopify-owned API or protocol route | Returns Hydrogen's response before App Router routing                                                 |
-| Cart API route                      | Uses session-aware cart handlers when authentication is enabled, otherwise the guest handlers         |
-| Customer account auth route         | Runs Hydrogen's auth handler with the same session-aware cart handlers when authentication is enabled |
-| Matched storefront route            | Lets Hydrogen decline it, forwards request-context headers, and continues to Next.js                  |
-| Other application `/api/*` route    | Skips proxy and runs its App Router Route Handler directly                                            |
+Run Shopify routing before locale negotiation, experiments, or request-dependent redirects. This keeps Shopify protocol endpoints locale-neutral while allowing storefront pages to use those features.
 
-No environment variables configure the proxy itself. Authentication behavior follows the feature flag described in [Environment Variables](/docs/reference/env-vars).
+Use static redirects for fixed URL changes. Use the proxy only when a decision depends on the incoming request.
 
-## Composing additional routing
+## Common extensions
 
-Run ownership-specific dispatch before cross-cutting routing. For example, the i18n and Shopify Markets integrations call Hydrogen first, then run next-intl only when `handleShopifyRoutes()` returns `null`. This keeps Shopify's reserved endpoints locale-neutral while allowing locale negotiation on storefront pages.
+- **Locale routing** — [Enable Shopify Markets](/docs/skills/enable-shopify-markets) and [Enable i18n](/docs/skills/enable-i18n) add locale handling after Shopify routing.
+- **Custom APIs** — application APIs remain outside the proxy unless explicitly claimed.
+- **Experiments and redirects** — request-dependent choices can run after Shopify declines the request.
+- **Location and bot signals** — coarse request signals are available here. Verified bot detection for assistant chat uses [Vercel BotID](https://vercel.com/docs/botid).
 
-Keep `export const config` static because Next.js analyzes matchers at build time. Add exact route families when a new integration owns a path; do not replace the Shopify entries with a blanket `/api/:path*` matcher. Broad API matching makes unrelated Route Handlers unexpectedly pass through Shopify or locale logic and creates collisions as an application grows.
+## Verify a routing change
 
-## Common customizations
-
-- **Multi-locale routing** — both [Enable Shopify Markets](/docs/skills/enable-shopify-markets) and [Enable i18n](/docs/skills/enable-i18n) compose locale negotiation after Shopify dispatch and add locale-prefixed Shopify matchers. The single-locale template does not reserve those paths.
-- **Custom APIs** — add Route Handlers under `/api` normally. They remain outside proxy unless the matcher explicitly claims them.
-- **Redirects and experiments** — request-dependent redirects or A/B bucketing can run after Shopify declines the request. Static redirects belong in `next.config.ts`.
-- **Geo and coarse bot handling** — request geo and user-agent data is available before routing. Verified bot detection on the assistant's chat endpoint is handled by [Vercel BotID](https://vercel.com/docs/botid) rather than proxy.
+Test the affected Shopify endpoint, an ordinary storefront page, and an unrelated application API. Confirm that each reaches the expected owner and that locale handling does not alter Shopify protocol routes.

--- a/apps/docs/content/docs/anatomy/proxy.mdx
+++ b/apps/docs/content/docs/anatomy/proxy.mdx
@@ -22,13 +22,9 @@ Run Shopify routing before locale negotiation, experiments, or request-dependent
 
 Use static redirects for fixed URL changes. Use the proxy only when a decision depends on the incoming request.
 
-## Common extensions
+## What’s next
 
 - **Locale routing** — [Enable Shopify Markets](/docs/skills/enable-shopify-markets) and [Enable i18n](/docs/skills/enable-i18n) add locale handling after Shopify routing.
 - **Custom APIs** — application APIs remain outside the proxy unless explicitly claimed.
 - **Experiments and redirects** — request-dependent choices can run after Shopify declines the request.
 - **Location and bot signals** — coarse request signals are available here. Verified bot detection for assistant chat uses [Vercel BotID](https://vercel.com/docs/botid).
-
-## Verify a routing change
-
-Test the affected Shopify endpoint, an ordinary storefront page, and an unrelated application API. Confirm that each reaches the expected owner and that locale handling does not alter Shopify protocol routes.

--- a/apps/docs/content/docs/anatomy/sitemap.mdx
+++ b/apps/docs/content/docs/anatomy/sitemap.mdx
@@ -1,33 +1,33 @@
 ---
 title: Sitemap
-description: A sitemap index plus paged child sitemaps backed by Shopify's Storefront sitemap query — the same model Hydrogen uses.
+description: A sitemap index and paged child sitemaps for storefront content managed in Shopify.
 type: guide
 ---
 
-The storefront exposes a sitemap index at `/sitemap.xml` and paged children at `/sitemap/{shard}.xml`. Each child holds up to 250 entries — Shopify's Storefront `sitemap(type:)` query computes the pagination, so the storefront just iterates. `robots.ts` points crawlers at `/sitemap.xml`; that URL alone is enough to discover every product, collection, Shopify Page, blog, article, and configured policy.
+The storefront publishes `/sitemap.xml` as the single discovery URL for products, collections, Shopify Pages, blogs, articles, and configured policies. Crawl guidance points search engines to this index.
 
-## How it works
-
-**Shopify computes pagination; the storefront just iterates and shards.** Each resource type gets its own paged shards (`products-{n}`, `collections-{n}`, and so on), `{n}` 1-indexed and running to the `pagesCount` Shopify returns for that type. The index route lists every child shard so crawlers only need one entry point.
-
-**Cache invalidation piggybacks on the same handle tags as storefront pages.** All resource page counts and shards use `cacheLife("max")`. Each product and collection shard carries the same handle-specific tag as its storefront page, so its [webhook](/docs/anatomy/webhooks) refreshes the affected shard and its `lastmod` value alongside the page itself, and product/collection create/delete webhooks invalidate `products-index` or `collections-index` when membership shifts. Pages, blogs, and articles have no Shopify webhook topics, so their shards (tagged `pages`, `blogs`/`blogs-index`, and `articles`/`articles-index`) refresh only via a manual `revalidateTag` purge or a redeploy — the static shard's policy entries share that same limitation through the `policies` cache tag used by policy pages and the footer.
-
-## Out of the box
+## What the sitemap includes
 
 | URL                            | Contents                                  |
 | ------------------------------ | ----------------------------------------- |
-| `/sitemap.xml`                 | Sitemap index listing every child shard   |
+| `/sitemap.xml`                 | Index of every child sitemap              |
 | `/sitemap/static.xml`          | Home page and configured Shopify policies |
-| `/sitemap/products-{n}.xml`    | Up to 250 products per shard              |
-| `/sitemap/collections-{n}.xml` | Up to 250 collections per shard           |
-| `/sitemap/pages-{n}.xml`       | Up to 250 Shopify Pages per shard         |
-| `/sitemap/blogs-{n}.xml`       | Up to 250 Shopify blogs per shard         |
-| `/sitemap/articles-{n}.xml`    | Up to 250 Shopify articles per shard      |
+| `/sitemap/products-{n}.xml`    | Up to 250 products per page               |
+| `/sitemap/collections-{n}.xml` | Up to 250 collections per page            |
+| `/sitemap/pages-{n}.xml`       | Up to 250 Shopify Pages per page          |
+| `/sitemap/blogs-{n}.xml`       | Up to 250 Shopify blogs per page          |
+| `/sitemap/articles-{n}.xml`    | Up to 250 Shopify articles per page       |
 
-## Common customizations
+Shopify determines how many pages each content type needs. The storefront lists every page in the index, so crawlers need only `/sitemap.xml`.
 
-**Adding a resource type Shopify's sitemap API supports but the template doesn't shard yet** — the template scopes paginated sitemaps to products, collections, Pages, blogs, and articles, but Shopify's `SitemapType` enum also covers `METAOBJECT`. Both routes name the supported types explicitly, so adding one touches three places:
+## Freshness limits
 
-1. **`lib/shopify/operations/sitemap.ts`** — extend the `ShopifySitemapType` union.
-2. **`app/sitemap.xml/route.ts`** — fetch the new type's `getShopifySitemapPagesCount(...)` and spread its `{type}-{n}` ids into the index alongside the product and collection shards. The index lists only what you add here — it does not discover new types on its own.
-3. **`app/sitemap/[shard]/route.ts`** — widen the shard regex and the type mapping so the new `{type}-{n}` segments resolve, then map each item to its URL path.
+Product and collection webhooks refresh affected sitemap entries. Creating or deleting those resources also refreshes the relevant sitemap listing. See [Webhooks](/docs/anatomy/webhooks).
+
+Shopify does not provide webhook topics for Pages, blogs, or articles. Changes to those resources, and to policies, may remain cached until you manually purge the relevant cache or redeploy.
+
+## Verify discovery
+
+Open `/sitemap.xml` and confirm that every listed child sitemap responds successfully. Check representative product, collection, content, and policy URLs. After a product or collection change, confirm that its URL and modification date update after webhook processing.
+
+Shopify's sitemap API also supports metaobjects, but the template does not include them. Add that resource type only if metaobjects have public storefront URLs that search engines should discover.

--- a/apps/docs/content/docs/anatomy/sitemap.mdx
+++ b/apps/docs/content/docs/anatomy/sitemap.mdx
@@ -26,8 +26,6 @@ Product and collection webhooks refresh affected sitemap entries. Creating or de
 
 Shopify does not provide webhook topics for Pages, blogs, or articles. Changes to those resources, and to policies, may remain cached until you manually purge the relevant cache or redeploy.
 
-## Verify discovery
+## What’s next
 
-Open `/sitemap.xml` and confirm that every listed child sitemap responds successfully. Check representative product, collection, content, and policy URLs. After a product or collection change, confirm that its URL and modification date update after webhook processing.
-
-Shopify's sitemap API also supports metaobjects, but the template does not include them. Add that resource type only if metaobjects have public storefront URLs that search engines should discover.
+Shopify's sitemap API also supports metaobjects, but the template does not include them. Add that resource type only when metaobjects have public storefront URLs that search engines should discover. Stores with rich media may also add image or video sitemap data for content that search engines cannot discover reliably from the page itself.

--- a/apps/docs/content/docs/anatomy/webhooks.mdx
+++ b/apps/docs/content/docs/anatomy/webhooks.mdx
@@ -4,85 +4,64 @@ description: Shopify webhook handler that invalidates Next.js cache tags when pr
 type: guide
 ---
 
-Read paths in the template are cached aggressively with `"use cache"` or `"use cache: remote"` and `cacheLife("max")`. Without an invalidation signal, edits in Shopify Admin won't surface until the cache expires. The webhook handler at `/api/webhooks/shopify` closes that loop: Shopify posts a topic, the handler verifies the signature, and `revalidateTag()` invalidates the affected cache tags.
+Shopify webhooks make supported Admin changes appear on the storefront without waiting for cached data to expire. The template accepts Shopify notifications at `POST /api/webhooks/shopify` and refreshes the affected product, collection, recommendation, sitemap, or metaobject content.
 
-The handler is opt-in through `SHOPIFY_WEBHOOK_SECRET`. When the secret is unset, `POST /api/webhooks/shopify` returns `404` before reading the request body. Set the secret and register webhooks in Shopify Admin to enable the endpoint in any environment.
+Webhooks are disabled by default. Without `SHOPIFY_WEBHOOK_SECRET`, the endpoint returns `404` and Shopify changes appear only after cache expiry or a redeploy.
 
-## How it works
+## Set up Shopify webhooks
 
-**Fine-grained tags cascade rather than one broad flush per resource type.** The handler never fires the broad `products` or `collections` tags — those wrap _every_ read of their type and exist as manual break-glass levers (see below). It relies on fine-grained tags instead, which is sufficient because the reads in `lib/shopify/operations/` stamp each aggregate cache entry with the granular tag of every item it contains — `tagProducts()` adds a `product-{numericId}` tag per product on list/search/collection/recommendation reads, `getCollections`/`getCollectionsListing` add a `collection-{handle}` tag per collection, and sitemap shards add the handle tag for every product or collection they contain:
+1. Open **Shopify Admin → Settings → Notifications → Webhooks**.
+2. Set the destination to `https://your-domain.com/api/webhooks/shopify`.
+3. Choose **JSON** as the format.
+4. Register the product, collection, and metaobject topics you need.
+5. Copy the webhook signing secret into `SHOPIFY_WEBHOOK_SECRET` for that environment.
 
-- **Product topics** fire per-product tags. Invalidating one product cascades to exactly the surfaces that display it, including the sitemap shard carrying its `product-{handle}` tag. The numeric tag is derived from `admin_graphql_api_id` (falling back to the payload `id`) so reads that cache by ID are invalidated alongside handle-based PDP reads. Create and delete additionally fire **`products-index`**, which refreshes sitemap page counts and all product shards because their membership may shift.
-- **Collection topics** fire the `collection-{handle}` tag, which busts that collection's PLP reads — `getCollection` (metadata) and `getCollectionProducts` (the product list, including membership and sort changes) — and, because aggregate reads stamp every collection they return with that same tag, the all-collections listing and the affected sitemap shard whenever an existing collection is edited. Create and delete change the _set_ of collections (and a brand-new collection has no tag on already-cached entries), so they additionally fire **`collections-index`** — a tag carried by the all-collections reads (`getCollections`, `getCollectionsListing`) and every collections sitemap count or shard. So create/delete refresh the listing, page counts, and shifted shards without touching any individual collection's PLP. Product cards inside a collection list are independently covered by their own `product-{numericId}` tags via the product webhook. Navigation menus aren't busted here; menu titles and links are edited independently in Shopify Navigation, and there is no menu webhook topic.
+```bash
+SHOPIFY_WEBHOOK_SECRET="your-webhook-secret-here"
+```
 
-> **Index and break-glass tags.** `products-index` refreshes product sitemap counts and shards when membership changes. `collections-index` does the same for collection sitemaps and also refreshes the all-collections listing. The broader `collections` tag sits on every collection read, and `products` sits on every product read, but neither broad tag is fired automatically. They're manual purge levers — call `revalidateTag("collections")` (or `"products"`) to flush all data of that type at once, e.g. after a bulk import or a Storefront API change that touches everything. Routine edits should never need them.
+Register these supported topics:
 
-> **No `inventory_levels/*` branch.** The inventory webhook payload identifies an `inventory_item_id` and `location_id`, not a product — so it can't be scoped to a per-product tag without an extra lookup, and busting the catalog on every stock tick would destroy cache hit rates. The template intentionally omits this branch; availability propagates at cache expiry (or via any live, uncached reads you add). Registering the webhook anyway is harmless — it hits no branch and returns an empty `tagsInvalidated`.
+- `products/create`, `products/update`, and `products/delete`
+- `collections/create`, `collections/update`, and `collections/delete`
+- Metaobject create, update, and delete topics
 
-> **No `pages/*`, `blogs/*`, or `articles/*` branch.** Shopify exposes no webhook topics for Online Store pages, blogs, articles, or store policies — only metaobjects (the CMS) emit content webhooks — so there is nothing for the handler to catch. Those reads rely on cache lifetime instead: pages, blogs, articles, and policies all use `cacheLife("max")`, so they surface edits only via a manual `revalidateTag` purge or a redeploy. See [Content pages](/docs/anatomy/pages/content) for the temporary workaround.
+You can register only the topics your store uses. An unregistered topic simply means those changes wait for normal cache expiry.
 
-**Metaobjects trade per-type index tags for a cheap broad flush.** Metaobjects are tagged like every other resource: a broad `metaobjects` tag and a `metaobject-{handle}` tag built from the payload `handle` — no `type` inspection. Unlike the catalog, the handler _does_ fire the broad `metaobjects` tag (alongside the handle tag) because metaobjects are typically low-cardinality, so refreshing every metaobject read on any change is cheap and spares them from needing per-type index tags — the same trade the `articles` branch makes. The base template has no metaobject reads; these tags matter only if you read metaobjects yourself — tag those reads with `metaobjects` (and `metaobject-{handle}` where a handle is in scope) so this branch invalidates them.
+See [Environment Variables](/docs/reference/env-vars) for the full variable reference.
 
-**The handler validates before it trusts anything in the payload.** On each request:
+## Behavior and security
 
-1. Returns `404` immediately if `SHOPIFY_WEBHOOK_SECRET` is unset
-2. Reads the raw body as text — required for stable HMAC verification
-3. Computes the HMAC-SHA256 of the body and compares it to `x-shopify-hmac-sha256` using `crypto.timingSafeEqual`. A missing, malformed, or mismatched signature returns `401`.
-4. Reads `x-shopify-topic`. Missing topic returns `400`.
-5. Dispatches on the topic prefix (`products/`, `collections/`, or `metaobjects/`) and builds a tag list from the payload
-6. Calls `revalidateTag()` for each affected tag
-7. Returns `{ success, topic, tagsInvalidated }` for log inspection
+Every configured request must carry a valid Shopify signature. Missing, malformed, or incorrect signatures return `401`. The handler rejects the request before using its topic or payload.
 
-Payload parsing is wrapped in `try`/`catch`. Metaobject topics seed the broad `metaobjects` tag before parsing, so it still fires on a parse failure. Product and collection create/delete topics likewise seed their narrow index tag before parsing, ensuring sitemap membership is refreshed even if the resource identifiers cannot be read. Update topics need a parseable `handle` or product ID to scope invalidation; malformed update payloads log and invalidate nothing rather than busting the whole catalog. Real Shopify webhooks carry parseable payloads, so this distinction mainly matters for malformed test posts.
+Product notifications refresh the affected product wherever it appears, including recommendations and sitemap content. Product creation and deletion also refresh catalog membership.
 
-> **Security note:** The secret is the enablement gate, not only a verification option. An unconfigured deployment exposes no active webhook processor; a configured deployment accepts only valid Shopify-signed requests.
+Collection notifications refresh the affected collection and collection listings. Collection creation and deletion also refresh collection membership and sitemap content.
 
-## Out of the box
+Metaobject notifications refresh metaobject-backed content only when your custom reads participate in the template's metaobject invalidation behavior. The base template does not read metaobjects by default.
 
-A single route (`POST /api/webhooks/shopify`) handles every supported topic. Shopify sets the topic on each request via the `x-shopify-topic` header, and the handler dispatches to the appropriate tag set:
+## Limits
 
-| Webhook topic        | Tags invalidated                                                                        |
-| -------------------- | --------------------------------------------------------------------------------------- |
-| `products/create`    | `products-index`, `product-{handle}`, `product-{numericId}`, `recommendations-{handle}` |
-| `products/update`    | `product-{handle}`, `product-{numericId}`, `recommendations-{handle}`                   |
-| `products/delete`    | `products-index`, `product-{handle}`, `product-{numericId}`, `recommendations-{handle}` |
-| `collections/create` | `collections-index`, `collection-{handle}`                                              |
-| `collections/update` | `collection-{handle}`                                                                   |
-| `collections/delete` | `collections-index`, `collection-{handle}`                                              |
-| `metaobjects/*`      | `metaobjects`, `metaobject-{handle}`                                                    |
+The included handler does not refresh inventory-level changes. Stock updates therefore appear at cache expiry unless another supported product webhook arrives or you add a live inventory strategy.
 
-**Setting up webhooks in Shopify:**
+Shopify does not provide webhook topics for Online Store pages, blogs, articles, or store policies. Those edits rely on cache expiry, a manual purge, or a redeploy. See [Content pages](/docs/anatomy/pages/content) for the current content-page guidance.
 
-1. Open **Shopify Admin → Settings → Notifications → Webhooks**
-2. Set the URL to `https://your-domain.com/api/webhooks/shopify`
-3. Choose **JSON** as the format
-4. Create a webhook for each topic in the table above
-5. Copy the webhook signing secret and set it as `SHOPIFY_WEBHOOK_SECRET` in your environment
+Navigation menu edits are also outside this handler.
 
-You can register only the topics you care about. Skipping `collections/*`, for example, just means collection edits propagate at cache expiry instead of immediately. The handler has no `inventory_levels/*` branch (see above), so there's no need to register that topic.
+Malformed product or collection update payloads cannot identify a specific resource, so they do not refresh the full catalog. Valid Shopify deliveries include the expected identifiers.
 
-**Environment variables:**
+## Verify the setup
 
-| Variable                 | When to set                                                                                                                                              |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SHOPIFY_WEBHOOK_SECRET` | Set in every environment where Shopify posts to `/api/webhooks/shopify`. Without it, the endpoint is disabled and returns `404` before reading the body. |
-
-See [Environment Variables](/docs/reference/env-vars) for the full reference.
-
-**Verifying it works:** with `SHOPIFY_WEBHOOK_SECRET` unset, confirm the endpoint is disabled without sending a body:
+With the secret unset, confirm the endpoint is disabled:
 
 ```bash
 curl -i -X POST http://localhost:3000/api/webhooks/shopify
 ```
 
-The response should be `404`. After setting the secret, an unsigned request should return `401`. To verify successful processing with a valid signature, use the **Send test notification** button on each webhook in Shopify Admin and watch your function logs for the received topic and invalidated tags.
+The response should be `404`. After setting the secret, the same unsigned request should return `401`.
 
-## Common customizations
+Then use **Send test notification** for each registered webhook in Shopify Admin. Confirm the request succeeds in your function logs. Finally, edit a product or collection and verify the corresponding storefront content changes without a redeploy.
 
-**Adding a new topic:**
+## Customize webhook coverage
 
-1. Register the webhook in Shopify Admin pointing at `/api/webhooks/shopify`
-2. Add a branch in `app/api/webhooks/shopify/route.ts` that matches the topic prefix and pushes the cache tags you want to invalidate
-3. Confirm the tags you're invalidating actually wrap the reads you care about — `cacheTag("...")` calls inside `lib/shopify/operations/` and `lib/cms/`
-
-If the new topic touches data not currently cached by tag, add a `cacheTag()` to the operation that reads it before the webhook will have any effect.
+Add a topic only when Shopify offers a webhook for the resource and the storefront has a safe way to refresh the affected data. Prefer targeted refreshes for frequently changing catalog data. Use broader refreshes only when an event cannot be scoped or after an intentional bulk change.

--- a/apps/docs/content/docs/anatomy/webhooks.mdx
+++ b/apps/docs/content/docs/anatomy/webhooks.mdx
@@ -50,18 +50,8 @@ Navigation menu edits are also outside this handler.
 
 Malformed product or collection update payloads cannot identify a specific resource, so they do not refresh the full catalog. Valid Shopify deliveries include the expected identifiers.
 
-## Verify the setup
+After registering a topic, use **Send test notification** in Shopify Admin and confirm the delivery succeeds before relying on it for storefront freshness.
 
-With the secret unset, confirm the endpoint is disabled:
-
-```bash
-curl -i -X POST http://localhost:3000/api/webhooks/shopify
-```
-
-The response should be `404`. After setting the secret, the same unsigned request should return `401`.
-
-Then use **Send test notification** for each registered webhook in Shopify Admin. Confirm the request succeeds in your function logs. Finally, edit a product or collection and verify the corresponding storefront content changes without a redeploy.
-
-## Customize webhook coverage
+## What’s next
 
 Add a topic only when Shopify offers a webhook for the resource and the storefront has a safe way to refresh the affected data. Prefer targeted refreshes for frequently changing catalog data. Use broader refreshes only when an event cannot be scoped or after an intentional bulk change.

--- a/apps/docs/content/docs/anatomy/webmcp.mdx
+++ b/apps/docs/content/docs/anatomy/webmcp.mdx
@@ -1,37 +1,32 @@
 ---
 title: WebMCP
-description: Experimental browser agent tools - expose the storefront's catalog and cart to AI agents through the proposed WebMCP browser API.
+description: Experimental browser agent tools that expose storefront search and cart actions through the proposed WebMCP API.
 type: guide
 ---
 
-WebMCP is an **experimental**, in-progress browser API that lets a web page register structured tools for AI agents running in or alongside the browser. It is not a finalized standard, and it only exists today behind a Chrome flag. The storefront ships an opt-in integration that exposes Shopify's own storefront tools (search, cart read, add to cart) through this API when a supporting browser is present.
+WebMCP is an **experimental** browser API for exposing structured tools to AI agents running in or alongside a browser. The storefront can expose Shopify catalog search and cart actions through this API.
 
-Because the API is experimental, this feature is **disabled by default** and may change shape or be removed as the spec evolves.
+The integration is disabled by default. The proposed API may change or be removed, and unsupported browsers receive no fallback interface.
 
-## How it works
+## Decide whether to enable it
 
-**Feature-flagged and progressively enhanced.** The integration is gated by `webmcp.isEnabled` in `lib/config.ts`, which defaults to `false`. When enabled, the existing Shopify scripts component passes `webMcp: true` to Hydrogen's initialization. That loads Shopify's `webmcp.js` from the Shopify CDN — but only when the browser actually exposes `document.modelContext` or `navigator.modelContext`. Browsers without WebMCP support never fetch the script and see no behavioral change; there is no polyfill and no fallback UI.
+Enable WebMCP only for active testing. When enabled in a supporting browser, Shopify registers storefront tools that agents can discover and call with structured inputs. Cart actions use the same cart the shopper sees.
 
-**Shopify owns the tools, not the template.** The registered tools come from Shopify's hosted script rather than template code, so their schemas and behavior track Shopify's implementation instead of a hand-rolled copy. They operate on the same storefront context as the page: catalog reads go through the public Storefront surface, and cart writes reuse the standard cart actions, so an agent-driven add-to-cart lands in the same cart the shopper sees.
+Shopify defines and hosts the available tools. The template cannot select or change individual tools, and Shopify may update them independently.
 
-**Independent of Shopify analytics.** The shared Shopify scripts bootstrap (`window.Shopify`, standard actions) mounts by default, while WebMCP and Shopify analytics are enabled independently. Turning on WebMCP loads its CDN script without sending page views to Shopify unless storefront analytics is also enabled.
+WebMCP and Shopify analytics are separate choices. Enabling WebMCP does not enable Shopify page-view reporting.
 
-## Out of the box
+## Test locally
 
-When enabled and viewed in a supporting browser, Shopify's script registers storefront tools with the page's model context — catalog search and cart operations among them. A connected agent (browser assistant, extension, or MCP client) can discover these tools and invoke them with typed inputs, receiving structured JSON rather than scraping markup.
-
-## Testing locally
-
-WebMCP is experimental and only available behind a Chrome flag:
+WebMCP is available only behind a Chrome testing flag:
 
 1. Use Chrome 150 or newer.
-2. Open `chrome://flags/#enable-webmcp-testing`, enable **WebMCP for testing**, and relaunch Chrome.
-3. Set `webmcp.isEnabled` to `true` in `lib/config.ts` and load the storefront.
-4. Inspect the registered tools directly in the console (`navigator.modelContext` / `document.modelContext`), or install the WebMCP – Model Context Tool Inspector extension to list and manually execute tools, or connect Chrome DevTools MCP to drive them with natural language.
+2. Open `chrome://flags/#enable-webmcp-testing`.
+3. Enable **WebMCP for testing**, then relaunch Chrome.
+4. Set `webmcp.isEnabled` to `true` in `lib/config.ts`, then load the site.
+5. Use a WebMCP inspector or a connected browser agent to list and invoke the registered tools.
+6. Confirm that search returns structured catalog results and cart actions update the shopper's cart.
 
-Public deployments during Chrome's origin trial additionally require an origin-bound trial token for that exact origin.
+Public deployments during Chrome's origin trial also require a trial token bound to the exact deployment origin.
 
-## Common customizations
-
-- **Turning it on or off** — toggle `webmcp.isEnabled` in `lib/config.ts`. Leave it off unless you are actively testing, since the underlying API is not stable.
-- **Changing which tools exist** — not supported. The tool set is defined by Shopify's hosted `webmcp.js`, not by the template; Shopify updates it independently.
+Leave the feature disabled for shoppers unless you accept the compatibility and stability limits of an experimental API.

--- a/apps/docs/content/docs/getting-started/extending-with-agents.mdx
+++ b/apps/docs/content/docs/getting-started/extending-with-agents.mdx
@@ -6,31 +6,17 @@ prerequisites:
   - /docs/getting-started
 ---
 
-Vercel Shop is built for agentic development. Instead of copy-pasting snippets from docs, you describe what you want and a coding agent handles the implementation - editing files, running commands, and validating the result.
+Use a coding agent to change the storefront while following the template's conventions and verification steps.
 
-## How it works
+## Set up the agent
 
-**The template ships with structured context that agents read automatically.** `AGENTS.md` carries architecture rules and conventions - things like "new user-visible strings go in all locale files" or "components in `ui/` must not import domain types." Project-scoped plugins (`vercel-shop`, `vercel-plugin`, `shopify-ai-toolkit`) add template conventions, platform guidance, and authoritative Shopify documentation and validation on top.
-
-**Skills are agent-ready playbooks for specific tasks.** Each one names the files to touch, the patterns to follow, and the checks to run after. They're written and tested against the template, which means fewer hallucinations and consistent output than an ad-hoc prompt for the same task.
-
-**Not every agent integrates equally.** For best results, use an agent that reads `AGENTS.md` and supports skills and project-scoped plugins - for example [Claude Code](https://claude.ai/code), [Cursor](https://cursor.sh), or [Codex](https://openai.com/index/introducing-codex/). Claude Code has the deepest integration via the plugin install flow; Cursor and Codex lean more on the repo context and docs.
-
-## Setting up
-
-After [creating your project](/docs/getting-started), `create-vercel-shop` installs the project plugins:
-
-- `vercel-shop` for initialization and storefront skills plus drift and upgrade-planning commands
-- `vercel-plugin` for generic Vercel and Next.js guidance
-- `shopify-ai-toolkit` for current Shopify documentation, schemas, operation validation, and store execution
-
-If you already have a project and only want the agent setup:
+`create-vercel-shop` installs project plugins for Vercel Shop, Next.js, Vercel, and Shopify. To add the agent setup to an existing project without creating a storefront, run:
 
 ```bash
 npx create-vercel-shop@latest --no-template
 ```
 
-If any plugins are missing, rerun:
+If the plugins are missing, install them directly:
 
 ```bash
 npx plugins add vercel/shop --scope project --yes
@@ -38,56 +24,30 @@ npx plugins add vercel/vercel-plugin --scope project --yes
 npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 ```
 
-For upgrade work, use the [`update-shop` skill](/docs/skills/update-shop). The `vercel-shop` plugin carries a template rollout log so agents can reason about change-level updates instead of guessing from a single scaffold version. New scaffolds record bootstrap metadata so agents can compare rollout entries against when a project was created.
+Use an agent that reads `AGENTS.md` and supports project skills, such as [Claude Code](https://claude.ai/code), [Cursor](https://cursor.sh), or [Codex](https://openai.com/index/introducing-codex/).
 
-To initialize a storefront from an agent, use the `init-vercel-shop` skill and provide an explicit target directory. The skill delegates filesystem changes to `create-vercel-shop`, verifies the generated project, and can use Shopify CLI to connect an existing store or fall back to the Headless channel.
+## Give the agent a focused task
 
-## Custom blocks in AGENTS.md
+State the outcome, placement, data source, constraints, and expected verification. For example:
 
-Some sections of `AGENTS.md` are managed by external tools and wrapped in HTML comment markers:
-
-```md
-<!-- BEGIN:nextjs-agent-rules -->
-
-## This is NOT the Next.js you know
-
-...
-
-<!-- END:nextjs-agent-rules -->
+```text
+Add a size guide below the product description.
+Read it from the product metafield named sizing_guide.
+Hide the section when the metafield is empty.
+Run the relevant checks and verify the product page in a browser.
 ```
 
-The owning tool can overwrite the content between `BEGIN` and `END` on upgrade without touching your custom instructions. To drop an opinionated block, delete everything from `BEGIN` to `END` - the rest of the file stays intact.
+Ask the agent to propose its plan before editing when the change spans several parts of the storefront. Include exact errors when asking it to fix a failure.
 
-The template ships with two blocks:
+## Use storefront skills
 
-| Block                | Owner       | What it contains                                                                                                                                                                                     |
-| -------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `nextjs-agent-rules` | Next.js     | Reminds agents this Next.js version has breaking changes and to read bundled docs before writing code. Refreshed on Next.js upgrade.                                                                 |
-| `vercel-shop-style`  | Vercel Shop | Code style conventions: alphabetized exports and keys, no barrel files, push `"use client"` to leaves, naming rules, Tailwind patterns. Remove the block if your team prefers different conventions. |
-
-Everything outside these markers is yours. Add team conventions or domain constraints anywhere else and no upgrade will overwrite them.
-
-## Skills
-
-To run a storefront skill in Claude Code:
+Skills provide task-specific instructions and checks. In Claude Code, run a skill directly:
 
 ```bash
 /vercel-shop:enable-shopify-markets
 ```
 
-For a new project:
-
-```bash
-/vercel-shop:init-vercel-shop
-```
-
-In Cursor or Codex, describe the task and reference the matching skill doc when helpful:
-
-```
-Enable multi-locale support with Shopify Markets
-```
-
-You can also follow any skill manually from the docs, or inspect the source in the `vercel/shop` repository.
+In Cursor or Codex, describe the outcome and reference the matching skill page. Use the [`update-shop` skill](/docs/skills/update-shop) when bringing an existing storefront up to date.
 
 <Cards>
   <Card title="Build with Vercel Shop" href="/docs/skills/build-shop">
@@ -98,67 +58,6 @@ You can also follow any skill manually from the docs, or inspect the source in t
   </Card>
 </Cards>
 
-## Working effectively with an agent
+## Verify storefront changes
 
-Skills cover the common path. Most of your work will be ad-hoc prompts - restyle the PDP, add a wishlist, integrate a review system. A few habits make this go much smoother.
-
-**Let the agent propose first.** Before any code gets written, ask for the plan:
-
-```
-Add a size guide to the PDP. Before writing code, tell me your plan.
-```
-
-A good proposal names the files it will touch, the patterns it will follow, and how it will validate the result. Redirect there - not after the diff lands.
-
-**Be specific about what, where, and when.** Vague prompts get vague code. Compare `add size guide` with:
-
-```
-Add a size guide accordion below the product description on the PDP.
-Pull sizing data from a product metafield called "sizing_guide".
-Only show the section when the metafield exists.
-```
-
-The second version names the placement, the data source, and the empty-state behavior - all things the agent would otherwise guess.
-
-**Iterate with targeted follow-ups.** After the first pass, refine in place rather than re-prompting the whole task:
-
-```
-Make the accordion closed by default on mobile
-```
-
-The agent retains context from the previous exchange.
-
-**Use a browser feedback loop.** Storefront changes should be checked in a real browser, not only by reading diffs. v0 has this feedback loop built in. For agents without built-in browser control, install the standalone [`agent-browser`](https://github.com/vercel-labs/agent-browser) CLI:
-
-```bash
-npm install -g agent-browser
-agent-browser install
-```
-
-Then ask the agent to start the dev server, open the affected route, capture a snapshot and screenshot, interact through the changed commerce flow, and repeat until the browser result matches the intended behavior:
-
-```bash
-agent-browser open http://localhost:3000/products/example
-agent-browser wait --load networkidle
-agent-browser snapshot
-agent-browser screenshot --full
-```
-
-**When something breaks, name the failure.** Specific error messages and likely files beat "fix it":
-
-```
-The build fails with "Type 'string' is not assignable to type 'Money'".
-Check the transform in lib/shopify/transforms/product.ts.
-```
-
-## Try it yourself
-
-Ideas worth a single agent prompt - describe the outcome and let the agent work out the implementation.
-
-- **Recently viewed** — a carousel of the last few products a shopper visited, backed by `localStorage`.
-- **Narrower product grid** — 3 columns instead of 4 on desktop, without touching the mobile layout.
-- **Back to top button** — appears once the shopper scrolls past the fold.
-- **Promotional banner** — dismissible, driven by a metafield on the shop object.
-- **Product reviews** — from a metafield, or integrated with a service like Judge.me.
-- **Wishlist** — heart icons on cards and the PDP, a saved-products page, synced across tabs via `localStorage`.
-- **Swap search providers** — Algolia instead of built-in Shopify search, same filter sidebar.
+Ask the agent to run the relevant tests and inspect the changed route in a browser. Confirm the main flow, empty states, and mobile behavior before accepting the change.

--- a/apps/docs/content/docs/getting-started/extending-with-agents.mdx
+++ b/apps/docs/content/docs/getting-started/extending-with-agents.mdx
@@ -58,6 +58,6 @@ In Cursor or Codex, describe the outcome and reference the matching skill page. 
   </Card>
 </Cards>
 
-## Verify storefront changes
+## What’s next
 
-Ask the agent to run the relevant tests and inspect the changed route in a browser. Confirm the main flow, empty states, and mobile behavior before accepting the change.
+Start with a contained storefront change, such as adding a product metafield, adjusting navigation, or changing a merchandising section. For repeated work, turn your preferred conventions and checks into a project skill so future agent changes follow the same approach.

--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -4,52 +4,47 @@ title: Setup
 type: guide
 ---
 
-Vercel Shop needs a Shopify storefront token and two environment variables. You can scaffold it locally or deploy it directly to Vercel.
+Connect a Shopify store and run Vercel Shop locally in a few minutes.
 
-## Connect Shopify
+## 1. Get Shopify credentials
 
-Install Shopify's **Headless** sales channel, create a storefront, and copy its **Storefront API access token**. Enable the permissions used by the template; see [Storefront API Permissions](/docs/reference/storefront-api-permissions) for the exact scopes.
+Install Shopify's **Headless** sales channel, create a storefront, and copy its **Storefront API access token**. Enable the required [Storefront API permissions](/docs/reference/storefront-api-permissions).
 
-## Create your project
-
-Scaffold a local project:
+## 2. Create your project
 
 ```bash
 npx create-vercel-shop@latest my-store
+cd my-store
 ```
 
-Or deploy the template directly to Vercel:
+To deploy instead, use the Vercel flow:
 
 <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fshop%2Ftree%2Fmain%2Fapps%2Ftemplate&products=%5B%7B%22type%22%3A%22integration%22%2C%22integrationSlug%22%3A%22shopify%22%2C%22productSlug%22%3A%22shopify%22%2C%22protocol%22%3A%22other%22%7D%5D">
   <img src="https://vercel.com/button" alt="Deploy with Vercel" />
 </a>
 
-The deploy flow installs the Shopify integration, which connects a new or existing store and configures the required Shopify credentials on the project.
+The deploy flow connects your Shopify store and configures the required credentials.
 
-## Add your credentials
+## 3. Add your credentials
 
 Create `.env.local` in the project root:
 
 ```bash
 NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN="your-store.myshopify.com"
-NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN="[redacted]"
+NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN="shpat_1234567890abcdefghijklmnopqrstuvwxyz"
 ```
 
-The storefront display name is the `site.name` literal in `lib/config.ts` (defaults to `"Vercel Shop"`), not an environment variable.
+See [Environment Variables](/docs/reference/env-vars) for optional settings.
 
-See [Environment Variables](/docs/reference/env-vars) for optional features and deployment settings.
-
-## Run locally
-
-Start the development server with your package manager:
+## 4. Run the storefront
 
 ```bash
 npm run dev
 ```
 
-Open [localhost:3000](http://localhost:3000).
+Open [localhost:3000](http://localhost:3000) and confirm that your Shopify products appear.
 
-> **Local HTTPS:** Install [Portless](https://portless.sh) with `npm install -g portless`, then run `npm run dev:portless` to serve the storefront at [shop.localhost](https://shop.localhost). This is useful for testing OAuth callbacks and secure cookies.
+For local HTTPS, install [Portless](https://portless.sh) with `npm install -g portless`, then run `npm run dev:portless`. Use HTTPS when testing OAuth callbacks or secure cookies.
 
 ## Next steps
 

--- a/apps/docs/content/docs/getting-started/shopify-setup.mdx
+++ b/apps/docs/content/docs/getting-started/shopify-setup.mdx
@@ -22,14 +22,6 @@ Install [Shopify Search & Discovery](https://apps.shopify.com/search-and-discove
 
 Install [Shopify Bundles](https://apps.shopify.com/shopify-bundles) if you sell fixed bundles. Publish every bundle to **Headless**; bundles published only to **Online Store** do not appear in the storefront.
 
-## Verify the setup
-
-Open the storefront and confirm that:
-
-- A published product page loads.
-- Collection filters match your Search & Discovery settings.
-- Any configured complementary products or bundles appear on their product pages.
-
 ## Next steps
 
 <Cards>

--- a/apps/docs/content/docs/getting-started/shopify-setup.mdx
+++ b/apps/docs/content/docs/getting-started/shopify-setup.mdx
@@ -6,25 +6,29 @@ prerequisites:
   - /docs/getting-started
 ---
 
-Vercel Shop works with a standard Shopify catalog, but a few free Shopify apps unlock the storefront's full product discovery and merchandising experience.
+Publish your catalog to the **Headless** sales channel first. Add the other Shopify apps only when you need their storefront features.
 
-## Headless
+## Publish products to Headless
 
-Install Shopify's **Headless** sales channel and create a storefront. This gives you the Storefront API access token used by Vercel Shop and controls which products are available to it. Copy that storefront's numeric ID to `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ID` if you want Shopify to attribute server-side cart activity to this storefront.
+Install Shopify's **Headless** sales channel and create a storefront. Enable the required [Storefront API permissions](/docs/reference/storefront-api-permissions), then publish the products and collections you want to show to **Headless**. Content published only to **Online Store** does not appear in Vercel Shop.
 
-Enable the template's required [Storefront API permissions](/docs/reference/storefront-api-permissions), then publish your products and collections to the **Headless** channel. Content published only to **Online Store** will not appear in Vercel Shop.
+To attribute server-side cart activity to this storefront, copy the storefront's numeric ID to `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ID`.
 
-## Search & Discovery
+## Configure filters and recommendations
 
-Install the free [Shopify Search & Discovery](https://apps.shopify.com/search-and-discovery) app. Use it to configure storefront filters and complementary product recommendations.
+Install [Shopify Search & Discovery](https://apps.shopify.com/search-and-discovery) to configure collection and search filters. You can also assign complementary products, which appear as “Pairs Well With” on product pages. Shopify supplies related product recommendations automatically.
 
-Filters power the collection and search sidebars. Complementary products appear as “Pairs Well With” on product pages; products without recommendations simply omit that section. Shopify provides related product recommendations automatically.
+## Publish fixed bundles
 
-## Shopify Bundles
+Install [Shopify Bundles](https://apps.shopify.com/shopify-bundles) if you sell fixed bundles. Publish every bundle to **Headless**; bundles published only to **Online Store** do not appear in the storefront.
 
-For fixed product bundles, install the free [Shopify Bundles](https://apps.shopify.com/shopify-bundles) app. Vercel Shop displays bundle contents on product pages and preserves them as grouped items in the cart.
+## Verify the setup
 
-Bundles publish to **Online Store** by default. Publish each bundle to **Headless** as well or it will not appear in the storefront.
+Open the storefront and confirm that:
+
+- A published product page loads.
+- Collection filters match your Search & Discovery settings.
+- Any configured complementary products or bundles appear on their product pages.
 
 ## Next steps
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -4,34 +4,11 @@ title: Introduction
 type: overview
 ---
 
-Vercel Shop is a Shopify storefront template for Next.js, built to be the best way to run Next.js's newest performance features against a real commerce backend, and just as deliberately built to be easy for a coding agent to extend. Drop in your Shopify credentials and you have a fully-featured store in minutes; see [Getting Started](/docs/getting-started).
+Vercel Shop gives you a production-ready Shopify storefront built with Next.js. Connect Shopify, run the storefront, then adapt it to your business with your team or a coding agent.
 
-## How it works
+The template keeps pages fast while reflecting product and collection changes from Shopify. It uses Shopify's supported Next.js integration for storefront data and customer accounts, and includes documented conventions that help agents make consistent changes.
 
-**Pages load instantly and stay correct.** Every route ships as a fast, pre-rendered page by default, with the pieces that genuinely need a live look — a selected variant, a filtered grid, cart state — filled in around it without holding up the rest. Edit a product or collection in Shopify Admin and the storefront picks it up right away instead of waiting out a cache window. Getting this balance of speed and freshness right by hand, against a real commerce backend, is normally weeks of trial and error; the template applies it consistently across every route from the start. See [Why Use This](/docs/why-use-this) for the thinking behind the template.
-
-**Shopify integration follows Shopify's own patterns, not a bespoke wrapper.** Storefront data and customer authentication are both built on Shopify's official Next.js integration, so the way the template talks to Shopify is the way Shopify already documents and supports — not a one-off abstraction only this template understands.
-
-**The codebase is legible to agents, not just to whoever wrote it.** Every route, Shopify integration, and data transform follows one documented shape, so a coding agent can safely extend the storefront on day one instead of guessing at conventions from scratch. Skills describe common tasks — from enabling Shopify Markets to swapping your CMS — naming the files to touch, the patterns to follow, and how to validate the result, so an agent can execute them in a single command instead of a long back-and-forth. See [Extending with Agents](/docs/getting-started/extending-with-agents).
-
-## Out of the box
-
-Your Shopify credentials are the only thing standing between a fresh clone and a fully working storefront — everything below ships pre-wired.
-
-| Area                      | Ships with                                                                                                                                                                  |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Product pages**         | Variant picker, color-aware gallery, optimistic add-to-cart, bundles, complementary & related products, Buy with Shop, structured data — see [PDP](/docs/anatomy/pages/pdp) |
-| **Collections & search**  | Faceted filters, swatch filters, sorting, infinite scroll, predictive search — see [PLP](/docs/anatomy/pages/plp)                                                           |
-| **Cart**                  | Optimistic overlay and full cart page, server-action mutations, bundle-aware line items — see [Cart](/docs/anatomy/cart)                                                    |
-| **Content**               | Shopify Pages, policies, blogs, and articles rendered as storefront routes — see [Content pages](/docs/anatomy/pages/content)                                               |
-| **Navigation & footer**   | Responsive nav and mobile menu, policy links, social links — see [Navigation](/docs/anatomy/navigation)                                                                     |
-| **AI shopping assistant** | Opt-in agent with product discovery, cart tools, and generative UI, built on AI SDK — see [Agent](/docs/anatomy/agent)                                                      |
-| **Customer accounts**     | Opt-in Hydrogen OAuth, profile, orders, and address book — see [Authentication](/docs/anatomy/authentication)                                                               |
-| **AEO & GEO**             | Markdown content negotiation, `llms.txt`, JSON-LD, sitemap — see [AEO & GEO](/docs/anatomy/aeo-geo)                                                                         |
-| **Request handling**      | Root proxy that adds Hydrogen's request context and hosts the customer account auth routes — see [Proxy](/docs/anatomy/proxy)                                               |
-| **Cache invalidation**    | Signed Shopify webhook handler that busts exactly the right cache tags — see [Webhooks](/docs/anatomy/webhooks)                                                             |
-
-Analytics (Vercel Web Analytics, Speed Insights) and multi-locale routing (Shopify Markets, or plain i18n) live in the codebase already and turn on with a skill or a flag, not a rewrite — see [Enable Analytics](/docs/skills/enable-analytics) and [Enable Shopify Markets](/docs/skills/enable-shopify-markets).
+Start with [Getting Started](/docs/getting-started). For the design goals behind the template, read [Why Use This](/docs/why-use-this).
 
 <Cards>
   <Card title="Getting Started" href="/docs/getting-started">

--- a/apps/docs/content/docs/reference/env-vars.mdx
+++ b/apps/docs/content/docs/reference/env-vars.mdx
@@ -6,30 +6,30 @@ type: reference
 
 ## Required
 
-| Variable                                      | Description                                                                                                        |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN`            | Your Shopify store domain, e.g. `your-store.myshopify.com`. Found in **Settings → Domains** in your Shopify admin. |
-| `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN` | Public Storefront API access token (browser-safe). Found in **Settings → Apps and sales channels → Headless**.     |
+| Variable                                      | Description                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN`            | Shopify store domain, such as `your-store.myshopify.com`. Find it in **Settings → Domains** in Shopify admin. |
+| `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN` | Public, browser-safe Storefront API token. Find it in **Settings → Apps and sales channels → Headless**.      |
 
-## Customer Authentication
+## Customer authentication
 
-Required when `auth.isEnabled` is set to `true` in [`lib/config.ts`](/docs/reference/shop-config). These variables have different owners: Shopify provides the Customer Account API client ID, while you generate the session secret for this application.
+These variables are required when `auth.isEnabled` is `true` in [`lib/config.ts`](/docs/reference/shop-config).
 
-The template stores Hydrogen's OAuth session data in encrypted HttpOnly cookies. `CUSTOMER_ACCOUNT_SESSION_SECRET` is the private application key used to derive the AES-256-GCM encryption key for those cookies; it is not a Shopify credential. Generate it with `openssl rand -base64 32`, keep one stable value across all instances of a deployment, and store it only in server-side environment variables. Rotating it invalidates all existing customer sessions. The variable is required by the template's encrypted-cookie implementation, but an application that replaces it with protected server-side session storage can use that storage system's key management instead.
+| Variable                                 | Description                                                                                       |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `CUSTOMER_ACCOUNT_SESSION_SECRET`        | App-generated secret that encrypts customer session cookies. Shopify does not provide this value. |
+| `SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID` | Public client ID from **Sales channels → Headless → Customer Account API** in Shopify admin.      |
 
-| Variable                                 | Description                                                                                             |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `CUSTOMER_ACCOUNT_SESSION_SECRET`        | App-generated private secret that protects encrypted customer session cookies. Not supplied by Shopify. |
-| `SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID` | Public Customer Account API client ID. Found in **Sales channels → Headless → Customer Account API**.   |
+Generate `CUSTOMER_ACCOUNT_SESSION_SECRET` with `openssl rand -base64 32`. Store one stable value in server-side environment variables across all deployment instances. Rotating it invalidates existing customer sessions.
 
 ## Optional
 
-| Variable                            | Description                                                                                                                                                                  |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DEBUG_SHOPIFY`                     | Set to `true` to include structured Storefront and Customer Account API operation timings in Hydrogen's server logs.                                                         |
-| `NEXT_PUBLIC_BASE_URL`              | Bare domain (no protocol) used to build the canonical base URL for sitemap entries, OG tags, and auth callbacks. Defaults to `VERCEL_PROJECT_PRODUCTION_URL` on Vercel.      |
-| `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ID` | Numeric storefront ID from the Headless channel. Hydrogen sends it as a trusted Storefront API header for cart attribution and includes it in Shopify runtime configuration. |
-| `SHOPIFY_API_VERSION`               | Override the Shopify Storefront API version. Defaults to `unstable`; Hydrogen selects its dated Customer Account API version.                                                |
-| `SHOPIFY_WEBHOOK_SECRET`            | Shared secret used to verify HMAC signatures on incoming Shopify webhooks at `/api/webhooks/shopify`.                                                                        |
+| Variable                            | Description                                                                                                             |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `DEBUG_SHOPIFY`                     | Set to `true` to log structured Storefront and Customer Account API operation timings.                                  |
+| `NEXT_PUBLIC_BASE_URL`              | Canonical domain without a protocol, such as `shop.example.com`. Defaults to `VERCEL_PROJECT_PRODUCTION_URL` on Vercel. |
+| `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ID` | Numeric storefront ID from the Headless channel, used for cart attribution and Shopify runtime configuration.           |
+| `SHOPIFY_API_VERSION`               | Storefront API version override. Defaults to `unstable`. Hydrogen selects the Customer Account API version.             |
+| `SHOPIFY_WEBHOOK_SECRET`            | Shared secret used to verify HMAC signatures for `POST /api/webhooks/shopify`.                                          |
 
-System variables auto-injected on Vercel that the build reads (`VERCEL_PROJECT_PRODUCTION_URL`, `V0_CALLBACK_URL`) are listed in `turbo.json` `globalEnv` so Turbo's strict-mode build sees them. You don't set these yourself.
+Vercel supplies `VERCEL_PROJECT_PRODUCTION_URL` and `V0_CALLBACK_URL` automatically. Do not set them yourself.

--- a/apps/docs/content/docs/reference/routes.mdx
+++ b/apps/docs/content/docs/reference/routes.mdx
@@ -6,32 +6,29 @@ type: reference
 
 ## Pages
 
-| Route                                 | Description                                                                                        |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `/`                                   | Home page with hero, products grid, info section                                                   |
-| `/products/[handle]`                  | Product detail page; `?color=…&size=…` option params select a variant                              |
-| `/collections`                        | All-collections index; each card links to a collection, image falls back to its first product      |
-| `/collections/[handle]`               | Collection listing with filters, sort, pagination                                                  |
-| `/collections/all`                    | Virtual "All Products" listing; synthesized since Shopify's Storefront API has no `all` collection |
-| `/search`                             | Search results (same grid as collections)                                                          |
-| `/cart`                               | Full cart page with related products                                                               |
-| `/blogs/[blogHandle]`                 | Shopify blog listing with latest articles                                                          |
-| `/blogs/[blogHandle]/[articleHandle]` | Shopify article with localized rich text and SEO metadata                                          |
-| `/pages/[handle]`                     | Shopify Page with localized rich text and SEO metadata                                             |
-| `/policies/[handle]`                  | Configured Shopify store policy                                                                    |
+| Route                                 | Description                                                   |
+| ------------------------------------- | ------------------------------------------------------------- |
+| `/`                                   | Home page                                                     |
+| `/products/[handle]`                  | Product detail page; option query parameters select a variant |
+| `/collections`                        | Collection index                                              |
+| `/collections/[handle]`               | Collection listing with filters, sorting, and pagination      |
+| `/collections/all`                    | All-products listing                                          |
+| `/search`                             | Product search results                                        |
+| `/cart`                               | Cart and related products                                     |
+| `/blogs/[blogHandle]`                 | Shopify blog listing                                          |
+| `/blogs/[blogHandle]/[articleHandle]` | Shopify article                                               |
+| `/pages/[handle]`                     | Shopify page                                                  |
+| `/policies/[handle]`                  | Shopify store policy                                          |
 
 ## API routes
 
 | Route                        | Description                                    |
 | ---------------------------- | ---------------------------------------------- |
 | `POST /api/webhooks/shopify` | Shopify webhook handler for cache invalidation |
-| `POST /api/chat`             | Guarded AI SDK shopping-assistant stream       |
+| `POST /api/chat`             | Shopping-assistant stream                      |
 
 ## Variant URLs
 
-Product variant selection uses one query parameter per option, keyed by the lowercased option name:
+Product options use one query parameter per option. The key is the lowercased option name and the value is the selected option value.
 
-| URL                                    | Purpose                                                   |
-| -------------------------------------- | --------------------------------------------------------- |
-| `/products/:handle?color=Blue&size=XS` | Opens the product page with the matching variant selected |
-| `/products/:handle`                    | No options selected — renders the first available variant |
+For example, `/products/your-product?color=Blue&size=XS` selects the blue, extra-small variant. Without option parameters, the page selects the first available variant.

--- a/apps/docs/content/docs/reference/shop-config.mdx
+++ b/apps/docs/content/docs/reference/shop-config.mdx
@@ -4,107 +4,49 @@ description: Configure storefront identity, analytics, and cross-cutting feature
 type: reference
 ---
 
-`lib/config.ts` contains secret-free values that describe the storefront across multiple parts of the application: site identity, analytics integrations, and installation-level feature availability.
+Edit `lib/config.ts` to set storefront-wide, secret-free options. Keep credentials in environment variables and merchandising data in Shopify.
 
-Environment variables still own credentials and deployment-specific overrides. Component composition, Shopify query behavior, result counts, and agent runtime policy stay with the code that implements them rather than becoming a configuration API.
+## Settings
 
-## Default configuration
+| Setting                               | Default          | Behavior                                                                                        |
+| ------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------- |
+| `agent.isEnabled`                     | `false`          | Shows the shopping assistant and enables `POST /api/chat`. The disabled endpoint returns `404`. |
+| `analytics.vercel.isEnabled`          | `false`          | Enables Vercel Web Analytics.                                                                   |
+| `analytics.speedInsights.isEnabled`   | `false`          | Enables Vercel Speed Insights.                                                                  |
+| `analytics.shopify.isEnabled`         | `false`          | Sends storefront page views to Shopify analytics.                                               |
+| `analytics.shopify.consentMode`       | `default-banner` | Selects the Shopify consent experience described below.                                         |
+| `auth.isEnabled`                      | `false`          | Enables customer authentication.                                                                |
+| `botid.isEnabled`                     | `false`          | Protects `POST /api/chat` with [Vercel BotID](https://vercel.com/docs/botid).                   |
+| `botid.checkLevel`                    | `basic`          | Selects `basic` or `deepAnalysis` detection.                                                    |
+| `pdp.bundles.isEnabled`               | `true`           | Shows product bundle relationships when Shopify provides them.                                  |
+| `pdp.buyWithShop.isEnabled`           | `true`           | Shows Buy with Shop.                                                                            |
+| `pdp.complementaryProducts.isEnabled` | `true`           | Shows complementary products when Shopify provides them.                                        |
+| `pdp.quantityPicker.isEnabled`        | `true`           | Shows the quantity picker.                                                                      |
+| `pdp.relatedProducts.isEnabled`       | `true`           | Shows related products when Shopify provides them.                                              |
+| `site.name`                           | `"Vercel Shop"`  | Sets the name used in navigation, metadata, structured data, the footer, and the assistant.     |
+| `site.url`                            | `defaultUrl`     | Sets the canonical base URL for sitemaps, structured data, and absolute links.                  |
+| `webmcp.isEnabled`                    | `false`          | Enables the experimental WebMCP integration in supported browsers.                              |
 
-```ts
-export const shopConfig = {
-  agent: {
-    isEnabled: false,
-  },
-  analytics: {
-    shopify: { consentMode: "default-banner", isEnabled: false },
-    speedInsights: { isEnabled: false },
-    vercel: { isEnabled: false },
-  },
-  auth: {
-    isEnabled: false,
-  },
-  botid: {
-    checkLevel: "basic",
-    isEnabled: false,
-  },
-  pdp: {
-    bundles: { isEnabled: true },
-    buyWithShop: { isEnabled: true },
-    complementaryProducts: { isEnabled: true },
-    quantityPicker: { isEnabled: true },
-    relatedProducts: { isEnabled: true },
-  },
-  site: {
-    name: "Vercel Shop",
-    url: defaultUrl,
-  },
-  webmcp: {
-    isEnabled: false,
-  },
-} satisfies ShopConfig;
-```
+## Required constraints
 
-Consumers import `shopConfig` directly from `@/lib/config`. Feature flags are literal booleans edited in this file; `site.url` is the only environment-backed value.
+Before enabling `auth.isEnabled`, set `CUSTOMER_ACCOUNT_SESSION_SECRET` and `SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID` as described in [Environment Variables](/docs/reference/env-vars). The build fails if either variable is missing.
 
-## Agent
+Enable `botid.isEnabled` with `agent.isEnabled`. BotID verification runs only on Vercel, so leave it disabled when self-hosting. The `deepAnalysis` level is [billed per check](https://vercel.com/docs/botid#pricing) on Pro plans.
 
-`agent.isEnabled` controls whether the shopping assistant is available. It defaults to `false`. When disabled, the assistant button is hidden and the chat endpoint returns `404`. The model, tools, prompts, and loop limits are implementation details in the agent module, not shop configuration.
+`site.url` resolves from `NEXT_PUBLIC_BASE_URL` or the Vercel production URL. `NEXT_PUBLIC_BASE_URL` must be a bare domain without a protocol, such as `shop.example.com`.
 
-## Analytics
+## Shopify consent modes
 
-- `vercel.isEnabled` controls Vercel Web Analytics.
-- `speedInsights.isEnabled` controls Vercel Speed Insights.
-- `shopify.isEnabled` controls Shopify storefront analytics.
+| Value            | Behavior                                                                                     |
+| ---------------- | -------------------------------------------------------------------------------------------- |
+| `default-banner` | Uses Shopify's hosted privacy banner where consent is required.                              |
+| `custom-banner`  | Uses the storefront's own consent interface.                                                 |
+| `no-banner`      | Shows no consent interface. Where consent is required, analytics events cannot be delivered. |
 
-The Vercel integrations are disabled by default. Set an individual integration to `true` to render it. The root analytics component owns these gates and does not mount disabled Vercel providers. Additional storefront-wide analytics integrations can be added alongside them.
+Only expose the public Storefront API token to the browser. Never use a private token for Shopify analytics or consent requests.
 
-Hydrogen's Shopify scripts mount by default to initialize Shopify's storefront runtime and consent flow. `shopify.isEnabled` independently controls whether those scripts send storefront page views to Shopify analytics, so they appear in Shopify admin alongside the rest of the store's reporting. It is disabled by default and needs no credentials beyond the Storefront API variables the storefront already requires. Set it to `true` to turn analytics on.
+## Related configuration
 
-`shopify.consentMode` selects how visitors grant tracking consent and defaults to `default-banner`, where Shopify's hosted privacy banner is rendered for visitors in regions that require consent. Use `custom-banner` when the storefront provides its own consent UI. Choosing `no-banner` means visitors in those regions have no way to grant consent and their events are never delivered. Hydrogen sends consent requests through the storefront's local Storefront API proxy so the privacy flow remains first-party; the public Storefront token is included in the request, while private tokens must never be exposed to the browser.
+Navigation and footer menus are managed outside `shopConfig`. Use the [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) skill to manage them in Shopify.
 
-## Authentication
-
-`auth.isEnabled` controls whether customer authentication is active. It defaults to `false`.
-
-Enabling auth still requires the Hydrogen session secret and Shopify Customer Account API client ID documented in [Environment Variables](/docs/reference/env-vars). The build validates those variables when auth is enabled.
-
-## BotID
-
-`botid.isEnabled` controls [Vercel BotID](https://vercel.com/docs/botid) protection on the assistant's chat endpoint. It defaults to `false`; enable it alongside `agent.isEnabled` to protect the assistant.
-
-`botid.checkLevel` selects the detection level. It defaults to `basic`, which is free on all plans. Setting it to `deepAnalysis` enables Vercel's machine-learning detection, which is [billed per check](https://vercel.com/docs/botid#pricing) on Pro plans.
-
-Verification only runs on Vercel; elsewhere every request is treated as human. Leave the flag off when self-hosting so the storefront doesn't ship a challenge it can't verify.
-
-## Navigation and footer
-
-The primary navigation and footer menus are not part of `shopConfig`. Each is an inline `MenuItem[]` literal in its own component: the nav default (a single Shop link) in `components/nav/index.tsx`, and the footer menu columns plus social links in `components/footer/index.tsx`. The [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) skill swaps these static defaults for menus managed in Shopify.
-
-## PDP capabilities
-
-The PDP capability flags are enabled by default so storefronts render Shopify's merchandising features whenever the catalog provides data:
-
-- `bundles.isEnabled` adds Shopify's `components`, `groupedBy`, and `requiresComponents` fields to the existing product and selected-variant requests, then renders bundle relationships and purchase restrictions.
-- `buyWithShop.isEnabled` renders the full-width Buy with Shop accelerated checkout action below Add to Cart.
-- `complementaryProducts.isEnabled` adds one cached `COMPLEMENTARY` recommendation request per product and renders merchant-curated cross-sells near the buy section.
-- `quantityPicker.isEnabled` renders a 1–99 quantity control beside Add to Cart and applies the selected quantity to both purchase actions.
-- `relatedProducts.isEnabled` adds one cached `RELATED` recommendation request per product and renders algorithmic recommendations on PDP and cart pages.
-
-Sections with no applicable Shopify data render nothing. Set an individual flag to `false` to skip its fields or recommendation request. Display counts and component composition remain implementation details rather than configuration.
-
-## Site
-
-`site` carries storefront identity shared by metadata, structured data, sitemaps, and the footer.
-
-- `name` is the storefront display name, used in the nav logo, footer copyright, page titles, SEO metadata, and the agent's system prompt. Defaults to `"Vercel Shop"`.
-- `url` is the canonical base URL, resolved from `NEXT_PUBLIC_BASE_URL` (a bare domain, no protocol) or the Vercel production URL, used for sitemaps, schema, and absolute links.
-
-## What does not belong here
-
-Do not put secrets, access tokens, store-specific product data, arbitrary Shopify query fields, display counts, component-level presentation switches, or AI runtime wiring in `lib/config.ts`. Keep credentials in environment variables, merchandising data in Shopify, and implementation policy beside the code that owns it.
-
-## WebMCP
-
-`webmcp.isEnabled` controls the experimental WebMCP integration. It defaults to `false`. WebMCP is an in-progress browser API available only behind a Chrome flag, not a finalized standard, so this feature is experimental and its behavior may change as the spec and Shopify's implementation evolve.
-
-When enabled, Hydrogen's Shopify scripts mount loads Shopify's hosted `webmcp.js` in browsers that expose the model-context API; other browsers skip the script entirely. Shopify's script defines and registers the storefront tools, not the template. Enabling WebMCP does not enable Shopify analytics — the two are gated independently. See [WebMCP](/docs/anatomy/webmcp) for testing instructions.
+WebMCP does not enable Shopify analytics. See [WebMCP](/docs/anatomy/webmcp) for testing instructions.

--- a/apps/docs/content/docs/reference/storefront-api-permissions.mdx
+++ b/apps/docs/content/docs/reference/storefront-api-permissions.mdx
@@ -6,36 +6,24 @@ prerequisites:
   - /docs/getting-started
 ---
 
-After you create a storefront in Shopify Headless, open **Settings → Apps and sales channels → Headless → your storefront** and review the **Storefront API permissions** for that token.
+After [Getting Started](/docs/getting-started), open **Settings → Apps and sales channels → Headless → your storefront** in Shopify admin and grant these Storefront API permissions to the token.
 
-## Required for the default storefront
+## Required
 
-| Scope                                      | Purpose                                                   |
-| ------------------------------------------ | --------------------------------------------------------- |
-| `unauthenticated_read_product_listings`    | Product pages, search, and recommendations                |
-| `unauthenticated_read_product_inventory`   | Stock availability on product and collection pages        |
-| `unauthenticated_read_collection_listings` | Collection pages and navigation                           |
-| `unauthenticated_write_checkouts`          | Cart operations and checkout                              |
-| `unauthenticated_read_content`             | Shopify Pages, policies, blogs, articles, and metaobjects |
+| Scope                                      | Enables                                           |
+| ------------------------------------------ | ------------------------------------------------- |
+| `unauthenticated_read_product_listings`    | Product pages, search, and recommendations        |
+| `unauthenticated_read_product_inventory`   | Product and collection availability               |
+| `unauthenticated_read_collection_listings` | Collection pages and navigation                   |
+| `unauthenticated_write_checkouts`          | Cart operations and checkout                      |
+| `unauthenticated_read_content`             | Pages, policies, blogs, articles, and metaobjects |
 
-## Optional skills
+## Optional
 
-Enable these only when you add the corresponding feature:
+Grant optional scopes only when you enable the related feature.
 
 | Scope                                | Required by                                    |
 | ------------------------------------ | ---------------------------------------------- |
 | `unauthenticated_read_customer_tags` | [Authentication](/docs/anatomy/authentication) |
 
-## Related docs
-
-<Cards>
-  <Card title="Getting Started" href="/docs/getting-started">
-    The shortest path from Shopify token to a local storefront.
-  </Card>
-  <Card title="Environment Variables" href="/docs/reference/env-vars">
-    Required and optional environment variables for local development and deploys.
-  </Card>
-  <Card title="Storefront API" href="/docs/reference/storefront-api">
-    Query patterns, caching, and the shared Shopify client used by the template.
-  </Card>
-</Cards>
+See [Environment Variables](/docs/reference/env-vars) for token configuration and [Storefront API](/docs/reference/storefront-api) for query validation and runtime behavior.

--- a/apps/docs/content/docs/reference/storefront-api.mdx
+++ b/apps/docs/content/docs/reference/storefront-api.mdx
@@ -6,209 +6,66 @@ prerequisites:
   - /docs/getting-started
 ---
 
-All Storefront API data flows through a shared client built with [`@shopify/hydrogen`](https://www.npmjs.com/package/@shopify/hydrogen)'s `createStorefrontClient`, exported as `storefront` from `lib/shopify/storefront.ts`. The Hydrogen client injects `$country`/`$language` from the `i18n` on its request context on every request, so the wrapper creates the client with the country/language pair taken from the request variables (client creation is plain config allocation — there's nothing stateful worth caching). Queries are tagged `#graphql` and validated against the live schema by [`@shopify/api-codegen-preset`](https://www.npmjs.com/package/@shopify/api-codegen-preset) (see [Codegen](#codegen)).
+The template uses [Shopify Hydrogen](https://www.npmjs.com/package/@shopify/hydrogen) for Storefront GraphQL API queries and mutations. Configure its domain, public token, and API version with the variables in [Environment Variables](/docs/reference/env-vars). Grant the scopes in [Storefront API Permissions](/docs/reference/storefront-api-permissions).
 
-For Shopify admin setup and required token scopes, see [Storefront API Permissions](/docs/reference/storefront-api-permissions).
+The Customer Account API uses a separate endpoint, schema, client ID, and session secret. Storefront API codegen does not validate Customer Account API operations.
 
-> The Customer Account API is a separate endpoint and schema. `customerAccountFetch` in `lib/shopify/customer-account.ts` wraps `@shopify/hydrogen/customer-account`'s `createCustomerAccountClient` — a distinct client from the Storefront one, with its own schema and not covered by the storefront codegen.
+## Write and validate operations
 
-## storefront.request
+Define each operation as a static `#graphql` document and pass dynamic values as GraphQL variables. Do not interpolate runtime values or conditional fields into the document.
 
-```ts
-import { assertStorefrontOk } from "@/lib/shopify/errors";
-import { storefront } from "@/lib/shopify/storefront";
-
-const response = await storefront.request<{ productByHandle: ShopifyProduct }>(
-  GET_PRODUCT_BY_HANDLE_QUERY,
-  { variables: { handle, country, language } },
-);
-assertStorefrontOk(response, "getProductByHandle");
-const { data } = response;
-```
-
-- **query** (first argument) - the full `#graphql`-tagged query or mutation, including any fragment interpolations.
-- **variables** - passed in the options object as JSON in the request body. Never interpolate values into the query string directly.
-- The generic is the expected shape of `data`. Codegen validates the query against the schema; this type describes the response for transforms and is narrowed to non-null by `assertStorefrontOk`.
-
-## Request details
-
-The client `POST`s to `https://{NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN}/api/{SHOPIFY_API_VERSION}/graphql.json` with the `X-Shopify-Storefront-Access-Token` header (mapped from the `publicAccessToken` passed at init). A `customFetchApi` wrapper in `lib/shopify/storefront.ts` preserves three intentionally app-specific behaviors: the `?operation=<name>` URL annotation for network logs, `Accept-Encoding: gzip, br`, and operation timing. Cache isolation between different variables comes from the `"use cache"` wrappers in `lib/shopify/operations/`, which key on function arguments.
-
-## Writing a query
-
-Define the query as a template string. Start it with the `#graphql` tag (so codegen parses it) and end the declaration with `as const` (so its literal type propagates through fragment interpolation). Interpolate shared fragments at the top:
+Include Shopify's `@inContext` directive when localized pricing or content depends on country and language:
 
 ```ts
-import { PRODUCT_FRAGMENT } from "@/lib/shopify/fragments";
-
-const GET_PRODUCT_BY_HANDLE_QUERY = `#graphql
-  ${PRODUCT_FRAGMENT}
-  query getProductByHandle(
+const GET_PRODUCT_QUERY = `#graphql
+  query getProduct(
     $handle: String!
     $country: CountryCode
     $language: LanguageCode
   ) @inContext(country: $country, language: $language) {
     productByHandle(handle: $handle) {
-      ...ProductFields
+      id
+      title
     }
   }
 ` as const;
 ```
 
-The `@inContext` directive passes country and language for localized pricing and content. Use `getCountryCode(locale)` and `getLanguageCode(locale)` from `lib/i18n` to extract these from a locale string.
-
-Keep documents static so codegen can parse them. Don't build a query with runtime string interpolation (a ternary that swaps in a field, a computed selection set) — pass the variable part as a GraphQL variable instead, or split it into two static `#graphql` documents and pick one at the call site. For example, the opt-in product-metafields query passes its identifiers through a `$metafieldIdentifiers: [HasMetafieldsIdentifier!]!` variable rather than interpolating them, and `getProduct` selects between the plain and with-metafields documents based on config.
+Validate current field names, arguments, and types with Shopify AI Toolkit. Then use the [`shopify-graphql-reference` skill](/docs/skills/shopify-graphql-reference) for template integration conventions. The skill is not a schema source.
 
 ## Codegen
 
-`pnpm --filter template codegen` runs `graphql-codegen` (configured in `.graphqlrc.ts`). It pulls the Storefront schema from Shopify's direct-proxy endpoint for the configured `SHOPIFY_API_VERSION`, parses every `#graphql`-tagged query, and **fails if any field, argument, or type is invalid** — automating the "never guess field names" rule.
+Use this [codegen](#codegen) contract while editing an operation. The template runs [`@shopify/api-codegen-preset`](https://www.npmjs.com/package/@shopify/api-codegen-preset):
 
-Codegen runs automatically at dev and build time, so type generation is not a manual step:
-
-- `pnpm dev` regenerates types on start. It is **non-fatal** there (the app never imports the generated files, so a stale or missing output doesn't break local dev when you're offline).
-- `pnpm build` runs codegen as a **hard gate** — the build fails if a query no longer matches the live schema.
-
-Output lands in `lib/shopify/types/generated/`, which is **gitignored**. Nothing in the app imports it; it is purely the validation artifact. Run `pnpm --filter template codegen` (or `codegen:watch`) manually while iterating on a query.
-
-Because codegen resolves interpolations of other `#graphql` consts by name, every fragment in `lib/shopify/fragments.ts` is also tagged `#graphql ... as const`. A raw selection snippet that isn't a valid standalone document (it can't be `#graphql`-tagged) must be inlined into each operation rather than interpolated.
-
-Always use Shopify AI Toolkit to search current Shopify documentation and validate the final operation. Then use [`/vercel-shop:shopify-graphql-reference`](/docs/skills/shopify-graphql-reference) for Vercel Shop integration conventions. The Vercel Shop skill is not a schema source.
-
-## Fragments
-
-Shared fragments in `lib/shopify/fragments.ts` avoid repeating field selections:
-
-| Fragment                   | Covers                                                                                          |
-| -------------------------- | ----------------------------------------------------------------------------------------------- |
-| `MONEY_FRAGMENT`           | `amount` and `currencyCode` on `MoneyV2`                                                        |
-| `IMAGE_FRAGMENT`           | `url`, `altText`, `width`, `height` on `Image`                                                  |
-| `PRODUCT_VARIANT_FRAGMENT` | Variant price, options, image, availability                                                     |
-| `PRODUCT_FRAGMENT`         | Full product: media, variants (up to 250), options with swatches, metafields, price ranges, SEO |
-| `PRODUCT_CARD_FRAGMENT`    | Lightweight product for listing pages (fewer fields)                                            |
-
-Each fragment is declared as `` `#graphql ...` as const `` and embedded in a query with template literal interpolation: `` `#graphql ${PRODUCT_FRAGMENT} query ...` as const ``.
-
-## Writing an operation function
-
-Operation functions live in `lib/shopify/operations/` and follow a consistent pattern:
-
-```ts
-import { cacheLife, cacheTag } from "next/cache";
-import { assertStorefrontOk } from "../errors";
-import { storefront } from "../storefront";
-import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
-import type { ProductDetails } from "@/lib/types";
-
-export async function getProduct({
-  handle,
-  locale = defaultLocale,
-}: {
-  handle: string;
-  locale?: string;
-}): Promise<ProductDetails | undefined> {
-  "use cache";
-  cacheLife("max");
-  cacheTag("products", `product-${handle}`);
-
-  const response = await storefront.request<{ productByHandle: ShopifyProduct }>(
-    GET_PRODUCT_BY_HANDLE_QUERY,
-    {
-      variables: {
-        handle,
-        country: getCountryCode(locale),
-        language: getLanguageCode(locale),
-      },
-    },
-  );
-  assertStorefrontOk(response, "getProductByHandle");
-  const { data } = response;
-
-  if (!data.productByHandle) return undefined;
-
-  return transformShopifyProductDetails(data.productByHandle);
-}
+```bash
+pnpm --filter template codegen
 ```
 
-Key elements:
-
-1. **`"use cache"`** - includes the stable product body coherently in the PDP's prerendered shell
-2. **`cacheLife("max")`** - caches indefinitely until manually revalidated
-3. **`cacheTag(...)`** - assigns tags for granular invalidation via `revalidateTag()`
-4. **Transform** - convert the Shopify response to a domain type before returning. Components never import Shopify types directly.
+Codegen reads `SHOPIFY_API_VERSION` and fails when an operation does not match Shopify's live schema. Development runs codegen without blocking startup, while the production build treats failure as a hard error. Generated validation files are gitignored.
 
 ## Caching
 
-Read operations choose cache behavior from their render role:
+Choose caching by data sensitivity and behavior:
 
-| Render role                                                                     | Treatment                                                        |
-| ------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| Public identity/body that belongs coherently in the prerendered shell           | Plain `"use cache"`                                              |
-| Public results resolved after request inputs such as filters, search, or cursor | `"use cache: remote"` when shared Runtime Cache is justified     |
-| Cart, session, authorization, or Customer Account data                          | Request-scoped or private; never public remote cache             |
-| Mutation                                                                        | No read-cache directive; invalidate affected state after success |
+| Data or operation                                          | Cache contract                                                |
+| ---------------------------------------------------------- | ------------------------------------------------------------- |
+| Public product, collection, menu, or content data          | Cache and invalidate when Shopify changes                     |
+| Public results that vary by filters, search, or pagination | Share only when the cache key includes every varying input    |
+| Cart, session, authorization, or customer data             | Keep request-scoped or private; never place in a public cache |
+| Mutations                                                  | Do not cache                                                  |
 
-Cached public operations use the established `cacheLife` and tags. Combined with webhook-driven invalidation, those tags refresh the intended shell or runtime entry when Shopify changes. Tags follow a hierarchy:
-
-| Tag pattern                | Scope                                |
-| -------------------------- | ------------------------------------ |
-| `products`                 | All product queries                  |
-| `product-{handle}`         | Single product by handle             |
-| `product-{numericId}`      | Single product by Shopify numeric ID |
-| `recommendations-{handle}` | Product recommendations              |
-| `collections`              | All collection queries               |
-| `collection-{handle}`      | Single collection                    |
-| `menus`                    | Navigation menus                     |
-
-Invalidate with `revalidateTag("product-blue-tee")` in server actions. Carts are never placed in the Next.js data cache — cart reads are memoized per request via `getCart`, so cart mutations don't need any cache invalidation step.
+Webhook-driven invalidation keeps cached Shopify content current. Configure `POST /api/webhooks/shopify` as described in [Webhooks](/docs/anatomy/webhooks).
 
 ## Mutations
 
-Cart mutations use the same `storefront.request` client but are not cached. They call Shopify `cartLinesAdd`, `cartLinesUpdate`, and `cartLinesRemove` mutations:
+Cart mutations are uncached and return the updated cart. Use the returned cart instead of issuing a follow-up read.
 
-```ts
-export async function addToCart(lines: CartLineInput[], cartId: string, locale: string) {
-  const response = await storefront.request<{ cartLinesAdd: { cart: ShopifyCart } }>(
-    ADD_TO_CART_MUTATION,
-    { variables: { cartId, lines, country: getCountryCode(locale) } },
-  );
-  assertStorefrontOk(response, "addToCart");
+Never cache cart IDs, customer data, session data, or authenticated responses in a shared public cache.
 
-  return transformShopifyCart(response.data.cartLinesAdd.cart);
-}
-```
+## Errors and missing resources
 
-Shopify returns the full updated cart in every mutation response, so there's no need for a follow-up query.
+Storefront requests throw on transport failures, timeouts, and GraphQL failures without usable data. A response with both data and GraphQL errors logs a warning and allows the operation to use the partial data.
 
-## Error handling
+A missing resource is not an API failure. Read operations return `undefined`, `null`, or an empty list when the requested resource does not exist.
 
-The Hydrogen client resolves to `{ data, errors? }` for GraphQL-level errors, but **throws** on transport failures — `StorefrontApiError` for non-OK HTTP responses and malformed payloads, `StorefrontTimeoutError` when the default 30s timeout elapses. The template applies its contract through `assertStorefrontOk(response, operation)` in `lib/shopify/errors.ts`:
-
-**GraphQL failure** - if `errors` is present and there's no `data`, it throws Hydrogen's `StorefrontApiError` with the operation name plus Shopify's locations, path, extensions, and any additional errors.
-
-**Partial success** - if there are `errors` but `data` is also present, it sends a structured warning through the configured Hydrogen logger and lets the operation use the partial data.
-
-**Narrowing** - on success it narrows `response.data` to non-null, so the operation can read it without optional chaining on the top level.
-
-Individual operations follow a consistent contract on top of this: they **throw** on transport or GraphQL failure, and **return** `undefined`/`null`/`[]` when a resource is simply missing. For example, `getProduct()` returns `undefined` when the product isn't found (rather than throwing), and `getCart()` returns `undefined` when there's no cart. For render paths that should degrade gracefully instead of crashing on a transport error, wrap the call in the `withFallback(promise, fallback)` helper — e.g. `withFallback(getCart(), undefined)` in the nav and cart page.
-
-## Debug logging
-
-Hydrogen logging is configured once when the Next.js server starts. Set `DEBUG_SHOPIFY=true` to include structured Storefront and Customer Account API timings alongside Hydrogen's own runtime logs:
-
-```
-[shopify:debug:storefront] Storefront API request { durationMs: 45, operation: "getProductByHandle" }
-[shopify:debug:customer-account] Customer Account API request { durationMs: 120, operation: "getCustomerProfile" }
-```
-
-Warnings and errors remain enabled without the debug flag. Customer Account API failures retain that client's error contract; `StorefrontApiError` and `StorefrontTimeoutError` apply specifically to Storefront API requests.
-
-## Transforms
-
-Every operation converts the Shopify response to a domain type before returning. Transforms live in `lib/shopify/transforms/`:
-
-| Transform                        | Input → Output                      |
-| -------------------------------- | ----------------------------------- |
-| `transformShopifyProductDetails` | `ShopifyProduct` → `ProductDetails` |
-| `transformShopifyCart`           | `ShopifyCart` → `Cart`              |
-
-Domain types are defined in `lib/types.ts` and are provider-agnostic. Components import these types, never the Shopify-specific response shapes. This keeps the UI decoupled from the API layer.
+Set `DEBUG_SHOPIFY=true` to include structured Storefront and Customer Account API operation timings in server logs. Warnings and errors remain enabled when debug logging is off.

--- a/apps/docs/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/content/docs/reference/troubleshooting.mdx
@@ -4,81 +4,122 @@ description: Solutions to common setup and runtime issues.
 type: troubleshooting
 ---
 
-## Products not showing up
+## Products do not appear
 
-The most common cause is missing Storefront API permissions. In your Shopify admin, go to **Settings → Apps and sales channels → Headless → your storefront** and compare your token scopes against [Storefront API Permissions](/docs/reference/storefront-api-permissions).
+**Symptom:** Product pages or listings are empty.
 
-Also check that your products are set to the **Online Store** and **Headless** sales channels in Shopify admin.
+**Check:** In Shopify admin, confirm the Storefront token has the scopes in [Storefront API Permissions](/docs/reference/storefront-api-permissions). Confirm each product is published to both the **Online Store** and **Headless** sales channels.
 
-## Bundles not appearing (404 on the storefront)
+**Fix:** Grant the missing scopes and publish the products to both channels.
 
-A bundle that is **ACTIVE** in Shopify admin but 404s on the storefront is almost always missing from your **Headless** sales channel. The free Shopify Bundles app publishes a new bundle to the **Online Store** channel only, while the template's Storefront token reads from Headless — so `getProduct()` returns nothing and the route renders `notFound()`.
+**Expected result:** Published products appear in listings and product routes resolve.
 
-Fix it in admin: open the bundle product → **Publishing** → add your Headless channel. Then, because product reads are cached with `cacheLife("max")`, redeploy (or fire a product webhook) so the cached "not found" clears. The bundle's component products must be on Headless too, or their relationships won't resolve.
+## A bundle returns 404
 
-## Cart not persisting across page loads
+**Symptom:** A bundle is active in Shopify admin but its storefront route returns `404`.
 
-The cart ID is stored in a `shopify_cartId` HTTP-only cookie with a 7-day expiry. Common causes:
+**Check:** Open the bundle product's **Publishing** settings. Confirm the bundle and its component products are published to the **Headless** sales channel.
 
-- **Cookie domain mismatch** - if you're running on a different domain than expected, the cookie may not be sent. Check your browser dev tools → Application → Cookies.
+**Fix:** Publish all required products to Headless. Then trigger a product webhook or redeploy to clear the cached not-found response.
 
-## Variant selection not working
+**Expected result:** The bundle route loads and its component relationships appear.
 
-Variant selection uses one option param per axis (`?color=Blue&size=XS`). If option links change the URL but the price/buy buttons do not update, check that `app/products/[handle]/page.tsx` parses the params with `parseSelectedOptions()` and resolves the variant with `getProductVariant()` inside the streamed `selectionPromise`.
+## The cart does not persist
 
-Also confirm option links are generated with `buildOptionUrl()` from `lib/product.ts` (a pure merge of the current selection with the changed option), and that swatch availability comes from `getAvailableOptionValues()` in `lib/shopify/encoded-variants.ts` — if every value shows as available, the product's `encodedVariantAvailability` may be missing from the query.
+**Symptom:** The cart becomes empty after navigation or reload.
 
-## Images not loading
+**Check:** In browser developer tools, open **Application → Cookies** and confirm the HttpOnly `cart` cookie exists for the current domain. It should have a 14-day expiry.
 
-Shopify serves images from its CDN. The template's `next.config.ts` must include Shopify's image domain in `images.remotePatterns`. Verify that `cdn.shopify.com` is listed:
+**Fix:** Use one consistent storefront domain and remove any deployment or proxy setting that rewrites the cookie domain.
+
+**Expected result:** The same cart remains available across page loads for up to 14 days.
+
+## Variant selection does not update the product
+
+**Symptom:** Selecting an option changes the URL but not the price or purchase controls.
+
+**Check:** Confirm the URL contains one query parameter per option, such as `?color=Blue&size=XS`. Option names are lowercase. Confirm the selected combination exists in Shopify.
+
+**Fix:** Correct links to preserve all selected option parameters. If a valid combination still fails, validate the product and variant queries against the Storefront API schema.
+
+**Expected result:** The URL, selected variant, price, availability, and purchase controls update together.
+
+## Images do not load
+
+**Symptom:** Shopify product images are broken or rejected by Next.js Image.
+
+**Check:** Confirm `next.config.ts` allows `cdn.shopify.com` in `images.remotePatterns`.
+
+**Fix:** Add the Shopify CDN hostname:
 
 ```ts
 images: {
-  remotePatterns: [
-    { hostname: "cdn.shopify.com" },
-  ],
+  remotePatterns: [{ hostname: "cdn.shopify.com" }],
 },
 ```
 
-## Build fails with GraphQL errors
+**Expected result:** Shopify CDN images render through Next.js Image.
 
-This usually means the query references a field, argument, or enum value that doesn't exist on the live Shopify API version your store is using.
+## The build fails with GraphQL errors
 
-Re-check and validate the operation with Shopify AI Toolkit first. Then use the [`shopify-graphql-reference` skill](/docs/skills/shopify-graphql-reference) for the template integration and cache role.
+**Symptom:** Codegen or the production build reports an invalid GraphQL field, argument, type, or enum value.
 
-If the Shopify plugin is missing, reinstall it:
+**Check:** Validate the operation against the live Storefront API schema for the configured `SHOPIFY_API_VERSION` using Shopify AI Toolkit.
+
+**Fix:** Correct the operation, then run:
+
+```bash
+pnpm --filter template codegen
+```
+
+If Shopify AI Toolkit is unavailable, install the project plugin:
 
 ```bash
 npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 ```
 
-## Changes in Shopify not appearing on the site
+Use the [`shopify-graphql-reference` skill](/docs/skills/shopify-graphql-reference) only for template integration conventions.
 
-All product and collection data is cached with `cacheLife("max")`. Without webhooks configured, changes only appear when the cache expires.
+**Expected result:** Codegen exits successfully and the production build passes its GraphQL validation gate.
 
-To get near-instant updates, set up Shopify webhooks pointed at `/api/webhooks/shopify`. See [Webhooks](/docs/anatomy/webhooks) for the full setup guide.
+## Shopify changes do not appear
 
-## Locale or currency not changing
+**Symptom:** Updated products or collections still show old content.
 
-Multi-locale commerce requires Shopify Markets to be enabled. The template ships as single-locale by default. Run [`/vercel-shop:enable-shopify-markets`](/docs/skills/enable-shopify-markets) to add regional locale routing and propagate Shopify's localized country, language, and currency context. The skill supports locale-prefixed, invisible cookie-based, and per-domain routing.
+**Check:** Confirm Shopify webhooks are configured and signed with `SHOPIFY_WEBHOOK_SECRET`.
 
-## Agent can't find context files
+**Fix:** Point the required Shopify webhooks to `POST /api/webhooks/shopify`. Follow [Webhooks](/docs/anatomy/webhooks) for setup. Redeploy once if you need to clear existing stale entries.
 
-Coding agents rely on `AGENTS.md` in the project root plus the expected project-scoped plugins. If an agent is missing context or commands:
+**Expected result:** Shopify changes invalidate the affected cached content and appear without a redeploy.
 
-- Verify you cloned from the correct template (`vercel/shop`, `apps/template` path)
-- The `AGENTS.md` file should be at the project root, not nested in a subdirectory
-- Check that `.claude/settings.json` exists and that the project plugins are enabled
-- Rerun the project plugin setup from the project root if needed:
+## Locale or currency does not change
+
+**Symptom:** The storefront keeps one language or currency after a regional selection.
+
+**Check:** Confirm Shopify Markets is enabled. The template is single-locale by default.
+
+**Fix:** Run [`/vercel-shop:enable-shopify-markets`](/docs/skills/enable-shopify-markets) and choose locale-prefixed, cookie-based, or per-domain routing.
+
+**Expected result:** Requests carry the selected country and language context, and Shopify returns localized content and currency.
+
+## A coding agent cannot find project context
+
+**Symptom:** A coding agent misses project commands or shop-specific guidance.
+
+**Check:** Confirm the project root contains `AGENTS.md` and `.claude/settings.json`, and that the expected project plugins are enabled.
+
+**Fix:** From the project root, run:
 
 ```bash
 npx create-vercel-shop@latest --no-template
 ```
 
-If that still fails, rerun the plugin installs individually:
+If needed, install the plugins individually:
 
 ```bash
 npx plugins add vercel/shop --scope project --yes
 npx plugins add vercel/vercel-plugin --scope project --yes
 npx plugins add Shopify/shopify-ai-toolkit --scope project --yes
 ```
+
+**Expected result:** The agent loads the project guidance and the Vercel Shop, Vercel, and Shopify tools.

--- a/apps/docs/content/docs/shopify/index.mdx
+++ b/apps/docs/content/docs/shopify/index.mdx
@@ -6,29 +6,20 @@ prerequisites:
   - /docs/getting-started
 ---
 
-The template connects to Shopify through the Storefront API. This page is an orientation map from Shopify concepts to template routes — for the API client and query mechanics, see [Storefront API](/docs/reference/storefront-api). For token setup and scopes, see [Getting Started](/docs/getting-started) and [Storefront API Permissions](/docs/reference/storefront-api-permissions).
+Use this page to find where Shopify content appears in the storefront. For credentials and permissions, see [Getting Started](/docs/getting-started) and [Storefront API Permissions](/docs/reference/storefront-api-permissions).
 
-## How it works
+| Shopify content | Storefront location      | Setup or behavior                                                                                    |
+| --------------- | ------------------------ | ---------------------------------------------------------------------------------------------------- |
+| Products        | `/products/[handle]`     | [Product setup](/docs/shopify/pdp) and [PDP anatomy](/docs/anatomy/pages/pdp)                        |
+| Collections     | `/collections/[handle]`  | [PLP anatomy](/docs/anatomy/pages/plp)                                                               |
+| Pages           | `/pages/[handle]`        | [Content pages](/docs/anatomy/pages/content)                                                         |
+| Policies        | `/policies/[handle]`     | [Footer](/docs/anatomy/footer)                                                                       |
+| Search          | `/search`                | [PLP and search anatomy](/docs/anatomy/pages/plp)                                                    |
+| Cart            | `/cart` and cart overlay | [Cart](/docs/anatomy/cart)                                                                           |
+| Menus           | Navigation and footer    | [Navigation](/docs/anatomy/navigation) and [Enable Shopify menus](/docs/skills/enable-shopify-menus) |
 
-**Every Shopify concept maps to exactly one template route.** Products, collections, pages, policies, and search each render through a dedicated route backed by a cached Storefront API read; cart spans the whole app through a context provider instead of a single route.
+Navigation uses the template's configured links by default. To manage it from Shopify Admin, enable Shopify menus and configure `main-menu` and `footer` under **Online Store → Navigation**.
 
-**Navigation ships hardcoded, not fetched from Shopify.** The nav and footer render static links from `shopConfig.navigation` by default. [`enable-shopify-menus`](/docs/skills/enable-shopify-menus) swaps in live menus fetched by handle from **Online Store → Navigation**.
+Configure [Shopify webhooks](/docs/anatomy/webhooks) so product and collection edits appear promptly. Without webhooks, cached content remains until its cache lifetime expires.
 
-**Cached reads need a webhook to invalidate promptly.** Public reads use `"use cache"` or `"use cache: remote"` with a long `cacheLife`, not a per-request fetch. Without webhooks configured, edits made in Shopify Admin surface only once the cache lifetime expires.
-
-## Out of the box
-
-| Shopify concept | Template route          | Docs                                                                                              |
-| --------------- | ----------------------- | ------------------------------------------------------------------------------------------------- |
-| Products        | `/products/[handle]`    | [PDP anatomy](/docs/anatomy/pages/pdp), [Product setup](/docs/shopify/pdp)                        |
-| Collections     | `/collections/[handle]` | [PLP anatomy](/docs/anatomy/pages/plp)                                                            |
-| Menus           | Navigation, footer      | [Navigation](/docs/anatomy/navigation), [Enable Shopify menus](/docs/skills/enable-shopify-menus) |
-| Pages           | `/pages/[handle]`       | [Content pages](/docs/anatomy/pages/content)                                                      |
-| Policies        | `/policies/[handle]`    | [Footer](/docs/anatomy/footer)                                                                    |
-| Search          | `/search`               | [PLP & Search anatomy](/docs/anatomy/pages/plp)                                                   |
-| Cart            | `/cart` + overlay       | [Cart](/docs/anatomy/cart)                                                                        |
-
-## Common customizations
-
-- **Shopify-powered menus** — run [`/vercel-shop:enable-shopify-menus`](/docs/skills/enable-shopify-menus) to fetch `main-menu` and `footer` menus from Shopify instead of the hardcoded defaults.
-- **Near-instant cache invalidation** — configure Shopify webhooks pointed at `/api/webhooks/shopify` so Admin edits invalidate cache tags immediately. See [Webhooks](/docs/anatomy/webhooks) for the endpoint, supported topics, and setup steps.
+For Storefront API behavior, see [Storefront API](/docs/reference/storefront-api).

--- a/apps/docs/content/docs/shopify/pdp.mdx
+++ b/apps/docs/content/docs/shopify/pdp.mdx
@@ -6,28 +6,28 @@ prerequisites:
   - /docs/anatomy/pages/pdp
 ---
 
-This page covers the Shopify admin configuration the PDP expects. For how the page renders and how variant selection works, see [Anatomy → PDP](/docs/anatomy/pages/pdp).
+Configure a Shopify product so shoppers can find it, choose a variant, and add it to the cart. For storefront behavior, see [Anatomy → PDP](/docs/anatomy/pages/pdp).
 
-## How it works
+## Publish the product
 
-**A product needs a title, description, one variant, and a featured image.** `descriptionHtml` renders as the body copy; even single-option products get a default variant. The PDP shell fetches product options and Shopify's encoded variant-availability data rather than the full variant list, resolving the selected variant per request from its options — the AI agent and markdown routes fetch the full variant list (up to 250) via `getProductWithVariants` instead.
+Add a title, description, featured image, and at least one variant. Assign the product to a collection if it should appear on a collection page, then publish it to the **Headless** sales channel.
 
-**Swatches, SEO, and taxonomy fall back gracefully when unset.** A product option with swatch data (a hex color or swatch image, read from `optionValues.swatch`) renders as color swatches; without it, the option renders as a standard text picker. `seo.title`/`seo.description` populate the page title and Open Graph tags when set, falling back to the product title and description otherwise. Product Taxonomy category (up to 3 levels) feeds structured data when configured under a product's **Category** field.
+Open its storefront URL and confirm that the product loads and an available variant can be added to the cart.
 
-**Related and complementary products come from two different Shopify systems.** Related products use Shopify's automatic recommendation API (purchase history and similarity) — nothing to configure. Complementary products ("Pairs Well With") are **configured by hand** per product in the free [Shopify Search & Discovery](https://apps.shopify.com/search-and-discovery) app's **Product recommendations** settings; a product with none configured renders nothing.
+## Add option swatches
 
-**Bundles publish to a separate sales channel from the storefront.** The Shopify Bundles app publishes to **Online Store** only, but the template reads from the **Headless** channel — a bundle that 404s on the storefront while showing fine in admin is almost always missing from Headless.
+In Shopify Admin, edit the product and open an option such as **Color**. Assign a color or image swatch to each value. Options without swatch data use a text picker.
 
-## Out of the box
+## Configure recommendations
 
-- **Basic fields** — title, `descriptionHtml`, variants, featured image, and up to 10 media items (images or videos). Products must belong to at least one collection to appear on collection listing pages.
-- **Color swatches** — configure in Shopify admin: edit a product → open an option like "Color" → assign a swatch color or image to each value.
-- **SEO fields** — `seo.title` and `seo.description`, editable per product.
-- **Related products** — Shopify's automatic recommendation API. On by default; disable with `pdp.relatedProducts.isEnabled: false` in `lib/config.ts`.
-- **Complementary products** — hand-curated in the Search & Discovery app. On by default; disable with `pdp.complementaryProducts.isEnabled: false`.
-- **Bundles** — fixed bundles (e.g. from the free **Shopify Bundles** app) render contents and add to cart normally via `components` (a bundle's items and quantities) and `groupedBy` (up to 10 bundles containing the current product). Disable with `pdp.bundles.isEnabled: false`.
+Shopify provides related products automatically. To show complementary products as “Pairs Well With,” install [Shopify Search & Discovery](https://apps.shopify.com/search-and-discovery) and assign recommendations under **Product recommendations**. The section stays hidden when no complementary products are assigned.
 
-## Common customizations
+## Publish a fixed bundle
 
-- **Customized bundles** — a bundle whose parent sets `requiresComponents` but has no fixed `components` stays disabled in the buy buttons until you build a component picker that sends shopper selections through `CartLineInput.parent`.
-- **Bundles not appearing** — publish the bundle to the **Headless** channel under the product's **Publishing** section. See [Troubleshooting → Bundles not appearing](/docs/reference/troubleshooting).
+Create the bundle with [Shopify Bundles](https://apps.shopify.com/shopify-bundles), then publish it to **Headless**. A bundle available only on **Online Store** does not appear in Vercel Shop.
+
+If a published bundle still does not appear, see [Troubleshooting → Bundles not appearing](/docs/reference/troubleshooting).
+
+## Set search and sharing details
+
+Set the product's search engine title and description in Shopify Admin when the defaults are not suitable. Otherwise, the storefront uses the product title and description. Assign a product category to improve structured product data.

--- a/apps/docs/content/docs/why-use-this.mdx
+++ b/apps/docs/content/docs/why-use-this.mdx
@@ -4,14 +4,10 @@ description: Why we built Vercel Shop — an agent-first Shopify starter for Nex
 type: overview
 ---
 
-A storefront can be a piece of software a business knows and shapes for itself. That has always been the appeal of composable commerce. The commerce platform runs the business underneath, while the storefront is free to reflect the particular way that business wants to meet its customers. In 2026, that freedom matters more than ever.
+Vercel Shop gives your team an owned storefront without making you rebuild the foundation of headless commerce.
 
-Headless commerce made this possible, though it placed the whole surrounding system in your hands. The complexity particular to your store arrived together with the complexity required to keep an independent storefront running. Both became part of the work. Choosing composability meant accepting that you would spend time on decisions that expressed your business and on details that merely made those decisions possible.
+Shopify runs the commerce platform. Next.js and Vercel provide the storefront framework and delivery platform. The template connects them with supported integrations and established patterns, so your team can focus on the experience that distinguishes your business.
 
-Agentic development has changed that balance. A well-prepared agent can understand a codebase and carry its conventions into new work. The surrounding complexity still exists, but much more of it can be handled without claiming the team's full attention. People can spend more of their time deciding what the store should become.
+The code lives in your repository. You can inspect it, change it, and give coding agents clear project conventions for future work. That makes agent-assisted development practical without giving up control of the storefront.
 
-Vercel Shop is the foundation we believe makes that practical. It is built by Vercel in direct collaboration with Shopify, joining Shopify's commerce platform with Next.js on Vercel. Each side is responsible for the part it knows best, and the connection between them is maintained as a shared concern. The result is a storefront built from the supported work of both companies.
-
-The code lives in your repository. Your team can understand it, teach an agent how to work within it, and change it whenever the business calls for something new. Over time, the storefront can become more particular to the people who run it. That is the point of owning it.
-
-Start with Vercel Shop, then take responsibility for where it goes. Make the decisions that only your team can make. Build a storefront that could only belong to your business.
+Start with a working store, then invest in the choices only your team can make.


### PR DESCRIPTION
## Summary

- refocus the storefront documentation on reader outcomes, defaults, required actions, and real limitations
- replace standard closing verification sections with concise "What’s next" guidance about common ways teams extend each feature
- remove nonessential implementation inventories and internal request choreography from anatomy, setup, Shopify, and reference guides
- add docs authoring guidance so future pages apply the same essentiality and next-step conventions

## Verification

- `pnpm build` in `apps/docs` — passed; 124 static pages generated
- `pnpm exec oxlint .` in `apps/docs` — passed with one existing `next/no-img-element` warning
- `pnpm exec oxfmt --check -- <modified files>` in `apps/docs` — passed
- `git diff --check` — passed

## Note

The full `pnpm lint` remains blocked by unrelated pre-existing formatting in `app/[lang]/(home)/components/one-two-section.tsx`.
