### PR TITLE
Use Hydrogen flattenConnection for Storefront edges

### DIFF
--- a/apps/template/lib/shopify/fetch.ts
+++ b/apps/template/lib/shopify/fetch.ts
@@ -1,4 +1,4 @@
-import { gql } from "@shopify/hydrogen";
+import { flattenConnection, gql } from "@shopify/hydrogen";
 import type {
   ProductCollectionSortKeys,
   SearchSortKeys,
@@ -408,7 +408,7 @@ export async function fetchCollectionProducts(
     };
   }
 
-  const shopifyProducts = data.collection.products.edges.map((edge) => edge.node);
+  const shopifyProducts = flattenConnection(data.collection.products);
   const selectedColor = getSelectedColorFilterLabel(
     activeFilters,
     filters,
@@ -490,7 +490,7 @@ export async function fetchCollections({
   });
   assertStorefrontOk(response, "getCollections");
 
-  return transformShopifyCollections(response.data.collections.edges.map((edge) => edge.node));
+  return transformShopifyCollections(flattenConnection(response.data.collections));
 }
 
 export async function fetchCart(cartId: string): Promise<Cart | undefined> {

--- a/apps/template/lib/shopify/operations/collections.ts
+++ b/apps/template/lib/shopify/operations/collections.ts
@@ -1,4 +1,4 @@
-import { gql } from "@shopify/hydrogen";
+import { flattenConnection, gql } from "@shopify/hydrogen";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { defaultLocale } from "@/lib/i18n";
@@ -107,7 +107,7 @@ export async function getCollectionsListing({
   assertStorefrontOk(response, "getCollectionsListing");
   const { data } = response;
 
-  const nodes = data.collections.edges.map((edge) => edge.node);
+  const nodes = flattenConnection(data.collections);
 
   // The first product tag covers collection thumbnails that fall back to product imagery.
   tagCollections(nodes);

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -1,4 +1,4 @@
-import { gql } from "@shopify/hydrogen";
+import { flattenConnection, gql } from "@shopify/hydrogen";
 import type { ProductSortKeys } from "@shopify/hydrogen/storefront-api-types";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -455,7 +455,7 @@ async function fetchCatalogProducts({
   assertStorefrontOk(response, "catalogProducts");
   const { data } = response;
 
-  const shopifyProducts = data.products.edges.map((edge) => edge.node);
+  const shopifyProducts = flattenConnection(data.products);
 
   tagProducts(shopifyProducts);
 
@@ -735,7 +735,7 @@ export async function getProductsByHandles({
   assertStorefrontOk(response, "getProductsByHandles");
   const { data } = response;
 
-  const productMap = new Map(data.products.edges.map((edge) => [edge.node.handle, edge.node]));
+  const productMap = new Map(flattenConnection(data.products).map((node) => [node.handle, node]));
 
   const shopifyProducts = handles.flatMap((handle) => {
     const product = productMap.get(handle);

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -1,3 +1,5 @@
+import { flattenConnection } from "@shopify/hydrogen";
+
 import type {
   BUNDLE_COMPONENT_VARIANT_FRAGMENT,
   FILTERABLE_PRODUCT_CARD_FRAGMENT,
@@ -9,7 +11,6 @@ import type {
   TAXONOMY_CATEGORY_FRAGMENT,
 } from "@/lib/shopify/fragments";
 import type { ResultOf } from "@/lib/shopify/storefront";
-import { flattenEdges } from "@/lib/shopify/utils";
 import type {
   Category,
   Image,
@@ -65,7 +66,7 @@ function extractMediaFromProduct(product: ShopifyProduct): {
   const images: Image[] = [];
   const videos: Video[] = [];
 
-  for (const node of flattenEdges<ShopifyMediaNode>(product.media)) {
+  for (const node of flattenConnection<ShopifyMediaNode>(product.media)) {
     if (node.__typename === "MediaImage") {
       const img = transformImage(node.image);
       if (img) images.push(img);
@@ -222,7 +223,7 @@ function hasUniformPriceRange(product: ShopifyProduct): boolean {
 
 export function transformShopifyProductDetails(product: ShopifyProduct): ProductDetails {
   const variants = product.variants
-    ? flattenEdges(product.variants).map(transformVariant)
+    ? flattenConnection(product.variants).map(transformVariant)
     : undefined;
   const defaultVariant = product.selectedOrFirstAvailableVariant
     ? transformVariant(product.selectedOrFirstAvailableVariant)
@@ -264,7 +265,7 @@ export function transformShopifyProductDetails(product: ShopifyProduct): Product
     currencyCode: product.priceRange.minVariantPrice.currencyCode,
     manufacturerName: product.vendor,
     categoryId: product.category?.id,
-    collectionHandles: flattenEdges(product.collections).map((c) => c.handle),
+    collectionHandles: flattenConnection(product.collections).map((c) => c.handle),
   };
 }
 

--- a/apps/template/lib/shopify/utils.ts
+++ b/apps/template/lib/shopify/utils.ts
@@ -1,9 +1,3 @@
-export type ShopifyEdges<T> = { edges: Array<{ node: T }> };
-
-export function flattenEdges<T>(connection: ShopifyEdges<T>): T[] {
-  return connection.edges.map((edge) => edge.node);
-}
-
 export function getNumericShopifyId(gid: string): string | null {
   let decoded = gid;
 


### PR DESCRIPTION
## Summary

Swaps the template's one-line `flattenEdges` helper and five raw `edges.map((edge) => edge.node)` sites for `flattenConnection` from `@shopify/hydrogen`, then deletes `flattenEdges`/`ShopifyEdges` from `lib/shopify/utils.ts`.

The `data.search.edges.flatMap` in `fetchSearchIndexProducts` is left as-is since it type-narrows a `Product | Article | Page` union, not a plain flatten.

Follow-up to #542 / #543 from the Hydrogen coherence pass.

## Verification

- `tsc --noEmit` exit 0
- `oxlint lib/shopify` clean
- `next build` + `next start`: `/`, `/products/[handle]`, `/collections`, `/collections/hoodies`, `/search?q=hoodie` all 200; PDP variant title, 14 collection links, 40 search product cards render