### PR TITLE
Type Storefront and Customer Account documents with Hydrogen gql()

### DIFF
--- a/apps/docs/content/docs/reference/storefront-api.mdx
+++ b/apps/docs/content/docs/reference/storefront-api.mdx
@@ -8,16 +8,18 @@ prerequisites:
 
 The template uses [Shopify Hydrogen](https://www.npmjs.com/package/@shopify/hydrogen) for Storefront GraphQL API queries and mutations. Configure its domain, public token, and API version with the variables in [Environment Variables](/docs/reference/env-vars). Grant the scopes in [Storefront API Permissions](/docs/reference/storefront-api-permissions).
 
-The Customer Account API uses a separate endpoint, schema, client ID, and session secret. Storefront API codegen does not validate Customer Account API operations.
+The Customer Account API uses a separate endpoint, schema, client ID, and session secret. Its documents use `gql` from `@shopify/hydrogen/customer-account` and are typed by Hydrogen; Storefront API codegen does not validate them.
 
 ## Write and validate operations
 
-Define each operation as a static `#graphql` document and pass dynamic values as GraphQL variables. Do not interpolate runtime values or conditional fields into the document.
+Define each operation with Hydrogen's `gql()` tag and pass dynamic values as GraphQL variables. Do not interpolate runtime values or conditional fields into the document. Compose shared selections by passing fragment documents as the second argument.
 
-Include Shopify's `@inContext` directive when localized pricing or content depends on country and language:
+Result and variable types are inferred from the document, so the request wrapper returns typed data without a hand-written response type. Include Shopify's `@inContext` directive when localized pricing or content depends on country and language; the wrapper fills `$country` and `$language` from the `locale` option:
 
 ```ts
-const GET_PRODUCT_QUERY = `#graphql
+import { gql } from "@shopify/hydrogen";
+
+const GET_PRODUCT_QUERY = gql(`#graphql
   query getProduct(
     $handle: String!
     $country: CountryCode
@@ -28,14 +30,19 @@ const GET_PRODUCT_QUERY = `#graphql
       title
     }
   }
-` as const;
+`);
+
+const response = await storefront.request(GET_PRODUCT_QUERY, {
+  locale,
+  variables: { handle },
+});
 ```
 
 Validate current field names, arguments, and types with Shopify AI Toolkit. Then use the [`shopify-graphql-reference` skill](/docs/skills/shopify-graphql-reference) for template integration conventions. The skill is not a schema source.
 
 ## Codegen
 
-Use this [codegen](#codegen) contract while editing an operation. The template runs [`@shopify/api-codegen-preset`](https://www.npmjs.com/package/@shopify/api-codegen-preset):
+Type inference does not reject unknown fields, so the template keeps a schema check. It runs [`@shopify/api-codegen-preset`](https://www.npmjs.com/package/@shopify/api-codegen-preset) over every Storefront `#graphql` document:
 
 ```bash
 pnpm --filter template codegen

--- a/apps/docs/content/docs/skills/enable-shopify-markets.mdx
+++ b/apps/docs/content/docs/skills/enable-shopify-markets.mdx
@@ -306,13 +306,15 @@ Keep the mutation in a server action, validate both inputs, and update the cart'
 ```ts
 "use server";
 
+import { gql } from "@shopify/hydrogen";
+import type { CountryCode } from "@shopify/hydrogen/storefront-api-types";
 import { cookies } from "next/headers";
 
 import { getCartIdFromCookie } from "@/lib/cart/server";
 import { getCountryCode, isEnabledLocale, LOCALE_COOKIE_NAME } from "@/lib/i18n";
 import { storefront } from "@/lib/shopify/storefront";
 
