### PR TITLE
Fix product card variant links

### DIFF
--- a/apps/docs/content/docs/anatomy/product-card.mdx
+++ b/apps/docs/content/docs/anatomy/product-card.mdx
@@ -10,6 +10,8 @@ Product cards give shoppers a consistent way to recognize and compare products. 
 
 Each card links to the product and shows its image, title, and price. Products with a price range show both bounds. A single discounted price can show the original price and a discount badge; ranges do not show a discount because discounts may differ by variant.
 
+When a shopper applies one color filter, collection and search cards use the image assigned to that color's first selectable variant and link to its selected options. Assign an image to each color variant in Shopify so filtered cards can show the matching merchandise. Cards fall back to the product image when the matching variant has no image.
+
 Unavailable products keep their image visible under an out-of-stock label. Products without an image show a placeholder instead of a broken image. Loading, empty, and loaded states reserve the same square space so grids remain stable.
 
 The featured style adds a Featured badge and stronger image treatment. Standard grids use the default style.

--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -12,6 +12,7 @@ import {
   ProductCardTitle,
   ProductCard as ProductCardRoot,
 } from "@/components/product-card/components";
+import { buildProductUrl } from "@/lib/product";
 import type { PageInfo, ProductCard } from "@/lib/types";
 
 interface InfiniteProductGridProps<TParams> {
@@ -118,9 +119,7 @@ function ClientProductCard({
   locale: string;
   outOfStockText: string;
 }) {
-  const href = product.defaultVariantNumericId
-    ? `/products/${product.handle}?variant=${product.defaultVariantNumericId}`
-    : `/products/${product.handle}`;
+  const href = buildProductUrl(product.handle, product.defaultVariantSelectedOptions ?? []);
 
   return (
     <Link href={href}>

--- a/apps/template/components/collections/results-grid.tsx
+++ b/apps/template/components/collections/results-grid.tsx
@@ -27,7 +27,7 @@ async function Render({
   locale: Locale;
   collectionResultsDataPromise: Promise<CollectionResultsData>;
 }) {
-  const [{ result, filters, collection, sort }, t, tProduct] = await Promise.all([
+  const [{ activeFilters, result, filters, collection, sort }, t, tProduct] = await Promise.all([
     collectionResultsDataPromise,
     getTranslations("search"),
     getTranslations("product"),
@@ -61,7 +61,7 @@ async function Render({
         locale={locale}
         outOfStockText={tProduct("outOfStock")}
         loadMore={loadMoreSearchProducts}
-        loadMoreParams={{ sortKey: sort, filters, locale }}
+        loadMoreParams={{ activeFilters, sortKey: sort, filters, locale }}
       >
         {cards}
       </InfiniteProductGrid>
@@ -75,7 +75,7 @@ async function Render({
       locale={locale}
       outOfStockText={tProduct("outOfStock")}
       loadMore={loadMoreCollectionProducts}
-      loadMoreParams={{ collection, sortKey: sort, filters, locale }}
+      loadMoreParams={{ activeFilters, collection, sortKey: sort, filters, locale }}
     >
       {cards}
     </InfiniteProductGrid>

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 
 import type { Locale } from "@/lib/i18n";
+import { buildProductUrl } from "@/lib/product";
 import type { ProductCard as ProductCardType } from "@/lib/types";
 
 import {
@@ -32,9 +33,10 @@ export async function ProductCard({
 }: ProductCardProps) {
   const isFeatured = variant === "featured";
   const t = isFeatured ? await getTranslations("product") : null;
+  const href = buildProductUrl(product.handle, product.defaultVariantSelectedOptions ?? []);
 
   return (
-    <Link href={`/products/${product.handle}`} className={className}>
+    <Link href={href} className={className}>
       <ProductCardRoot variant={variant}>
         {isFeatured && t && (
           <ProductCardBadge>

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -47,6 +47,7 @@ export async function getSearchResultsData({
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
   const [results, facets] = await Promise.all([
     fetchSearchIndexProducts({
+      activeFilters,
       query,
       collection,
       sortKey: sort,
@@ -130,6 +131,7 @@ async function SearchResultsGridRender({
           outOfStockText={tProduct("outOfStock")}
           loadMore={loadMoreSearchProducts}
           loadMoreParams={{
+            activeFilters: data.activeFilters,
             query: data.query,
             collection: data.collection,
             sortKey: data.sort,

--- a/apps/template/lib/collections/action.ts
+++ b/apps/template/lib/collections/action.ts
@@ -5,6 +5,7 @@ import type { ProductFilter } from "@/lib/shopify/types/filters";
 import type { PageInfo, ProductCard } from "@/lib/types";
 
 export async function loadMoreCollectionProducts(params: {
+  activeFilters?: Record<string, string | string[] | undefined>;
   collection: string;
   cursor: string;
   sortKey?: string;
@@ -12,6 +13,7 @@ export async function loadMoreCollectionProducts(params: {
   locale: string;
 }): Promise<{ products: ProductCard[]; pageInfo: PageInfo }> {
   const result = await fetchCollectionProducts({
+    activeFilters: params.activeFilters,
     collection: params.collection,
     cursor: params.cursor,
     sortKey: params.sortKey,

--- a/apps/template/lib/collections/server.ts
+++ b/apps/template/lib/collections/server.ts
@@ -139,6 +139,7 @@ export async function getAllProductsResultsData({
   const shopifyFilters = buildProductFiltersFromParams(activeFilters);
   const [products, facets] = await Promise.all([
     fetchSearchIndexProducts({
+      activeFilters,
       sortKey: sort,
       limit: RESULTS_PER_PAGE,
       filters: shopifyFilters,

--- a/apps/template/lib/product.ts
+++ b/apps/template/lib/product.ts
@@ -31,6 +31,13 @@ export function toSelectedOptionList(selectedOptions: SelectedOptions): Selected
   return Object.entries(selectedOptions).map(([name, value]) => ({ name, value }));
 }
 
+export function buildProductUrl(handle: string, selectedOptions: SelectedOption[]): string {
+  const parts = selectedOptions.map(
+    ({ name, value }) => `${encodeURIComponent(name.toLowerCase())}=${encodeURIComponent(value)}`,
+  );
+  return parts.length > 0 ? `/products/${handle}?${parts.join("&")}` : `/products/${handle}`;
+}
+
 export function buildOptionUrl(
   handle: string,
   currentOptions: SelectedOptions,
@@ -38,10 +45,7 @@ export function buildOptionUrl(
   optionValue: string,
 ): string {
   const next = { ...currentOptions, [optionName]: optionValue };
-  const parts = Object.entries(next).map(
-    ([name, value]) => `${encodeURIComponent(name.toLowerCase())}=${encodeURIComponent(value)}`,
-  );
-  return parts.length > 0 ? `/products/${handle}?${parts.join("&")}` : `/products/${handle}`;
+  return buildProductUrl(handle, toSelectedOptionList(next));
 }
 
 function findColorOption(options: ProductOption[]): ProductOption | undefined {

--- a/apps/template/lib/search/action.ts
+++ b/apps/template/lib/search/action.ts
@@ -6,15 +6,17 @@ import type { PageInfo, ProductCard } from "@/lib/types";
 import { RESULTS_PER_PAGE } from "@/lib/utils";
 
 export async function loadMoreSearchProducts(params: {
-  query?: string;
+  activeFilters?: Record<string, string | string[] | undefined>;
   collection?: string;
   cursor: string;
+  query?: string;
   sortKey?: string;
   filters?: ProductFilter[];
   locale: string;
 }): Promise<{ products: ProductCard[]; pageInfo: PageInfo }> {
   // Storefront `search` cursor is anchored to the original `first`; using a different page size returns count=0.
   const result = await fetchSearchIndexProducts({
+    activeFilters: params.activeFilters,
     query: params.query,
     collection: params.collection,
     cursor: params.cursor,

--- a/apps/template/lib/shopify/fetch.ts
+++ b/apps/template/lib/shopify/fetch.ts
@@ -14,16 +14,18 @@ import { assertStorefrontOk, type CartMutationPayload, unwrapCartMutation } from
 import {
   CART_FRAGMENT,
   COLLECTION_FIELDS_FRAGMENT,
+  FILTERABLE_PRODUCT_CARD_FRAGMENT,
   PRODUCT_CARD_FRAGMENT,
   PRODUCT_WITH_VARIANTS_FRAGMENT,
 } from "./fragments";
 import { storefront } from "./storefront";
 import { type ShopifyCart, transformShopifyCart } from "./transforms/cart";
 import { type ShopifyCollection, transformShopifyCollections } from "./transforms/collection";
-import { transformShopifyFilters } from "./transforms/filters";
+import { getSelectedColorFilterLabel, transformShopifyFilters } from "./transforms/filters";
 import {
   type ShopifyProduct,
   type ShopifyProductCard,
+  transformFilteredShopifyProductCard,
   transformShopifyProductCard,
   transformShopifyProductDetails,
 } from "./transforms/product";
@@ -63,7 +65,7 @@ const COLLECTION_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolea
 };
 
 const PRODUCTS_SEARCH_QUERY = `#graphql
-  ${PRODUCT_CARD_FRAGMENT}
+  ${FILTERABLE_PRODUCT_CARD_FRAGMENT}
   query searchProducts($query: String!, $first: Int!, $after: String, $productFilters: [ProductFilter!], $sortKey: SearchSortKeys, $reverse: Boolean, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     search(
       query: $query
@@ -79,7 +81,7 @@ const PRODUCTS_SEARCH_QUERY = `#graphql
         cursor
         node {
           ... on Product {
-            ...ProductCardFields
+            ...FilterableProductCardFields
           }
         }
       }
@@ -89,12 +91,18 @@ const PRODUCTS_SEARCH_QUERY = `#graphql
         startCursor
         endCursor
       }
+      productFilters {
+        values {
+          label
+          input
+        }
+      }
     }
   }
 ` as const;
 
 const COLLECTION_PRODUCTS_QUERY = `#graphql
-  ${PRODUCT_CARD_FRAGMENT}
+  ${FILTERABLE_PRODUCT_CARD_FRAGMENT}
   query collectionProducts($handle: String!, $first: Int!, $after: String, $sortKey: ProductCollectionSortKeys, $reverse: Boolean, $filters: [ProductFilter!], $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     collection(handle: $handle) {
       products(first: $first, after: $after, sortKey: $sortKey, reverse: $reverse, filters: $filters) {
@@ -121,7 +129,7 @@ const COLLECTION_PRODUCTS_QUERY = `#graphql
         edges {
           cursor
           node {
-            ...ProductCardFields
+            ...FilterableProductCardFields
           }
         }
         pageInfo {
@@ -240,6 +248,7 @@ const CART_NOTE_UPDATE_MUTATION = `#graphql
 ` as const;
 
 export type SearchIndexProductsParams = {
+  activeFilters?: ActiveFilters;
   collection?: string;
   cursor?: string;
   filters?: ProductFilter[];
@@ -294,6 +303,7 @@ export async function fetchSearchIndexProducts(
   params: SearchIndexProductsParams,
 ): Promise<SearchIndexProductsResult> {
   const {
+    activeFilters = {},
     collection,
     cursor,
     filters = [],
@@ -318,6 +328,9 @@ export async function fetchSearchIndexProducts(
       totalCount: number;
       edges: Array<{ cursor: string; node: ShopifyProductCard | null }>;
       pageInfo: PageInfo;
+      productFilters: Array<{
+        values: Array<Pick<ShopifyFilter["values"][number], "input" | "label">>;
+      }>;
     };
   }>(PRODUCTS_SEARCH_QUERY, {
     variables: {
@@ -338,9 +351,17 @@ export async function fetchSearchIndexProducts(
     .map((edge) => edge.node)
     .filter((node): node is ShopifyProductCard => node !== null);
 
+  const selectedColor = getSelectedColorFilterLabel(
+    activeFilters,
+    filters,
+    data.search.productFilters,
+  );
+
   return {
     pageInfo: data.search.pageInfo,
-    products: shopifyProducts.map(transformShopifyProductCard),
+    products: shopifyProducts.map((product) =>
+      transformFilteredShopifyProductCard(product, selectedColor),
+    ),
     total: data.search.totalCount,
   };
 }
@@ -394,7 +415,14 @@ export async function fetchCollectionProducts(
   }
 
   const shopifyProducts = data.collection.products.edges.map((edge) => edge.node);
-  const products = shopifyProducts.map(transformShopifyProductCard);
+  const selectedColor = getSelectedColorFilterLabel(
+    activeFilters,
+    filters,
+    data.collection.products.filters,
+  );
+  const products = shopifyProducts.map((product) =>
+    transformFilteredShopifyProductCard(product, selectedColor),
+  );
   const transformed = transformShopifyFilters(data.collection.products.filters, {
     activeFilters,
     currencyCode: products[0]?.price.currencyCode,

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -442,11 +442,41 @@ export const PRODUCT_CARD_FRAGMENT = `#graphql
       id
       availableForSale
       image {
-        url
+        ...ImageFields
       }
       selectedOptions {
         name
         value
+      }
+    }
+  }
+` as const;
+
+export const FILTERABLE_PRODUCT_CARD_FRAGMENT = `#graphql
+  ${PRODUCT_CARD_FRAGMENT}
+  fragment FilterableProductCardFields on Product {
+    ...ProductCardFields
+    options {
+      name
+      optionValues {
+        name
+        swatch {
+          color
+          image {
+            previewImage {
+              url
+            }
+          }
+        }
+        firstSelectableVariant {
+          image {
+            ...ImageFields
+          }
+          selectedOptions {
+            name
+            value
+          }
+        }
       }
     }
   }

--- a/apps/template/lib/shopify/transforms/filters.ts
+++ b/apps/template/lib/shopify/transforms/filters.ts
@@ -33,6 +33,48 @@ export interface ActiveFilterBadge {
   filterLabel: string;
 }
 
+function isColorKey(value: string): boolean {
+  return value.toLowerCase().includes("colo");
+}
+
+export function getSelectedColorFilterLabel(
+  activeFilters: Record<string, string | string[] | undefined>,
+  filters: ProductFilter[],
+  shopifyFilters: Array<{
+    values: Array<Pick<ShopifyFilterValue, "input" | "label">>;
+  }>,
+): string | undefined {
+  const selectedValues = new Set(
+    filters.flatMap((filter) => {
+      if (filter.variantOption && isColorKey(filter.variantOption.name)) {
+        return [filter.variantOption.value];
+      }
+      if (filter.taxonomyMetafield && isColorKey(filter.taxonomyMetafield.key)) {
+        return [filter.taxonomyMetafield.value];
+      }
+      return [];
+    }),
+  );
+
+  if (selectedValues.size !== 1) return undefined;
+  const selectedValue = selectedValues.values().next().value;
+  if (!selectedValue) return undefined;
+
+  const hasExactlyOneSelectedColor = Object.entries(activeFilters).some(([key, value]) => {
+    if (!key.startsWith("filter.") || !isColorKey(key)) return false;
+    return Array.isArray(value) ? value.length === 1 : Boolean(value);
+  });
+  if (!hasExactlyOneSelectedColor) return undefined;
+
+  for (const filter of shopifyFilters) {
+    for (const value of filter.values) {
+      if (parseShopifyFilterValue(value.input) === selectedValue) return value.label;
+    }
+  }
+
+  return selectedValue;
+}
+
 export function getParamKeyFromShopifyId(filterId: string): string {
   return filterId.toLowerCase();
 }

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -1,4 +1,3 @@
-import { getNumericShopifyId } from "@/lib/shopify/utils";
 import { flattenEdges, type ShopifyEdges } from "@/lib/shopify/utils";
 import type {
   Category,
@@ -291,14 +290,12 @@ function transformOption(option: ShopifyOption): ProductOption {
   return {
     id: option.id,
     name: option.name,
-    values: option.values.map(
-      (value): OptionValue => ({
-        id: value,
-        image: imageLookup.get(value),
-        name: value,
-        swatch: swatchLookup.get(value),
-      }),
-    ),
+    values: option.values.map((value): OptionValue => ({
+      id: value,
+      image: imageLookup.get(value),
+      name: value,
+      swatch: swatchLookup.get(value),
+    })),
   };
 }
 
@@ -315,10 +312,6 @@ export function transformShopifyProductCard(product: ShopifyProductCard): Produc
     vendor: product.vendor || undefined,
     availableForSale: product.availableForSale,
     isGiftCard: product.isGiftCard,
-    defaultVariantId: defaultVariant?.id,
-    defaultVariantNumericId: defaultVariant
-      ? (getNumericShopifyId(defaultVariant.id) ?? undefined)
-      : undefined,
     defaultVariantSelectedOptions: defaultVariant?.selectedOptions ?? [],
   };
 }
@@ -357,10 +350,6 @@ export function transformShopifyProductDetails(product: ShopifyProduct): Product
     hasUniformPricing: hasUniformPriceRange(product),
     variantsCount: product.variantsCount.count,
     defaultVariant,
-    defaultVariantId: defaultVariant?.id,
-    defaultVariantNumericId: defaultVariant
-      ? (getNumericShopifyId(defaultVariant.id) ?? undefined)
-      : undefined,
     defaultVariantSelectedOptions: defaultVariant?.selectedOptions ?? [],
     description: product.description,
     descriptionHtml: product.descriptionHtml,

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -61,7 +61,10 @@ interface ShopifyOptionValue {
   id: string;
   name: string;
   swatch: ShopifyOptionValueSwatch | null;
-  firstSelectableVariant?: { image: ShopifyImage | null } | null;
+  firstSelectableVariant?: {
+    image: ShopifyImage | null;
+    selectedOptions?: Array<{ name: string; value: string }>;
+  } | null;
 }
 
 interface ShopifyOption {
@@ -156,9 +159,10 @@ export interface ShopifyProductCard {
   selectedOrFirstAvailableVariant?: {
     id: string;
     availableForSale: boolean;
-    image?: { url: string } | null;
+    image?: ShopifyImage | null;
     selectedOptions: Array<{ name: string; value: string }>;
   } | null;
+  options?: Array<Pick<ShopifyOption, "name" | "optionValues">>;
 }
 
 function transformImage(image: ShopifyImage | null): Image | null {
@@ -299,21 +303,45 @@ function transformOption(option: ShopifyOption): ProductOption {
   };
 }
 
-export function transformShopifyProductCard(product: ShopifyProductCard): ProductCard {
+function transformProductCard(
+  product: ShopifyProductCard,
+  selectedOptionValue?: string,
+): ProductCard {
   const defaultVariant = product.selectedOrFirstAvailableVariant;
+  const colorOption = product.options?.find(
+    (option) =>
+      option.name.toLowerCase().includes("colo") ||
+      option.optionValues?.some((value) => value.swatch?.color || value.swatch?.image),
+  );
+  const matchedVariant = colorOption?.optionValues?.find(
+    (value) => value.name.toLowerCase() === selectedOptionValue?.toLowerCase(),
+  )?.firstSelectableVariant;
+  const cardVariant = matchedVariant ?? defaultVariant;
+
   return {
     id: product.id,
     handle: product.handle,
     title: product.title,
-    featuredImage: transformImage(product.featuredImage),
+    featuredImage: transformImage(matchedVariant?.image ?? product.featuredImage),
     price: product.priceRange.minVariantPrice,
     maxPrice: product.priceRange.maxVariantPrice,
     compareAtPrice: product.compareAtPriceRange?.minVariantPrice ?? undefined,
     vendor: product.vendor || undefined,
     availableForSale: product.availableForSale,
     isGiftCard: product.isGiftCard,
-    defaultVariantSelectedOptions: defaultVariant?.selectedOptions ?? [],
+    defaultVariantSelectedOptions: cardVariant?.selectedOptions ?? [],
   };
+}
+
+export function transformFilteredShopifyProductCard(
+  product: ShopifyProductCard,
+  selectedOptionValue?: string,
+): ProductCard {
+  return transformProductCard(product, selectedOptionValue);
+}
+
+export function transformShopifyProductCard(product: ShopifyProductCard): ProductCard {
+  return transformProductCard(product);
 }
 
 function hasUniformPriceRange(product: ShopifyProduct): boolean {

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -41,8 +41,6 @@ export interface SEO {
 export interface ProductCard {
   availableForSale: boolean;
   compareAtPrice?: Money;
-  defaultVariantId?: string;
-  defaultVariantNumericId?: string;
   defaultVariantSelectedOptions?: SelectedOption[];
   featuredImage: Image | null;
   handle: string;


### PR DESCRIPTION
## Summary

- build product URLs from selected option parameters that the PDP already understands
- use the same variant-aware URL for server-rendered and infinite-scroll product cards
- show the image assigned to the first selectable variant when one color filter is active
- preserve that filtered color selection across initial results and infinite-scroll pages
- fall back to the product image when the matching variant has no assigned image
- remove the unused numeric variant link fields and the ignored `?variant=` card URL
- document the variant-image requirement for filtered product cards

## Testing

- `pnpm --filter template codegen`
- `pnpm --filter template exec tsc --noEmit --pretty false`
- `pnpm --filter template exec oxlint components/collections/results-grid.tsx components/search/results.tsx lib/collections/action.ts lib/collections/server.ts lib/search/action.ts lib/shopify/fetch.ts lib/shopify/fragments.ts lib/shopify/transforms/filters.ts lib/shopify/transforms/product.ts`
- `pnpm --filter template exec oxfmt --check components/collections/results-grid.tsx components/search/results.tsx lib/collections/action.ts lib/collections/server.ts lib/search/action.ts lib/shopify/fetch.ts lib/shopify/fragments.ts lib/shopify/transforms/filters.ts lib/shopify/transforms/product.ts`
- `pnpm --filter docs exec oxfmt --check content/docs/anatomy/product-card.mdx`
- `git diff --check`

The package-wide `pnpm --filter template lint` remains blocked by a pre-existing formatting issue in `components/product-detail/bundle-components.tsx`, which this PR does not modify.