### PR TITLE
Use Hydrogen form bindings for PDP and agent add-to-cart

### DIFF
--- a/apps/template/components/agent/registry.tsx
+++ b/apps/template/components/agent/registry.tsx
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/button";
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
 import { catalog } from "@/lib/agent";
 import type { AgentVariant } from "@/lib/agent/products";
+import { useCartForm } from "@/lib/cart/client";
 import { cn } from "@/lib/utils";
 
 import { useCart } from "../cart/context";
@@ -211,7 +212,8 @@ export const { registry } = defineRegistry(catalog, {
       const locale = useLocale();
       const t = useTranslations("cart");
       const tAgent = useTranslations("agent");
-      const { addToCartOptimistic } = useCart();
+      const { openOverlay } = useCart();
+      const { formProps, register } = useCartForm();
       const product = useAgentProductDetails(props.handle);
       const [selectedId, setSelectedId] = useState<string | null>(null);
 
@@ -278,29 +280,13 @@ export const { registry } = defineRegistry(catalog, {
               }
               locale={locale}
             />
-            <Button
-              disabled={!canAdd}
-              onClick={() => {
-                if (!selected) return;
-                addToCartOptimistic(selected.id, 1, {
-                  image: {
-                    altText: product.title,
-                    height: 0,
-                    url: product.image ?? "",
-                    width: 0,
-                  },
-                  price: selected.price,
-                  productHandle: product.handle,
-                  productTitle: product.title,
-                  selectedOptions: selected.options,
-                  variantTitle: selected.title,
-                });
-              }}
-              size="sm"
-              type="button"
-            >
-              {t("addToCart")}
-            </Button>
+            <form {...formProps({ beforeSubmit: openOverlay })}>
+              <input type="hidden" {...register("merchandiseId", { value: selected?.id ?? "" })} />
+              <input type="hidden" {...register("quantity", { value: 1 })} />
+              <Button {...register("add")} disabled={!canAdd} size="sm" type="submit">
+                {t("addToCart")}
+              </Button>
+            </form>
           </div>
         </div>
       );

--- a/apps/template/components/cart/context.tsx
+++ b/apps/template/components/cart/context.tsx
@@ -11,29 +11,21 @@ import {
 } from "react";
 
 import { toDomainCart } from "@/lib/cart";
-import { addToCart, HydrogenCartProvider, useHydrogenCart } from "@/lib/cart/client";
-import type { OptimisticProductInfo } from "@/lib/product";
+import { HydrogenCartProvider, useHydrogenCart } from "@/lib/cart/client";
 import type { Cart, CartWarning } from "@/lib/types";
 
 type CartMutationError = "add" | "remove" | "update";
 
 type CartContextType = {
-  addToCartOptimistic: (
-    variantId: string,
-    quantity: number,
-    productInfo?: OptimisticProductInfo,
-  ) => void;
   cart: Cart | null;
   cartWithPending: Cart | null;
   clearError: () => void;
   clearWarnings: () => void;
-  isAddingToCart: boolean;
   isOverlayOpen: boolean;
   isUpdatingCart: boolean;
   lastError: CartMutationError | null;
   lastWarnings: CartWarning[];
   openOverlay: () => void;
-  pendingQuantity: number;
   setOverlayOpen: (open: boolean) => void;
   setWarnings: (warnings: CartWarning[]) => void;
 };
@@ -41,18 +33,15 @@ type CartContextType = {
 const CartContext = createContext<CartContextType | null>(null);
 
 const serverFallbackCartContext: CartContextType = {
-  addToCartOptimistic: () => {},
   cart: null,
   cartWithPending: null,
   clearError: () => {},
   clearWarnings: () => {},
-  isAddingToCart: false,
   isOverlayOpen: false,
   isUpdatingCart: false,
   lastError: null,
   lastWarnings: [],
   openOverlay: () => {},
-  pendingQuantity: 0,
   setOverlayOpen: () => {},
   setWarnings: () => {},
 };
@@ -67,7 +56,6 @@ function hasCartFailure(errors: CartErrorState): boolean {
 
 export function CartProvider({ children }: { children: ReactNode }) {
   const [isOverlayOpen, setOverlayOpen] = useState(false);
-  const [isAddingToCart, setIsAddingToCart] = useState(false);
   const [dismissedError, setDismissedError] = useState<CartErrorState | null>(null);
   const [warningsOverride, setWarningsOverride] = useState<{
     errors: CartErrorState;
@@ -91,15 +79,6 @@ export function CartProvider({ children }: { children: ReactNode }) {
     cartState.revalidating,
   );
 
-  // The store registers the optimistic line one tick after the click; only clear once pending has actually drained.
-  const pendingQuantity = cartState.pending.lines.size;
-  const [sawPending, setSawPending] = useState(false);
-  if (isAddingToCart && pendingQuantity > 0 && !sawPending) setSawPending(true);
-  if (isAddingToCart && sawPending && pendingQuantity === 0) {
-    setIsAddingToCart(false);
-    setSawPending(false);
-  }
-
   const { errors } = cartState;
   const isErrorVisible = hasCartFailure(errors) && dismissedError !== errors;
   const lastError: CartMutationError | null = isErrorVisible ? "update" : null;
@@ -116,35 +95,23 @@ export function CartProvider({ children }: { children: ReactNode }) {
     [errors],
   );
   const clearWarnings = useCallback(() => setWarnings([]), [setWarnings]);
-  const openOverlay = useCallback(() => setOverlayOpen(true), []);
-
-  const addToCartOptimistic = useCallback(
-    (variantId: string, quantity: number, productInfo?: OptimisticProductInfo) => {
-      setDismissedError(errors);
-      if (!isOverlayOpen) {
-        setIsAddingToCart(true);
-        setOverlayOpen(true);
-      }
-      addToCart(variantId, quantity, productInfo);
-    },
-    [errors, isOverlayOpen],
-  );
+  const openOverlay = useCallback(() => {
+    setDismissedError(errors);
+    setOverlayOpen(true);
+  }, [errors]);
 
   return (
     <CartContext.Provider
       value={{
-        addToCartOptimistic,
         cart,
         cartWithPending,
         clearError,
         clearWarnings,
-        isAddingToCart,
         isOverlayOpen,
         isUpdatingCart,
         lastError,
         lastWarnings,
         openOverlay,
-        pendingQuantity,
         setOverlayOpen,
         setWarnings,
       }}
@@ -187,10 +154,11 @@ interface CartContextSyncProps {
   children: ReactNode;
 }
 
+// The layout streams `initialData` as a promise, so the store has no lines during SSR; the page's
+// own server read fills the HTML until the store hydrates.
 export function CartContextSync({ cart, children }: CartContextSyncProps) {
   const { cartWithPending } = useCart();
 
-  // Fall back to the server-fetched cart until the provider is seeded — avoids a hydration flash.
   return (
     <CartRenderContext.Provider value={cartWithPending ?? cart}>
       {children}

--- a/apps/template/components/product-detail/buy-buttons.tsx
+++ b/apps/template/components/product-detail/buy-buttons.tsx
@@ -6,10 +6,9 @@ import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 
 import { useCart } from "@/components/cart/context";
-import { useProductFormState } from "@/components/product-detail/product-form";
+import { useProductForm } from "@/components/product-detail/product-form";
 import { Button } from "@/components/ui/button";
-import { type ProductFormVariant, variantToOptimisticInfo } from "@/lib/product";
-import type { Image } from "@/lib/types";
+import type { ProductFormVariant } from "@/lib/product";
 import { cn } from "@/lib/utils";
 
 import { BuyWithShopLogo } from "./buy-with-shop-logo";
@@ -18,27 +17,21 @@ export function BuyButtons({
   availableForSale = true,
   buyWithShop = true,
   fallbackVariant,
-  featuredImage,
-  handle,
   quantityPicker = true,
-  title,
 }: {
   availableForSale?: boolean;
   buyWithShop?: boolean;
   fallbackVariant: ProductFormVariant | undefined;
-  featuredImage: Image | null;
-  handle: string;
   quantityPicker?: boolean;
-  title: string;
 }) {
-  const selectedVariant = useProductFormState().selectedVariant ?? fallbackVariant;
-  const selectedVariantId = selectedVariant?.id;
+  const { formProps, pending, register, selectedVariant: storeVariant } = useProductForm();
+  const selectedVariant = storeVariant ?? fallbackVariant;
 
   const t = useTranslations("product");
   const tCart = useTranslations("cart");
   const [isBuyingNow, setIsBuyingNow] = useState(false);
   const [quantity, setQuantity] = useState(1);
-  const { addToCartOptimistic, pendingQuantity, isAddingToCart } = useCart();
+  const { openOverlay } = useCart();
 
   // Reset pending state when returning from checkout (bfcache / back navigation)
   useEffect(() => {
@@ -48,20 +41,6 @@ export function BuyButtons({
     window.addEventListener("pageshow", handlePageShow);
     return () => window.removeEventListener("pageshow", handlePageShow);
   }, []);
-
-  const handleAddToCart = () => {
-    if (selectedVariantId && selectedVariant) {
-      addToCartOptimistic(
-        selectedVariantId,
-        quantity,
-        variantToOptimisticInfo(selectedVariant, {
-          title,
-          handle,
-          featuredImage,
-        }),
-      );
-    }
-  };
 
   if (!selectedVariant) {
     return null;
@@ -78,15 +57,16 @@ export function BuyButtons({
   });
 
   const getButtonText = () => {
-    if (pendingQuantity > 0) return t("addingQuantity", { quantity: String(pendingQuantity) });
-    if (isAddingToCart) return t("addingToCart");
+    if (pending) return t("addingToCart");
     if (requiresBundleConfiguration) return t("bundleConfigurationRequired");
     if (isOutOfStock) return t("outOfStock");
     return t("addToCart");
   };
 
   return (
-    <div className="grid gap-2.5">
+    <form {...formProps({ beforeSubmit: openOverlay })} className="grid gap-2.5">
+      <input type="hidden" {...register("merchandiseId", {})} />
+      <input type="hidden" {...register("quantity", { value: quantity })} />
       <div className="flex gap-2.5">
         {quantityPicker ? (
           <div
@@ -122,9 +102,8 @@ export function BuyButtons({
           </div>
         ) : null}
         <Button
-          type="button"
-          disabled={isOutOfStock || requiresBundleConfiguration}
-          onClick={handleAddToCart}
+          {...register("addToCart", {})}
+          disabled={isOutOfStock || requiresBundleConfiguration || pending}
           className="h-12 min-w-0 flex-1 justify-center"
         >
           {getButtonText()}
@@ -152,6 +131,6 @@ export function BuyButtons({
           )}
         </a>
       ) : null}
-    </div>
+    </form>
   );
 }

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -283,9 +283,6 @@ function ProductInfoContent({
       ) : (
         <BuyButtons
           fallbackVariant={fallbackVariant}
-          title={product.title}
-          handle={product.handle}
-          featuredImage={product.featuredImage}
           availableForSale={product.availableForSale}
           buyWithShop={shopConfig.pdp.buyWithShop.isEnabled}
           quantityPicker={shopConfig.pdp.quantityPicker.isEnabled}

--- a/apps/template/components/product-detail/product-form.tsx
+++ b/apps/template/components/product-detail/product-form.tsx
@@ -18,7 +18,9 @@ import {
 } from "@/lib/product";
 import type { Image } from "@/lib/types";
 
-const { ProductProvider, useProduct } = createProductComponents<ProductFormInput>();
+const { ProductProvider, useProduct, useProductForm } = createProductComponents<ProductFormInput>();
+
+export { useProductForm };
 
 const ProductHandleContext = createContext<string | null>(null);
 

--- a/apps/template/lib/cart/client.ts
+++ b/apps/template/lib/cart/client.ts
@@ -107,7 +107,7 @@ function dispatchLinesAdd(
   document.dispatchEvent(event);
 }
 
-// This preview's add form drops line attributes and cannot attach optimistic product detail.
+// Only for adds that need line attributes; this preview's add form drops them. Use useProductForm/useCartForm otherwise.
 export function addToCart(
   merchandiseId: string,
   quantity: number,

--- a/apps/template/lib/cart/index.ts
+++ b/apps/template/lib/cart/index.ts
@@ -104,15 +104,23 @@ function toDomainLine(line: HydrogenLine): CartLine {
   };
 }
 
+// A fresh optimistic cart has no cost currency until Shopify responds; the first line's price supplies it.
+function withLineCurrency(money: Money, lines: HydrogenLine[]): Money {
+  if (money.currencyCode) return money;
+  const currencyCode = lines[0]?.cost.totalAmount.currencyCode;
+  return currencyCode ? { ...money, currencyCode } : money;
+}
+
 export function toDomainCart(data: CartData | null | undefined): Cart | null {
   if (!data) return null;
   if (data.id === null && data.totalQuantity === 0 && data.lines.nodes.length === 0) return null;
+  const rawLines = data.lines.nodes as unknown as HydrogenLine[];
   return {
     appliedGiftCards: [],
     checkoutUrl: data.checkoutUrl ?? "",
     cost: {
-      subtotalAmount: data.cost.subtotalAmount,
-      totalAmount: data.cost.totalAmount,
+      subtotalAmount: withLineCurrency(data.cost.subtotalAmount, rawLines),
+      totalAmount: withLineCurrency(data.cost.totalAmount, rawLines),
     },
     discountAllocations: [],
     discountCodes: data.discountCodes.map((d) => ({
@@ -120,8 +128,8 @@ export function toDomainCart(data: CartData | null | undefined): Cart | null {
       code: d.code,
     })),
     id: data.id ?? undefined,
-    lines: data.lines.nodes
-      .map((l) => toDomainLine(l as unknown as HydrogenLine))
+    lines: rawLines
+      .map(toDomainLine)
       .sort(
         (a, b) =>
           Number(b.id?.startsWith(OPTIMISTIC_LINE_ID_PREFIX) ?? false) -

--- a/apps/template/lib/product.ts
+++ b/apps/template/lib/product.ts
@@ -37,7 +37,7 @@ export type ProductFormVariant = Pick<
   ProductVariant,
   "availableForSale" | "compareAtPrice" | "id" | "image" | "price" | "selectedOptions" | "title"
 > & {
-  product: { handle: string };
+  product: { handle: string; title: string };
   requiresBundleConfiguration: boolean;
 };
 
@@ -97,7 +97,7 @@ export function toProductFormVariant(variant: ProductVariant): ProductFormVarian
     id: variant.id,
     image: variant.image,
     price: variant.price,
-    product: { handle: variant.productHandle },
+    product: { handle: variant.productHandle, title: variant.productTitle },
     requiresBundleConfiguration: variant.requiresComponents && variant.components.length === 0,
     selectedOptions: variant.selectedOptions,
     title: variant.title,

--- a/apps/template/lib/shopify/fragments.ts
+++ b/apps/template/lib/shopify/fragments.ts
@@ -28,6 +28,7 @@ export const PRODUCT_VARIANT_FRAGMENT = gql(
     }
     product {
       handle
+      title
     }
   }
 `,

--- a/apps/template/lib/shopify/transforms/product.ts
+++ b/apps/template/lib/shopify/transforms/product.ts
@@ -135,6 +135,7 @@ export function transformVariant(variant: ShopifyVariant): ProductVariant {
     price: variant.price,
     compareAtPrice: variant.compareAtPrice ?? undefined,
     productHandle: variant.product.handle,
+    productTitle: variant.product.title,
     selectedOptions: variant.selectedOptions,
     image: transformImage(variant.image),
     bundleParents: variant.groupedBy?.nodes.map(transformVariantReference) ?? [],

--- a/apps/template/lib/types.ts
+++ b/apps/template/lib/types.ts
@@ -83,6 +83,7 @@ export interface ProductVariant {
   price: Money;
   /** Differs from the page's handle for combined-listing option values. */
   productHandle: string;
+  productTitle: string;
   requiresComponents: boolean;
   selectedOptions: SelectedOption[];
   title: string;


### PR DESCRIPTION
## Summary

Move the PDP and agent add-to-cart paths onto Hydrogen's form bindings instead of a hand-built `shopify:cart:lines-update` DOM event.

- `BuyButtons` is now a real `<form>` via `useProductForm()`: `formProps`, `register("merchandiseId")`, `register("quantity")`, `register("addToCart")`. Hydrogen seeds the optimistic line from the selected variant itself, so the `title`/`handle`/`featuredImage` props and `variantToOptimisticInfo` call go away. Pending state comes from the hook's `pending` rather than the hand-tracked `isAddingToCart`/`pendingQuantity` counters.
- The agent variant picker's add button is a real form via `useCartForm()` (no product store there).
- `CartProvider` drops `addToCartOptimistic`, `isAddingToCart`, `pendingQuantity`, and the pending-drain heuristic. `openOverlay` now also dismisses the prior error, which is what `addToCartOptimistic` did.
- `lib/cart/client.ts`: `addToCart` remains only for the gift card form (line attributes don't ride through the add form in this preview). `applyServerCart` remains for the agent bridge: `CartStore.hydrate()` exists but `createCartComponents` doesn't expose the store.
- `CartContextSync` on `/cart` was checked and kept. The layout streams `initialData` as a promise, so the store has no lines at SSR time; removing it dropped the line items from the server HTML. Added a comment saying why.

Net: 6 files, +33 / -101.

## Verification

- `oxfmt` on touched files: exit 0
- `oxlint components/product-detail components/agent components/cart components/cart-page app/cart lib/cart`: 0 warnings, 0 errors
- `tsc --noEmit -p tsconfig.json`: exit 0
- Dev server, PDP HTML renders `<form action="/api/cart" method="post">` with `merchandiseId` and the `add-to-cart` submit
- No-JS: `curl -X POST /api/cart -d 'merchandiseId=…&quantity=2&intent=add'` → 303, cart cookie set, `/api/cart` reports qty 2, `/cart` SSR renders the line
- Headless Chrome: click → overlay opens within 600ms with 1 optimistic line, one POST to `/api/cart`, cookie set, `GET /api/cart` qty 1, drawer shows the line and total
- Not exercised: agent variant-picker add (agent disabled locally), gift card add (code path unchanged)
