### PR TITLE
Unify formatPrice on Money objects and route price-filter badge through formatMoney

### DIFF
--- a/apps/template/app/account/(authenticated)/orders/[id]/page.tsx
+++ b/apps/template/app/account/(authenticated)/orders/[id]/page.tsx
@@ -56,13 +56,7 @@ async function OrderDetailContent({ params }: { params: Promise<{ id: string }> 
         <SummaryRow label={t("tax")} money={order.totalTax} />
         <div className="flex items-center justify-between border-t pt-2 font-medium">
           <dt>{t("total")}</dt>
-          <dd className="font-mono tabular-nums">
-            {formatPrice(
-              Number(order.totalPrice.amount),
-              order.totalPrice.currencyCode,
-              defaultLocale,
-            )}
-          </dd>
+          <dd className="font-mono tabular-nums">{formatPrice(order.totalPrice, defaultLocale)}</dd>
         </div>
       </dl>
 
@@ -113,7 +107,7 @@ function OrderLineItemRow({ item }: { item: OrderLineItem }) {
       </div>
       {item.totalPrice ? (
         <span className="font-mono text-sm tabular-nums">
-          {formatPrice(Number(item.totalPrice.amount), item.totalPrice.currencyCode, defaultLocale)}
+          {formatPrice(item.totalPrice, defaultLocale)}
         </span>
       ) : null}
     </li>
@@ -125,9 +119,7 @@ function SummaryRow({ label, money }: { label: string; money: Money | null }) {
   return (
     <div className="flex items-center justify-between">
       <dt className="text-muted-foreground">{label}</dt>
-      <dd className="font-mono tabular-nums">
-        {formatPrice(Number(money.amount), money.currencyCode, defaultLocale)}
-      </dd>
+      <dd className="font-mono tabular-nums">{formatPrice(money, defaultLocale)}</dd>
     </div>
   );
 }

--- a/apps/template/app/account/(authenticated)/orders/page.tsx
+++ b/apps/template/app/account/(authenticated)/orders/page.tsx
@@ -64,11 +64,7 @@ async function OrdersContent({
               <div className="flex items-center gap-3">
                 <OrderStatusBadge status={order.fulfillmentStatus} />
                 <span className="text-sm tabular-nums">
-                  {formatPrice(
-                    Number(order.totalPrice.amount),
-                    order.totalPrice.currencyCode,
-                    defaultLocale,
-                  )}
+                  {formatPrice(order.totalPrice, defaultLocale)}
                 </span>
               </div>
             </Link>

--- a/apps/template/components/cart-page/summary.tsx
+++ b/apps/template/components/cart-page/summary.tsx
@@ -93,7 +93,7 @@ export function Summary({
         <div className="flex items-baseline justify-between">
           <span className="text-base text-muted-foreground">{estimatedTotalLabel}</span>
           <span className="text-xl font-medium text-foreground">
-            {formatPrice(estimatedTotal, currencyCode, locale)}
+            {formatPrice({ amount: estimatedTotal, currencyCode }, locale)}
           </span>
         </div>
         <p className="text-xs text-muted-foreground mt-1">{taxesAndShippingNote}</p>

--- a/apps/template/components/cart/overlay-item.tsx
+++ b/apps/template/components/cart/overlay-item.tsx
@@ -40,7 +40,7 @@ export function OverlayItem({ item, locale }: OverlayItemProps) {
   return (
     <li
       className="flex gap-2.5"
-      aria-label={`${item.merchandise.product.title} - ${formatPrice(finalUnitPrice * quantity, currencyCode, locale)}`}
+      aria-label={`${item.merchandise.product.title} - ${formatPrice({ amount: finalUnitPrice * quantity, currencyCode }, locale)}`}
     >
       <Link
         href={`/products/${item.merchandise.product.handle}`}
@@ -156,15 +156,18 @@ export function OverlayItem({ item, locale }: OverlayItemProps) {
       <div className="self-start py-0.5 text-sm text-right">
         <div className="grid gap-0.5">
           <span className="font-medium text-foreground">
-            {formatPrice(hasCartDiscount ? finalUnitPrice : sellingUnitPrice, currencyCode, locale)}
+            {formatPrice(
+              { amount: hasCartDiscount ? finalUnitPrice : sellingUnitPrice, currencyCode },
+              locale,
+            )}
           </span>
           {hasCartDiscount ? (
             <span className="text-xs text-muted-foreground line-through">
-              {formatPrice(sellingUnitPrice, currencyCode, locale)}
+              {formatPrice({ amount: sellingUnitPrice, currencyCode }, locale)}
             </span>
           ) : hasCompareAt ? (
             <span className="text-xs text-muted-foreground line-through">
-              {formatPrice(compareAtUnitPrice, currencyCode, locale)}
+              {formatPrice({ amount: compareAtUnitPrice, currencyCode }, locale)}
             </span>
           ) : null}
         </div>

--- a/apps/template/components/collections/filter-sidebar.tsx
+++ b/apps/template/components/collections/filter-sidebar.tsx
@@ -20,7 +20,7 @@ import {
 import { Swatch } from "@/components/ui/swatch";
 import { getActiveFilterBadges } from "@/lib/shopify/transforms/filters";
 import type { Filter, PriceRange } from "@/lib/types";
-import { parseFiltersFromSearchParams, searchParamsToRecord } from "@/lib/utils";
+import { formatPrice, parseFiltersFromSearchParams, searchParamsToRecord } from "@/lib/utils";
 
 import {
   FilterBadge,
@@ -185,6 +185,10 @@ function FilterSidebarContent({
               <FilterBadge variant="primary" onRemove={() => onApplyPrice(null, null)}>
                 {formatPriceRangeLabel({
                   currencyCode: priceRange?.currencyCode,
+                  labels: {
+                    from: tCategory("priceRangeFrom"),
+                    upTo: tCategory("priceRangeUpTo"),
+                  },
                   locale,
                   max: priceFilter.max,
                   min: priceFilter.min,
@@ -311,22 +315,24 @@ function findFilterInput(filters: Filter[], key: string, value: string): string 
 
 function formatPriceRangeLabel({
   currencyCode,
+  labels,
   locale,
   max,
   min,
 }: {
   currencyCode?: string;
+  labels: { from: string; upTo: string };
   locale: string;
   max: number | null;
   min: number | null;
 }): string {
   const format = (value: number) =>
     currencyCode
-      ? new Intl.NumberFormat(locale, { currency: currencyCode, style: "currency" }).format(value)
+      ? formatPrice({ amount: value, currencyCode }, locale)
       : new Intl.NumberFormat(locale).format(value);
   if (min !== null && max !== null) return `${format(min)} - ${format(max)}`;
-  if (min !== null) return `From ${format(min)}`;
-  return `Up to ${format(max ?? 0)}`;
+  if (min !== null) return `${labels.from} ${format(min)}`;
+  return `${labels.upTo} ${format(max ?? 0)}`;
 }
 
 function getFilterValues(value: string | string[] | undefined): string[] {

--- a/apps/template/components/product-detail/complementary-products.tsx
+++ b/apps/template/components/product-detail/complementary-products.tsx
@@ -43,7 +43,7 @@ export async function ComplementaryProducts({
               )}
               <span className="min-w-0 flex-1 truncate font-medium text-sm">{product.title}</span>
               <span className="shrink-0 text-foreground/50 text-sm">
-                {formatPrice(Number(product.price.amount), product.price.currencyCode, locale)}
+                {formatPrice(product.price, locale)}
               </span>
             </Link>
           </li>

--- a/apps/template/lib/i18n/messages/en.json
+++ b/apps/template/lib/i18n/messages/en.json
@@ -166,6 +166,8 @@
     "pages": "pages",
     "price": "Price",
     "priceFrom": "From",
+    "priceRangeFrom": "From",
+    "priceRangeUpTo": "Up to",
     "priceTo": "To",
     "productCount": "{count, plural, one {# product} other {# products}}",
     "size": "Size",

--- a/apps/template/lib/markdown/catalog.ts
+++ b/apps/template/lib/markdown/catalog.ts
@@ -1,7 +1,8 @@
 import { getActiveFilterBadges } from "@/lib/shopify/transforms/filters";
 import type { Filter, PageInfo, PriceRange, ProductCard } from "@/lib/types";
+import { formatPrice } from "@/lib/utils";
 
-import { createTable, escapeMarkdown, formatPrice } from "./utils";
+import { createTable, escapeMarkdown } from "./utils";
 
 const SORT_LABELS: Record<string, string> = {
   "best-matches": "Best matches",

--- a/apps/template/lib/markdown/home.ts
+++ b/apps/template/lib/markdown/home.ts
@@ -1,7 +1,8 @@
 import { shopConfig } from "@/lib/config";
 import type { ProductCard } from "@/lib/types";
+import { formatPrice } from "@/lib/utils";
 
-import { escapeMarkdown, formatPrice } from "./utils";
+import { escapeMarkdown } from "./utils";
 
 export function homeToMarkdown({
   description,

--- a/apps/template/lib/markdown/product.ts
+++ b/apps/template/lib/markdown/product.ts
@@ -1,6 +1,7 @@
 import type { ProductDetails } from "@/lib/types";
+import { formatPrice } from "@/lib/utils";
 
-import { createTable, escapeMarkdown, formatPrice } from "./utils";
+import { createTable, escapeMarkdown } from "./utils";
 
 /** Output is consumed by agents/crawlers, so structure must stay parseable. */
 export function productToMarkdown(product: ProductDetails, locale: string): string {

--- a/apps/template/lib/markdown/utils.ts
+++ b/apps/template/lib/markdown/utils.ts
@@ -1,11 +1,3 @@
-import { formatMoney } from "@shopify/hydrogen";
-
-import type { Money } from "@/lib/types";
-
-export function formatPrice(money: Money, locale: string): string {
-  return formatMoney(money, { currencyDisplay: "narrowSymbol", locale }).localizedString;
-}
-
 export function escapeMarkdown(text: string): string {
   return text
     .replace(/\|/g, "\\|")

--- a/apps/template/lib/utils.ts
+++ b/apps/template/lib/utils.ts
@@ -6,9 +6,12 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function formatPrice(amount: number, currencyCode: string, locale: string): string {
+export function formatPrice(
+  money: { amount: number | string; currencyCode: string },
+  locale: string,
+): string {
   return formatMoney(
-    { amount: String(amount), currencyCode },
+    { amount: String(money.amount), currencyCode: money.currencyCode },
     { currencyDisplay: "narrowSymbol", locale },
   ).localizedString;
 }


### PR DESCRIPTION
## Why

Money formatting was already on Hydrogen's `formatMoney`, but with two inconsistencies:

- Two `formatPrice` functions with different signatures (`lib/utils.ts` took `(number, currencyCode, locale)`; `lib/markdown/utils.ts` took `(Money, locale)`). Callers were doing `Number(money.amount)` only to have it re-stringified inside.
- The collection price-range filter badge used raw `Intl.NumberFormat` with default `currencyDisplay`, so on a non-USD store it rendered differently from every other price. Its "From" / "Up to" prefixes were also hardcoded English.

## What

- `formatPrice(money: { amount: number | string; currencyCode }, locale)` — one signature. Storefront `Money` values pass through directly; cart math that has already produced a number wraps it in an object literal.
- `lib/markdown/*` imports `formatPrice` from `@/lib/utils`; the duplicate is deleted.
- Filter badge routes through `formatPrice`; prefixes come from new `category.priceRangeFrom` / `category.priceRangeUpTo` keys.

## Verification

- `tsc --noEmit` exit 0, oxlint clean, oxfmt applied.
- Headless Chromium against dev server, `/search` with the filter sheet open:
  - `?filter.v.price.gte=50` → `From $50.00`
  - `?filter.v.price.lte=80` → `Up to $80.00`
  - both → `$50.00 - $80.00`