### PR TITLE
Limit Markdown negotiation to document requests

### DIFF
--- a/apps/template/proxy.ts
+++ b/apps/template/proxy.ts
@@ -68,7 +68,8 @@ export async function proxy(request: NextRequest): Promise<Response> {
   });
   if (shopifyRoute) return shopifyRoute;
 
-  const markdownPath = getMarkdownPath(pathname);
+  const isDocumentRequest = request.method === "GET" || request.method === "HEAD";
+  const markdownPath = isDocumentRequest ? getMarkdownPath(pathname) : null;
   if (markdownPath) {
     const representation = negotiateRepresentation(request.headers.get("Accept"));
 


### PR DESCRIPTION
## Summary

- restrict HTML/Markdown content negotiation to `GET` and `HEAD` requests
- allow Server Actions and other mutations on storefront document paths to pass through to Next.js
- preserve the existing `406 Not Acceptable` behavior for unsupported document representations

## Regression

A Server Action `POST` to a product page uses an `Accept` value that is not HTML or Markdown. The proxy previously treated that mutation as a representation request and returned `406` before Next.js could execute the action. This surfaced in the enterprise demo as virtual try-on failing.

## Verification

- `pnpm exec oxfmt --check proxy.ts` — passed
- `pnpm exec oxlint proxy.ts` — passed with 0 warnings and 0 errors
- `pnpm build` in `apps/template` — passed; TypeScript passed and 33 static pages generated
- deployed reproduction on the enterprise integration preview after applying the same guard:
  - Server Action-style `POST` with `Accept: text/x-component` — `200`
  - document `GET` with unsupported `Accept: application/json` — `406`
