### PR TITLE
Experiment with selective PDP caching

### DIFF
--- a/apps/template/app/[cacheable]/products/[handle]/page.tsx
+++ b/apps/template/app/[cacheable]/products/[handle]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { connection } from "next/server";
 import { Suspense } from "react";
 
 import { ProductViewedTracker } from "@/components/analytics/trackers";
@@ -20,18 +21,22 @@ import { buildAlternates, buildOpenGraph } from "@/lib/seo";
 import {
   getCatalogProducts,
   getProduct,
+  getProductUncached,
   getProductVariant,
+  getProductVariantUncached,
 } from "@/lib/shopify/operations/products";
 import type { ProductVariant } from "@/lib/types";
 
 const PLACEHOLDER_HANDLE = "__placeholder__";
 
 async function buildProductMetadata(
+  cacheable: boolean,
   handle: string,
   locale: string,
   canonicalPath: string,
 ): Promise<Metadata> {
-  const product = await getProduct({ handle, locale });
+  const getProductForRequest = cacheable ? getProduct : getProductUncached;
+  const product = await getProductForRequest({ handle, locale });
   if (!product) notFound();
   const images = product.featuredImage
     ? [
@@ -69,20 +74,22 @@ export async function generateStaticParams() {
   try {
     const { products } = await getCatalogProducts({ limit: 1 });
     const first = products[0];
-    return [{ handle: first ? first.handle : PLACEHOLDER_HANDLE }];
+    return [{ cacheable: "1", handle: first ? first.handle : PLACEHOLDER_HANDLE }];
   } catch {
-    return [{ handle: PLACEHOLDER_HANDLE }];
+    return [{ cacheable: "1", handle: PLACEHOLDER_HANDLE }];
   }
 }
 
 export async function generateMetadata({
   params,
-}: PageProps<"/products/[handle]">): Promise<Metadata> {
-  const [{ handle }, locale] = await Promise.all([params, getLocale()]);
+}: PageProps<"/[cacheable]/products/[handle]">): Promise<Metadata> {
+  await connection();
+  const [{ cacheable, handle }, locale] = await Promise.all([params, getLocale()]);
 
   if (handle === PLACEHOLDER_HANDLE) return {};
 
-  return buildProductMetadata(handle, locale, `/products/${handle}`);
+  const isCacheable = cacheable === "1";
+  return buildProductMetadata(isCacheable, handle, locale, `/products/${handle}`);
 }
 
 export const instant = false;
@@ -90,11 +97,15 @@ export const instant = false;
 export default async function ProductPage({
   params,
   searchParams,
-}: PageProps<"/products/[handle]">) {
-  const [{ handle }, locale] = await Promise.all([params, getLocale()]);
+}: PageProps<"/[cacheable]/products/[handle]">) {
+  await connection();
+  const [{ cacheable, handle }, locale] = await Promise.all([params, getLocale()]);
   if (handle === PLACEHOLDER_HANDLE) notFound();
 
-  const product = await getProduct({ handle, locale });
+  const isCacheable = cacheable === "1";
+  const getProductForRequest = isCacheable ? getProduct : getProductUncached;
+  const getProductVariantForRequest = isCacheable ? getProductVariant : getProductVariantUncached;
+  const product = await getProductForRequest({ handle, locale });
   if (!product) notFound();
 
   // Keep selection separate from the variant query so the static shell stays coherent and the picker never waits on Shopify.
@@ -111,7 +122,7 @@ export default async function ProductPage({
       ) {
         return product.defaultVariant;
       }
-      return getProductVariant({
+      return getProductVariantForRequest({
         handle,
         locale,
         selectedOptions: toSelectedOptionList({
@@ -137,7 +148,12 @@ export default async function ProductPage({
               locale={locale}
             />
             {shopConfig.pdp.relatedProducts.isEnabled ? (
-              <RelatedProductsSection handle={handle} limit={4} locale={locale} />
+              <RelatedProductsSection
+                cacheable={isCacheable}
+                handle={handle}
+                limit={4}
+                locale={locale}
+              />
             ) : null}
           </Sections>
         </Container>

--- a/apps/template/app/[cacheable]/products/[handle]/page.tsx
+++ b/apps/template/app/[cacheable]/products/[handle]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { connection } from "next/server";
 import { Suspense } from "react";
 
 import { ProductViewedTracker } from "@/components/analytics/trackers";
@@ -9,6 +8,7 @@ import { RelatedProductsSection } from "@/components/product/related-products-se
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
+import { CACHEABLE_PRODUCT_HANDLES } from "@/lib/cacheable-product-handles";
 import { shopConfig } from "@/lib/config";
 import { getLocale } from "@/lib/params";
 import {
@@ -19,7 +19,6 @@ import {
 } from "@/lib/product";
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
 import {
-  getCatalogProducts,
   getProduct,
   getProductUncached,
   getProductVariant,
@@ -35,8 +34,9 @@ async function buildProductMetadata(
   locale: string,
   canonicalPath: string,
 ): Promise<Metadata> {
-  const getProductForRequest = cacheable ? getProduct : getProductUncached;
-  const product = await getProductForRequest({ handle, locale });
+  const product = cacheable
+    ? await getProduct({ handle, locale })
+    : await getProductUncached({ handle, locale });
   if (!product) notFound();
   const images = product.featuredImage
     ? [
@@ -70,20 +70,13 @@ async function buildProductMetadata(
   };
 }
 
-export async function generateStaticParams() {
-  try {
-    const { products } = await getCatalogProducts({ limit: 1 });
-    const first = products[0];
-    return [{ cacheable: "1", handle: first ? first.handle : PLACEHOLDER_HANDLE }];
-  } catch {
-    return [{ cacheable: "1", handle: PLACEHOLDER_HANDLE }];
-  }
+export function generateStaticParams() {
+  return CACHEABLE_PRODUCT_HANDLES.map((handle) => ({ cacheable: "1", handle }));
 }
 
 export async function generateMetadata({
   params,
 }: PageProps<"/[cacheable]/products/[handle]">): Promise<Metadata> {
-  await connection();
   const [{ cacheable, handle }, locale] = await Promise.all([params, getLocale()]);
 
   if (handle === PLACEHOLDER_HANDLE) return {};
@@ -98,14 +91,13 @@ export default async function ProductPage({
   params,
   searchParams,
 }: PageProps<"/[cacheable]/products/[handle]">) {
-  await connection();
   const [{ cacheable, handle }, locale] = await Promise.all([params, getLocale()]);
   if (handle === PLACEHOLDER_HANDLE) notFound();
 
   const isCacheable = cacheable === "1";
-  const getProductForRequest = isCacheable ? getProduct : getProductUncached;
-  const getProductVariantForRequest = isCacheable ? getProductVariant : getProductVariantUncached;
-  const product = await getProductForRequest({ handle, locale });
+  const product = isCacheable
+    ? await getProduct({ handle, locale })
+    : await getProductUncached({ handle, locale });
   if (!product) notFound();
 
   // Keep selection separate from the variant query so the static shell stays coherent and the picker never waits on Shopify.
@@ -122,14 +114,17 @@ export default async function ProductPage({
       ) {
         return product.defaultVariant;
       }
-      return getProductVariantForRequest({
+      const variantParams = {
         handle,
         locale,
         selectedOptions: toSelectedOptionList({
           ...defaultSelectedOptions(product),
           ...parseSelectedOptions(product.options, resolvedSearchParams ?? {}),
         }),
-      });
+      };
+      return isCacheable
+        ? getProductVariant(variantParams)
+        : getProductVariantUncached(variantParams);
     },
   );
 

--- a/apps/template/components/product/related-products-section.tsx
+++ b/apps/template/components/product/related-products-section.tsx
@@ -41,10 +41,10 @@ async function Render({
   locale: Locale;
 }) {
   const resolvedHandle = await handle;
-  const getProducts = cacheable ? getRelatedProducts : getRelatedProductsUncached;
+  const params = { handle: resolvedHandle, locale };
   const [t, related] = await Promise.all([
     getTranslations("product"),
-    getProducts({ handle: resolvedHandle, locale }),
+    cacheable ? getRelatedProducts(params) : getRelatedProductsUncached(params),
   ]);
 
   if (related.length === 0) return null;

--- a/apps/template/components/product/related-products-section.tsx
+++ b/apps/template/components/product/related-products-section.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { ProductCard, ProductCardSkeleton } from "@/components/product-card/product-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Locale } from "@/lib/i18n";
-import { getRelatedProducts } from "@/lib/shopify/operations/products";
+import { getRelatedProducts, getRelatedProductsUncached } from "@/lib/shopify/operations/products";
 
 export function RelatedProductsSectionSkeleton({
   limit,
@@ -30,18 +30,21 @@ export function RelatedProductsSectionSkeleton({
 }
 
 async function Render({
+  cacheable = true,
   handle,
   limit,
   locale,
 }: {
+  cacheable?: boolean;
   handle: string | Promise<string>;
   limit: number;
   locale: Locale;
 }) {
   const resolvedHandle = await handle;
+  const getProducts = cacheable ? getRelatedProducts : getRelatedProductsUncached;
   const [t, related] = await Promise.all([
     getTranslations("product"),
-    getRelatedProducts({ handle: resolvedHandle, locale }),
+    getProducts({ handle: resolvedHandle, locale }),
   ]);
 
   if (related.length === 0) return null;
@@ -64,10 +67,12 @@ async function Render({
 }
 
 export async function RelatedProductsSection({
+  cacheable = true,
   handle,
   limit,
   locale,
 }: {
+  cacheable?: boolean;
   handle: string | Promise<string>;
   limit: number;
   locale: Locale;
@@ -77,7 +82,7 @@ export async function RelatedProductsSection({
     <Suspense
       fallback={<RelatedProductsSectionSkeleton limit={limit} title={t("recommendations")} />}
     >
-      <Render handle={handle} limit={limit} locale={locale} />
+      <Render cacheable={cacheable} handle={handle} limit={limit} locale={locale} />
     </Suspense>
   );
 }

--- a/apps/template/lib/cacheable-product-handles.ts
+++ b/apps/template/lib/cacheable-product-handles.ts
@@ -1,0 +1,10 @@
+export const CACHEABLE_PRODUCT_HANDLES = [
+  "arcgauge-jacket-mens-0811c3",
+  "briskrun-jacket-unisex-88b464",
+  "cadenceshift-sweatshirt-unisex-244263",
+  "climbbeam-hoodie-mens-fc66e1",
+  "framepoint-tank-unisex-237435",
+  "orbitproof-sweatshirt-youth-2226d1",
+  "vistamesh-tee-womens-684491",
+  "voltcurrent-tank-mens-d86de7",
+] as const;

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -94,16 +94,13 @@ const GET_PRODUCT_BY_HANDLE_WITH_BUNDLES_QUERY = `#graphql
   }
 ` as const;
 
-export async function getProduct({
+async function fetchProduct({
   handle,
   locale = defaultLocale,
 }: {
   handle: string;
   locale?: string;
-}): Promise<ProductDetails | undefined> {
-  "use cache";
-  cacheLife("max");
-  cacheTag("products", `product-${handle}`);
+}): Promise<{ product: ProductDetails; productId: string } | undefined> {
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 
@@ -122,9 +119,33 @@ export async function getProduct({
     return undefined;
   }
 
-  tagProducts([data.productByHandle]);
+  return {
+    product: transformShopifyProductDetails(data.productByHandle),
+    productId: data.productByHandle.id,
+  };
+}
 
-  return transformShopifyProductDetails(data.productByHandle);
+export async function getProduct(params: {
+  handle: string;
+  locale?: string;
+}): Promise<ProductDetails | undefined> {
+  "use cache";
+  cacheLife("max");
+  cacheTag("products", `product-${params.handle}`);
+
+  const result = await fetchProduct(params);
+  if (!result) return undefined;
+
+  tagProducts([{ id: result.productId }]);
+  return result.product;
+}
+
+export async function getProductUncached(params: {
+  handle: string;
+  locale?: string;
+}): Promise<ProductDetails | undefined> {
+  const result = await fetchProduct(params);
+  return result?.product;
 }
 
 const GET_PRODUCT_VARIANT_QUERY = `#graphql
@@ -151,19 +172,18 @@ const GET_PRODUCT_VARIANT_WITH_BUNDLES_QUERY = `#graphql
   }
 ` as const;
 
-// Empty selections intentionally resolve Shopify's first available variant.
-export async function getProductVariant({
-  handle,
-  locale = defaultLocale,
-  selectedOptions,
-}: {
+interface ProductVariantParams {
   handle: string;
   locale?: string;
   selectedOptions: SelectedOption[];
-}): Promise<ProductVariant | undefined> {
-  "use cache";
-  cacheLife("max");
-  cacheTag("products", `product-${handle}`);
+}
+
+// Empty selections intentionally resolve Shopify's first available variant.
+async function fetchProductVariant({
+  handle,
+  locale = defaultLocale,
+  selectedOptions,
+}: ProductVariantParams): Promise<ProductVariant | undefined> {
   const country = getCountryCode(locale);
   const language = getLanguageCode(locale);
 
@@ -182,6 +202,21 @@ export async function getProductVariant({
 
   const variant = data.productByHandle?.selectedOrFirstAvailableVariant;
   return variant ? transformVariant(variant) : undefined;
+}
+
+export async function getProductVariant(
+  params: ProductVariantParams,
+): Promise<ProductVariant | undefined> {
+  "use cache";
+  cacheLife("max");
+  cacheTag("products", `product-${params.handle}`);
+  return fetchProductVariant(params);
+}
+
+export async function getProductVariantUncached(
+  params: ProductVariantParams,
+): Promise<ProductVariant | undefined> {
+  return fetchProductVariant(params);
 }
 
 export async function getProductWithVariants(params: {
@@ -629,6 +664,13 @@ export async function getRelatedProducts(params: {
   const products = await fetchRelatedProducts(params);
   tagProducts(products);
   return products;
+}
+
+export async function getRelatedProductsUncached(params: {
+  handle: string;
+  locale?: string;
+}): Promise<ProductCard[]> {
+  return fetchRelatedProducts(params);
 }
 
 const GET_PRODUCTS_BY_HANDLES_QUERY = `#graphql

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -1,4 +1,5 @@
 import { cacheLife, cacheTag } from "next/cache";
+import { connection } from "next/server";
 
 import { shopConfig } from "@/lib/config";
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
@@ -144,6 +145,7 @@ export async function getProductUncached(params: {
   handle: string;
   locale?: string;
 }): Promise<ProductDetails | undefined> {
+  await connection();
   const result = await fetchProduct(params);
   return result?.product;
 }
@@ -216,6 +218,7 @@ export async function getProductVariant(
 export async function getProductVariantUncached(
   params: ProductVariantParams,
 ): Promise<ProductVariant | undefined> {
+  await connection();
   return fetchProductVariant(params);
 }
 
@@ -670,6 +673,7 @@ export async function getRelatedProductsUncached(params: {
   handle: string;
   locale?: string;
 }): Promise<ProductCard[]> {
+  await connection();
   return fetchRelatedProducts(params);
 }
 

--- a/apps/template/proxy.ts
+++ b/apps/template/proxy.ts
@@ -107,6 +107,7 @@ export async function proxy(request: NextRequest): Promise<Response> {
     const response = NextResponse.rewrite(url, {
       request: { headers: requestContext.getForwardedRequestHeaders() },
     });
+    if (markdownPath) appendVaryAccept(response.headers);
     requestContext.applyResponseHeaders(response.headers);
     return response;
   }

--- a/apps/template/proxy.ts
+++ b/apps/template/proxy.ts
@@ -14,6 +14,7 @@ import {
   getCustomerRequestOrigin,
   getHydrogenCustomerSession,
 } from "@/lib/auth/server";
+import { CACHEABLE_PRODUCT_HANDLES } from "@/lib/cacheable-product-handles";
 import { cartHandlers, createCustomerCartHandlers } from "@/lib/cart/server";
 import { shopConfig } from "@/lib/config";
 import { appendVaryAccept, negotiateRepresentation } from "@/lib/markdown/negotiation";
@@ -28,16 +29,7 @@ const AUTH_PATHS = new Set<string>([
   CUSTOMER_ACCOUNT_REFRESH_PATH,
 ]);
 
-const CACHEABLE_PRODUCT_HANDLES = new Set([
-  "arcgauge-jacket-mens-0811c3",
-  "briskrun-jacket-unisex-88b464",
-  "cadenceshift-sweatshirt-unisex-244263",
-  "climbbeam-hoodie-mens-fc66e1",
-  "framepoint-tank-unisex-237435",
-  "orbitproof-sweatshirt-youth-2226d1",
-  "vistamesh-tee-womens-684491",
-  "voltcurrent-tank-mens-d86de7",
-]);
+const CACHEABLE_PRODUCT_HANDLE_SET = new Set<string>(CACHEABLE_PRODUCT_HANDLES);
 
 const NOOP_SESSION_MANAGER = {
   getSessionItem: () => undefined,
@@ -109,7 +101,7 @@ export async function proxy(request: NextRequest): Promise<Response> {
   const productMatch = pathname.match(/^\/products\/([^/]+)$/);
   if (productMatch) {
     const handle = decodeURIComponent(productMatch[1]);
-    const cacheable = CACHEABLE_PRODUCT_HANDLES.has(handle) ? "1" : "0";
+    const cacheable = CACHEABLE_PRODUCT_HANDLE_SET.has(handle) ? "1" : "0";
     const url = request.nextUrl.clone();
     url.pathname = `/${cacheable}${pathname}`;
     const response = NextResponse.rewrite(url, {

--- a/apps/template/proxy.ts
+++ b/apps/template/proxy.ts
@@ -28,6 +28,17 @@ const AUTH_PATHS = new Set<string>([
   CUSTOMER_ACCOUNT_REFRESH_PATH,
 ]);
 
+const CACHEABLE_PRODUCT_HANDLES = new Set([
+  "arcgauge-jacket-mens-0811c3",
+  "briskrun-jacket-unisex-88b464",
+  "cadenceshift-sweatshirt-unisex-244263",
+  "climbbeam-hoodie-mens-fc66e1",
+  "framepoint-tank-unisex-237435",
+  "orbitproof-sweatshirt-youth-2226d1",
+  "vistamesh-tee-womens-684491",
+  "voltcurrent-tank-mens-d86de7",
+]);
+
 const NOOP_SESSION_MANAGER = {
   getSessionItem: () => undefined,
   getSessionOrigin: () => "",
@@ -93,6 +104,19 @@ export async function proxy(request: NextRequest): Promise<Response> {
       requestContext.applyResponseHeaders(response.headers);
       return response;
     }
+  }
+
+  const productMatch = pathname.match(/^\/products\/([^/]+)$/);
+  if (productMatch) {
+    const handle = decodeURIComponent(productMatch[1]);
+    const cacheable = CACHEABLE_PRODUCT_HANDLES.has(handle) ? "1" : "0";
+    const url = request.nextUrl.clone();
+    url.pathname = `/${cacheable}${pathname}`;
+    const response = NextResponse.rewrite(url, {
+      request: { headers: requestContext.getForwardedRequestHeaders() },
+    });
+    requestContext.applyResponseHeaders(response.headers);
+    return response;
   }
 
   const response = NextResponse.next({


### PR DESCRIPTION
## Summary

- rewrite public PDP requests to an internal `[cacheable]` route segment
- share one list of eight homepage handles between proxy routing and static param generation
- prerender only those eight `/1/products/...` paths; never generate a build-time `/0` miss
- split PDP product, variant, metadata, and related-product reads into cached and uncached paths
- enter request time with `connection()` inside uncached operations only

## Verification

- `pnpm exec next typegen`
- focused `oxfmt` and `oxlint` on changed files: 0 warnings, 0 errors
- `pnpm build`: passed; route output lists eight `/1/products/...` paths and no `/0` paths
- `pnpm start`, then requested one hit and one miss twice with no server warnings:
  - hit: 200, 474ms then 24ms
  - miss: 200, 177ms then 157ms

## Note

The full `pnpm lint` still fails its repository-wide format check on the pre-existing `components/product-detail/bundle-components.tsx`; oxlint reports 20 warnings and 0 errors, and all files changed by this PR pass focused formatting and lint checks.
