### PR TITLE
Read browse results live in the markdown routes to match HTML

### DIFF
--- a/apps/template/app/md/collections/[handle]/route.ts
+++ b/apps/template/app/md/collections/[handle]/route.ts
@@ -9,7 +9,7 @@ import { collectionToMarkdown } from "@/lib/markdown/collection";
 import { markdownHeaders } from "@/lib/markdown/headers";
 import { notFoundMarkdown } from "@/lib/markdown/not-found";
 import { getCollection } from "@/lib/shopify/operations/collections";
-import { getCollectionProducts } from "@/lib/shopify/operations/products";
+import { fetchCollectionProducts } from "@/lib/shopify/operations/products";
 import { RESULTS_PER_PAGE } from "@/lib/utils";
 
 export async function GET(request: Request, { params }: { params: Promise<{ handle: string }> }) {
@@ -50,9 +50,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ hand
     const cursor = url.searchParams.get("cursor") ?? undefined;
     const { activeFilters, filters, sort } = searchState;
 
+    // Same live read as the HTML page so agents and shoppers see one result set per URL.
     const [collection, result] = await Promise.all([
       getCollection({ handle, locale }),
-      getCollectionProducts({
+      fetchCollectionProducts({
         activeFilters,
         collection: handle,
         sortKey: sort,

--- a/apps/template/app/md/search/route.ts
+++ b/apps/template/app/md/search/route.ts
@@ -2,7 +2,7 @@ import { resolveBrowseParams } from "@/lib/collections/server";
 import { defaultLocale, resolveLocale } from "@/lib/i18n";
 import { markdownHeaders } from "@/lib/markdown/headers";
 import { searchResultsToMarkdown } from "@/lib/markdown/search";
-import { getSearchFacets, searchIndexProducts } from "@/lib/shopify/operations/products";
+import { fetchSearchFacets, fetchSearchIndexProducts } from "@/lib/shopify/operations/products";
 import { RESULTS_PER_PAGE } from "@/lib/utils";
 
 export async function GET(request: Request) {
@@ -14,8 +14,9 @@ export async function GET(request: Request) {
   const { activeFilters, filters, sort } = resolveBrowseParams(url.searchParams);
 
   try {
+    // Same live reads as the HTML page so agents and shoppers see one result set per URL.
     const [results, facets] = await Promise.all([
-      searchIndexProducts({
+      fetchSearchIndexProducts({
         query,
         collection,
         sortKey: sort,
@@ -24,7 +25,7 @@ export async function GET(request: Request) {
         filters,
         locale,
       }),
-      getSearchFacets({ activeFilters, query, collection, filters, locale }),
+      fetchSearchFacets({ activeFilters, query, collection, filters, locale }),
     ]);
 
     const markdown = searchResultsToMarkdown({

--- a/apps/template/lib/shopify/operations/products.ts
+++ b/apps/template/lib/shopify/operations/products.ts
@@ -540,14 +540,6 @@ export async function fetchSearchFacets(params: SearchFacetsParams): Promise<Sea
   };
 }
 
-export async function getSearchFacets(params: SearchFacetsParams): Promise<SearchFacetsResult> {
-  "use cache: remote";
-  cacheLife("max");
-  cacheTag("products");
-
-  return fetchSearchFacets(params);
-}
-
 export async function getProductOptionValues(params: {
   ids: string[];
 }): Promise<ProductOptionValues> {


### PR DESCRIPTION
## Summary

`/md/search` and `/md/collections/[handle]` were reading through the `"use cache: remote"` wrappers (`searchIndexProducts`, `getCollectionProducts`, `getSearchFacets`) while the HTML pages for the same URLs read live (`fetchSearchIndexProducts`, `fetchCollectionProducts`, `fetchSearchFacets`) since #359. So an agent fetching `Accept: text/markdown` and a shopper loading the HTML could get different product sets and facet counts for the same URL.

Both markdown routes now use the same live reads as the HTML pages. `getSearchFacets` had no callers left and is removed. `searchIndexProducts` / `getCollectionProducts` stay for the non-paginated consumers (home page grid, `/md` home, agent tools).

The response-level `Cache-Control: public, max-age=86400, stale-while-revalidate=604800` on the markdown routes is unchanged; this only aligns what the origin renders.

## Verification

- `pnpm exec tsc --noEmit` — exit 0
- `pnpm lint` — Found 0 warnings and 0 errors
- `pnpm build` — exit 0
- Against `pnpm start`, fetched HTML and `Accept: text/markdown` for the same URL and compared the ordered, de-duplicated product handles:
  - `/search?q=jacket&sort_by=price-descending` — 20 vs 20, identical
  - `/collections/all?filter.v.t.shopify.color-pattern=…&sort_by=price-descending` — 18 vs 18, identical
  - `/collections/jackets?sort_by=price-ascending` — 20 vs 20, identical
  - markdown responses still `text/markdown; charset=utf-8` with the existing `Cache-Control`
