### PR TITLE
Build Buy with Shop link from Hydrogen getShopPayButtonUrl

### DIFF
--- a/apps/template/components/product-detail/buy-buttons.tsx
+++ b/apps/template/components/product-detail/buy-buttons.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { getShopPayButtonUrl } from "@shopify/hydrogen";
 import { Loader2, MinusIcon, PlusIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useState } from "react";
 
 import { useCart } from "@/components/cart/context";
 import { Button } from "@/components/ui/button";
-import { buyNowAction } from "@/lib/cart/action";
 import { variantToOptimisticInfo } from "@/lib/product";
 import type { Image, Money, SelectedOption } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -45,7 +45,6 @@ export function BuyButtons({
 
   const t = useTranslations("product");
   const tCart = useTranslations("cart");
-  const [, startBuyNowTransition] = useTransition();
   const [isBuyingNow, setIsBuyingNow] = useState(false);
   const [quantity, setQuantity] = useState(1);
   const { addToCartOptimistic, pendingQuantity, isAddingToCart } = useCart();
@@ -73,29 +72,17 @@ export function BuyButtons({
     }
   };
 
-  const handleBuyNow = () => {
-    if (!selectedVariantId) return;
-    setIsBuyingNow(true);
-    startBuyNowTransition(async () => {
-      try {
-        const { checkoutUrl } = await buyNowAction(selectedVariantId, quantity);
-        if (checkoutUrl) {
-          window.location.href = checkoutUrl;
-        } else {
-          setIsBuyingNow(false);
-        }
-      } catch {
-        setIsBuyingNow(false);
-      }
-    });
-  };
-
   if (!selectedVariant) {
     return null;
   }
 
   const requiresBundleConfiguration = selectedVariant.requiresBundleConfiguration;
   const isOutOfStock = !selectedVariant.availableForSale;
+  // Same-origin permalink; handleShopifyRoutes in proxy.ts 302s it to the store's checkout with attribution.
+  const buyNowUrl = getShopPayButtonUrl({
+    disabled: isOutOfStock || isBuyingNow || requiresBundleConfiguration,
+    variants: [{ id: selectedVariant.id, quantity }],
+  });
 
   const getButtonText = () => {
     if (pendingQuantity > 0) return t("addingQuantity", { quantity: String(pendingQuantity) });
@@ -151,14 +138,15 @@ export function BuyButtons({
         </Button>
       </div>
       {buyWithShop ? (
-        <button
-          type="button"
+        <a
+          aria-disabled={buyNowUrl ? undefined : true}
           className={cn(
-            "flex h-12 w-full cursor-pointer items-center justify-center rounded-lg bg-shop px-4 text-white transition-colors hover:bg-shop/85 disabled:cursor-not-allowed disabled:opacity-50",
+            "flex h-12 w-full cursor-pointer items-center justify-center rounded-lg bg-shop px-4 text-white transition-colors hover:bg-shop/85 aria-disabled:pointer-events-none aria-disabled:opacity-50",
             !availableForSale && "invisible",
           )}
-          disabled={isOutOfStock || isBuyingNow || requiresBundleConfiguration}
-          onClick={handleBuyNow}
+          href={buyNowUrl ?? undefined}
+          onClick={() => setIsBuyingNow(true)}
+          rel="nofollow"
         >
           {isBuyingNow ? (
             <Loader2 className="size-4 animate-spin" />
@@ -168,7 +156,7 @@ export function BuyButtons({
               <BuyWithShopLogo aria-hidden="true" className="h-auto w-24.5" />
             </>
           )}
-        </button>
+        </a>
       ) : null}
     </div>
   );

--- a/apps/template/components/product-detail/buy-buttons.tsx
+++ b/apps/template/components/product-detail/buy-buttons.tsx
@@ -79,8 +79,10 @@ export function BuyButtons({
   const requiresBundleConfiguration = selectedVariant.requiresBundleConfiguration;
   const isOutOfStock = !selectedVariant.availableForSale;
   // Same-origin permalink; handleShopifyRoutes in proxy.ts 302s it to the store's checkout with attribution.
+  // isBuyingNow must not feed `disabled`: React flushes the click's setState before the anchor's activation
+  // behavior runs, so removing href here would cancel the navigation.
   const buyNowUrl = getShopPayButtonUrl({
-    disabled: isOutOfStock || isBuyingNow || requiresBundleConfiguration,
+    disabled: isOutOfStock || requiresBundleConfiguration,
     variants: [{ id: selectedVariant.id, quantity }],
   });
 
@@ -139,9 +141,10 @@ export function BuyButtons({
       </div>
       {buyWithShop ? (
         <a
+          aria-busy={isBuyingNow || undefined}
           aria-disabled={buyNowUrl ? undefined : true}
           className={cn(
-            "flex h-12 w-full cursor-pointer items-center justify-center rounded-lg bg-shop px-4 text-white transition-colors hover:bg-shop/85 aria-disabled:pointer-events-none aria-disabled:opacity-50",
+            "flex h-12 w-full cursor-pointer items-center justify-center rounded-lg bg-shop px-4 text-white transition-colors hover:bg-shop/85 aria-busy:pointer-events-none aria-disabled:pointer-events-none aria-disabled:opacity-50",
             !availableForSale && "invisible",
           )}
           href={buyNowUrl ?? undefined}

--- a/apps/template/lib/cart/action.ts
+++ b/apps/template/lib/cart/action.ts
@@ -3,46 +3,6 @@
 import { getCart } from "@/lib/cart/server";
 import { withFallback } from "@/lib/shopify/errors";
 
-/** Uses Shopify's cart permalink format (`/cart/{numericId}:{qty}`) — no API cart is created. */
-export async function buyNowAction(
-  merchandiseId: string,
-  quantity: number = 1,
-): Promise<{ checkoutUrl: string | null; error?: string }> {
-  if (!merchandiseId) {
-    return { checkoutUrl: null, error: "Invalid product ID" };
-  }
-
-  if (quantity < 1 || quantity > 99 || !Number.isInteger(quantity)) {
-    return { checkoutUrl: null, error: "Quantity must be between 1 and 99" };
-  }
-
-  const domain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
-  if (!domain) {
-    return { checkoutUrl: null, error: "Store domain not configured" };
-  }
-
-  let numericId: string | null = merchandiseId;
-  if (merchandiseId.startsWith("gid://") || !merchandiseId.match(/^\d+$/)) {
-    let decoded = merchandiseId;
-    if (!decoded.startsWith("gid://")) {
-      try {
-        decoded = atob(decoded);
-      } catch {
-        return { checkoutUrl: null, error: "Invalid variant ID" };
-      }
-    }
-    const match = decoded.match(/gid:\/\/shopify\/\w+\/(\d+)/);
-    numericId = match?.[1] ?? null;
-  }
-
-  if (!numericId) {
-    return { checkoutUrl: null, error: "Could not resolve variant ID" };
-  }
-
-  const checkoutUrl = `https://${domain}/cart/${numericId}:${quantity}?payment=shop_pay`;
-  return { checkoutUrl };
-}
-
 export async function prepareCheckoutAction(): Promise<{
   checkoutUrl: string | null;
 }> {


### PR DESCRIPTION
Keeps our `BuyButtons` / `BuyWithShopLogo` component and styling, but derives the URL from Hydrogen's `getShopPayButtonUrl` instead of the `buyNowAction` server action.

**Before:** click → server action (atob + regex gid decode, reads `NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN`) → `window.location = https://{store}/cart/{id}:{qty}?payment=shop_pay`

**After:** plain `<a href="/cart/{id}:{qty}?payment=shop_pay&source=hydrogen">`. `handleShopifyRoutes` in `proxy.ts` already intercepts this permalink and 302s to the store's checkout.

What this buys:
- `source=hydrogen` attribution on checkout (what Shopify's own button sends; we were sending none)
- No server round-trip on click; link is in SSR HTML and works before hydration
- Disabled state via `aria-disabled` + no href, matching Hydrogen's button semantics
- `buyNowAction` deleted (-38 lines of gid parsing)

Verified against dev on vpparel:
```
GET /products/arcgauge-jacket-mens-0811c3 → 200
  <a href="/cart/47200736346166:1?payment=shop_pay&source=hydrogen" rel="nofollow">
GET /cart/47200736346166:1?payment=shop_pay&source=hydrogen → 302
  location: https://vpparel.myshopify.com/cart/47200736346166:1?payment=shop_pay&source=hydrogen
```

- tsc --noEmit: exit 0
- oxlint / oxfmt: clean
- No docs/skills reference `buyNowAction`