-const BUYER_IDENTITY_MUTATION = /* GraphQL */ `
+const BUYER_IDENTITY_MUTATION = gql(`#graphql
   mutation cartBuyerIdentityUpdate($cartId: ID!, $buyerIdentity: CartBuyerIdentityInput!) {
     cartBuyerIdentityUpdate(cartId: $cartId, buyerIdentity: $buyerIdentity) {
       cart {
@@ -320,7 +322,7 @@ const BUYER_IDENTITY_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export async function switchLocaleAction(currentValue: string, nextValue: string) {
   if (!isEnabledLocale(currentValue) || !isEnabledLocale(nextValue)) {
@@ -332,7 +334,7 @@ export async function switchLocaleAction(currentValue: string, nextValue: string
     if (cartId) {
       await storefront.request(BUYER_IDENTITY_MUTATION, {
         variables: {
-          buyerIdentity: { countryCode: getCountryCode(nextValue) },
+          buyerIdentity: { countryCode: getCountryCode(nextValue) as CountryCode },
           cartId,
         },
       });

--- a/apps/docs/content/docs/skills/shopify-graphql-reference.mdx
+++ b/apps/docs/content/docs/skills/shopify-graphql-reference.mdx
@@ -36,10 +36,10 @@ Read `references/REFERENCE.md` before editing.
 
 1. Inspect the consuming route before choosing cache behavior. Classify the read as static-shell content, request-time shared content, or private/request-scoped data.
 2. Add the operation to the closest file in `lib/shopify/operations/`; create a file only for a genuinely new domain.
-3. Keep `#graphql` documents static, end them with `as const`, and use variables for dynamic values so codegen can validate them.
-4. Reuse the smallest existing fragment that fits. Extend a shared fragment only when multiple operations need the same selection.
-5. Pass locale context through existing country and language helpers when Shopify localizes the result.
-6. Keep raw Shopify response types under `lib/shopify/**`; transform them into provider-independent domain types before presentation.
+3. Wrap documents in Hydrogen's `gql()` with a leading `#graphql` comment, keep them static, and use variables for dynamic values so inference and codegen can both validate them.
+4. Reuse the smallest existing fragment that fits by passing it in the `gql(source, [FRAGMENT])` list. Extend a shared fragment only when multiple operations need the same selection.
+5. Pass `locale` to `storefront.request` when Shopify localizes the result; never add `country` or `language` to `variables`.
+6. Derive raw Shopify types from fragment documents with `ResultOf<typeof FRAGMENT>` under `lib/shopify/**`; transform them into provider-independent domain types before presentation.
 7. Preserve cache tags and the existing webhook invalidation hierarchy. Do not cache mutations.
 8. Never place carts in the Next.js data cache; cart reads are memoized per request via `getCart`, so cart mutations need no cache invalidation step.
 

--- a/apps/template/.graphqlrc.ts
+++ b/apps/template/.graphqlrc.ts
@@ -1,7 +1,13 @@
 import { ApiType, shopifyApiProject } from "@shopify/api-codegen-preset";
 
 const apiVersion = process.env.SHOPIFY_API_VERSION ?? "unstable";
-const documents = ["lib/shopify/**/*.ts", "!lib/shopify/types/generated/**"];
+// Customer Account documents are validated by Hydrogen's CAAPI introspection types, not this Storefront schema.
+const documents = [
+  "lib/shopify/**/*.ts",
+  "!lib/shopify/customer-account*.ts",
+  "!lib/shopify/operations/customer.ts",
+  "!lib/shopify/types/generated/**",
+];
 
 export default {
   schema: `https://shopify.dev/storefront-graphql-direct-proxy/${apiVersion}`,

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -180,7 +180,7 @@ pnpm format
 ## Data Flow
 
 ```text
-Request → Page → Operation → storefront.request → Shopify API → Transform → Domain type → Component
+Request → Page → Operation → storefront.request(gql doc) → Shopify API → Transform → Domain type → Component
 ```
 
 ## Storefront Skills (Optional Plugin)
@@ -218,6 +218,8 @@ The nav reserves a fixed `size-5` icon container to avoid layout shift. The `(au
 - Use the API-specific Shopify AI Toolkit skill first: Storefront GraphQL for catalog/cart/public storefront operations, Customer for authenticated customer data, and custom-data first for metafields or metaobjects.
 - Let Shopify AI Toolkit search current documentation and validate the complete operation. If it is unavailable, use official Shopify documentation and validation tooling; never guess.
 - Use `/vercel-shop:shopify-graphql-reference` afterward for template-specific operation placement, fragments, locale flow, cache role, transforms, invalidation, and route composition.
+- Write documents with `gql()` from `@shopify/hydrogen` (Storefront) or `@shopify/hydrogen/customer-account` (Customer Account), compose fragments through the second `gql()` argument, and derive raw response types with `ResultOf<typeof DOC>` instead of hand-writing interfaces. `storefront.request` injects `$country`/`$language` from its `locale` option.
+- Keep the `#graphql` comment at the top of every Storefront document; `pnpm codegen` still validates them against the live schema because type inference alone does not reject unknown fields.
 - Do not add repo-local schema snapshots or agent-specific folders to the template.
 
 ## Key Patterns

--- a/apps/template/lib/shopify/customer-account-fragments.ts
+++ b/apps/template/lib/shopify/customer-account-fragments.ts
@@ -1,0 +1,85 @@
+import { gql } from "@shopify/hydrogen/customer-account";
+
+export const ADDRESS_FRAGMENT = gql(`#graphql
+  fragment AddressFields on CustomerAddress {
+    address1
+    address2
+    city
+    company
+    firstName
+    formatted
+    id
+    lastName
+    phoneNumber
+    territoryCode
+    zip
+    zoneCode
+  }
+`);
+
+export const ORDER_SUMMARY_FRAGMENT = gql(`#graphql
+  fragment OrderSummaryFields on Order {
+    financialStatus
+    fulfillmentStatus
+    id
+    name
+    number
+    processedAt
+    totalPrice {
+      amount
+      currencyCode
+    }
+  }
+`);
+
+export const ORDER_FRAGMENT = gql(
+  `#graphql
+  fragment OrderFields on Order {
+    ...OrderSummaryFields
+    lineItems(first: 50) {
+      nodes {
+        image {
+          altText
+          height
+          url
+          width
+        }
+        quantity
+        title
+        totalPrice {
+          amount
+          currencyCode
+        }
+        variantTitle
+      }
+    }
+    shippingAddress {
+      ...AddressFields
+    }
+    statusPageUrl
+    subtotal {
+      amount
+      currencyCode
+    }
+    totalShipping {
+      amount
+      currencyCode
+    }
+    totalTax {
+      amount
+      currencyCode
+    }
+  }
+`,
+  [ADDRESS_FRAGMENT, ORDER_SUMMARY_FRAGMENT],
+);
+
+export const CUSTOMER_PROFILE_FRAGMENT = gql(`#graphql
+  fragment CustomerProfileFields on Customer {
+    emailAddress {
+      emailAddress
+    }
+    firstName
+    lastName
+  }
+`);

--- a/apps/template/lib/shopify/customer-account.ts
+++ b/apps/template/lib/shopify/customer-account.ts
@@ -1,10 +1,10 @@
 import "server-only";
 import { createShopifyRequestContext } from "@shopify/hydrogen";
 import {
+  type AnyCustomerAccountDocument,
   type CustomerAccountClient,
   type CustomerAccountDocument,
   createCustomerAccountClient,
-  gql,
 } from "@shopify/hydrogen/customer-account";
 
 import { shopConfig } from "@/lib/config";
@@ -13,17 +13,29 @@ import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
 import { resolveShopId } from "./discovery";
 import { logShopifyDebug, shopifyLogger } from "./logging";
 
-export async function customerAccountFetch<T>({
-  accessToken,
-  operation,
-  query,
-  variables,
-}: {
+export type CustomerAccountResultOf<Doc> =
+  Doc extends CustomerAccountDocument<infer Result, never, string> ? Result : never;
+
+// Hydrogen auto-injects `$language`; the app owns `country` in the request context.
+type CustomerAccountVariables<Doc extends AnyCustomerAccountDocument> = Omit<
+  Doc extends CustomerAccountDocument<unknown, infer Variables, string> ? Variables : never,
+  "language"
+>;
+
+type CustomerAccountFetchOptions<Doc extends AnyCustomerAccountDocument> = {
   accessToken: string;
+  document: Doc;
   operation: string;
-  query: string;
-  variables?: Record<string, unknown>;
-}): Promise<T> {
+} & (Record<string, never> extends CustomerAccountVariables<Doc>
+  ? { variables?: CustomerAccountVariables<Doc> }
+  : { variables: CustomerAccountVariables<Doc> });
+
+export async function customerAccountFetch<const Doc extends AnyCustomerAccountDocument>({
+  accessToken,
+  document,
+  operation,
+  variables,
+}: CustomerAccountFetchOptions<Doc>): Promise<CustomerAccountResultOf<Doc>> {
   const shopId = await resolveShopId();
   const client: CustomerAccountClient = createCustomerAccountClient({
     shopId,
@@ -37,10 +49,8 @@ export async function customerAccountFetch<T>({
   });
 
   const start = performance.now();
-  // Brand runtime strings so Hydrogen does not infer `never` variables.
-  const doc = gql(query) as CustomerAccountDocument<T, Record<string, unknown>>;
   try {
-    const { data, errors } = await client.graphql(doc, { accessToken, variables });
+    const { data, errors } = await client.graphql(document, { accessToken, variables } as never);
 
     if (errors) {
       if (!data) {
@@ -53,7 +63,7 @@ export async function customerAccountFetch<T>({
       });
     }
 
-    return data as T;
+    return data as CustomerAccountResultOf<Doc>;
   } finally {
     logShopifyDebug("Customer Account API request", {
       durationMs: Math.round(performance.now() - start),

--- a/apps/template/lib/shopify/errors.ts
+++ b/apps/template/lib/shopify/errors.ts
@@ -69,9 +69,12 @@ export class ShopifyUserError extends Error {
 }
 
 export function unwrapCartMutation<T>(
-  payload: CartMutationPayload<T>,
+  payload: CartMutationPayload<T> | null | undefined,
   operation: string,
 ): { cart: T; warnings: CartWarning[] } {
+  if (!payload) {
+    throw new Error(`Shopify ${operation}: mutation returned no payload`);
+  }
   if (payload.userErrors && payload.userErrors.length > 0) {
     throw new ShopifyUserError(payload.userErrors, operation);
   }

--- a/apps/template/lib/shopify/fetch.ts
+++ b/apps/template/lib/shopify/fetch.ts
@@ -1,4 +1,11 @@
-import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
+import { gql } from "@shopify/hydrogen";
+import type {
+  ProductCollectionSortKeys,
+  SearchSortKeys,
+} from "@shopify/hydrogen/storefront-api-types";
+import type { CountryCode } from "@shopify/hydrogen/storefront-api-types";
+
+import { defaultLocale, getCountryCode } from "@/lib/i18n";
 import type {
   Cart,
   CartWarning,
@@ -14,22 +21,21 @@ import { assertStorefrontOk, type CartMutationPayload, unwrapCartMutation } from
 import {
   CART_FRAGMENT,
   COLLECTION_FIELDS_FRAGMENT,
+  FILTER_FRAGMENT,
   FILTERABLE_PRODUCT_CARD_FRAGMENT,
   PRODUCT_CARD_FRAGMENT,
   PRODUCT_WITH_VARIANTS_FRAGMENT,
 } from "./fragments";
 import { storefront } from "./storefront";
 import { type ShopifyCart, transformShopifyCart } from "./transforms/cart";
-import { type ShopifyCollection, transformShopifyCollections } from "./transforms/collection";
+import { transformShopifyCollections } from "./transforms/collection";
 import { getSelectedColorFilterLabel, transformShopifyFilters } from "./transforms/filters";
 import {
-  type ShopifyProduct,
-  type ShopifyProductCard,
   transformFilteredShopifyProductCard,
   transformShopifyProductCard,
   transformShopifyProductDetails,
 } from "./transforms/product";
-import type { ProductFilter, ShopifyFilter } from "./types/filters";
+import type { ProductFilter } from "./types/filters";
 
 export type ActiveFilters = Record<string, string | string[] | undefined>;
 
@@ -38,7 +44,7 @@ export function escapeProductQuery(value: string): string {
 }
 
 // SearchSortKeys only supports PRICE and RELEVANCE — used by the AI agent text-search path.
-const SEARCH_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolean }> = {
+const SEARCH_SORT_KEY_MAP: Record<string, { sortKey: SearchSortKeys; reverse: boolean }> = {
   "best-matches": { sortKey: "RELEVANCE", reverse: false },
   "price-high-to-low": { sortKey: "PRICE", reverse: true },
   "price-low-to-high": { sortKey: "PRICE", reverse: false },
@@ -46,7 +52,10 @@ const SEARCH_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolean }>
   RELEVANCE: { sortKey: "RELEVANCE", reverse: false },
 };
 
-const COLLECTION_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolean }> = {
+const COLLECTION_SORT_KEY_MAP: Record<
+  string,
+  { sortKey: ProductCollectionSortKeys; reverse: boolean }
+> = {
   "best-matches": { sortKey: "COLLECTION_DEFAULT", reverse: false },
   "best-selling": { sortKey: "BEST_SELLING", reverse: false },
   "price-low-to-high": { sortKey: "PRICE", reverse: false },
@@ -64,8 +73,8 @@ const COLLECTION_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolea
   COLLECTION_DEFAULT: { sortKey: "COLLECTION_DEFAULT", reverse: false },
 };
 
-const PRODUCTS_SEARCH_QUERY = `#graphql
-  ${FILTERABLE_PRODUCT_CARD_FRAGMENT}
+const PRODUCTS_SEARCH_QUERY = gql(
+  `#graphql
   query searchProducts($query: String!, $first: Int!, $after: String, $productFilters: [ProductFilter!], $sortKey: SearchSortKeys, $reverse: Boolean, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     search(
       query: $query
@@ -80,6 +89,7 @@ const PRODUCTS_SEARCH_QUERY = `#graphql
       edges {
         cursor
         node {
+          __typename
           ... on Product {
             ...FilterableProductCardFields
           }
@@ -99,32 +109,17 @@ const PRODUCTS_SEARCH_QUERY = `#graphql
       }
     }
   }
-` as const;
+`,
+  [FILTERABLE_PRODUCT_CARD_FRAGMENT],
+);
 
-const COLLECTION_PRODUCTS_QUERY = `#graphql
-  ${FILTERABLE_PRODUCT_CARD_FRAGMENT}
+const COLLECTION_PRODUCTS_QUERY = gql(
+  `#graphql
   query collectionProducts($handle: String!, $first: Int!, $after: String, $sortKey: ProductCollectionSortKeys, $reverse: Boolean, $filters: [ProductFilter!], $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     collection(handle: $handle) {
       products(first: $first, after: $after, sortKey: $sortKey, reverse: $reverse, filters: $filters) {
         filters {
-          id
-          label
-          type
-          presentation
-          values {
-            id
-            label
-            count
-            input
-            swatch {
-              color
-              image {
-                previewImage {
-                  url
-                }
-              }
-            }
-          }
+          ...FilterFields
         }
         edges {
           cursor
@@ -141,37 +136,45 @@ const COLLECTION_PRODUCTS_QUERY = `#graphql
       }
     }
   }
-` as const;
+`,
+  [FILTER_FRAGMENT, FILTERABLE_PRODUCT_CARD_FRAGMENT],
+);
 
-const GET_PRODUCT_WITH_VARIANTS_QUERY = `#graphql
-  ${PRODUCT_WITH_VARIANTS_FRAGMENT}
+const GET_PRODUCT_WITH_VARIANTS_QUERY = gql(
+  `#graphql
   query getProductWithVariants($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     productByHandle(handle: $handle) {
       ...ProductWithVariantsFields
     }
   }
-` as const;
+`,
+  [PRODUCT_WITH_VARIANTS_FRAGMENT],
+);
 
-const COMPLEMENTARY_PRODUCTS_QUERY = `#graphql
-  ${PRODUCT_CARD_FRAGMENT}
+const COMPLEMENTARY_PRODUCTS_QUERY = gql(
+  `#graphql
   query complementaryProducts($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     productRecommendations(productHandle: $handle, intent: COMPLEMENTARY) {
       ...ProductCardFields
     }
   }
-` as const;
+`,
+  [PRODUCT_CARD_FRAGMENT],
+);
 
-const RELATED_PRODUCTS_QUERY = `#graphql
-  ${PRODUCT_CARD_FRAGMENT}
+const RELATED_PRODUCTS_QUERY = gql(
+  `#graphql
   query relatedProducts($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     productRecommendations(productHandle: $handle, intent: RELATED) {
       ...ProductCardFields
     }
   }
-` as const;
+`,
+  [PRODUCT_CARD_FRAGMENT],
+);
 
-const GET_COLLECTIONS_QUERY = `#graphql
-  ${COLLECTION_FIELDS_FRAGMENT}
+const GET_COLLECTIONS_QUERY = gql(
+  `#graphql
   query getCollections($first: Int!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     collections(first: $first) {
       edges {
@@ -181,19 +184,23 @@ const GET_COLLECTIONS_QUERY = `#graphql
       }
     }
   }
-` as const;
+`,
+  [COLLECTION_FIELDS_FRAGMENT],
+);
 
-const GET_CART_QUERY = `#graphql
-  ${CART_FRAGMENT}
+const GET_CART_QUERY = gql(
+  `#graphql
   query getCart($cartId: ID!) {
     cart(id: $cartId) {
       ...CartFields
     }
   }
-` as const;
+`,
+  [CART_FRAGMENT],
+);
 
-const CART_CREATE_MUTATION = `#graphql
-  ${CART_FRAGMENT}
+const CART_CREATE_MUTATION = gql(
+  `#graphql
   mutation cartCreate($input: CartInput, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     cartCreate(input: $input) {
       cart { ...CartFields }
@@ -201,10 +208,12 @@ const CART_CREATE_MUTATION = `#graphql
       warnings { code message target }
     }
   }
-` as const;
+`,
+  [CART_FRAGMENT],
+);
 
-const CART_LINES_ADD_MUTATION = `#graphql
-  ${CART_FRAGMENT}
+const CART_LINES_ADD_MUTATION = gql(
+  `#graphql
   mutation cartLinesAdd($cartId: ID!, $lines: [CartLineInput!]!) {
     cartLinesAdd(cartId: $cartId, lines: $lines) {
       cart { ...CartFields }
@@ -212,10 +221,12 @@ const CART_LINES_ADD_MUTATION = `#graphql
       warnings { code message target }
     }
   }
-` as const;
+`,
+  [CART_FRAGMENT],
+);
 
-const CART_LINES_UPDATE_MUTATION = `#graphql
-  ${CART_FRAGMENT}
+const CART_LINES_UPDATE_MUTATION = gql(
+  `#graphql
   mutation cartLinesUpdate($cartId: ID!, $lines: [CartLineUpdateInput!]!) {
     cartLinesUpdate(cartId: $cartId, lines: $lines) {
       cart { ...CartFields }
@@ -223,10 +234,12 @@ const CART_LINES_UPDATE_MUTATION = `#graphql
       warnings { code message target }
     }
   }
-` as const;
+`,
+  [CART_FRAGMENT],
+);
 
-const CART_LINES_REMOVE_MUTATION = `#graphql
-  ${CART_FRAGMENT}
+const CART_LINES_REMOVE_MUTATION = gql(
+  `#graphql
   mutation cartLinesRemove($cartId: ID!, $lineIds: [ID!]!) {
     cartLinesRemove(cartId: $cartId, lineIds: $lineIds) {
       cart { ...CartFields }
@@ -234,10 +247,12 @@ const CART_LINES_REMOVE_MUTATION = `#graphql
       warnings { code message target }
     }
   }
-` as const;
+`,
+  [CART_FRAGMENT],
+);
 
-const CART_NOTE_UPDATE_MUTATION = `#graphql
-  ${CART_FRAGMENT}
+const CART_NOTE_UPDATE_MUTATION = gql(
+  `#graphql
   mutation cartNoteUpdate($cartId: ID!, $note: String!) {
     cartNoteUpdate(cartId: $cartId, note: $note) {
       cart { ...CartFields }
@@ -245,7 +260,9 @@ const CART_NOTE_UPDATE_MUTATION = `#graphql
       warnings { code message target }
     }
   }
-` as const;
+`,
+  [CART_FRAGMENT],
+);
 
 export type SearchIndexProductsParams = {
   activeFilters?: ActiveFilters;
@@ -286,12 +303,12 @@ export type CartMutationResult = { cart: Cart; warnings: CartWarning[] };
 export interface CartLineInput {
   attributes?: { key: string; value: string }[];
   merchandiseId: string;
-  parent?: { lineId?: string; merchandiseId?: string };
+  parent?: { lineId: string } | { merchandiseId: string };
   quantity: number;
 }
 
 export function applyCartMutation(
-  payload: CartMutationPayload<ShopifyCart>,
+  payload: CartMutationPayload<ShopifyCart> | null | undefined,
   operation: string,
 ): CartMutationResult {
   const { cart, warnings } = unwrapCartMutation(payload, operation);
@@ -314,8 +331,6 @@ export async function fetchSearchIndexProducts(
   } = params;
 
   const sortConfig = SEARCH_SORT_KEY_MAP[rawSortKey] ?? SEARCH_SORT_KEY_MAP["best-matches"];
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
 
   const trimmedQuery = query?.trim() ?? "";
   const queryParts: string[] = [];
@@ -323,16 +338,8 @@ export async function fetchSearchIndexProducts(
   if (collection) queryParts.push(`collection:'${escapeProductQuery(collection)}'`);
   const searchQuery = queryParts.length > 0 ? queryParts.join(" AND ") : "*";
 
-  const response = await storefront.request<{
-    search: {
-      totalCount: number;
-      edges: Array<{ cursor: string; node: ShopifyProductCard | null }>;
-      pageInfo: PageInfo;
-      productFilters: Array<{
-        values: Array<Pick<ShopifyFilter["values"][number], "input" | "label">>;
-      }>;
-    };
-  }>(PRODUCTS_SEARCH_QUERY, {
+  const response = await storefront.request(PRODUCTS_SEARCH_QUERY, {
+    locale,
     variables: {
       query: searchQuery,
       first: limit,
@@ -340,16 +347,14 @@ export async function fetchSearchIndexProducts(
       productFilters: filters.length > 0 ? filters : undefined,
       sortKey: sortConfig.sortKey,
       reverse: sortConfig.reverse,
-      country,
-      language,
     },
   });
   assertStorefrontOk(response, "searchProducts");
   const { data } = response;
 
-  const shopifyProducts = data.search.edges
-    .map((edge) => edge.node)
-    .filter((node): node is ShopifyProductCard => node !== null);
+  const shopifyProducts = data.search.edges.flatMap((edge) =>
+    edge.node.__typename === "Product" ? [edge.node] : [],
+  );
 
   const selectedColor = getSelectedColorFilterLabel(
     activeFilters,
@@ -380,18 +385,9 @@ export async function fetchCollectionProducts(
   } = params;
 
   const sortConfig = COLLECTION_SORT_KEY_MAP[rawSortKey] ?? COLLECTION_SORT_KEY_MAP["best-matches"];
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
 
-  const response = await storefront.request<{
-    collection: {
-      products: {
-        edges: Array<{ node: ShopifyProductCard }>;
-        pageInfo: PageInfo;
-        filters: ShopifyFilter[];
-      };
-    } | null;
-  }>(COLLECTION_PRODUCTS_QUERY, {
+  const response = await storefront.request(COLLECTION_PRODUCTS_QUERY, {
+    locale,
     variables: {
       handle: collection,
       first: limit,
@@ -399,8 +395,6 @@ export async function fetchCollectionProducts(
       sortKey: sortConfig.sortKey,
       reverse: sortConfig.reverse,
       filters: filters.length > 0 ? filters : undefined,
-      country,
-      language,
     },
   });
   assertStorefrontOk(response, "collectionProducts");
@@ -443,13 +437,10 @@ export async function fetchProductWithVariants({
   handle: string;
   locale?: string;
 }): Promise<ProductDetails | undefined> {
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-
-  const response = await storefront.request<{ productByHandle: ShopifyProduct }>(
-    GET_PRODUCT_WITH_VARIANTS_QUERY,
-    { variables: { handle, country, language } },
-  );
+  const response = await storefront.request(GET_PRODUCT_WITH_VARIANTS_QUERY, {
+    locale,
+    variables: { handle },
+  });
   assertStorefrontOk(response, "getProductWithVariants");
   const { data } = response;
 
@@ -464,12 +455,10 @@ export async function fetchComplementaryProducts({
   handle: string;
   locale?: string;
 }): Promise<ProductCard[]> {
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-
-  const response = await storefront.request<{
-    productRecommendations: ShopifyProductCard[] | null;
-  }>(COMPLEMENTARY_PRODUCTS_QUERY, { variables: { country, handle, language } });
+  const response = await storefront.request(COMPLEMENTARY_PRODUCTS_QUERY, {
+    locale,
+    variables: { handle },
+  });
   assertStorefrontOk(response, "complementaryProducts");
 
   return (response.data.productRecommendations ?? []).map(transformShopifyProductCard);
@@ -482,12 +471,10 @@ export async function fetchRelatedProducts({
   handle: string;
   locale?: string;
 }): Promise<ProductCard[]> {
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-
-  const response = await storefront.request<{
-    productRecommendations: ShopifyProductCard[] | null;
-  }>(RELATED_PRODUCTS_QUERY, { variables: { country, handle, language } });
+  const response = await storefront.request(RELATED_PRODUCTS_QUERY, {
+    locale,
+    variables: { handle },
+  });
   assertStorefrontOk(response, "relatedProducts");
 
   return (response.data.productRecommendations ?? []).map(transformShopifyProductCard);
@@ -497,28 +484,25 @@ export async function fetchCollections({
   limit = 250,
   locale = defaultLocale,
 }: { limit?: number; locale?: string } = {}): Promise<Collection[]> {
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-
-  const response = await storefront.request<{
-    collections: { edges: Array<{ node: ShopifyCollection }> };
-  }>(GET_COLLECTIONS_QUERY, { variables: { first: limit, country, language } });
+  const response = await storefront.request(GET_COLLECTIONS_QUERY, {
+    locale,
+    variables: { first: limit },
+  });
   assertStorefrontOk(response, "getCollections");
 
   return transformShopifyCollections(response.data.collections.edges.map((edge) => edge.node));
 }
 
 export async function fetchCart(cartId: string): Promise<Cart | undefined> {
-  const response = await storefront.request<{ cart: ShopifyCart | null }>(GET_CART_QUERY, {
-    variables: { cartId },
-  });
+  const response = await storefront.request(GET_CART_QUERY, { variables: { cartId } });
   assertStorefrontOk(response, "getCart");
   return response.data.cart ? transformShopifyCart(response.data.cart) : undefined;
 }
 
-const PRODUCT_OPTION_VALUES_QUERY = `#graphql
+const PRODUCT_OPTION_VALUES_QUERY = gql(`#graphql
   query productOptionValues($ids: [ID!]!) {
     nodes(ids: $ids) {
+      __typename
       ... on Product {
         handle
         options {
@@ -530,7 +514,7 @@ const PRODUCT_OPTION_VALUES_QUERY = `#graphql
       }
     }
   }
-` as const;
+`);
 
 export type ProductOptionValues = Map<string, Map<string, Set<string>>>;
 
@@ -542,21 +526,16 @@ export async function fetchProductOptionValues(ids: string[]): Promise<ProductOp
   const byHandle: ProductOptionValues = new Map();
   if (ids.length === 0) return byHandle;
 
-  const response = await storefront.request<{
-    nodes: Array<{
-      handle: string;
-      options: Array<{ name: string; optionValues: Array<{ name: string }> }>;
-    } | null>;
-  }>(PRODUCT_OPTION_VALUES_QUERY, { variables: { ids } });
+  const response = await storefront.request(PRODUCT_OPTION_VALUES_QUERY, { variables: { ids } });
   assertStorefrontOk(response, "productOptionValues");
 
   for (const node of response.data.nodes) {
-    if (!node?.handle) continue;
+    if (node?.__typename !== "Product") continue;
     const options = new Map<string, Set<string>>();
-    for (const option of node.options ?? []) {
+    for (const option of node.options) {
       options.set(
         option.name.toLowerCase(),
-        new Set((option.optionValues ?? []).map((value) => value.name.toLowerCase())),
+        new Set(option.optionValues.map((value) => value.name.toLowerCase())),
       );
     }
     byHandle.set(node.handle, options);
@@ -565,13 +544,12 @@ export async function fetchProductOptionValues(ids: string[]): Promise<ProductOp
 }
 
 export async function createCartCore(locale: string = defaultLocale): Promise<CartMutationResult> {
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-
-  const response = await storefront.request<{ cartCreate: CartMutationPayload<ShopifyCart> }>(
-    CART_CREATE_MUTATION,
-    { variables: { input: { buyerIdentity: { countryCode: country } }, country, language } },
-  );
+  const response = await storefront.request(CART_CREATE_MUTATION, {
+    locale,
+    variables: {
+      input: { buyerIdentity: { countryCode: getCountryCode(locale) as CountryCode } },
+    },
+  });
   assertStorefrontOk(response, "cartCreate");
   return applyCartMutation(response.data.cartCreate, "cartCreate");
 }
@@ -580,10 +558,9 @@ export async function addToCartCore(
   lines: CartLineInput[],
   cartId: string,
 ): Promise<CartMutationResult> {
-  const response = await storefront.request<{ cartLinesAdd: CartMutationPayload<ShopifyCart> }>(
-    CART_LINES_ADD_MUTATION,
-    { variables: { cartId, lines } },
-  );
+  const response = await storefront.request(CART_LINES_ADD_MUTATION, {
+    variables: { cartId, lines },
+  });
   assertStorefrontOk(response, "cartLinesAdd");
   return applyCartMutation(response.data.cartLinesAdd, "cartLinesAdd");
 }
@@ -592,10 +569,9 @@ export async function updateCartCore(
   lines: { id: string; quantity: number }[],
   cartId: string,
 ): Promise<CartMutationResult> {
-  const response = await storefront.request<{ cartLinesUpdate: CartMutationPayload<ShopifyCart> }>(
-    CART_LINES_UPDATE_MUTATION,
-    { variables: { cartId, lines } },
-  );
+  const response = await storefront.request(CART_LINES_UPDATE_MUTATION, {
+    variables: { cartId, lines },
+  });
   assertStorefrontOk(response, "cartLinesUpdate");
   return applyCartMutation(response.data.cartLinesUpdate, "cartLinesUpdate");
 }
@@ -604,10 +580,9 @@ export async function removeFromCartCore(
   lineIds: string[],
   cartId: string,
 ): Promise<CartMutationResult> {
-  const response = await storefront.request<{ cartLinesRemove: CartMutationPayload<ShopifyCart> }>(
-    CART_LINES_REMOVE_MUTATION,
-    { variables: { cartId, lineIds } },
-  );
+  const response = await storefront.request(CART_LINES_REMOVE_MUTATION, {
+    variables: { cartId, lineIds },
+  });
   assertStorefrontOk(response, "cartLinesRemove");
   return applyCartMutation(response.data.cartLinesRemove, "cartLinesRemove");
 }
@@ -616,10 +591,9 @@ export async function updateCartNoteCore(
   note: string,
   cartId: string,
 ): Promise<CartMutationResult> {
-  const response = await storefront.request<{ cartNoteUpdate: CartMutationPayload<ShopifyCart> }>(
-    CART_NOTE_UPDATE_MUTATION,
-    { variables: { cartId, note } },
-  );
+  const response = await storefront.request(CART_NOTE_UPDATE_MUTATION, {
+    variables: { cartId, note },
+  });
   assertStorefrontOk(response, "cartNoteUpdate");
   return applyCartMutation(response.data.cartNoteUpdate, "cartNoteUpdate");
 }

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -1,63 +1,61 @@
-export const MONEY_FRAGMENT = `#graphql
-  fragment MoneyFields on MoneyV2 {
-    amount
-    currencyCode
-  }
-` as const;
+import { gql } from "@shopify/hydrogen";
 
-export const IMAGE_FRAGMENT = `#graphql
-  fragment ImageFields on Image {
-    url
-    altText
-    width
-    height
-  }
-` as const;
+// Money and Image selections are inlined so diamond-shaped fragment composition never emits one leaf fragment twice.
 
-// Parent documents must include IMAGE_FRAGMENT.
-export const PRODUCT_VARIANT_FRAGMENT = `#graphql
-  ${MONEY_FRAGMENT}
+export const PRODUCT_VARIANT_FRAGMENT = gql(
+  `#graphql
   fragment ProductVariantFields on ProductVariant {
     id
     title
     availableForSale
     price {
-      ...MoneyFields
+      amount
+        currencyCode
     }
     compareAtPrice {
-      ...MoneyFields
+      amount
+        currencyCode
     }
     selectedOptions {
       name
       value
     }
     image {
-      ...ImageFields
+      url
+        altText
+        width
+        height
     }
   }
-` as const;
+`,
+);
 
-export const BUNDLE_COMPONENT_VARIANT_FRAGMENT = `#graphql
+export const BUNDLE_COMPONENT_VARIANT_FRAGMENT = gql(`#graphql
   fragment BundleComponentVariantFields on ProductVariant {
     id
     title
     image {
-      ...ImageFields
+      url
+        altText
+        width
+        height
     }
     product {
       id
       title
       handle
       featuredImage {
-        ...ImageFields
+        url
+        altText
+        width
+        height
       }
     }
   }
-` as const;
+`);
 
-// Parent documents must include IMAGE_FRAGMENT.
-export const BUNDLE_RELATIONSHIPS_FRAGMENT = `#graphql
-  ${BUNDLE_COMPONENT_VARIANT_FRAGMENT}
+export const BUNDLE_RELATIONSHIPS_FRAGMENT = gql(
+  `#graphql
   fragment BundleRelationshipFields on ProductVariant {
     requiresComponents
     groupedBy(first: 10) {
@@ -75,19 +73,21 @@ export const BUNDLE_RELATIONSHIPS_FRAGMENT = `#graphql
       }
     }
   }
-` as const;
+`,
+  [BUNDLE_COMPONENT_VARIANT_FRAGMENT],
+);
 
-// Parent documents must include IMAGE_FRAGMENT.
-export const PURCHASABLE_PRODUCT_VARIANT_FRAGMENT = `#graphql
-  ${BUNDLE_RELATIONSHIPS_FRAGMENT}
-  ${PRODUCT_VARIANT_FRAGMENT}
+export const PURCHASABLE_PRODUCT_VARIANT_FRAGMENT = gql(
+  `#graphql
   fragment PurchasableProductVariantFields on ProductVariant {
     ...BundleRelationshipFields
     ...ProductVariantFields
   }
-` as const;
+`,
+  [BUNDLE_RELATIONSHIPS_FRAGMENT, PRODUCT_VARIANT_FRAGMENT],
+);
 
-export const TAXONOMY_CATEGORY_FRAGMENT = `#graphql
+export const TAXONOMY_CATEGORY_FRAGMENT = gql(`#graphql
   fragment TaxonomyCategoryFields on TaxonomyCategory {
     id
     name
@@ -96,12 +96,32 @@ export const TAXONOMY_CATEGORY_FRAGMENT = `#graphql
       name
     }
   }
-` as const;
+`);
 
-// Fixed bundle components carry Shopify edit restrictions on nested CartLines.
-export const CART_FRAGMENT = `#graphql
-  ${IMAGE_FRAGMENT}
-  ${MONEY_FRAGMENT}
+export const FILTER_FRAGMENT = gql(`#graphql
+  fragment FilterFields on Filter {
+    id
+    label
+    type
+    presentation
+    values {
+      id
+      label
+      count
+      input
+      swatch {
+        color
+        image {
+          previewImage {
+            url
+          }
+        }
+      }
+    }
+  }
+`);
+
+export const CART_LINE_FRAGMENT = gql(`#graphql
   fragment CartLineFields on CartLine {
     id
     quantity
@@ -111,13 +131,15 @@ export const CART_FRAGMENT = `#graphql
     }
     cost {
       totalAmount {
-        ...MoneyFields
+        amount
+        currencyCode
       }
     }
     discountAllocations {
       __typename
       discountedAmount {
-        ...MoneyFields
+        amount
+        currencyCode
       }
       ... on CartCodeDiscountAllocation {
         code
@@ -138,37 +160,52 @@ export const CART_FRAGMENT = `#graphql
           value
         }
         image {
-          ...ImageFields
+          url
+        altText
+        width
+        height
         }
         price {
-          ...MoneyFields
+          amount
+        currencyCode
         }
         compareAtPrice {
-          ...MoneyFields
+          amount
+        currencyCode
         }
         product {
           id
           title
           handle
           featuredImage {
-            ...ImageFields
+            url
+        altText
+        width
+        height
           }
         }
       }
     }
   }
+`);
+
+// Fixed bundle components carry Shopify edit restrictions on nested CartLines.
+export const COMPONENTIZABLE_CART_LINE_FRAGMENT = gql(
+  `#graphql
   fragment ComponentizableCartLineFields on ComponentizableCartLine {
     id
     quantity
     cost {
       totalAmount {
-        ...MoneyFields
+        amount
+        currencyCode
       }
     }
     discountAllocations {
       __typename
       discountedAmount {
-        ...MoneyFields
+        amount
+        currencyCode
       }
       ... on CartCodeDiscountAllocation {
         code
@@ -189,20 +226,28 @@ export const CART_FRAGMENT = `#graphql
           value
         }
         image {
-          ...ImageFields
+          url
+        altText
+        width
+        height
         }
         price {
-          ...MoneyFields
+          amount
+        currencyCode
         }
         compareAtPrice {
-          ...MoneyFields
+          amount
+        currencyCode
         }
         product {
           id
           title
           handle
           featuredImage {
-            ...ImageFields
+            url
+        altText
+        width
+        height
           }
         }
       }
@@ -211,6 +256,12 @@ export const CART_FRAGMENT = `#graphql
       ...CartLineFields
     }
   }
+`,
+  [CART_LINE_FRAGMENT],
+);
+
+export const CART_FRAGMENT = gql(
+  `#graphql
   fragment CartFields on Cart {
     id
     checkoutUrl
@@ -224,10 +275,12 @@ export const CART_FRAGMENT = `#graphql
     }
     cost {
       totalAmount {
-        ...MoneyFields
+        amount
+        currencyCode
       }
       subtotalAmount {
-        ...MoneyFields
+        amount
+        currencyCode
       }
     }
     discountCodes {
@@ -237,7 +290,8 @@ export const CART_FRAGMENT = `#graphql
     discountAllocations {
       __typename
       discountedAmount {
-        ...MoneyFields
+        amount
+        currencyCode
       }
       ... on CartCodeDiscountAllocation {
         code
@@ -253,10 +307,12 @@ export const CART_FRAGMENT = `#graphql
       id
       lastCharacters
       amountUsed {
-        ...MoneyFields
+        amount
+        currencyCode
       }
       balance {
-        ...MoneyFields
+        amount
+        currencyCode
       }
     }
     deliveryGroups(first: 5) {
@@ -264,23 +320,29 @@ export const CART_FRAGMENT = `#graphql
         selectedDeliveryOption {
           title
           estimatedCost {
-            ...MoneyFields
+            amount
+        currencyCode
           }
         }
       }
     }
   }
-` as const;
+`,
+  [COMPONENTIZABLE_CART_LINE_FRAGMENT],
+);
 
-export const COLLECTION_FIELDS_FRAGMENT = `#graphql
-  ${IMAGE_FRAGMENT}
+export const COLLECTION_FIELDS_FRAGMENT = gql(
+  `#graphql
   fragment CollectionFields on Collection {
     id
     handle
     title
     description
     image {
-      ...ImageFields
+      url
+        altText
+        width
+        height
     }
     updatedAt
     seo {
@@ -288,12 +350,11 @@ export const COLLECTION_FIELDS_FRAGMENT = `#graphql
       description
     }
   }
-` as const;
+`,
+);
 
-export const PRODUCT_FRAGMENT = `#graphql
-  ${IMAGE_FRAGMENT}
-  ${PRODUCT_VARIANT_FRAGMENT}
-  ${TAXONOMY_CATEGORY_FRAGMENT}
+export const PRODUCT_FRAGMENT = gql(
+  `#graphql
   fragment ProductFields on Product {
     id
     title
@@ -306,20 +367,30 @@ export const PRODUCT_FRAGMENT = `#graphql
     availableForSale
     isGiftCard
     featuredImage {
-      ...ImageFields
+      url
+        altText
+        width
+        height
     }
     media(first: 10) {
       edges {
         node {
+          __typename
           mediaContentType
           ... on MediaImage {
             image {
-              ...ImageFields
+              url
+        altText
+        width
+        height
             }
           }
           ... on Video {
             previewImage {
-              ...ImageFields
+              url
+        altText
+        width
+        height
             }
             sources {
               url
@@ -333,18 +404,22 @@ export const PRODUCT_FRAGMENT = `#graphql
     }
     priceRange {
       minVariantPrice {
-        ...MoneyFields
+        amount
+        currencyCode
       }
       maxVariantPrice {
-        ...MoneyFields
+        amount
+        currencyCode
       }
     }
     compareAtPriceRange {
       minVariantPrice {
-        ...MoneyFields
+        amount
+        currencyCode
       }
       maxVariantPrice {
-        ...MoneyFields
+        amount
+        currencyCode
       }
     }
     encodedVariantExistence
@@ -372,7 +447,10 @@ export const PRODUCT_FRAGMENT = `#graphql
         }
         firstSelectableVariant {
           image {
-            ...ImageFields
+            url
+        altText
+        width
+        height
           }
         }
       }
@@ -392,11 +470,12 @@ export const PRODUCT_FRAGMENT = `#graphql
       }
     }
   }
-` as const;
+`,
+  [PRODUCT_VARIANT_FRAGMENT, TAXONOMY_CATEGORY_FRAGMENT],
+);
 
-export const PRODUCT_WITH_VARIANTS_FRAGMENT = `#graphql
-  ${BUNDLE_RELATIONSHIPS_FRAGMENT}
-  ${PRODUCT_FRAGMENT}
+export const PRODUCT_WITH_VARIANTS_FRAGMENT = gql(
+  `#graphql
   fragment ProductWithVariantsFields on Product {
     ...ProductFields
     selectedOrFirstAvailableVariant {
@@ -410,11 +489,12 @@ export const PRODUCT_WITH_VARIANTS_FRAGMENT = `#graphql
       }
     }
   }
-` as const;
+`,
+  [BUNDLE_RELATIONSHIPS_FRAGMENT, PRODUCT_FRAGMENT],
+);
 
-export const PRODUCT_CARD_FRAGMENT = `#graphql
-  ${IMAGE_FRAGMENT}
-  ${MONEY_FRAGMENT}
+export const PRODUCT_CARD_FRAGMENT = gql(
+  `#graphql
   fragment ProductCardFields on Product {
     id
     title
@@ -423,26 +503,35 @@ export const PRODUCT_CARD_FRAGMENT = `#graphql
     availableForSale
     isGiftCard
     featuredImage {
-      ...ImageFields
+      url
+        altText
+        width
+        height
     }
     priceRange {
       minVariantPrice {
-        ...MoneyFields
+        amount
+        currencyCode
       }
       maxVariantPrice {
-        ...MoneyFields
+        amount
+        currencyCode
       }
     }
     compareAtPriceRange {
       minVariantPrice {
-        ...MoneyFields
+        amount
+        currencyCode
       }
     }
     selectedOrFirstAvailableVariant {
       id
       availableForSale
       image {
-        ...ImageFields
+        url
+        altText
+        width
+        height
       }
       selectedOptions {
         name
@@ -450,10 +539,11 @@ export const PRODUCT_CARD_FRAGMENT = `#graphql
       }
     }
   }
-` as const;
+`,
+);
 
-export const FILTERABLE_PRODUCT_CARD_FRAGMENT = `#graphql
-  ${PRODUCT_CARD_FRAGMENT}
+export const FILTERABLE_PRODUCT_CARD_FRAGMENT = gql(
+  `#graphql
   fragment FilterableProductCardFields on Product {
     ...ProductCardFields
     options {
@@ -470,7 +560,10 @@ export const FILTERABLE_PRODUCT_CARD_FRAGMENT = `#graphql
         }
         firstSelectableVariant {
           image {
-            ...ImageFields
+            url
+        altText
+        width
+        height
           }
           selectedOptions {
             name
@@ -480,4 +573,6 @@ export const FILTERABLE_PRODUCT_CARD_FRAGMENT = `#graphql
       }
     }
   }
-` as const;
+`,
+  [PRODUCT_CARD_FRAGMENT],
+);

--- a/apps/template/lib/shopify/operations/blogs.ts
+++ b/apps/template/lib/shopify/operations/blogs.ts
@@ -1,114 +1,84 @@
+import { gql } from "@shopify/hydrogen";
 import { cacheLife, cacheTag } from "next/cache";
 
-import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
+import { defaultLocale } from "@/lib/i18n";
 import type { Blog, BlogArticle } from "@/lib/types";
 
 import { assertStorefrontOk } from "../errors";
-import { storefront } from "../storefront";
+import { type ResultOf, storefront } from "../storefront";
 
-interface ShopifyArticle {
-  authorV2: { name: string } | null;
-  content: string;
-  contentHtml?: string;
-  excerpt: string | null;
-  handle: string;
-  image: {
-    altText: string | null;
-    height: number;
-    url: string;
-    width: number;
-  } | null;
-  publishedAt: string;
-  seo?: {
-    description: string | null;
-    title: string | null;
-  } | null;
-  tags?: string[];
-  title: string;
-}
+const ARTICLE_SUMMARY_FRAGMENT = gql(`#graphql
+  fragment ArticleSummaryFields on Article {
+    authorV2 {
+      name
+    }
+    content(truncateAt: 240)
+    excerpt
+    handle
+    image {
+      altText
+      height
+      url
+      width
+    }
+    publishedAt
+    title
+  }
+`);
 
-interface ShopifyBlog {
-  handle: string;
-  seo: {
-    description: string | null;
-    title: string | null;
-  } | null;
-  title: string;
-}
+const BLOG_FRAGMENT = gql(`#graphql
+  fragment BlogFields on Blog {
+    handle
+    seo {
+      description
+      title
+    }
+    title
+  }
+`);
 
-interface GetBlogResponse {
-  blog: (ShopifyBlog & { articles: { nodes: ShopifyArticle[] } }) | null;
-}
-
-interface GetBlogArticleResponse {
-  blog: (ShopifyBlog & { articleByHandle: ShopifyArticle | null }) | null;
-}
-
-const GET_BLOG_QUERY = `#graphql
+const GET_BLOG_QUERY = gql(
+  `#graphql
   query getBlog($handle: String!, $first: Int!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     blog(handle: $handle) {
-      handle
-      seo {
-        description
-        title
-      }
-      title
+      ...BlogFields
       articles(first: $first, sortKey: PUBLISHED_AT, reverse: true) {
         nodes {
-          authorV2 {
-            name
-          }
-          content(truncateAt: 240)
-          excerpt
-          handle
-          image {
-            altText
-            height
-            url
-            width
-          }
-          publishedAt
-          title
+          ...ArticleSummaryFields
         }
       }
     }
   }
-` as const;
+`,
+  [ARTICLE_SUMMARY_FRAGMENT, BLOG_FRAGMENT],
+);
 
-const GET_BLOG_ARTICLE_QUERY = `#graphql
+const GET_BLOG_ARTICLE_QUERY = gql(
+  `#graphql
   query getBlogArticle($blogHandle: String!, $articleHandle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     blog(handle: $blogHandle) {
-      handle
-      seo {
-        description
-        title
-      }
-      title
+      ...BlogFields
       articleByHandle(handle: $articleHandle) {
-        authorV2 {
-          name
-        }
-        content(truncateAt: 240)
+        ...ArticleSummaryFields
         contentHtml
-        excerpt
-        handle
-        image {
-          altText
-          height
-          url
-          width
-        }
-        publishedAt
         seo {
           description
           title
         }
         tags
-        title
       }
     }
   }
-` as const;
+`,
+  [ARTICLE_SUMMARY_FRAGMENT, BLOG_FRAGMENT],
+);
+
+type ShopifyBlog = ResultOf<typeof BLOG_FRAGMENT>;
+type ShopifyArticle = ResultOf<typeof ARTICLE_SUMMARY_FRAGMENT> & {
+  contentHtml?: string;
+  seo?: { description: string | null; title: string | null } | null;
+  tags?: string[];
+};
 
 function transformArticle(article: ShopifyArticle, blog: ShopifyBlog): BlogArticle {
   return {
@@ -121,9 +91,9 @@ function transformArticle(article: ShopifyArticle, blog: ShopifyBlog): BlogArtic
     image: article.image
       ? {
           altText: article.image.altText ?? article.title,
-          height: article.image.height,
+          height: article.image.height ?? 0,
           url: article.image.url,
-          width: article.image.width,
+          width: article.image.width ?? 0,
         }
       : null,
     publishedAt: article.publishedAt,
@@ -149,10 +119,9 @@ export async function getBlog({
   cacheLife("max");
   cacheTag("articles", "blogs", `blog-${handle}`);
 
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-  const response = await storefront.request<GetBlogResponse>(GET_BLOG_QUERY, {
-    variables: { country, first: limit, handle, language },
+  const response = await storefront.request(GET_BLOG_QUERY, {
+    locale,
+    variables: { first: limit, handle },
   });
   assertStorefrontOk(response, "getBlog");
 
@@ -183,10 +152,9 @@ export async function getBlogArticle({
   cacheLife("max");
   cacheTag("articles", "blogs", `article-${blogHandle}-${articleHandle}`, `blog-${blogHandle}`);
 
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-  const response = await storefront.request<GetBlogArticleResponse>(GET_BLOG_ARTICLE_QUERY, {
-    variables: { articleHandle, blogHandle, country, language },
+  const response = await storefront.request(GET_BLOG_ARTICLE_QUERY, {
+    locale,
+    variables: { articleHandle, blogHandle },
   });
   assertStorefrontOk(response, "getBlogArticle");
 

--- a/apps/template/lib/shopify/operations/collections.ts
+++ b/apps/template/lib/shopify/operations/collections.ts
@@ -1,18 +1,15 @@
+import { gql } from "@shopify/hydrogen";
 import { cacheLife, cacheTag } from "next/cache";
 
-import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
+import { defaultLocale } from "@/lib/i18n";
 import type { Collection, CollectionWithThumbnail } from "@/lib/types";
 
 import { assertStorefrontOk } from "../errors";
 import { fetchCollections } from "../fetch";
 import { COLLECTION_FIELDS_FRAGMENT } from "../fragments";
 import { storefront } from "../storefront";
-import { type ShopifyCollection, transformShopifyCollection } from "../transforms/collection";
+import { transformShopifyCollection } from "../transforms/collection";
 import { getNumericShopifyId } from "../utils";
-
-type CollectionResponse = {
-  collection: ShopifyCollection | null;
-};
 
 function tagCollections(collections: Array<{ handle: string }>): void {
   for (const collection of collections) {
@@ -20,29 +17,19 @@ function tagCollections(collections: Array<{ handle: string }>): void {
   }
 }
 
-const GET_COLLECTION_QUERY = `#graphql
-  ${COLLECTION_FIELDS_FRAGMENT}
+const GET_COLLECTION_QUERY = gql(
+  `#graphql
   query getCollection($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     collection(handle: $handle) {
       ...CollectionFields
     }
   }
-` as const;
+`,
+  [COLLECTION_FIELDS_FRAGMENT],
+);
 
-type ListingImage = { altText: string | null; height: number; url: string; width: number };
-
-type CollectionsListingResponse = {
-  collections: {
-    edges: Array<{
-      node: ShopifyCollection & {
-        products: { edges: Array<{ node: { featuredImage: ListingImage | null; id: string } }> };
-      };
-    }>;
-  };
-};
-
-const GET_COLLECTIONS_WITH_FEATURED_IMAGE_QUERY = `#graphql
-  ${COLLECTION_FIELDS_FRAGMENT}
+const GET_COLLECTIONS_WITH_FEATURED_IMAGE_QUERY = gql(
+  `#graphql
   query getCollectionsWithFeaturedImage($first: Int!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     collections(first: $first) {
       edges {
@@ -53,7 +40,10 @@ const GET_COLLECTIONS_WITH_FEATURED_IMAGE_QUERY = `#graphql
               node {
                 id
                 featuredImage {
-                  ...ImageFields
+                  url
+                  altText
+                  width
+                  height
                 }
               }
             }
@@ -62,7 +52,9 @@ const GET_COLLECTIONS_WITH_FEATURED_IMAGE_QUERY = `#graphql
       }
     }
   }
-` as const;
+`,
+  [COLLECTION_FIELDS_FRAGMENT],
+);
 
 export async function getCollections(
   params: { limit?: number; locale?: string } = {},
@@ -88,11 +80,9 @@ export async function getCollection({
   cacheLife("max");
   cacheTag("collections", `collection-${handle}`);
 
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-
-  const response = await storefront.request<CollectionResponse>(GET_COLLECTION_QUERY, {
-    variables: { handle, country, language },
+  const response = await storefront.request(GET_COLLECTION_QUERY, {
+    locale,
+    variables: { handle },
   });
   assertStorefrontOk(response, "getCollection");
   const { data } = response;
@@ -110,15 +100,10 @@ export async function getCollectionsListing({
   cacheLife("max");
   cacheTag("collections", "collections-index");
 
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-
-  const response = await storefront.request<CollectionsListingResponse>(
-    GET_COLLECTIONS_WITH_FEATURED_IMAGE_QUERY,
-    {
-      variables: { country, first: limit, language },
-    },
-  );
+  const response = await storefront.request(GET_COLLECTIONS_WITH_FEATURED_IMAGE_QUERY, {
+    locale,
+    variables: { first: limit },
+  });
   assertStorefrontOk(response, "getCollectionsListing");
   const { data } = response;
 
@@ -139,7 +124,12 @@ export async function getCollectionsListing({
     return {
       ...transformShopifyCollection(node),
       thumbnail: raw
-        ? { altText: raw.altText ?? node.title, height: raw.height, url: raw.url, width: raw.width }
+        ? {
+            altText: raw.altText ?? node.title,
+            height: raw.height ?? 0,
+            url: raw.url,
+            width: raw.width ?? 0,
+          }
         : null,
     };
   });

--- a/apps/template/lib/shopify/operations/customer.ts
+++ b/apps/template/lib/shopify/operations/customer.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { type AnyCustomerAccountDocument, gql } from "@shopify/hydrogen/customer-account";
 import { cache } from "react";
 
 import { requireCustomerAccessToken } from "@/lib/auth/server";
@@ -10,12 +11,14 @@ import type {
   CustomerProfile,
 } from "@/lib/types";
 
-import { customerAccountFetch } from "../customer-account";
+import { customerAccountFetch, type CustomerAccountResultOf } from "../customer-account";
 import {
-  type ShopifyCustomerAddress,
-  type ShopifyCustomerProfile,
-  type ShopifyOrder,
-  type ShopifyOrderSummary,
+  ADDRESS_FRAGMENT,
+  CUSTOMER_PROFILE_FRAGMENT,
+  ORDER_FRAGMENT,
+  ORDER_SUMMARY_FRAGMENT,
+} from "../customer-account-fragments";
+import {
   transformCustomerAddress,
   transformCustomerProfile,
   transformOrder,
@@ -30,52 +33,19 @@ export interface CustomerUserError {
   message: string;
 }
 
-const ADDRESS_FRAGMENT = `
-  fragment AddressFields on CustomerAddress {
-    address1
-    address2
-    city
-    company
-    firstName
-    formatted
-    id
-    lastName
-    phoneNumber
-    territoryCode
-    zip
-    zoneCode
-  }
-`;
-
-const ORDER_SUMMARY_FRAGMENT = `
-  fragment OrderSummaryFields on Order {
-    financialStatus
-    fulfillmentStatus
-    id
-    name
-    number
-    processedAt
-    totalPrice {
-      amount
-      currencyCode
-    }
-  }
-`;
-
-const GET_CUSTOMER_PROFILE_QUERY = `
+const GET_CUSTOMER_PROFILE_QUERY = gql(
+  `#graphql
   query getCustomerProfile {
     customer {
-      emailAddress {
-        emailAddress
-      }
-      firstName
-      lastName
+      ...CustomerProfileFields
     }
   }
-`;
+`,
+  [CUSTOMER_PROFILE_FRAGMENT],
+);
 
-const GET_CUSTOMER_ORDERS_QUERY = `
-  ${ORDER_SUMMARY_FRAGMENT}
+const GET_CUSTOMER_ORDERS_QUERY = gql(
+  `#graphql
   query getCustomerOrders($after: String, $before: String, $first: Int, $last: Int) {
     customer {
       orders(after: $after, before: $before, first: $first, last: $last, reverse: true, sortKey: PROCESSED_AT) {
@@ -91,53 +61,23 @@ const GET_CUSTOMER_ORDERS_QUERY = `
       }
     }
   }
-`;
+`,
+  [ORDER_SUMMARY_FRAGMENT],
+);
 
-const GET_CUSTOMER_ORDER_QUERY = `
-  ${ADDRESS_FRAGMENT}
-  ${ORDER_SUMMARY_FRAGMENT}
+const GET_CUSTOMER_ORDER_QUERY = gql(
+  `#graphql
   query getCustomerOrder($id: ID!) {
     order(id: $id) {
-      ...OrderSummaryFields
-      lineItems(first: 50) {
-        nodes {
-          image {
-            altText
-            height
-            url
-            width
-          }
-          quantity
-          title
-          totalPrice {
-            amount
-            currencyCode
-          }
-          variantTitle
-        }
-      }
-      shippingAddress {
-        ...AddressFields
-      }
-      statusPageUrl
-      subtotal {
-        amount
-        currencyCode
-      }
-      totalShipping {
-        amount
-        currencyCode
-      }
-      totalTax {
-        amount
-        currencyCode
-      }
+      ...OrderFields
     }
   }
-`;
+`,
+  [ORDER_FRAGMENT],
+);
 
-const GET_CUSTOMER_ADDRESSES_QUERY = `
-  ${ADDRESS_FRAGMENT}
+const GET_CUSTOMER_ADDRESSES_QUERY = gql(
+  `#graphql
   query getCustomerAddresses {
     customer {
       addresses(first: 30) {
@@ -150,9 +90,11 @@ const GET_CUSTOMER_ADDRESSES_QUERY = `
       }
     }
   }
-`;
+`,
+  [ADDRESS_FRAGMENT],
+);
 
-const CUSTOMER_ADDRESS_CREATE_MUTATION = `
+const CUSTOMER_ADDRESS_CREATE_MUTATION = gql(`#graphql
   mutation customerAddressCreate($address: CustomerAddressInput!, $defaultAddress: Boolean) {
     customerAddressCreate(address: $address, defaultAddress: $defaultAddress) {
       customerAddress {
@@ -165,9 +107,9 @@ const CUSTOMER_ADDRESS_CREATE_MUTATION = `
       }
     }
   }
-`;
+`);
 
-const CUSTOMER_ADDRESS_UPDATE_MUTATION = `
+const CUSTOMER_ADDRESS_UPDATE_MUTATION = gql(`#graphql
   mutation customerAddressUpdate($address: CustomerAddressInput, $addressId: ID!, $defaultAddress: Boolean) {
     customerAddressUpdate(address: $address, addressId: $addressId, defaultAddress: $defaultAddress) {
       customerAddress {
@@ -180,9 +122,9 @@ const CUSTOMER_ADDRESS_UPDATE_MUTATION = `
       }
     }
   }
-`;
+`);
 
-const CUSTOMER_ADDRESS_DELETE_MUTATION = `
+const CUSTOMER_ADDRESS_DELETE_MUTATION = gql(`#graphql
   mutation customerAddressDelete($addressId: ID!) {
     customerAddressDelete(addressId: $addressId) {
       deletedAddressId
@@ -193,9 +135,9 @@ const CUSTOMER_ADDRESS_DELETE_MUTATION = `
       }
     }
   }
-`;
+`);
 
-const CUSTOMER_UPDATE_MUTATION = `
+const CUSTOMER_UPDATE_MUTATION = gql(`#graphql
   mutation customerUpdate($input: CustomerUpdateInput!) {
     customerUpdate(input: $input) {
       customer {
@@ -208,24 +150,37 @@ const CUSTOMER_UPDATE_MUTATION = `
       }
     }
   }
-`;
+`);
 
-async function customerFetch<T>(
-  operation: string,
-  query: string,
-  returnTo: string,
-  variables?: Record<string, unknown>,
-): Promise<T> {
+type CustomerFetchOptions<Doc extends AnyCustomerAccountDocument> = Omit<
+  Parameters<typeof customerAccountFetch<Doc>>[0],
+  "accessToken"
+> & { returnTo: string };
+
+async function customerFetch<const Doc extends AnyCustomerAccountDocument>({
+  returnTo,
+  ...options
+}: CustomerFetchOptions<Doc>): Promise<CustomerAccountResultOf<Doc>> {
   const accessToken = await requireCustomerAccessToken(returnTo);
-  return customerAccountFetch<T>({ accessToken, operation, query, variables });
+  return customerAccountFetch<Doc>({ accessToken, ...options } as never);
+}
+
+function toUserErrors(
+  errors: Array<{ code?: string | null; field?: string[] | null; message: string }>,
+): CustomerUserError[] {
+  return errors.map((error) => ({
+    code: error.code ?? undefined,
+    field: error.field,
+    message: error.message,
+  }));
 }
 
 export const getCustomerProfile = cache(async (): Promise<CustomerProfile | null> => {
-  const data = await customerFetch<{ customer: ShopifyCustomerProfile | null }>(
-    "getCustomerProfile",
-    GET_CUSTOMER_PROFILE_QUERY,
-    "/account/profile",
-  );
+  const data = await customerFetch({
+    document: GET_CUSTOMER_PROFILE_QUERY,
+    operation: "getCustomerProfile",
+    returnTo: "/account/profile",
+  });
 
   if (!data.customer) return null;
 
@@ -242,23 +197,16 @@ export async function getCustomerOrders(cursor?: {
   if (cursor?.before) orderParams.set("before", cursor.before);
   const returnTo = `/account/orders${orderParams.size > 0 ? `?${orderParams}` : ""}`;
 
-  const data = await customerFetch<{
-    customer: {
-      orders: {
-        nodes: ShopifyOrderSummary[];
-        pageInfo: {
-          endCursor: string | null;
-          hasNextPage: boolean;
-          hasPreviousPage: boolean;
-          startCursor: string | null;
-        };
-      };
-    } | null;
-  }>("getCustomerOrders", GET_CUSTOMER_ORDERS_QUERY, returnTo, {
-    after: cursor?.after,
-    before: cursor?.before,
-    first: paginateBackward ? undefined : ORDERS_PER_PAGE,
-    last: paginateBackward ? ORDERS_PER_PAGE : undefined,
+  const data = await customerFetch({
+    document: GET_CUSTOMER_ORDERS_QUERY,
+    operation: "getCustomerOrders",
+    returnTo,
+    variables: {
+      after: cursor?.after,
+      before: cursor?.before,
+      first: paginateBackward ? undefined : ORDERS_PER_PAGE,
+      last: paginateBackward ? ORDERS_PER_PAGE : undefined,
+    },
   });
 
   const orders = data.customer?.orders;
@@ -276,17 +224,22 @@ export async function getCustomerOrders(cursor?: {
 
   return {
     orders: orders.nodes.map(transformOrderSummary),
-    pageInfo: orders.pageInfo,
+    pageInfo: {
+      endCursor: orders.pageInfo.endCursor ?? null,
+      hasNextPage: orders.pageInfo.hasNextPage,
+      hasPreviousPage: orders.pageInfo.hasPreviousPage,
+      startCursor: orders.pageInfo.startCursor ?? null,
+    },
   };
 }
 
 export async function getCustomerOrder(id: string): Promise<CustomerOrder | null> {
-  const data = await customerFetch<{ order: ShopifyOrder | null }>(
-    "getCustomerOrder",
-    GET_CUSTOMER_ORDER_QUERY,
-    `/account/orders/${encodeURIComponent(id)}`,
-    { id },
-  );
+  const data = await customerFetch({
+    document: GET_CUSTOMER_ORDER_QUERY,
+    operation: "getCustomerOrder",
+    returnTo: `/account/orders/${encodeURIComponent(id)}`,
+    variables: { id },
+  });
 
   if (!data.order) return null;
 
@@ -294,12 +247,11 @@ export async function getCustomerOrder(id: string): Promise<CustomerOrder | null
 }
 
 export async function getCustomerAddresses(): Promise<CustomerAddress[]> {
-  const data = await customerFetch<{
-    customer: {
-      addresses: { nodes: ShopifyCustomerAddress[] };
-      defaultAddress: { id: string } | null;
-    } | null;
-  }>("getCustomerAddresses", GET_CUSTOMER_ADDRESSES_QUERY, "/account/addresses");
+  const data = await customerFetch({
+    document: GET_CUSTOMER_ADDRESSES_QUERY,
+    operation: "getCustomerAddresses",
+    returnTo: "/account/addresses",
+  });
 
   if (!data.customer) return [];
 
@@ -315,14 +267,14 @@ export async function createCustomerAddress(
   address: CustomerAddressInput,
   defaultAddress: boolean,
 ): Promise<CustomerUserError[]> {
-  const data = await customerFetch<{
-    customerAddressCreate: { userErrors: CustomerUserError[] };
-  }>("customerAddressCreate", CUSTOMER_ADDRESS_CREATE_MUTATION, "/account/addresses", {
-    address,
-    defaultAddress,
+  const data = await customerFetch({
+    document: CUSTOMER_ADDRESS_CREATE_MUTATION,
+    operation: "customerAddressCreate",
+    returnTo: "/account/addresses",
+    variables: { address, defaultAddress },
   });
 
-  return data.customerAddressCreate.userErrors;
+  return toUserErrors(data.customerAddressCreate?.userErrors ?? []);
 }
 
 export async function updateCustomerAddress(
@@ -330,34 +282,37 @@ export async function updateCustomerAddress(
   address: CustomerAddressInput,
   defaultAddress: boolean,
 ): Promise<CustomerUserError[]> {
-  const data = await customerFetch<{
-    customerAddressUpdate: { userErrors: CustomerUserError[] };
-  }>("customerAddressUpdate", CUSTOMER_ADDRESS_UPDATE_MUTATION, "/account/addresses", {
-    address,
-    addressId,
-    defaultAddress,
+  const data = await customerFetch({
+    document: CUSTOMER_ADDRESS_UPDATE_MUTATION,
+    operation: "customerAddressUpdate",
+    returnTo: "/account/addresses",
+    variables: { address, addressId, defaultAddress },
   });
 
-  return data.customerAddressUpdate.userErrors;
+  return toUserErrors(data.customerAddressUpdate?.userErrors ?? []);
 }
 
 export async function deleteCustomerAddress(addressId: string): Promise<CustomerUserError[]> {
-  const data = await customerFetch<{
-    customerAddressDelete: { userErrors: CustomerUserError[] };
-  }>("customerAddressDelete", CUSTOMER_ADDRESS_DELETE_MUTATION, "/account/addresses", {
-    addressId,
+  const data = await customerFetch({
+    document: CUSTOMER_ADDRESS_DELETE_MUTATION,
+    operation: "customerAddressDelete",
+    returnTo: "/account/addresses",
+    variables: { addressId },
   });
 
-  return data.customerAddressDelete.userErrors;
+  return toUserErrors(data.customerAddressDelete?.userErrors ?? []);
 }
 
 export async function updateCustomerProfile(input: {
   firstName: string;
   lastName: string;
 }): Promise<CustomerUserError[]> {
-  const data = await customerFetch<{
-    customerUpdate: { userErrors: CustomerUserError[] };
-  }>("customerUpdate", CUSTOMER_UPDATE_MUTATION, "/account/profile", { input });
+  const data = await customerFetch({
+    document: CUSTOMER_UPDATE_MUTATION,
+    operation: "customerUpdate",
+    returnTo: "/account/profile",
+    variables: { input },
+  });
 
-  return data.customerUpdate.userErrors;
+  return toUserErrors(data.customerUpdate?.userErrors ?? []);
 }

--- a/apps/template/lib/shopify/operations/menu.ts
+++ b/apps/template/lib/shopify/operations/menu.ts
@@ -1,11 +1,12 @@
+import { gql } from "@shopify/hydrogen";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { assertStorefrontOk } from "../errors";
 import { storefront } from "../storefront";
-import { type ShopifyMenuResponse, transformShopifyMenu } from "../transforms/menu";
+import { transformShopifyMenu } from "../transforms/menu";
 import type { Menu } from "../types/menu";
 
-const MENU_ITEM_FIELDS_FRAGMENT = `#graphql
+const MENU_ITEM_FIELDS_FRAGMENT = gql(`#graphql
   fragment MenuItemFields on MenuItem {
     id
     title
@@ -18,10 +19,10 @@ const MENU_ITEM_FIELDS_FRAGMENT = `#graphql
       ... on Page { handle }
     }
   }
-` as const;
+`);
 
-const GET_MENU_QUERY = `#graphql
-  ${MENU_ITEM_FIELDS_FRAGMENT}
+const GET_MENU_QUERY = gql(
+  `#graphql
   query getMenu($handle: String!) {
     menu(handle: $handle) {
       id
@@ -38,16 +39,16 @@ const GET_MENU_QUERY = `#graphql
       }
     }
   }
-` as const;
+`,
+  [MENU_ITEM_FIELDS_FRAGMENT],
+);
 
 export async function getMenu({ handle }: { handle: string }): Promise<Menu | null> {
   "use cache: remote";
   cacheLife("max");
   cacheTag("menus");
 
-  const response = await storefront.request<ShopifyMenuResponse>(GET_MENU_QUERY, {
-    variables: { handle },
-  });
+  const response = await storefront.request(GET_MENU_QUERY, { variables: { handle } });
   assertStorefrontOk(response, "getMenu");
 
   return transformShopifyMenu(response.data.menu);

--- a/apps/template/lib/shopify/operations/pages.ts
+++ b/apps/template/lib/shopify/operations/pages.ts
@@ -1,24 +1,13 @@
+import { gql } from "@shopify/hydrogen";
 import { cacheLife, cacheTag } from "next/cache";
 
-import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
+import { defaultLocale } from "@/lib/i18n";
 import type { ContentPage } from "@/lib/types";
 
 import { assertStorefrontOk } from "../errors";
 import { storefront } from "../storefront";
 
-interface ShopifyPage {
-  body: string;
-  bodySummary: string;
-  handle: string;
-  seo: {
-    description: string | null;
-    title: string | null;
-  } | null;
-  title: string;
-  updatedAt: string;
-}
-
-const GET_PAGE_QUERY = `#graphql
+const GET_PAGE_QUERY = gql(`#graphql
   query getPage($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     page(handle: $handle) {
       body
@@ -32,7 +21,7 @@ const GET_PAGE_QUERY = `#graphql
       updatedAt
     }
   }
-` as const;
+`);
 
 export async function getPage({
   handle,
@@ -45,11 +34,7 @@ export async function getPage({
   cacheLife("max");
   cacheTag("pages", `page-${handle}`);
 
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-  const response = await storefront.request<{ page: ShopifyPage | null }>(GET_PAGE_QUERY, {
-    variables: { country, handle, language },
-  });
+  const response = await storefront.request(GET_PAGE_QUERY, { locale, variables: { handle } });
   assertStorefrontOk(response, "getPage");
 
   const page = response.data.page;

--- a/apps/template/lib/shopify/operations/policies.ts
+++ b/apps/template/lib/shopify/operations/policies.ts
@@ -1,66 +1,50 @@
+import { gql } from "@shopify/hydrogen";
 import { cacheLife, cacheTag } from "next/cache";
 
-import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
+import { defaultLocale } from "@/lib/i18n";
 import type { ShopPolicy } from "@/lib/types";
 
 import { assertStorefrontOk } from "../errors";
 import { storefront } from "../storefront";
 
-const GET_SHOP_POLICIES_QUERY = `#graphql
+const SHOP_POLICY_FRAGMENT = gql(`#graphql
+  fragment ShopPolicyFields on ShopPolicy {
+    body
+    handle
+    title
+  }
+`);
+
+const GET_SHOP_POLICIES_QUERY = gql(
+  `#graphql
   query getShopPolicies($country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     shop {
       contactInformation {
-        body
-        handle
-        title
+        ...ShopPolicyFields
       }
       legalNotice {
-        body
-        handle
-        title
+        ...ShopPolicyFields
       }
       privacyPolicy {
-        body
-        handle
-        title
+        ...ShopPolicyFields
       }
       refundPolicy {
-        body
-        handle
-        title
+        ...ShopPolicyFields
       }
       shippingPolicy {
-        body
-        handle
-        title
+        ...ShopPolicyFields
       }
       termsOfSale {
-        body
-        handle
-        title
+        ...ShopPolicyFields
       }
       termsOfService {
-        body
-        handle
-        title
+        ...ShopPolicyFields
       }
     }
   }
-` as const;
-
-type ShopifyPolicy = ShopPolicy | null | undefined;
-
-interface ShopPoliciesResponse {
-  shop: {
-    contactInformation: ShopifyPolicy;
-    legalNotice: ShopifyPolicy;
-    privacyPolicy: ShopifyPolicy;
-    refundPolicy: ShopifyPolicy;
-    shippingPolicy: ShopifyPolicy;
-    termsOfSale: ShopifyPolicy;
-    termsOfService: ShopifyPolicy;
-  };
-}
+`,
+  [SHOP_POLICY_FRAGMENT],
+);
 
 export async function getShopPolicies({
   locale = defaultLocale,
@@ -69,11 +53,7 @@ export async function getShopPolicies({
   cacheLife("max");
   cacheTag("policies");
 
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-  const response = await storefront.request<ShopPoliciesResponse>(GET_SHOP_POLICIES_QUERY, {
-    variables: { country, language },
-  });
+  const response = await storefront.request(GET_SHOP_POLICIES_QUERY, { locale });
   assertStorefrontOk(response, "getShopPolicies");
 
   return Object.values(response.data.shop).filter(

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -1,7 +1,9 @@
+import { gql } from "@shopify/hydrogen";
+import type { ProductSortKeys } from "@shopify/hydrogen/storefront-api-types";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { shopConfig } from "@/lib/config";
-import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
+import { defaultLocale } from "@/lib/i18n";
 import type {
   Filter,
   PageInfo,
@@ -30,7 +32,7 @@ import {
 } from "../fetch";
 import {
   BUNDLE_RELATIONSHIPS_FRAGMENT,
-  IMAGE_FRAGMENT,
+  FILTER_FRAGMENT,
   PRODUCT_CARD_FRAGMENT,
   PRODUCT_FRAGMENT,
   PRODUCT_VARIANT_FRAGMENT,
@@ -40,14 +42,11 @@ import {
 import { storefront } from "../storefront";
 import { transformShopifyFilters } from "../transforms/filters";
 import {
-  type ShopifyProduct,
-  type ShopifyProductCard,
-  type ShopifyVariant,
   transformShopifyProductCard,
   transformShopifyProductDetails,
   transformVariant,
 } from "../transforms/product";
-import type { ProductFilter, ShopifyFilter } from "../types/filters";
+import type { ProductFilter } from "../types/filters";
 import { getNumericShopifyId } from "../utils";
 
 export {
@@ -72,18 +71,19 @@ function tagProducts(products: Array<{ id: string }>): void {
   }
 }
 
-const GET_PRODUCT_BY_HANDLE_QUERY = `#graphql
-  ${PRODUCT_FRAGMENT}
+const GET_PRODUCT_BY_HANDLE_QUERY = gql(
+  `#graphql
   query getProductByHandle($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     productByHandle(handle: $handle) {
       ...ProductFields
     }
   }
-` as const;
+`,
+  [PRODUCT_FRAGMENT],
+);
 
-const GET_PRODUCT_BY_HANDLE_WITH_BUNDLES_QUERY = `#graphql
-  ${BUNDLE_RELATIONSHIPS_FRAGMENT}
-  ${PRODUCT_FRAGMENT}
+const GET_PRODUCT_BY_HANDLE_WITH_BUNDLES_QUERY = gql(
+  `#graphql
   query getProductByHandleWithBundles($handle: String!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     productByHandle(handle: $handle) {
       ...ProductFields
@@ -92,7 +92,9 @@ const GET_PRODUCT_BY_HANDLE_WITH_BUNDLES_QUERY = `#graphql
       }
     }
   }
-` as const;
+`,
+  [BUNDLE_RELATIONSHIPS_FRAGMENT, PRODUCT_FRAGMENT],
+);
 
 export async function getProduct({
   handle,
@@ -104,17 +106,13 @@ export async function getProduct({
   "use cache";
   cacheLife("max");
   cacheTag("products", `product-${handle}`);
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
 
-  const response = await storefront.request<{ productByHandle: ShopifyProduct }>(
-    shopConfig.pdp.bundles.isEnabled
-      ? GET_PRODUCT_BY_HANDLE_WITH_BUNDLES_QUERY
-      : GET_PRODUCT_BY_HANDLE_QUERY,
-    {
-      variables: { handle, country, language },
-    },
-  );
+  const response = shopConfig.pdp.bundles.isEnabled
+    ? await storefront.request(GET_PRODUCT_BY_HANDLE_WITH_BUNDLES_QUERY, {
+        locale,
+        variables: { handle },
+      })
+    : await storefront.request(GET_PRODUCT_BY_HANDLE_QUERY, { locale, variables: { handle } });
   assertStorefrontOk(response, "getProductByHandle");
   const { data } = response;
 
@@ -127,9 +125,8 @@ export async function getProduct({
   return transformShopifyProductDetails(data.productByHandle);
 }
 
-const GET_PRODUCT_VARIANT_QUERY = `#graphql
-  ${IMAGE_FRAGMENT}
-  ${PRODUCT_VARIANT_FRAGMENT}
+const GET_PRODUCT_VARIANT_QUERY = gql(
+  `#graphql
   query getProductVariant($handle: String!, $selectedOptions: [SelectedOptionInput!]!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     productByHandle(handle: $handle) {
       selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {
@@ -137,11 +134,12 @@ const GET_PRODUCT_VARIANT_QUERY = `#graphql
       }
     }
   }
-` as const;
+`,
+  [PRODUCT_VARIANT_FRAGMENT],
+);
 
-const GET_PRODUCT_VARIANT_WITH_BUNDLES_QUERY = `#graphql
-  ${IMAGE_FRAGMENT}
-  ${PURCHASABLE_PRODUCT_VARIANT_FRAGMENT}
+const GET_PRODUCT_VARIANT_WITH_BUNDLES_QUERY = gql(
+  `#graphql
   query getProductVariantWithBundles($handle: String!, $selectedOptions: [SelectedOptionInput!]!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     productByHandle(handle: $handle) {
       selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {
@@ -149,7 +147,9 @@ const GET_PRODUCT_VARIANT_WITH_BUNDLES_QUERY = `#graphql
       }
     }
   }
-` as const;
+`,
+  [PURCHASABLE_PRODUCT_VARIANT_FRAGMENT],
+);
 
 // Empty selections intentionally resolve Shopify's first available variant.
 export async function getProductVariant({
@@ -164,19 +164,16 @@ export async function getProductVariant({
   "use cache";
   cacheLife("max");
   cacheTag("products", `product-${handle}`);
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
 
-  const response = await storefront.request<{
-    productByHandle: { selectedOrFirstAvailableVariant: ShopifyVariant | null } | null;
-  }>(
-    shopConfig.pdp.bundles.isEnabled
-      ? GET_PRODUCT_VARIANT_WITH_BUNDLES_QUERY
-      : GET_PRODUCT_VARIANT_QUERY,
-    {
-      variables: { handle, selectedOptions, country, language },
-    },
-  );
+  const response = shopConfig.pdp.bundles.isEnabled
+    ? await storefront.request(GET_PRODUCT_VARIANT_WITH_BUNDLES_QUERY, {
+        locale,
+        variables: { handle, selectedOptions },
+      })
+    : await storefront.request(GET_PRODUCT_VARIANT_QUERY, {
+        locale,
+        variables: { handle, selectedOptions },
+      });
   assertStorefrontOk(response, "getProductVariant");
   const { data } = response;
 
@@ -197,8 +194,8 @@ export async function getProductWithVariants(params: {
   return product;
 }
 
-const CATALOG_PRODUCTS_QUERY = `#graphql
-  ${PRODUCT_CARD_FRAGMENT}
+const CATALOG_PRODUCTS_QUERY = gql(
+  `#graphql
   query catalogProducts($first: Int!, $after: String, $query: String, $sortKey: ProductSortKeys, $reverse: Boolean, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     products(
       first: $first
@@ -221,9 +218,12 @@ const CATALOG_PRODUCTS_QUERY = `#graphql
       }
     }
   }
-` as const;
+`,
+  [PRODUCT_CARD_FRAGMENT],
+);
 
-const SEARCH_FACETS_QUERY = `#graphql
+const SEARCH_FACETS_QUERY = gql(
+  `#graphql
   query searchFacets($query: String!, $productFilters: [ProductFilter!], $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     search(
       query: $query
@@ -233,6 +233,7 @@ const SEARCH_FACETS_QUERY = `#graphql
     ) {
       totalCount
       nodes {
+        __typename
         ... on Product {
           priceRange {
             minVariantPrice {
@@ -242,30 +243,15 @@ const SEARCH_FACETS_QUERY = `#graphql
         }
       }
       productFilters {
-        id
-        label
-        type
-        presentation
-        values {
-          id
-          label
-          count
-          input
-          swatch {
-            color
-            image {
-              previewImage {
-                url
-              }
-            }
-          }
-        }
+        ...FilterFields
       }
     }
   }
-` as const;
+`,
+  [FILTER_FRAGMENT],
+);
 
-const CATALOG_SORT_KEY_MAP: Record<string, { sortKey: string; reverse: boolean }> = {
+const CATALOG_SORT_KEY_MAP: Record<string, { sortKey: ProductSortKeys; reverse: boolean }> = {
   "best-matches": { sortKey: "RELEVANCE", reverse: false },
   "best-selling": { sortKey: "BEST_SELLING", reverse: false },
   "date-new-to-old": { sortKey: "CREATED_AT", reverse: true },
@@ -450,36 +436,26 @@ async function fetchCatalogProducts({
   sortKey: rawSortKey = "best-matches",
 }: FilteredCatalogProductsParams): Promise<CatalogProductsResult> {
   const sortConfig = CATALOG_SORT_KEY_MAP[rawSortKey] ?? CATALOG_SORT_KEY_MAP["best-matches"];
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
   const catalogQuery = buildCatalogQuery({ query, collection, filters });
 
   // RELEVANCE is meaningless without a query; fall back to BEST_SELLING for plain browse.
   const sortKey =
     sortConfig.sortKey === "RELEVANCE" && !catalogQuery ? "BEST_SELLING" : sortConfig.sortKey;
 
-  const response = await storefront.request<{
-    products: {
-      edges: Array<{ cursor: string; node: ShopifyProductCard | null }>;
-      pageInfo: PageInfo;
-    };
-  }>(CATALOG_PRODUCTS_QUERY, {
+  const response = await storefront.request(CATALOG_PRODUCTS_QUERY, {
+    locale,
     variables: {
       first: limit,
       after: cursor,
       query: catalogQuery || undefined,
       sortKey,
       reverse: sortConfig.reverse,
-      country,
-      language,
     },
   });
   assertStorefrontOk(response, "catalogProducts");
   const { data } = response;
 
-  const shopifyProducts = data.products.edges
-    .map((edge) => edge.node)
-    .filter((node): node is ShopifyProductCard => node !== null);
+  const shopifyProducts = data.products.edges.map((edge) => edge.node);
 
   tagProducts(shopifyProducts);
 
@@ -522,35 +498,25 @@ type SearchFacetsResult = { filters: Filter[]; priceRange?: PriceRange; total: n
 // Browse facets stay uncached so Search & Discovery changes appear immediately.
 export async function fetchSearchFacets(params: SearchFacetsParams): Promise<SearchFacetsResult> {
   const { activeFilters = {}, collection, filters = [], locale = defaultLocale, query } = params;
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
 
   const queryParts: string[] = [];
   if (query?.trim()) queryParts.push(query.trim());
   if (collection) queryParts.push(`collection:'${escapeProductQuery(collection)}'`);
   const searchQuery = queryParts.length > 0 ? queryParts.join(" AND ") : "*";
 
-  const response = await storefront.request<{
-    search: {
-      nodes: Array<{
-        priceRange: { minVariantPrice: { currencyCode: string } };
-      } | null>;
-      productFilters: ShopifyFilter[];
-      totalCount: number;
-    };
-  }>(SEARCH_FACETS_QUERY, {
+  const response = await storefront.request(SEARCH_FACETS_QUERY, {
+    locale,
     variables: {
       query: searchQuery,
       productFilters: filters.length > 0 ? filters : undefined,
-      country,
-      language,
     },
   });
   assertStorefrontOk(response, "searchFacets");
   const { data } = response;
 
-  const currencyCode = data.search.nodes.find((node) => node !== null)?.priceRange.minVariantPrice
-    .currencyCode;
+  const currencyCode = data.search.nodes.flatMap((node) =>
+    node.__typename === "Product" ? [node.priceRange.minVariantPrice.currencyCode] : [],
+  )[0];
   const transformed = transformShopifyFilters(data.search.productFilters, {
     activeFilters,
     currencyCode,
@@ -631,8 +597,8 @@ export async function getRelatedProducts(params: {
   return products;
 }
 
-const GET_PRODUCTS_BY_HANDLES_QUERY = `#graphql
-  ${PRODUCT_CARD_FRAGMENT}
+const GET_PRODUCTS_BY_HANDLES_QUERY = gql(
+  `#graphql
   query getProductsByHandles($query: String!, $first: Int!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     products(first: $first, query: $query) {
       edges {
@@ -642,29 +608,37 @@ const GET_PRODUCTS_BY_HANDLES_QUERY = `#graphql
       }
     }
   }
-` as const;
+`,
+  [PRODUCT_CARD_FRAGMENT],
+);
 
-const GET_PRODUCT_BY_ID_QUERY = `#graphql
-  ${PRODUCT_WITH_VARIANTS_FRAGMENT}
+const GET_PRODUCT_BY_ID_QUERY = gql(
+  `#graphql
   query getProductById($id: ID!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     node(id: $id) {
+      __typename
       ... on Product {
         ...ProductWithVariantsFields
       }
     }
   }
-` as const;
+`,
+  [PRODUCT_WITH_VARIANTS_FRAGMENT],
+);
 
-const GET_PRODUCTS_BY_IDS_QUERY = `#graphql
-  ${PRODUCT_CARD_FRAGMENT}
+const GET_PRODUCTS_BY_IDS_QUERY = gql(
+  `#graphql
   query getProductsByIds($ids: [ID!]!, $country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     nodes(ids: $ids) {
+      __typename
       ... on Product {
         ...ProductCardFields
       }
     }
   }
-` as const;
+`,
+  [PRODUCT_CARD_FRAGMENT],
+);
 
 function decodeShopifyId(id: string): string {
   if (id.startsWith("gid://")) {
@@ -684,20 +658,16 @@ export async function getProductById({
   cacheLife("max");
   cacheTag("products");
 
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
   const gid = decodeShopifyId(id);
 
-  const response = await storefront.request<{ node: ShopifyProduct | null }>(
-    GET_PRODUCT_BY_ID_QUERY,
-    {
-      variables: { id: gid, country, language },
-    },
-  );
+  const response = await storefront.request(GET_PRODUCT_BY_ID_QUERY, {
+    locale,
+    variables: { id: gid },
+  });
   assertStorefrontOk(response, "getProductById");
   const { data } = response;
 
-  const product = data.node;
+  const product = data.node?.__typename === "Product" ? data.node : null;
   if (!product) {
     return undefined;
   }
@@ -723,20 +693,18 @@ export async function getProductsByIds({
     return [];
   }
 
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
   const gids = ids.map(decodeShopifyId);
 
-  const response = await storefront.request<{ nodes: (ShopifyProductCard | null)[] }>(
-    GET_PRODUCTS_BY_IDS_QUERY,
-    {
-      variables: { ids: gids, country, language },
-    },
-  );
+  const response = await storefront.request(GET_PRODUCTS_BY_IDS_QUERY, {
+    locale,
+    variables: { ids: gids },
+  });
   assertStorefrontOk(response, "getProductsByIds");
   const { data } = response;
 
-  const shopifyProducts = data.nodes.filter((node): node is ShopifyProductCard => node !== null);
+  const shopifyProducts = data.nodes.flatMap((node) =>
+    node?.__typename === "Product" ? [node] : [],
+  );
 
   tagProducts(shopifyProducts);
 
@@ -758,27 +726,21 @@ export async function getProductsByHandles({
     return [];
   }
 
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-
   const searchQuery = handles.map((h) => `handle:${h}`).join(" OR ");
 
-  const response = await storefront.request<{
-    products: { edges: Array<{ node: ShopifyProductCard }> };
-  }>(GET_PRODUCTS_BY_HANDLES_QUERY, {
-    variables: { query: searchQuery, first: handles.length, country, language },
+  const response = await storefront.request(GET_PRODUCTS_BY_HANDLES_QUERY, {
+    locale,
+    variables: { query: searchQuery, first: handles.length },
   });
   assertStorefrontOk(response, "getProductsByHandles");
   const { data } = response;
 
-  const productMap = new Map<string, ShopifyProductCard>();
-  for (const edge of data.products.edges) {
-    productMap.set(edge.node.handle, edge.node);
-  }
+  const productMap = new Map(data.products.edges.map((edge) => [edge.node.handle, edge.node]));
 
-  const shopifyProducts = handles
-    .map((handle) => productMap.get(handle))
-    .filter((product): product is ShopifyProductCard => product !== undefined);
+  const shopifyProducts = handles.flatMap((handle) => {
+    const product = productMap.get(handle);
+    return product ? [product] : [];
+  });
 
   tagProducts(shopifyProducts);
 

--- a/apps/template/lib/shopify/operations/shop.ts
+++ b/apps/template/lib/shopify/operations/shop.ts
@@ -1,4 +1,4 @@
-import type { I18nConfig } from "@shopify/hydrogen";
+import { gql, type I18nConfig } from "@shopify/hydrogen";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
@@ -7,7 +7,7 @@ import type { ShopAnalyticsData } from "@/lib/types";
 import { assertStorefrontOk } from "../errors";
 import { storefront } from "../storefront";
 
-const GET_SHOP_ANALYTICS_QUERY = `#graphql
+const GET_SHOP_ANALYTICS_QUERY = gql(`#graphql
   query getShopAnalytics($country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
     localization {
       country {
@@ -20,20 +20,7 @@ const GET_SHOP_ANALYTICS_QUERY = `#graphql
       id
     }
   }
-` as const;
-
-interface ShopAnalyticsResponse {
-  localization: {
-    country: {
-      currency: {
-        isoCode: string;
-      };
-    };
-  };
-  shop: {
-    id: string;
-  };
-}
+`);
 
 export async function getShopAnalytics({
   locale = defaultLocale,
@@ -42,16 +29,12 @@ export async function getShopAnalytics({
   cacheLife("max");
   cacheTag("shop-analytics");
 
-  const country = getCountryCode(locale);
-  const language = getLanguageCode(locale);
-  const response = await storefront.request<ShopAnalyticsResponse>(GET_SHOP_ANALYTICS_QUERY, {
-    variables: { country, language },
-  });
+  const response = await storefront.request(GET_SHOP_ANALYTICS_QUERY, { locale });
   assertStorefrontOk(response, "getShopAnalytics");
 
   return {
-    acceptedLanguage: language as I18nConfig["language"],
-    country: country as I18nConfig["country"],
+    acceptedLanguage: getLanguageCode(locale) as I18nConfig["language"],
+    country: getCountryCode(locale) as I18nConfig["country"],
     currency: response.data.localization.country.currency.isoCode,
     shopId: response.data.shop.id,
     storeDomain: process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN as string,

--- a/apps/template/lib/shopify/operations/sitemap.ts
+++ b/apps/template/lib/shopify/operations/sitemap.ts
@@ -1,10 +1,11 @@
-import type { GraphQLFormattedError } from "@shopify/hydrogen";
+import { gql } from "@shopify/hydrogen";
+import type { SitemapType } from "@shopify/hydrogen/storefront-api-types";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { assertStorefrontOk } from "../errors";
-import { storefront } from "../storefront";
+import { type ResultOf, storefront, type StorefrontResponse } from "../storefront";
 
-export type ShopifySitemapType = "ARTICLE" | "BLOG" | "COLLECTION" | "PAGE" | "PRODUCT";
+export type ShopifySitemapType = SitemapType;
 
 export interface SitemapResource {
   handle: string;
@@ -12,26 +13,7 @@ export interface SitemapResource {
   updatedAt: string;
 }
 
-interface StorefrontResponse<T> {
-  data?: T | null;
-  errors?: GraphQLFormattedError[];
-}
-
-interface ArticleSitemapPageResponse {
-  articles: {
-    nodes: Array<{
-      blog: { handle: string };
-      handle: string;
-      publishedAt: string;
-    }>;
-    pageInfo: {
-      endCursor: string | null;
-      hasNextPage: boolean;
-    };
-  };
-}
-
-const GET_ARTICLE_SITEMAP_PAGE_QUERY = `#graphql
+const GET_ARTICLE_SITEMAP_PAGE_QUERY = gql(`#graphql
   query getArticleSitemapPage($first: Int!, $after: String) {
     articles(first: $first, after: $after, sortKey: UPDATED_AT) {
       nodes {
@@ -47,9 +29,9 @@ const GET_ARTICLE_SITEMAP_PAGE_QUERY = `#graphql
       }
     }
   }
-` as const;
+`);
 
-const GET_SITEMAP_PAGES_COUNT_QUERY = `#graphql
+const GET_SITEMAP_PAGES_COUNT_QUERY = gql(`#graphql
   query getSitemapPagesCount($type: SitemapType!) {
     sitemap(type: $type) {
       pagesCount {
@@ -57,9 +39,9 @@ const GET_SITEMAP_PAGES_COUNT_QUERY = `#graphql
       }
     }
   }
-` as const;
+`);
 
-const GET_SITEMAP_PAGE_QUERY = `#graphql
+const GET_SITEMAP_PAGE_QUERY = gql(`#graphql
   query getSitemapPage($type: SitemapType!, $page: Int!) {
     sitemap(type: $type) {
       resources(page: $page) {
@@ -71,7 +53,9 @@ const GET_SITEMAP_PAGE_QUERY = `#graphql
       }
     }
   }
-` as const;
+`);
+
+type ArticleSitemapPage = ResultOf<typeof GET_ARTICLE_SITEMAP_PAGE_QUERY>["articles"];
 
 function cacheTagsFor(type: ShopifySitemapType): string[] {
   if (type === "ARTICLE") return ["articles", "articles-index"];
@@ -94,15 +78,12 @@ export async function getShopifySitemapPagesCount(type: ShopifySitemapType): Pro
   cacheLife("max");
   cacheTag(...cacheTagsFor(type));
 
-  const response = await storefront.request<{ sitemap: { pagesCount: { count: number } } }>(
-    GET_SITEMAP_PAGES_COUNT_QUERY,
-    {
-      variables: { type },
-    },
-  );
+  const response = await storefront.request(GET_SITEMAP_PAGES_COUNT_QUERY, {
+    variables: { type },
+  });
   assertStorefrontOk(response, "getSitemapPagesCount");
 
-  return response.data.sitemap.pagesCount.count;
+  return response.data.sitemap.pagesCount?.count ?? 0;
 }
 
 export async function getShopifySitemapPage(
@@ -115,16 +96,16 @@ export async function getShopifySitemapPage(
 
   if (type === "ARTICLE") {
     let after: string | null = null;
-    let articlePage: ArticleSitemapPageResponse["articles"] | undefined;
+    let articlePage: ArticleSitemapPage | undefined;
 
     for (let currentPage = 1; currentPage <= page; currentPage += 1) {
-      const response: StorefrontResponse<ArticleSitemapPageResponse> =
-        await storefront.request<ArticleSitemapPageResponse>(GET_ARTICLE_SITEMAP_PAGE_QUERY, {
+      const response: StorefrontResponse<ResultOf<typeof GET_ARTICLE_SITEMAP_PAGE_QUERY>> =
+        await storefront.request(GET_ARTICLE_SITEMAP_PAGE_QUERY, {
           variables: { after, first: 250 },
         });
       assertStorefrontOk(response, "getArticleSitemapPage");
       articlePage = response.data.articles;
-      after = articlePage.pageInfo.endCursor;
+      after = articlePage.pageInfo.endCursor ?? null;
 
       if (!articlePage.pageInfo.hasNextPage && currentPage < page) {
         return { hasNextPage: false, items: [] };
@@ -145,14 +126,18 @@ export async function getShopifySitemapPage(
     };
   }
 
-  const response = await storefront.request<{
-    sitemap: { resources: { hasNextPage: boolean; items: SitemapResource[] } };
-  }>(GET_SITEMAP_PAGE_QUERY, {
+  const response = await storefront.request(GET_SITEMAP_PAGE_QUERY, {
     variables: { type, page },
   });
   assertStorefrontOk(response, "getSitemapPage");
 
   const resources = response.data.sitemap.resources;
-  tagSitemapResources(type, resources.items);
-  return resources;
+  if (!resources) return { hasNextPage: false, items: [] };
+
+  const items = resources.items.map((item) => ({
+    handle: item.handle,
+    updatedAt: item.updatedAt,
+  }));
+  tagSitemapResources(type, items);
+  return { hasNextPage: resources.hasNextPage, items };
 }

--- a/apps/template/lib/shopify/storefront.ts
+++ b/apps/template/lib/shopify/storefront.ts
@@ -1,10 +1,11 @@
 import {
+  type AnyStorefrontQueryString,
   createShopifyRequestContext,
   createStorefrontClient,
   type GraphQLFormattedError,
   type I18nConfig,
+  type StorefrontApi,
   type StorefrontClient,
-  type StorefrontQueryString,
 } from "@shopify/hydrogen";
 
 import { defaultLocale, getCountryCode, getLanguageCode } from "@/lib/i18n";
@@ -71,30 +72,41 @@ function getClient(country: string, language: string): StorefrontClient {
   );
 }
 
-interface StorefrontRequestOptions {
-  variables?: Record<string, unknown>;
-}
+// Hydrogen's StorefrontApi.ResultOf collapses on fragment documents (Variables = never), so read the gql.tada decoration directly.
+export type ResultOf<Doc> = Doc extends { __apiType?: (variables: never) => infer Result }
+  ? Result
+  : never;
 
-interface StorefrontResponse<T> {
+// Hydrogen injects `$country`/`$language` from the client's i18n, so callers pass a locale instead.
+type StorefrontVariables<Doc extends AnyStorefrontQueryString> = Omit<
+  StorefrontApi.VariablesOf<Doc>,
+  "country" | "language"
+>;
+
+type StorefrontRequestOptions<Doc extends AnyStorefrontQueryString> = {
+  locale?: string;
+} & (Record<string, never> extends StorefrontVariables<Doc>
+  ? { variables?: StorefrontVariables<Doc> }
+  : { variables: StorefrontVariables<Doc> });
+
+export interface StorefrontResponse<T> {
   data?: T | null;
   errors?: GraphQLFormattedError[];
 }
 
 export const storefront = {
-  async request<T>(
-    query: string,
-    options?: StorefrontRequestOptions,
-  ): Promise<StorefrontResponse<T>> {
-    const variables = options?.variables;
-    const country =
-      typeof variables?.country === "string" ? variables.country : getCountryCode(defaultLocale);
-    const language =
-      typeof variables?.language === "string" ? variables.language : getLanguageCode(defaultLocale);
-
-    // Brand runtime strings so Hydrogen does not infer `never` variables.
-    const doc = query as StorefrontQueryString<T, Record<string, unknown>>;
-    const { data, errors } = await getClient(country, language).graphql(doc, { variables });
-    return { data, errors };
+  async request<const Doc extends AnyStorefrontQueryString>(
+    doc: Doc,
+    ...[options]: Record<string, never> extends StorefrontVariables<Doc>
+      ? [options?: StorefrontRequestOptions<Doc>]
+      : [options: StorefrontRequestOptions<Doc>]
+  ): Promise<StorefrontResponse<ResultOf<Doc>>> {
+    const locale = options?.locale ?? defaultLocale;
+    const client = getClient(getCountryCode(locale), getLanguageCode(locale));
+    const { data, errors } = await client.graphql(doc, {
+      variables: options?.variables,
+    } as never);
+    return { data: data as ResultOf<Doc> | null, errors };
   },
 };
 

--- a/apps/template/lib/shopify/transforms/cart.ts
+++ b/apps/template/lib/shopify/transforms/cart.ts
@@ -1,3 +1,5 @@
+import type { CART_FRAGMENT, CART_LINE_FRAGMENT } from "@/lib/shopify/fragments";
+import type { ResultOf } from "@/lib/shopify/storefront";
 import type {
   AppliedGiftCard,
   Cart,
@@ -9,89 +11,18 @@ import type {
   Money,
 } from "@/lib/types";
 
-interface ShopifyMoney {
-  amount: string;
-  currencyCode: string;
-}
+export type ShopifyCart = ResultOf<typeof CART_FRAGMENT>;
+type ShopifyCartLineNode = ShopifyCart["lines"]["nodes"][number];
+type ShopifyCartLine = ResultOf<typeof CART_LINE_FRAGMENT>;
+type ShopifyDiscountAllocation = ShopifyCart["discountAllocations"][number];
+type ShopifyAppliedGiftCard = ShopifyCart["appliedGiftCards"][number];
+type ShopifyMerchandise = Extract<
+  ShopifyCartLine["merchandise"],
+  { __typename?: "ProductVariant" }
+>;
+type ShopifyImage = NonNullable<ShopifyMerchandise["image"]>;
 
-interface ShopifyImage {
-  url: string;
-  altText: string | null;
-  width: number;
-  height: number;
-}
-
-interface ShopifyDiscountAllocation {
-  __typename:
-    | "CartAutomaticDiscountAllocation"
-    | "CartCodeDiscountAllocation"
-    | "CartCustomDiscountAllocation";
-  code?: string;
-  discountedAmount: ShopifyMoney;
-  title?: string;
-}
-
-interface ShopifyAppliedGiftCard {
-  amountUsed: ShopifyMoney;
-  balance: ShopifyMoney;
-  id: string;
-  lastCharacters: string;
-}
-
-interface ShopifyCartLine {
-  cost: {
-    totalAmount: ShopifyMoney;
-  };
-  discountAllocations: ShopifyDiscountAllocation[];
-  id: string;
-  // ComponentizableCartLine parents omit instructions and default to editable.
-  instructions?: {
-    canRemove: boolean;
-    canUpdateQuantity: boolean;
-  };
-  lineComponents?: ShopifyCartLine[];
-  merchandise: {
-    compareAtPrice?: ShopifyMoney | null;
-    id: string;
-    image?: ShopifyImage | null;
-    price?: ShopifyMoney;
-    product: {
-      description?: string;
-      featuredImage: ShopifyImage | null;
-      handle: string;
-      id: string;
-      title: string;
-    };
-    selectedOptions: Array<{ name: string; value: string }>;
-    title: string;
-  };
-  quantity: number;
-}
-
-interface ShopifyDeliveryGroup {
-  selectedDeliveryOption: {
-    estimatedCost: ShopifyMoney;
-    title: string | null;
-  } | null;
-}
-
-export interface ShopifyCart {
-  appliedGiftCards: ShopifyAppliedGiftCard[];
-  checkoutUrl: string;
-  cost: {
-    subtotalAmount: ShopifyMoney;
-    totalAmount: ShopifyMoney;
-  };
-  deliveryGroups?: { nodes: ShopifyDeliveryGroup[] };
-  discountAllocations: ShopifyDiscountAllocation[];
-  discountCodes: Array<{ applicable: boolean; code: string }>;
-  id: string;
-  lines: { nodes: ShopifyCartLine[] };
-  note: string | null;
-  totalQuantity: number;
-}
-
-function transformImage(image: ShopifyImage | null): Image {
+function transformImage(image: ShopifyImage | null | undefined): Image {
   return {
     url: image?.url ?? "",
     altText: image?.altText ?? "",
@@ -100,7 +31,7 @@ function transformImage(image: ShopifyImage | null): Image {
   };
 }
 
-function transformCartProduct(product: ShopifyCartLine["merchandise"]["product"]): CartProduct {
+function transformCartProduct(product: ShopifyMerchandise["product"]): CartProduct {
   return {
     id: product.id,
     handle: product.handle,
@@ -123,7 +54,7 @@ function transformDiscountAllocation(
   const kind = allocation.__typename === "CartAutomaticDiscountAllocation" ? "automatic" : "custom";
   return {
     kind,
-    title: allocation.title ?? "",
+    title: ("title" in allocation ? allocation.title : undefined) ?? "",
     discountedAmount: allocation.discountedAmount,
   };
 }
@@ -136,9 +67,7 @@ function transformDiscountAllocations(
     .filter((a): a is DiscountAllocation => a !== null);
 }
 
-function transformDiscountCodes(
-  codes: Array<{ applicable: boolean; code: string }>,
-): DiscountCode[] {
+function transformDiscountCodes(codes: ShopifyCart["discountCodes"]): DiscountCode[] {
   return codes.map(({ code, applicable }) => ({ code, applicable }));
 }
 
@@ -151,32 +80,37 @@ function transformAppliedGiftCards(cards: ShopifyAppliedGiftCard[]): AppliedGift
   }));
 }
 
-function transformCartLine(line: ShopifyCartLine): CartLine {
+// Lines are a CartLine | ComponentizableCartLine union; only CartLine carries instructions.
+function transformCartLine(line: ShopifyCartLineNode): CartLine {
+  // The Merchandise union has a single member today, so the narrowing never fails at runtime.
+  const merchandise = line.merchandise as ShopifyMerchandise;
+  const instructions = "instructions" in line ? line.instructions : undefined;
+  const lineComponents = "lineComponents" in line ? line.lineComponents : undefined;
   return {
     id: line.id,
     quantity: line.quantity,
-    canRemove: line.instructions?.canRemove ?? true,
-    canUpdateQuantity: line.instructions?.canUpdateQuantity ?? true,
-    components: line.lineComponents?.map(transformCartLine) ?? [],
+    canRemove: instructions?.canRemove ?? true,
+    canUpdateQuantity: instructions?.canUpdateQuantity ?? true,
+    components: lineComponents?.map(transformCartLine) ?? [],
     cost: {
       totalAmount: line.cost.totalAmount,
     },
     merchandise: {
-      compareAtPrice: line.merchandise.compareAtPrice ?? undefined,
-      id: line.merchandise.id,
-      title: line.merchandise.title,
-      image: line.merchandise.image ? transformImage(line.merchandise.image) : undefined,
-      price: line.merchandise.price,
-      selectedOptions: line.merchandise.selectedOptions,
-      product: transformCartProduct(line.merchandise.product),
+      compareAtPrice: merchandise.compareAtPrice ?? undefined,
+      id: merchandise.id,
+      title: merchandise.title,
+      image: merchandise.image ? transformImage(merchandise.image) : undefined,
+      price: merchandise.price,
+      selectedOptions: merchandise.selectedOptions,
+      product: transformCartProduct(merchandise.product),
     },
     discountAllocations: transformDiscountAllocations(line.discountAllocations),
   };
 }
 
 function transformShippingCost(cart: ShopifyCart): Money | null {
-  const groups = cart.deliveryGroups?.nodes;
-  if (!groups?.length) return null;
+  const groups = cart.deliveryGroups.nodes;
+  if (!groups.length) return null;
 
   const selected = groups
     .map((g) => g.selectedDeliveryOption)
@@ -195,7 +129,7 @@ export function transformShopifyCart(cart: ShopifyCart): Cart {
     id: cart.id,
     checkoutUrl: cart.checkoutUrl,
     totalQuantity: cart.totalQuantity,
-    note: cart.note,
+    note: cart.note ?? null,
     cost: {
       subtotalAmount: cart.cost.subtotalAmount,
       totalAmount: cart.cost.totalAmount,

--- a/apps/template/lib/shopify/transforms/collection.ts
+++ b/apps/template/lib/shopify/transforms/collection.ts
@@ -1,22 +1,8 @@
+import type { COLLECTION_FIELDS_FRAGMENT } from "@/lib/shopify/fragments";
+import type { ResultOf } from "@/lib/shopify/storefront";
 import type { Collection } from "@/lib/types";
 
-interface ShopifyCollection {
-  handle: string;
-  id: string;
-  title: string;
-  description: string;
-  image: {
-    url: string;
-    altText: string | null;
-    width: number;
-    height: number;
-  } | null;
-  updatedAt: string;
-  seo: {
-    title: string | null;
-    description: string | null;
-  };
-}
+export type ShopifyCollection = ResultOf<typeof COLLECTION_FIELDS_FRAGMENT>;
 
 export function transformShopifyCollection(collection: ShopifyCollection): Collection {
   return {
@@ -28,8 +14,8 @@ export function transformShopifyCollection(collection: ShopifyCollection): Colle
       ? {
           url: collection.image.url,
           altText: collection.image.altText ?? collection.title,
-          width: collection.image.width,
-          height: collection.image.height,
+          width: collection.image.width ?? 0,
+          height: collection.image.height ?? 0,
         }
       : null,
     path: `/collections/${collection.handle}`,
@@ -44,5 +30,3 @@ export function transformShopifyCollection(collection: ShopifyCollection): Colle
 export function transformShopifyCollections(collections: ShopifyCollection[]): Collection[] {
   return collections.map(transformShopifyCollection);
 }
-
-export type { ShopifyCollection };

--- a/apps/template/lib/shopify/transforms/customer.ts
+++ b/apps/template/lib/shopify/transforms/customer.ts
@@ -1,3 +1,10 @@
+import type { CustomerAccountResultOf } from "@/lib/shopify/customer-account";
+import type {
+  ADDRESS_FRAGMENT,
+  CUSTOMER_PROFILE_FRAGMENT,
+  ORDER_FRAGMENT,
+  ORDER_SUMMARY_FRAGMENT,
+} from "@/lib/shopify/customer-account-fragments";
 import type {
   CustomerAddress,
   CustomerOrder,
@@ -8,71 +15,19 @@ import type {
   OrderLineItem,
 } from "@/lib/types";
 
-interface ShopifyMoney {
-  amount: string;
-  currencyCode: string;
-}
-
-interface ShopifyImage {
-  altText: string | null;
-  height: number | null;
-  url: string;
-  width: number | null;
-}
-
-export interface ShopifyCustomerAddress {
-  address1: string | null;
-  address2: string | null;
-  city: string | null;
-  company: string | null;
-  firstName: string | null;
-  formatted: string[];
-  id: string;
-  lastName: string | null;
-  phoneNumber: string | null;
-  territoryCode: string | null;
-  zip: string | null;
-  zoneCode: string | null;
-}
-
-interface ShopifyLineItem {
-  image: ShopifyImage | null;
-  quantity: number;
-  title: string;
-  totalPrice: ShopifyMoney | null;
-  variantTitle: string | null;
-}
-
-export interface ShopifyOrderSummary {
-  financialStatus: string | null;
-  fulfillmentStatus: string;
-  id: string;
-  name: string;
-  number: number;
-  processedAt: string;
-  totalPrice: ShopifyMoney;
-}
-
-export interface ShopifyOrder extends ShopifyOrderSummary {
-  lineItems: { nodes: ShopifyLineItem[] };
-  shippingAddress: ShopifyCustomerAddress | null;
-  statusPageUrl: string;
-  subtotal: ShopifyMoney | null;
-  totalShipping: ShopifyMoney | null;
-  totalTax: ShopifyMoney | null;
-}
-
-export interface ShopifyCustomerProfile {
-  emailAddress: { emailAddress: string } | null;
-  firstName: string | null;
-  lastName: string | null;
-}
+export type ShopifyCustomerAddress = CustomerAccountResultOf<typeof ADDRESS_FRAGMENT>;
+export type ShopifyOrderSummary = CustomerAccountResultOf<typeof ORDER_SUMMARY_FRAGMENT>;
+export type ShopifyOrder = CustomerAccountResultOf<typeof ORDER_FRAGMENT>;
+export type ShopifyCustomerProfile = CustomerAccountResultOf<typeof CUSTOMER_PROFILE_FRAGMENT>;
+type ShopifyLineItem = ShopifyOrder["lineItems"]["nodes"][number];
+type ShopifyImage = NonNullable<ShopifyLineItem["image"]>;
+type ShopifyMoney = ShopifyOrderSummary["totalPrice"];
 
 function transformMoney(money: ShopifyMoney): Money {
   return { amount: money.amount, currencyCode: money.currencyCode };
 }
 
-function transformImage(image: ShopifyImage | null): Image | null {
+function transformImage(image: ShopifyImage | null | undefined): Image | null {
   if (!image) return null;
   return {
     altText: image.altText ?? "",
@@ -87,25 +42,25 @@ export function transformCustomerAddress(
   defaultAddressId?: string | null,
 ): CustomerAddress {
   return {
-    address1: address.address1,
-    address2: address.address2,
-    city: address.city,
-    company: address.company,
-    firstName: address.firstName,
+    address1: address.address1 ?? null,
+    address2: address.address2 ?? null,
+    city: address.city ?? null,
+    company: address.company ?? null,
+    firstName: address.firstName ?? null,
     formatted: address.formatted,
     id: address.id,
     isDefault: defaultAddressId != null && address.id === defaultAddressId,
-    lastName: address.lastName,
-    phoneNumber: address.phoneNumber,
-    territoryCode: address.territoryCode,
-    zip: address.zip,
-    zoneCode: address.zoneCode,
+    lastName: address.lastName ?? null,
+    phoneNumber: address.phoneNumber ?? null,
+    territoryCode: address.territoryCode ?? null,
+    zip: address.zip ?? null,
+    zoneCode: address.zoneCode ?? null,
   };
 }
 
 export function transformOrderSummary(order: ShopifyOrderSummary): CustomerOrderSummary {
   return {
-    financialStatus: order.financialStatus,
+    financialStatus: order.financialStatus ?? null,
     fulfillmentStatus: order.fulfillmentStatus,
     id: order.id,
     name: order.name,
@@ -121,7 +76,7 @@ function transformLineItem(item: ShopifyLineItem): OrderLineItem {
     quantity: item.quantity,
     title: item.title,
     totalPrice: item.totalPrice ? transformMoney(item.totalPrice) : null,
-    variantTitle: item.variantTitle,
+    variantTitle: item.variantTitle ?? null,
   };
 }
 
@@ -140,7 +95,7 @@ export function transformOrder(order: ShopifyOrder): CustomerOrder {
 export function transformCustomerProfile(customer: ShopifyCustomerProfile): CustomerProfile {
   return {
     email: customer.emailAddress?.emailAddress ?? "",
-    firstName: customer.firstName,
-    lastName: customer.lastName,
+    firstName: customer.firstName ?? null,
+    lastName: customer.lastName ?? null,
   };
 }

--- a/apps/template/lib/shopify/transforms/menu.ts
+++ b/apps/template/lib/shopify/transforms/menu.ts
@@ -1,38 +1,33 @@
 import type { Menu, MenuItem, MenuItemType } from "../types/menu";
 import { transformShopifyMenuItemUrl } from "../utils";
 
-export type ShopifyMenuItem = {
+// Structural shape shared by every nesting level of the menu query.
+export interface ShopifyMenuItem {
   id: string;
+  items?: ShopifyMenuItem[];
   title: string;
-  url: string | null;
   type: MenuItemType;
-  tags: string[];
-  resource: {
-    handle?: string;
-  } | null;
-  items: ShopifyMenuItem[];
-};
+  url?: string | null;
+}
 
-export type ShopifyMenuResponse = {
-  menu: {
-    id: string;
-    handle: string;
-    title: string;
-    items: ShopifyMenuItem[];
-  } | null;
-};
+export interface ShopifyMenu {
+  handle: string;
+  id: string;
+  items: ShopifyMenuItem[];
+  title: string;
+}
 
 function transformMenuItem(item: ShopifyMenuItem): MenuItem {
   return {
     id: item.id,
     title: item.title,
-    url: transformShopifyMenuItemUrl(item.url, item.type),
+    url: transformShopifyMenuItemUrl(item.url ?? null, item.type),
     type: item.type,
     items: (item.items ?? []).map(transformMenuItem),
   };
 }
 
-export function transformShopifyMenu(menu: ShopifyMenuResponse["menu"]): Menu | null {
+export function transformShopifyMenu(menu: ShopifyMenu | null | undefined): Menu | null {
   if (!menu) return null;
 
   return {

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -1,4 +1,15 @@
-import { flattenEdges, type ShopifyEdges } from "@/lib/shopify/utils";
+import type {
+  BUNDLE_COMPONENT_VARIANT_FRAGMENT,
+  FILTERABLE_PRODUCT_CARD_FRAGMENT,
+  PRODUCT_CARD_FRAGMENT,
+  PRODUCT_FRAGMENT,
+  PRODUCT_VARIANT_FRAGMENT,
+  PRODUCT_WITH_VARIANTS_FRAGMENT,
+  PURCHASABLE_PRODUCT_VARIANT_FRAGMENT,
+  TAXONOMY_CATEGORY_FRAGMENT,
+} from "@/lib/shopify/fragments";
+import type { ResultOf } from "@/lib/shopify/storefront";
+import { flattenEdges } from "@/lib/shopify/utils";
 import type {
   Category,
   Image,
@@ -13,165 +24,37 @@ import type {
   Video,
 } from "@/lib/types";
 
-interface ShopifyImage {
-  url: string;
-  altText: string | null;
-  width: number;
-  height: number;
-}
+type ShopifyBundleComponentVariant = ResultOf<typeof BUNDLE_COMPONENT_VARIANT_FRAGMENT>;
+export type ShopifyImage = NonNullable<ShopifyBundleComponentVariant["image"]>;
+type ShopifyBaseVariant = ResultOf<typeof PRODUCT_VARIANT_FRAGMENT>;
+type ShopifyPurchasableVariant = ResultOf<typeof PURCHASABLE_PRODUCT_VARIANT_FRAGMENT>;
+// Bundle fields are only selected when `shopConfig.pdp.bundles.isEnabled`.
+export type ShopifyVariant = ShopifyBaseVariant & Partial<ShopifyPurchasableVariant>;
+type ShopifyCategory = ResultOf<typeof TAXONOMY_CATEGORY_FRAGMENT>;
 
-interface ShopifyMoney {
-  amount: string;
-  currencyCode: string;
-}
-
-interface ShopifyBundleComponentVariant {
-  id: string;
-  title: string;
-  image: ShopifyImage | null;
-  product: {
-    id: string;
-    title: string;
-    handle: string;
-    featuredImage: ShopifyImage | null;
+type ShopifyBaseProduct = ResultOf<typeof PRODUCT_FRAGMENT>;
+type ShopifyProductWithVariants = ResultOf<typeof PRODUCT_WITH_VARIANTS_FRAGMENT>;
+// Variants and bundle relationships are optional selections layered on ProductFields.
+export type ShopifyProduct = ShopifyBaseProduct &
+  Partial<Pick<ShopifyProductWithVariants, "variants">> & {
+    selectedOrFirstAvailableVariant?: ShopifyVariant | null;
   };
-}
+type ShopifyOption = ShopifyProduct["options"][number];
+type ShopifyOptionValueSwatch = ShopifyOption["optionValues"][number]["swatch"];
+type ShopifyMediaNode = ShopifyProduct["media"]["edges"][number]["node"];
 
-export interface ShopifyVariant {
-  id: string;
-  title: string;
-  availableForSale: boolean;
-  price: ShopifyMoney;
-  compareAtPrice: ShopifyMoney | null;
-  selectedOptions: Array<{ name: string; value: string }>;
-  image: ShopifyImage | null;
-  requiresComponents?: boolean;
-  groupedBy?: { nodes: ShopifyBundleComponentVariant[] };
-  components?: {
-    nodes: Array<{ quantity: number; productVariant: ShopifyBundleComponentVariant }>;
-  };
-}
+type ShopifyBaseProductCard = ResultOf<typeof PRODUCT_CARD_FRAGMENT>;
+type ShopifyFilterableProductCard = ResultOf<typeof FILTERABLE_PRODUCT_CARD_FRAGMENT>;
+export type ShopifyProductCard = ShopifyBaseProductCard &
+  Partial<Pick<ShopifyFilterableProductCard, "options">>;
 
-interface ShopifyOptionValueSwatch {
-  color: string | null;
-  image: { previewImage: { url: string } } | null;
-}
-
-interface ShopifyOptionValue {
-  id: string;
-  name: string;
-  swatch: ShopifyOptionValueSwatch | null;
-  firstSelectableVariant?: {
-    image: ShopifyImage | null;
-    selectedOptions?: Array<{ name: string; value: string }>;
-  } | null;
-}
-
-interface ShopifyOption {
-  id: string;
-  name: string;
-  values: string[];
-  optionValues?: ShopifyOptionValue[];
-}
-
-interface ShopifyCategory {
-  id: string;
-  name: string;
-  ancestors: Array<{ id: string; name: string }>;
-}
-
-interface ShopifyVideoSource {
-  url: string;
-  mimeType: string;
-  width: number;
-  height: number;
-}
-
-interface ShopifyMediaImageNode {
-  mediaContentType: "IMAGE";
-  image: ShopifyImage | null;
-}
-
-interface ShopifyVideoNode {
-  mediaContentType: "VIDEO";
-  previewImage: ShopifyImage | null;
-  sources: ShopifyVideoSource[];
-}
-
-interface ShopifyOtherMediaNode {
-  mediaContentType: "EXTERNAL_VIDEO" | "MODEL_3D";
-}
-
-type ShopifyMediaNode = ShopifyMediaImageNode | ShopifyVideoNode | ShopifyOtherMediaNode;
-
-export interface ShopifyProduct {
-  id: string;
-  title: string;
-  handle: string;
-  description: string;
-  descriptionHtml: string;
-  vendor: string;
-  tags: string[];
-  updatedAt: string;
-  availableForSale: boolean;
-  isGiftCard: boolean;
-  featuredImage: ShopifyImage | null;
-  media?: ShopifyEdges<ShopifyMediaNode>;
-  /** @deprecated Kept for stale cache compatibility — new queries use `media` */
-  images?: ShopifyEdges<ShopifyImage>;
-  priceRange: {
-    minVariantPrice: ShopifyMoney;
-    maxVariantPrice: ShopifyMoney;
-  };
-  compareAtPriceRange: {
-    minVariantPrice: ShopifyMoney;
-    maxVariantPrice: ShopifyMoney;
-  } | null;
-  encodedVariantAvailability?: string | null;
-  encodedVariantExistence?: string | null;
-  variantsCount: { count: number };
-  selectedOrFirstAvailableVariant?: ShopifyVariant | null;
-  variants?: ShopifyEdges<ShopifyVariant>;
-  options: ShopifyOption[];
-  seo: {
-    title: string | null;
-    description: string | null;
-  };
-  category?: ShopifyCategory | null;
-  collections?: ShopifyEdges<{ handle: string }>;
-}
-
-export interface ShopifyProductCard {
-  id: string;
-  title: string;
-  handle: string;
-  vendor: string;
-  availableForSale: boolean;
-  isGiftCard: boolean;
-  featuredImage: ShopifyImage | null;
-  priceRange: {
-    minVariantPrice: ShopifyMoney;
-    maxVariantPrice: ShopifyMoney;
-  };
-  compareAtPriceRange?: {
-    minVariantPrice: ShopifyMoney;
-  } | null;
-  selectedOrFirstAvailableVariant?: {
-    id: string;
-    availableForSale: boolean;
-    image?: ShopifyImage | null;
-    selectedOptions: Array<{ name: string; value: string }>;
-  } | null;
-  options?: Array<Pick<ShopifyOption, "name" | "optionValues">>;
-}
-
-function transformImage(image: ShopifyImage | null): Image | null {
+export function transformImage(image: ShopifyImage | null | undefined): Image | null {
   if (!image) return null;
   return {
     url: image.url,
     altText: image.altText ?? "",
-    width: image.width,
-    height: image.height,
+    width: image.width ?? 0,
+    height: image.height ?? 0,
   };
 }
 
@@ -179,28 +62,14 @@ function extractMediaFromProduct(product: ShopifyProduct): {
   images: Image[];
   videos: Video[];
 } {
-  // Handle stale cached responses that still use the old `images` field
-  if (!product.media && product.images) {
-    return {
-      images: flattenEdges(product.images)
-        .map((img) => transformImage(img))
-        .filter(Boolean) as Image[],
-      videos: [],
-    };
-  }
-
-  if (!product.media) {
-    return { images: [], videos: [] };
-  }
-
   const images: Image[] = [];
   const videos: Video[] = [];
 
-  for (const node of flattenEdges(product.media)) {
-    if (node.mediaContentType === "IMAGE") {
+  for (const node of flattenEdges<ShopifyMediaNode>(product.media)) {
+    if (node.__typename === "MediaImage") {
       const img = transformImage(node.image);
       if (img) images.push(img);
-    } else if (node.mediaContentType === "VIDEO") {
+    } else if (node.__typename === "Video") {
       const mp4Sources = node.sources.filter((s) => s.mimeType.startsWith("video/mp4"));
       const bestSource = mp4Sources.sort((a, b) => b.width - a.width)[0] ?? node.sources[0];
       if (bestSource) {
@@ -272,7 +141,7 @@ export function transformVariant(variant: ShopifyVariant): ProductVariant {
   };
 }
 
-function transformSwatch(swatch: ShopifyOptionValueSwatch | null): OptionValueSwatch | undefined {
+function transformSwatch(swatch: ShopifyOptionValueSwatch): OptionValueSwatch | undefined {
   if (!swatch) return undefined;
   const result: OptionValueSwatch = {};
   if (swatch.color) result.color = swatch.color;
@@ -284,11 +153,9 @@ function transformSwatch(swatch: ShopifyOptionValueSwatch | null): OptionValueSw
 function transformOption(option: ShopifyOption): ProductOption {
   const swatchLookup = new Map<string, OptionValueSwatch | undefined>();
   const imageLookup = new Map<string, string | undefined>();
-  if (option.optionValues) {
-    for (const ov of option.optionValues) {
-      swatchLookup.set(ov.name, transformSwatch(ov.swatch));
-      imageLookup.set(ov.name, ov.firstSelectableVariant?.image?.url);
-    }
+  for (const ov of option.optionValues) {
+    swatchLookup.set(ov.name, transformSwatch(ov.swatch));
+    imageLookup.set(ov.name, ov.firstSelectableVariant?.image?.url);
   }
 
   return {
@@ -311,9 +178,9 @@ function transformProductCard(
   const colorOption = product.options?.find(
     (option) =>
       option.name.toLowerCase().includes("colo") ||
-      option.optionValues?.some((value) => value.swatch?.color || value.swatch?.image),
+      option.optionValues.some((value) => value.swatch?.color || value.swatch?.image),
   );
-  const matchedVariant = colorOption?.optionValues?.find(
+  const matchedVariant = colorOption?.optionValues.find(
     (value) => value.name.toLowerCase() === selectedOptionValue?.toLowerCase(),
   )?.firstSelectableVariant;
   const cardVariant = matchedVariant ?? defaultVariant;
@@ -325,7 +192,7 @@ function transformProductCard(
     featuredImage: transformImage(matchedVariant?.image ?? product.featuredImage),
     price: product.priceRange.minVariantPrice,
     maxPrice: product.priceRange.maxVariantPrice,
-    compareAtPrice: product.compareAtPriceRange?.minVariantPrice ?? undefined,
+    compareAtPrice: product.compareAtPriceRange.minVariantPrice,
     vendor: product.vendor || undefined,
     availableForSale: product.availableForSale,
     isGiftCard: product.isGiftCard,
@@ -350,7 +217,6 @@ function hasUniformPriceRange(product: ShopifyProduct): boolean {
   if (priceRange.minVariantPrice.currencyCode !== priceRange.maxVariantPrice.currencyCode) {
     return false;
   }
-  if (!compareAtPriceRange) return true;
   return compareAtPriceRange.minVariantPrice.amount === compareAtPriceRange.maxVariantPrice.amount;
 }
 
@@ -368,7 +234,7 @@ export function transformShopifyProductDetails(product: ShopifyProduct): Product
     featuredImage: transformImage(product.featuredImage),
     price: product.priceRange.minVariantPrice,
     maxPrice: product.priceRange.maxVariantPrice,
-    compareAtPrice: product.compareAtPriceRange?.minVariantPrice ?? undefined,
+    compareAtPrice: product.compareAtPriceRange.minVariantPrice,
     vendor: product.vendor || undefined,
     availableForSale: product.availableForSale,
     isGiftCard: product.isGiftCard,
@@ -376,7 +242,7 @@ export function transformShopifyProductDetails(product: ShopifyProduct): Product
       !product.encodedVariantExistence ||
       product.encodedVariantExistence === product.encodedVariantAvailability,
     hasUniformPricing: hasUniformPriceRange(product),
-    variantsCount: product.variantsCount.count,
+    variantsCount: product.variantsCount?.count ?? variants?.length ?? 0,
     defaultVariant,
     defaultVariantSelectedOptions: defaultVariant?.selectedOptions ?? [],
     description: product.description,
@@ -394,11 +260,11 @@ export function transformShopifyProductDetails(product: ShopifyProduct): Product
     category: transformCategory(product.category),
     updatedAt: product.updatedAt,
     priceRange: product.priceRange,
-    compareAtPriceRange: product.compareAtPriceRange ?? undefined,
+    compareAtPriceRange: product.compareAtPriceRange,
     currencyCode: product.priceRange.minVariantPrice.currencyCode,
     manufacturerName: product.vendor,
     categoryId: product.category?.id,
-    collectionHandles: flattenEdges(product.collections ?? { edges: [] }).map((c) => c.handle),
+    collectionHandles: flattenEdges(product.collections).map((c) => c.handle),
   };
 }
 

--- a/apps/template/lib/shopify/types/filters.ts
+++ b/apps/template/lib/shopify/types/filters.ts
@@ -1,28 +1,12 @@
-export type ShopifyFilterPresentation = "IMAGE" | "SWATCH" | "TEXT";
+import type { FILTER_FRAGMENT } from "@/lib/shopify/fragments";
+import type { ResultOf } from "@/lib/shopify/storefront";
 
-export type ShopifyFilterType = "LIST" | "PRICE_RANGE" | "BOOLEAN";
+export type ShopifyFilter = ResultOf<typeof FILTER_FRAGMENT>;
+export type ShopifyFilterValue = ShopifyFilter["values"][number];
+export type ShopifyFilterType = ShopifyFilter["type"];
+export type ShopifyFilterPresentation = NonNullable<ShopifyFilter["presentation"]>;
 
-export interface ShopifyFilterSwatch {
-  color: string | null;
-  image: { previewImage: { url: string } | null } | null;
-}
-
-export interface ShopifyFilterValue {
-  id: string;
-  label: string;
-  count: number;
-  input: string;
-  swatch?: ShopifyFilterSwatch | null;
-}
-
-export interface ShopifyFilter {
-  id: string;
-  label: string;
-  type: ShopifyFilterType;
-  presentation?: ShopifyFilterPresentation | null;
-  values: ShopifyFilterValue[];
-}
-
+// App-owned subset of Shopify's ProductFilter input; the gql() variables check enforces schema compatibility.
 export interface ProductFilter {
   available?: boolean;
   price?: {

--- a/packages/plugin/skills/enable-shopify-markets/SKILL.md
+++ b/packages/plugin/skills/enable-shopify-markets/SKILL.md
@@ -299,13 +299,15 @@ Keep the mutation in a server action, validate both inputs, and update the cart'
 ```ts
 "use server";
 
+import { gql } from "@shopify/hydrogen";
+import type { CountryCode } from "@shopify/hydrogen/storefront-api-types";
 import { cookies } from "next/headers";
 
 import { getCartIdFromCookie } from "@/lib/cart/server";
 import { getCountryCode, isEnabledLocale, LOCALE_COOKIE_NAME } from "@/lib/i18n";
 import { storefront } from "@/lib/shopify/storefront";
 
-const BUYER_IDENTITY_MUTATION = /* GraphQL */ `
+const BUYER_IDENTITY_MUTATION = gql(`#graphql
   mutation cartBuyerIdentityUpdate($cartId: ID!, $buyerIdentity: CartBuyerIdentityInput!) {
     cartBuyerIdentityUpdate(cartId: $cartId, buyerIdentity: $buyerIdentity) {
       cart {
@@ -313,7 +315,7 @@ const BUYER_IDENTITY_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export async function switchLocaleAction(currentValue: string, nextValue: string) {
   if (!isEnabledLocale(currentValue) || !isEnabledLocale(nextValue)) {
@@ -325,7 +327,7 @@ export async function switchLocaleAction(currentValue: string, nextValue: string
     if (cartId) {
       await storefront.request(BUYER_IDENTITY_MUTATION, {
         variables: {
-          buyerIdentity: { countryCode: getCountryCode(nextValue) },
+          buyerIdentity: { countryCode: getCountryCode(nextValue) as CountryCode },
           cartId,
         },
       });

--- a/packages/plugin/skills/shopify-graphql-reference/SKILL.md
+++ b/packages/plugin/skills/shopify-graphql-reference/SKILL.md
@@ -23,10 +23,10 @@ Read `references/REFERENCE.md` before editing.
 
 1. Inspect the consuming route before choosing cache behavior. Classify the read as static-shell content, request-time shared content, or private/request-scoped data.
 2. Add the operation to the closest file in `lib/shopify/operations/`; create a file only for a genuinely new domain.
-3. Keep `#graphql` documents static, end them with `as const`, and use variables for dynamic values so codegen can validate them.
-4. Reuse the smallest existing fragment that fits. Extend a shared fragment only when multiple operations need the same selection.
-5. Pass locale context through existing country and language helpers when Shopify localizes the result.
-6. Keep raw Shopify response types under `lib/shopify/**`; transform them into provider-independent domain types before presentation.
+3. Wrap documents in Hydrogen's `gql()` with a leading `#graphql` comment, keep them static, and use variables for dynamic values so inference and codegen can both validate them.
+4. Reuse the smallest existing fragment that fits by passing it in the `gql(source, [FRAGMENT])` list. Extend a shared fragment only when multiple operations need the same selection.
+5. Pass `locale` to `storefront.request` when Shopify localizes the result; never add `country` or `language` to `variables`.
+6. Derive raw Shopify types from fragment documents with `ResultOf<typeof FRAGMENT>` under `lib/shopify/**`; transform them into provider-independent domain types before presentation.
 7. Preserve cache tags and the existing webhook invalidation hierarchy. Do not cache mutations.
 8. Never place carts in the Next.js data cache; cart reads are memoized per request via `getCart`, so cart mutations need no cache invalidation step.
 

--- a/packages/plugin/skills/shopify-graphql-reference/references/REFERENCE.md
+++ b/packages/plugin/skills/shopify-graphql-reference/references/REFERENCE.md
@@ -13,14 +13,15 @@ Never duplicate Shopify API reference material here. Re-run Shopify validation w
 
 | Resource | Role |
 | --- | --- |
-| `lib/shopify/storefront.ts` | Shared `@shopify/hydrogen` storefront client wrapper and custom request behavior |
+| `lib/shopify/storefront.ts` | Shared `@shopify/hydrogen` storefront client wrapper, typed `storefront.request`, and `ResultOf<Doc>` |
 | `lib/shopify/errors.ts` | `assertStorefrontOk()` response contract |
-| `.graphqlrc.ts` + `pnpm codegen` | Validates static `#graphql` documents against the live schema |
-| `lib/shopify/customer-account.ts` | Separate Customer Account API transport |
+| `.graphqlrc.ts` + `pnpm codegen` | Validates Storefront `#graphql` documents against the live schema |
+| `lib/shopify/customer-account.ts` | Separate Customer Account API transport and `CustomerAccountResultOf<Doc>` |
+| `lib/shopify/customer-account-fragments.ts` | Shared Customer Account selections |
 | `lib/shopify/fragments.ts` | Shared Storefront selections |
 | `lib/shopify/operations/*.ts` | Domain-oriented query and mutation entry points |
-| `lib/shopify/transforms/*.ts` | Shopify response to domain mapping |
-| `lib/shopify/types/**` | Raw Shopify response shapes and generated validation output |
+| `lib/shopify/transforms/*.ts` | Shopify response to domain mapping; input types derive from fragment documents |
+| `lib/shopify/types/**` | App-owned filter input shape and generated validation output |
 | `lib/types.ts` | Provider-independent types consumed by presentation |
 | `lib/cart/server.ts` | Cart cookie helpers and server-side cart read seeding |
 | `app/api/webhooks/shopify/route.ts` | Public-content invalidation entry point |
@@ -36,12 +37,16 @@ Do not add an internal HTTP hop between a Server Component and `lib/shopify/oper
 
 ## Documents and codegen
 
-- Tag every query and fragment with `#graphql` and end the declaration with `as const`.
-- Keep documents static. Pass dynamic values as GraphQL variables or choose between separate static documents.
-- Call `storefront.request<ResponseType>(QUERY, { variables })`, then `assertStorefrontOk(response, operationName)`.
-- Run `pnpm --filter template codegen` after changing a document. Generated validation output is gitignored and regenerated during development and builds.
+- Wrap every Storefront query, mutation, and fragment in `gql()` from `@shopify/hydrogen`; Customer Account documents use `gql()` from `@shopify/hydrogen/customer-account`. Keep the leading `#graphql` comment so codegen plucks the document.
+- Compose fragments by passing them as the second `gql(source, [FRAGMENT_A, FRAGMENT_B])` argument. Never interpolate a fragment string into another document.
+- Do not add a separate `MoneyFields` or `ImageFields` fragment. Inline `amount currencyCode` and `url altText width height`; two fragments that both embed the same leaf fragment would emit it twice in one document.
+- Keep documents static. Pass dynamic values as GraphQL variables or choose between separate static documents at the call site.
+- Call `storefront.request(QUERY, { locale, variables })`, then `assertStorefrontOk(response, operationName)`. Result and variable types come from the document; do not write a response type. Omit `country` and `language` from `variables` — the wrapper injects them from `locale`.
+- Derive raw Shopify types for transforms with `ResultOf<typeof FRAGMENT>` (Storefront) or `CustomerAccountResultOf<typeof FRAGMENT>` (Customer Account) instead of hand-writing interfaces.
+- Select `__typename` on union or interface fields (`node`, `nodes`, `search` results) and narrow with `node.__typename === "Product"`.
+- Run `pnpm --filter template codegen` after changing a Storefront document. Generated validation output is gitignored and regenerated during development and builds.
 
-Shopify AI Toolkit validates Shopify correctness; local codegen ensures the integrated document still matches the configured live schema.
+Shopify AI Toolkit validates Shopify correctness; type inference gives editor feedback; local codegen ensures the integrated Storefront document still matches the configured live schema (inference resolves unknown fields to `unknown` rather than failing).
 
 ## Choose cache behavior from the consumer
 
@@ -65,7 +70,7 @@ Current examples of intent:
 - Preserve stable GraphQL operation names and pass the same name to error and logging helpers.
 - Reuse `PRODUCT_CARD_FRAGMENT` for listing payloads and `PRODUCT_FRAGMENT` for the stable PDP body only when their current selections fit the task.
 - Use `@inContext` and the existing locale helpers for locale-sensitive Storefront operations.
-- Add response fields to raw Shopify types, transforms, and domain types as one coherent change.
+- Add response fields to the fragment or operation document, the transform, and the domain type as one coherent change; the raw type follows the document automatically.
 - Preserve missing-resource contracts: use the existing `undefined`, `null`, or empty-collection convention for the domain.
 
 ## Invalidation


### PR DESCRIPTION
## Summary

The template had two GraphQL typing systems: Hydrogen's `gql()` for cart and predictive-search fragments, and plain `#graphql` template strings with hand-written `storefront.request<{ ... }>` response types plus ~15 hand-written `Shopify*` interfaces for everything else. This unifies on Hydrogen.

### Storefront
- `storefront.request(doc, { locale, variables })` is generic over Hydrogen's branded document. Result and variable types come from the document; `locale` replaces explicit `country`/`language` variables (Hydrogen injects them and its types reject them in `variables`). Exports `ResultOf<Doc>` because `StorefrontApi.ResultOf` collapses to `never` on fragment documents.
- All 13 fragments and 34 operations are `gql()` documents composed via the second argument. `MoneyFields`/`ImageFields` are inlined because `gql()` dedupes fragments by string identity, so diamond composition would emit a leaf twice. New `FILTER_FRAGMENT` replaces two copies of the filter selection.
- Transforms derive raw types with `ResultOf<typeof FRAGMENT>`. Real schema nullability surfaced and is handled: `Image.width/height` and `variantsCount` are nullable; `compareAtPriceRange` is non-null; mutation payloads are nullable (`unwrapCartMutation` guards); `CartLineInput.parent` is a oneOf.
- Union fields (`node`, `nodes`, `search`) select `__typename` and narrow on it.

### Customer Account
- `customerAccountFetch` accepts typed documents from `@shopify/hydrogen/customer-account`. New `customer-account-fragments.ts`; `operations/customer.ts` and `transforms/customer.ts` derive types from it. Documents are typed against Hydrogen's bundled CAAPI introspection.

### Validation
- `graphql-codegen` remains the Storefront schema check (inference resolves unknown fields to `unknown` rather than failing, and `hydrogen gql check` does not run on TS 7). It still plucks `#graphql` inside `gql()`; `.graphqlrc.ts` now excludes CAAPI files since they target a different schema.

### Docs / skills
- `reference/storefront-api.mdx`, `shopify-graphql-reference` skill + REFERENCE, `enable-shopify-markets` example, template `AGENTS.md`. Docs skill sync run.

## Verification

- `tsc --noEmit -p apps/template/tsconfig.json`: exit 0 (plus a throwaway probe confirming derived Storefront and CAAPI types are not `any`/`unknown`/`never` and reject unknown fields)
- `pnpm lint` (oxlint + oxfmt) in template: clean; `pnpm typecheck` + `pnpm lint` in docs: clean
- `graphql-codegen`: 0 errors, 18 fragments + all operations generated
- `next build`: succeeded
- `next start` smoke against the configured store: home, PDP, collection with filters, `/collections`, search, page, policy, blog index + article, `sitemap.xml`, sitemap shard, `/md` product + search all 200 with content; `POST /api/cart` created a cart and SSR `/cart` rendered the line; `/api/predictive-search` returned results
- Not tested: Customer Account routes (auth disabled locally), agent add-to-cart flow