### PR TITLE
Remove storefront io boundary

### DIFF
--- a/apps/template/lib/shopify/storefront.ts
+++ b/apps/template/lib/shopify/storefront.ts
@@ -6,7 +6,6 @@ import {
   type StorefrontClient,
   type StorefrontQueryString,
 } from "@shopify/hydrogen";
-import { io } from "next/cache";
 
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 
@@ -91,8 +90,6 @@ export const storefront = {
       typeof variables?.country === "string" ? variables.country : getCountryCode(defaultLocale);
     const language =
       typeof variables?.language === "string" ? variables.language : getLanguageCode(defaultLocale);
-
-    await io();
 
     // Brand runtime strings so Hydrogen does not infer `never` variables.
     const doc = query as StorefrontQueryString<T, Record<string, unknown>>;


### PR DESCRIPTION
## Summary

- remove the explicit `io()` boundary from the shared Storefront API request wrapper
- rely on the awaited GraphQL request as the suspension point
- remove the now-unused `next/cache` import

## Testing

- `pnpm exec oxlint lib/shopify/storefront.ts`
- `pnpm exec oxfmt --check lib/shopify/storefront.ts`
- verified storefront rendering without the explicit boundary