### PR TITLE
Use Hydrogen getSearchResultUrl for search links

### DIFF
--- a/apps/template/components/action-bar/predictive-search-results.tsx
+++ b/apps/template/components/action-bar/predictive-search-results.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getSearchResultUrl } from "@shopify/hydrogen";
 import { Search, Tag } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import Image from "next/image";
@@ -115,7 +116,7 @@ export function PredictiveSearchPanel({
 
               {query.trim() && (
                 <Link
-                  href={`/search?q=${encodeURIComponent(query.trim())}`}
+                  href={getSearchResultUrl({ baseUrl: "/search", term: query.trim() })}
                   onClick={onNavigate}
                   className="block px-5 py-2.5 text-sm font-medium text-primary hover:bg-accent/50 border-t border-border/30 transition-colors"
                 >

--- a/apps/template/components/nav/search-client.tsx
+++ b/apps/template/components/nav/search-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getSearchResultUrl } from "@shopify/hydrogen";
 import { SearchIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
@@ -29,7 +30,7 @@ export function SearchClient() {
     reset();
     setShowPanel(false);
     startTransition(() => {
-      router.push(`/search?q=${encodeURIComponent(q.trim())}`);
+      router.push(getSearchResultUrl({ baseUrl: "/search", term: q.trim() }));
     });
   }
 

--- a/apps/template/components/nav/search-modal.tsx
+++ b/apps/template/components/nav/search-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { getSearchResultUrl } from "@shopify/hydrogen";
 import { Search, X } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import Image from "next/image";
@@ -78,7 +79,7 @@ function SearchDialogContent({ onClose }: { onClose: () => void }) {
     e.preventDefault();
     const q = inputRef.current?.value?.trim();
     if (!q) return;
-    navigate(`/search?q=${encodeURIComponent(q)}`);
+    navigate(getSearchResultUrl({ baseUrl: "/search", term: q }));
   }
 
   // Only queries and products are rendered — exclude collections from keyboard nav
@@ -231,7 +232,9 @@ function SearchDialogContent({ onClose }: { onClose: () => void }) {
                           <button
                             type="button"
                             onClick={() =>
-                              navigate(`/search?q=${encodeURIComponent(query.trim())}`)
+                              navigate(
+                                getSearchResultUrl({ baseUrl: "/search", term: query.trim() }),
+                              )
                             }
                             className="inline-flex items-center justify-center rounded-lg bg-primary text-primary-foreground text-sm font-medium h-9 px-5 hover:bg-primary/90 transition-colors"
                           >

--- a/apps/template/lib/agent/routes.ts
+++ b/apps/template/lib/agent/routes.ts
@@ -1,3 +1,5 @@
+import { getSearchResultUrl } from "@shopify/hydrogen";
+
 import type { Locale } from "../i18n";
 import { defaultLocale } from "../i18n";
 
@@ -37,7 +39,7 @@ export function buildAgentPath(destination: AgentDestination, identifier?: strin
     case "product":
       return identifier ? `/products/${identifier}` : "/";
     case "search":
-      return identifier ? `/search?q=${encodeURIComponent(identifier)}` : "/search";
+      return identifier ? getSearchResultUrl({ baseUrl: "/search", term: identifier }) : "/search";
     default:
       return "/";
   }


### PR DESCRIPTION
Replaces five hand-built `/search?q=${encodeURIComponent(...)}` template strings (nav search-client, search-modal, predictive-search-results, agent routes) with Hydrogen's `getSearchResultUrl`.

Output equivalent: spaces encode as `+` instead of `%20`; both decode identically via URLSearchParams. Verified on `red shoes`, `a&b=c`, `日本`, `50% off`.

- tsc --noEmit: exit 0
- oxlint / oxfmt: clean