### PR TITLE
Upgrade PDP and PLP links to runtime prefetch on hover

### DIFF
--- a/apps/template/app/account/(authenticated)/orders/page.tsx
+++ b/apps/template/app/account/(authenticated)/orders/page.tsx
@@ -1,10 +1,10 @@
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
 import { Suspense } from "react";
 
 import { formatOrderDate, OrderStatusBadge } from "@/components/account/order-display";
 import { AccountPageHeader } from "@/components/account/page-header";
 import { Button } from "@/components/ui/button";
+import Link from "@/components/ui/link";
 import { Skeleton } from "@/components/ui/skeleton";
 import { defaultLocale } from "@/lib/i18n";
 import { getCustomerOrders } from "@/lib/shopify/operations/customer";

--- a/apps/template/app/collections/[handle]/page.tsx
+++ b/apps/template/app/collections/[handle]/page.tsx
@@ -1,8 +1,12 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 
-import { CollectionDetailPage } from "@/components/collections/collection-page";
+import {
+  CollectionDetailPage,
+  CollectionDetailSkeleton,
+} from "@/components/collections/collection-page";
 import { getCollectionResultsData, getCollectionSearchState } from "@/lib/collections/server";
 import { getLocale } from "@/lib/params";
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
@@ -83,12 +87,33 @@ export async function generateMetadata({
   };
 }
 
-export const instant = false;
-
+// The page itself reads no URL data so the route has a prefetchable App Shell. Everything that needs
+// `params`/`searchParams` lives under one Suspense boundary: a viewport prefetch shows the skeleton
+// on click, while a hover runtime prefetch resolves the cached collection header before the click.
 export default async function CollectionPage({
   params,
   searchParams,
 }: PageProps<"/collections/[handle]">) {
+  const tSearch = await getTranslations("search");
+
+  return (
+    <Suspense
+      fallback={
+        <CollectionDetailSkeleton
+          filtersLabel={tSearch("filters")}
+          sortByLabel={tSearch("sortBy")}
+        />
+      }
+    >
+      <CollectionPageContent params={params} searchParams={searchParams} />
+    </Suspense>
+  );
+}
+
+async function CollectionPageContent({
+  params,
+  searchParams,
+}: Pick<PageProps<"/collections/[handle]">, "params" | "searchParams">) {
   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
   if (handle === PLACEHOLDER_HANDLE) notFound();
 
@@ -97,16 +122,13 @@ export default async function CollectionPage({
 
   // Keep searchParams unawaited so the collection header stays in the static shell.
   const searchStatePromise = getCollectionSearchState(searchParams);
-  const collectionResultsDataPromise = getCollectionResultsData({
-    handle,
-    locale,
-    searchStatePromise,
-  });
 
   return (
     <CollectionDetailPage
       collection={collection}
-      collectionResultsDataPromise={collectionResultsDataPromise}
+      getCollectionResultsData={() =>
+        getCollectionResultsData({ handle, locale, searchStatePromise })
+      }
       handle={handle}
       locale={locale}
       searchStatePromise={searchStatePromise}

--- a/apps/template/app/collections/all/page.tsx
+++ b/apps/template/app/collections/all/page.tsx
@@ -51,15 +51,11 @@ export default async function AllProductsPage({ searchParams }: PageProps<"/coll
 
   // Keep searchParams unawaited so the collection header stays in the static shell.
   const searchStatePromise = getCollectionSearchState(searchParams);
-  const collectionResultsDataPromise = getAllProductsResultsData({
-    locale,
-    searchStatePromise,
-  });
 
   return (
     <CollectionDetailPage
       collection={collection}
-      collectionResultsDataPromise={collectionResultsDataPromise}
+      getCollectionResultsData={() => getAllProductsResultsData({ locale, searchStatePromise })}
       handle={ALL_PRODUCTS_HANDLE}
       locale={locale}
       searchStatePromise={searchStatePromise}

--- a/apps/template/app/not-found.tsx
+++ b/apps/template/app/not-found.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
 
 import { Container } from "@/components/ui/container";
+import Link from "@/components/ui/link";
 import { Page } from "@/components/ui/page";
 
 export default async function NotFoundError() {

--- a/apps/template/app/products/[handle]/page.tsx
+++ b/apps/template/app/products/[handle]/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 
 import { ProductViewedTracker } from "@/components/analytics/trackers";
 import { ProductDetailSection } from "@/components/product-detail/product-detail-section";
+import { ProductDetailSkeleton } from "@/components/product-detail/product-detail-skeleton";
 import { RelatedProductsSection } from "@/components/product/related-products-section";
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
@@ -85,12 +86,27 @@ export async function generateMetadata({
   return buildProductMetadata(handle, locale, `/products/${handle}`);
 }
 
-export const instant = false;
+// The static frame renders without URL data so the route has a prefetchable App Shell. Everything
+// that needs `params`/`searchParams` lives under one Suspense boundary: a viewport prefetch shows
+// the skeleton on click, while a hover runtime prefetch resolves the cached product before the click.
+export default function ProductPage({ params, searchParams }: PageProps<"/products/[handle]">) {
+  return (
+    <Page className="pt-0">
+      <Container className="bg-background">
+        <Sections>
+          <Suspense fallback={<ProductDetailSkeleton />}>
+            <ProductPageContent params={params} searchParams={searchParams} />
+          </Suspense>
+        </Sections>
+      </Container>
+    </Page>
+  );
+}
 
-export default async function ProductPage({
+async function ProductPageContent({
   params,
   searchParams,
-}: PageProps<"/products/[handle]">) {
+}: Pick<PageProps<"/products/[handle]">, "params" | "searchParams">) {
   const [{ handle }, locale] = await Promise.all([params, getLocale()]);
   if (handle === PLACEHOLDER_HANDLE) notFound();
 
@@ -135,21 +151,15 @@ export default async function ProductPage({
           variantPromise={variantPromise}
         />
       </Suspense>
-      <Page className="pt-0">
-        <Container className="bg-background">
-          <Sections>
-            <ProductDetailSection
-              product={product}
-              selectedOptionsPromise={selectedOptionsPromise}
-              variantPromise={variantPromise}
-              locale={locale}
-            />
-            {shopConfig.pdp.relatedProducts.isEnabled ? (
-              <RelatedProductsSection handle={handle} limit={4} locale={locale} />
-            ) : null}
-          </Sections>
-        </Container>
-      </Page>
+      <ProductDetailSection
+        product={product}
+        selectedOptionsPromise={selectedOptionsPromise}
+        variantPromise={variantPromise}
+        locale={locale}
+      />
+      {shopConfig.pdp.relatedProducts.isEnabled ? (
+        <RelatedProductsSection handle={handle} limit={4} locale={locale} />
+      ) : null}
     </>
   );
 }

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -2,7 +2,6 @@ import { SlidersHorizontalIcon } from "lucide-react";
 import type { Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations } from "next-intl/server";
-import Link from "next/link";
 import { Suspense } from "react";
 
 import { SearchViewedTracker } from "@/components/analytics/trackers";
@@ -23,6 +22,7 @@ import {
   getSearchResultsData,
 } from "@/components/search/results";
 import { Container } from "@/components/ui/container";
+import Link from "@/components/ui/link";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/apps/template/components/account/mobile-tabs-client.tsx
+++ b/apps/template/components/account/mobile-tabs-client.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import Link from "@/components/ui/link";
 import { cn } from "@/lib/utils";
 
 interface AccountTab {

--- a/apps/template/components/account/sidebar-client.tsx
+++ b/apps/template/components/account/sidebar-client.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import Link from "@/components/ui/link";
 import { cn } from "@/lib/utils";
 
 interface AccountSidebarLink {

--- a/apps/template/components/agent/registry.tsx
+++ b/apps/template/components/agent/registry.tsx
@@ -4,7 +4,6 @@ import { defineRegistry } from "@json-render/react";
 import { MinusIcon, PlusIcon, Trash2Icon } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import Image from "next/image";
-import Link from "next/link";
 import { useState } from "react";
 
 import { CartLineForm } from "@/components/cart/line-form";
@@ -19,6 +18,7 @@ import {
 import { Price } from "@/components/product/price";
 import { Button } from "@/components/ui/button";
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
+import Link from "@/components/ui/link";
 import { catalog } from "@/lib/agent";
 import type { AgentVariant } from "@/lib/agent/products";
 import { useCartForm } from "@/lib/cart/client";

--- a/apps/template/components/blog/article-card.tsx
+++ b/apps/template/components/blog/article-card.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
-import Link from "next/link";
 
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
+import Link from "@/components/ui/link";
 import type { BlogArticle } from "@/lib/types";
 
 export interface ArticleCardProps {

--- a/apps/template/components/blog/article-page.tsx
+++ b/apps/template/components/blog/article-page.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
-import Link from "next/link";
 
 import { Container } from "@/components/ui/container";
+import Link from "@/components/ui/link";
 import { Page } from "@/components/ui/page";
 import { Prose } from "@/components/ui/prose";
 import { Sections } from "@/components/ui/sections";

--- a/apps/template/components/cart-page/empty-cart.tsx
+++ b/apps/template/components/cart-page/empty-cart.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
+
+import Link from "@/components/ui/link";
 
 export async function Empty() {
   const t = await getTranslations("cart");

--- a/apps/template/components/cart/overlay-item.tsx
+++ b/apps/template/components/cart/overlay-item.tsx
@@ -3,11 +3,11 @@
 import { MinusIcon, PlusIcon, Trash2Icon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
-import Link from "next/link";
 
 import { CartLineForm } from "@/components/cart/line-form";
 import { Button } from "@/components/ui/button";
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
+import Link from "@/components/ui/link";
 import type { CartLine } from "@/lib/types";
 import { formatPrice } from "@/lib/utils";
 

--- a/apps/template/components/collections/collection-card.tsx
+++ b/apps/template/components/collections/collection-card.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
-import Link from "next/link";
 
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
+import Link from "@/components/ui/link";
 import type { CollectionWithThumbnail } from "@/lib/types";
 import { cn } from "@/lib/utils";
 

--- a/apps/template/components/collections/collection-page.tsx
+++ b/apps/template/components/collections/collection-page.tsx
@@ -1,7 +1,7 @@
 import { SlidersHorizontalIcon } from "lucide-react";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations } from "next-intl/server";
-import Link from "next/link";
+import { unstable_navigation } from "next/cache";
 import { Suspense } from "react";
 
 import { CollectionViewedTracker } from "@/components/analytics/trackers";
@@ -15,8 +15,10 @@ import { ProductsGridSkeleton } from "@/components/product/products-grid";
 import { BreadcrumbSchema } from "@/components/schema/breadcrumb-schema";
 import { CollectionSchema } from "@/components/schema/collection-schema";
 import { Container } from "@/components/ui/container";
+import Link from "@/components/ui/link";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { CollectionResultsData, CollectionSearchState } from "@/lib/collections/server";
 import type { Locale } from "@/lib/i18n";
 import type { Collection } from "@/lib/types";
@@ -29,14 +31,14 @@ import { FilterPendingScope } from "./filter-pending-context";
 
 export async function CollectionDetailPage({
   collection,
-  collectionResultsDataPromise,
+  getCollectionResultsData,
   handle,
   locale,
   searchStatePromise,
   sortExclude,
 }: {
   collection: Collection;
-  collectionResultsDataPromise: Promise<CollectionResultsData>;
+  getCollectionResultsData: () => Promise<CollectionResultsData>;
   handle: string;
   locale: Locale;
   searchStatePromise: Promise<CollectionSearchState>;
@@ -69,50 +71,102 @@ export async function CollectionDetailPage({
                 <CollectionBrowseFallback filtersLabel={filtersLabel} sortByLabel={sortByLabel} />
               }
             >
-              <NextIntlClientProvider
+              <CollectionBrowse
+                filtersLabel={filtersLabel}
+                getCollectionResultsData={getCollectionResultsData}
+                handle={handle}
+                locale={locale}
                 messages={{ category: messages.category, search: messages.search }}
-              >
-                <CollectionBrowseProvider handle={handle} searchStatePromise={searchStatePromise}>
-                  <CollectionToolbar
-                    filterSheet={
-                      <FilterSidebarSheet
-                        label={filtersLabel}
-                        trigger={
-                          <button
-                            type="button"
-                            className="flex items-center gap-2 text-sm font-medium"
-                          >
-                            <SlidersHorizontalIcon className="size-4" />
-                            <span>{filtersLabel}</span>
-                            <CollectionActiveFilterCountBadge />
-                          </button>
-                        }
-                      >
-                        <FilterPendingScope>
-                          <CollectionFilters
-                            facetsPromise={collectionResultsDataPromise.then(
-                              (data) => data.transformedFilters,
-                            )}
-                          />
-                        </FilterPendingScope>
-                      </FilterSidebarSheet>
-                    }
-                    sortSelect={<CollectionsSortSelect exclude={sortExclude} />}
-                  />
-
-                  <FilterPendingScope>
-                    <CollectionResultsGrid
-                      locale={locale}
-                      collectionResultsDataPromise={collectionResultsDataPromise}
-                    />
-                  </FilterPendingScope>
-                </CollectionBrowseProvider>
-              </NextIntlClientProvider>
+                searchStatePromise={searchStatePromise}
+                sortExclude={sortExclude}
+              />
             </Suspense>
           </Sections>
         </Container>
       </Page>
     </>
+  );
+}
+
+async function CollectionBrowse({
+  filtersLabel,
+  getCollectionResultsData,
+  handle,
+  locale,
+  messages,
+  searchStatePromise,
+  sortExclude,
+}: {
+  filtersLabel: string;
+  getCollectionResultsData: () => Promise<CollectionResultsData>;
+  handle: string;
+  locale: Locale;
+  messages: Pick<Awaited<ReturnType<typeof getMessages>>, "category" | "search">;
+  searchStatePromise: Promise<CollectionSearchState>;
+  sortExclude?: string[];
+}) {
+  // Results are uncached and per-user, so a per-link runtime prefetch must stop here; otherwise the
+  // whole page segment is marked partial and the header is refetched on click too.
+  await unstable_navigation();
+  const collectionResultsDataPromise = getCollectionResultsData();
+
+  return (
+    <NextIntlClientProvider messages={messages}>
+      <CollectionBrowseProvider handle={handle} searchStatePromise={searchStatePromise}>
+        <CollectionToolbar
+          filterSheet={
+            <FilterSidebarSheet
+              label={filtersLabel}
+              trigger={
+                <button type="button" className="flex items-center gap-2 text-sm font-medium">
+                  <SlidersHorizontalIcon className="size-4" />
+                  <span>{filtersLabel}</span>
+                  <CollectionActiveFilterCountBadge />
+                </button>
+              }
+            >
+              <FilterPendingScope>
+                <CollectionFilters
+                  facetsPromise={collectionResultsDataPromise.then(
+                    (data) => data.transformedFilters,
+                  )}
+                />
+              </FilterPendingScope>
+            </FilterSidebarSheet>
+          }
+          sortSelect={<CollectionsSortSelect exclude={sortExclude} />}
+        />
+
+        <FilterPendingScope>
+          <CollectionResultsGrid
+            locale={locale}
+            collectionResultsDataPromise={collectionResultsDataPromise}
+          />
+        </FilterPendingScope>
+      </CollectionBrowseProvider>
+    </NextIntlClientProvider>
+  );
+}
+
+export function CollectionDetailSkeleton({
+  filtersLabel,
+  sortByLabel,
+}: {
+  filtersLabel: string;
+  sortByLabel: string;
+}) {
+  return (
+    <Page className="pt-2.5 md:pt-10">
+      <Container>
+        <Sections className="gap-5">
+          <div aria-busy="true" className="grid gap-2.5">
+            <Skeleton className="h-9 w-64 sm:h-10 md:h-12 md:w-80" />
+            <Skeleton className="h-4 w-full max-w-xl" />
+          </div>
+          <CollectionBrowseFallback filtersLabel={filtersLabel} sortByLabel={sortByLabel} />
+        </Sections>
+      </Container>
+    </Page>
   );
 }
 

--- a/apps/template/components/collections/filter-primitives.tsx
+++ b/apps/template/components/collections/filter-primitives.tsx
@@ -8,10 +8,10 @@ import {
   SearchIcon,
   XIcon,
 } from "lucide-react";
-import Link from "next/link";
 import type * as React from "react";
 
 import { Input } from "@/components/ui/input";
+import Link from "@/components/ui/link";
 import { cn } from "@/lib/utils";
 
 function FilterSidebar({ className, children, ...props }: React.ComponentProps<"aside">) {

--- a/apps/template/components/collections/filter-sidebar.tsx
+++ b/apps/template/components/collections/filter-sidebar.tsx
@@ -9,9 +9,9 @@ import {
 } from "@shopify/hydrogen";
 import { useCollection, useCollectionActions } from "@shopify/hydrogen/react";
 import { useLocale, useTranslations } from "next-intl";
-import Link from "next/link";
 import { useState } from "react";
 
+import Link from "@/components/ui/link";
 import { Swatch } from "@/components/ui/swatch";
 import { getActiveFilters, parseFilterInput } from "@/lib/collections";
 import { getActiveFilterBadges } from "@/lib/shopify/transforms/filters";

--- a/apps/template/components/collections/infinite-product-grid.tsx
+++ b/apps/template/components/collections/infinite-product-grid.tsx
@@ -2,7 +2,6 @@
 
 import { useCollection } from "@shopify/hydrogen/react";
 import { LoaderCircleIcon } from "lucide-react";
-import Link from "next/link";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 
 import {
@@ -13,6 +12,7 @@ import {
   ProductCardTitle,
   ProductCard as ProductCardRoot,
 } from "@/components/product-card/components";
+import Link from "@/components/ui/link";
 import { getBrowseSearch } from "@/lib/collections";
 import { buildProductUrl } from "@/lib/product";
 import type { PageInfo, ProductCard } from "@/lib/types";

--- a/apps/template/components/error/error-boundary-content.tsx
+++ b/apps/template/components/error/error-boundary-content.tsx
@@ -2,9 +2,9 @@
 
 import { AlertCircleIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
-import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+import Link from "@/components/ui/link";
 
 export function ErrorBoundaryContent({ reset }: { reset: () => void }) {
   const t = useTranslations("common");

--- a/apps/template/components/footer/index.tsx
+++ b/apps/template/components/footer/index.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
 
 import { Container } from "@/components/ui/container";
+import Link from "@/components/ui/link";
 import { Sections } from "@/components/ui/sections";
 import { shopConfig } from "@/lib/config";
 import { getShopPolicies } from "@/lib/shopify/operations/policies";

--- a/apps/template/components/nav/account.tsx
+++ b/apps/template/components/nav/account.tsx
@@ -1,7 +1,7 @@
 import { UserRoundCheckIcon, UserRoundIcon } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
 
+import Link from "@/components/ui/link";
 import { isCustomerLoggedIn } from "@/lib/auth/server";
 
 export async function NavAccount() {

--- a/apps/template/components/nav/index.tsx
+++ b/apps/template/components/nav/index.tsx
@@ -1,10 +1,10 @@
 import { PredictiveSearchProvider } from "@shopify/hydrogen/react";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
-import Link from "next/link";
 import { Suspense } from "react";
 
 import { Container } from "@/components/ui/container";
+import Link from "@/components/ui/link";
 import { shopConfig } from "@/lib/config";
 import type { MenuItem } from "@/lib/shopify/types/menu";
 

--- a/apps/template/components/nav/mobile-menu.tsx
+++ b/apps/template/components/nav/mobile-menu.tsx
@@ -2,7 +2,6 @@
 
 import { Menu } from "lucide-react";
 import { useTranslations } from "next-intl";
-import Link from "next/link";
 import { useState } from "react";
 
 import {
@@ -11,6 +10,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import Link from "@/components/ui/link";
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import type { MenuItem } from "@/lib/shopify/types/menu";
 

--- a/apps/template/components/nav/quick-links.tsx
+++ b/apps/template/components/nav/quick-links.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown } from "lucide-react";
-import Link from "next/link";
 
+import Link from "@/components/ui/link";
 import type { MenuItem } from "@/lib/shopify/types/menu";
 import { cn } from "@/lib/utils";
 

--- a/apps/template/components/product-card/product-card.tsx
+++ b/apps/template/components/product-card/product-card.tsx
@@ -1,6 +1,6 @@
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
 
+import Link from "@/components/ui/link";
 import type { Locale } from "@/lib/i18n";
 import { buildProductUrl } from "@/lib/product";
 import type { ProductCard as ProductCardType } from "@/lib/types";

--- a/apps/template/components/product-detail/bundle-components.tsx
+++ b/apps/template/components/product-detail/bundle-components.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
-import Link from "next/link";
 
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
+import Link from "@/components/ui/link";
 import type { ProductVariantComponent, ProductVariantReference } from "@/lib/types";
 
 interface BundleListItem {

--- a/apps/template/components/product-detail/color-picker.tsx
+++ b/apps/template/components/product-detail/color-picker.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import type * as React from "react";
 
+import Link from "@/components/ui/link";
 import { Swatch } from "@/components/ui/swatch";
 import type { OptionGroupState } from "@/lib/product";
 import { cn } from "@/lib/utils";

--- a/apps/template/components/product-detail/complementary-products.tsx
+++ b/apps/template/components/product-detail/complementary-products.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
-import Link from "next/link";
 
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
+import Link from "@/components/ui/link";
 import { getComplementaryProducts } from "@/lib/shopify/operations/products";
 import type { ProductCard } from "@/lib/types";
 import { formatPrice } from "@/lib/utils";

--- a/apps/template/components/product-detail/option-picker.tsx
+++ b/apps/template/components/product-detail/option-picker.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import type * as React from "react";
 
+import Link from "@/components/ui/link";
 import type { OptionGroupState } from "@/lib/product";
 import { cn } from "@/lib/utils";
 

--- a/apps/template/components/product-detail/product-detail-skeleton.tsx
+++ b/apps/template/components/product-detail/product-detail-skeleton.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Shell fallback for the PDP while `params`/`searchParams` resolve on navigation. Mirrors the
+// ProductDetailSection grid (6/4 columns, sticky info) so the resolved content lands without CLS.
+// Image cells are plain canvases rather than pulsing skeletons: they're the LCP slot and a pulse
+// reads as a harder flash than an empty surface.
+export function ProductDetailSkeleton() {
+  return (
+    <div aria-busy="true" className="grid gap-10 lg:grid-cols-10 lg:items-start lg:gap-5">
+      <div className="lg:col-span-6">
+        <div className="aspect-square w-full bg-accent lg:hidden" />
+        <div className="hidden grid-cols-2 gap-2.5 lg:grid">
+          <div className="aspect-square w-full bg-accent" />
+          <div className="aspect-square w-full bg-accent" />
+          <div className="aspect-square w-full bg-accent" />
+          <div className="aspect-square w-full bg-accent" />
+        </div>
+      </div>
+      <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
+        <div className="grid gap-5">
+          <div className="grid gap-2.5">
+            <Skeleton className="h-9 w-3/4" />
+            <Skeleton className="h-7 w-24" />
+          </div>
+          <div className="grid gap-2.5">
+            <Skeleton className="h-4 w-16" />
+            <div className="flex gap-2.5">
+              <Skeleton className="h-10 w-16" />
+              <Skeleton className="h-10 w-16" />
+              <Skeleton className="h-10 w-16" />
+            </div>
+          </div>
+          <Skeleton className="h-12 w-full" />
+        </div>
+        <div className="grid gap-4">
+          <Skeleton className="h-6 w-40" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/template/components/product/products-grid.tsx
+++ b/apps/template/components/product/products-grid.tsx
@@ -1,8 +1,8 @@
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
 import { Suspense } from "react";
 
 import { ProductCard, ProductCardSkeleton } from "@/components/product-card/product-card";
+import Link from "@/components/ui/link";
 import type { Locale } from "@/lib/i18n";
 import { searchIndexProducts } from "@/lib/shopify/operations/products";
 import { cn } from "@/lib/utils";

--- a/apps/template/components/ui/link.tsx
+++ b/apps/template/components/ui/link.tsx
@@ -1,0 +1,28 @@
+import NextLink from "next/link";
+import type { ComponentProps } from "react";
+
+// Routes whose per-link runtime prefetch is worth paying for on intent: they read params/searchParams
+// behind a Suspense boundary and their data is "use cache", so a hover/touch prefetch resolves the
+// full page before the click. Everything else keeps the default shared App Shell prefetch.
+const DYNAMIC_ON_HOVER_PREFIXES = ["/collections", "/products"];
+
+export function shouldPrefetchOnHover(href: ComponentProps<typeof NextLink>["href"]): boolean {
+  const pathname = typeof href === "string" ? href : href.pathname;
+  if (!pathname) return false;
+  return DYNAMIC_ON_HOVER_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+// Drop-in for next/link. Product and collection URLs opt into unstable_dynamicOnHover automatically;
+// pass `prefetch` or `unstable_dynamicOnHover` explicitly to override per link.
+export function Link({ unstable_dynamicOnHover, ...props }: ComponentProps<typeof NextLink>) {
+  return (
+    <NextLink
+      {...props}
+      unstable_dynamicOnHover={unstable_dynamicOnHover ?? shouldPrefetchOnHover(props.href)}
+    />
+  );
+}
+
+export default Link;

--- a/apps/template/global.ts
+++ b/apps/template/global.ts
@@ -7,3 +7,15 @@ declare module "next-intl" {
     Messages: typeof messages;
   }
 }
+
+// `next/link` types resolve to the Pages Router declaration, which omits this App Router prop
+// even though the runtime (dist/client/app-dir/link) accepts it. Remove once Next declares it.
+declare module "next/dist/client/link" {
+  interface LinkProps {
+    /**
+     * (unstable) Upgrade the default App Shell prefetch to a per-link runtime prefetch on
+     * hover/touch. Requires `experimental.dynamicOnHover` in next.config.
+     */
+    unstable_dynamicOnHover?: boolean;
+  }
+}

--- a/apps/template/next.config.ts
+++ b/apps/template/next.config.ts
@@ -40,8 +40,13 @@ function assertRequiredEnv() {
 const nextConfig: NextConfig = {
   cacheComponents: true,
   partialPrefetching: true,
-  // TS7's native compiler doesn't expose the programmatic API Next uses for type checking; the CLI path does.
-  experimental: { useTypeScriptCli: true },
+  experimental: {
+    // Lets <Link unstable_dynamicOnHover> upgrade a viewport (App Shell) prefetch to a per-link
+    // runtime prefetch on hover/touch, so high-fan-out grids pay the per-link cost only on intent.
+    dynamicOnHover: true,
+    // TS7's native compiler doesn't expose the programmatic API Next uses for type checking; the CLI path does.
+    useTypeScriptCli: true,
+  },
   images: {
     deviceSizes: [1080],
     imageSizes: [],

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -33,7 +33,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "1.37.0",
-    "next": "16.3.3",
+    "next": "16.4.0-canary.17",
     "next-intl": "4.14.1",
     "oxfmt": "0.65.0",
     "oxlint": "1.80.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,10 +150,10 @@ importers:
         version: 19.2.5(@types/react@19.2.18)
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.1(next@16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       ai:
         specifier: 7.0.85
         version: 7.0.85(zod@4.5.4)
@@ -162,7 +162,7 @@ importers:
         version: 1.0.0
       botid:
         specifier: 1.5.11
-        version: 1.5.11(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 1.5.11(next@16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -173,11 +173,11 @@ importers:
         specifier: 1.37.0
         version: 1.37.0(react@19.2.8)
       next:
-        specifier: 16.3.3
-        version: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 16.4.0-canary.17
+        version: 16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl:
         specifier: 4.14.1
-        version: 4.14.1(@swc/helpers@0.5.23)(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 4.14.1(@swc/helpers@0.5.23)(next@16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       oxfmt:
         specifier: 0.65.0
         version: 0.65.0
@@ -1131,8 +1131,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-arm64@0.35.4':
+    resolution: {integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-x64@0.35.3':
     resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.4':
+    resolution: {integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
@@ -1142,8 +1154,18 @@ packages:
     engines: {node: '>=20.9.0'}
     os: [freebsd]
 
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    resolution: {integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
   '@img/sharp-libvips-darwin-arm64@1.3.2':
     resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
+    resolution: {integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1152,8 +1174,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    resolution: {integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-linux-arm64@1.3.2':
     resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm64@1.3.3':
+    resolution: {integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -1164,8 +1197,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    resolution: {integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-ppc64@1.3.2':
     resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
+    resolution: {integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -1176,8 +1221,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    resolution: {integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.3.2':
     resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.3':
+    resolution: {integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -1188,8 +1245,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    resolution: {integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    resolution: {integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
@@ -1200,8 +1269,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    resolution: {integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linux-arm64@0.35.3':
     resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm64@0.35.4':
+    resolution: {integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
@@ -1214,8 +1296,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-arm@0.35.4':
+    resolution: {integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-ppc64@0.35.3':
     resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.4':
+    resolution: {integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
@@ -1228,8 +1324,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-riscv64@0.35.4':
+    resolution: {integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-s390x@0.35.3':
     resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.4':
+    resolution: {integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
@@ -1242,8 +1352,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-x64@0.35.4':
+    resolution: {integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linuxmusl-arm64@0.35.3':
     resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    resolution: {integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
@@ -1256,8 +1380,19 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    resolution: {integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-wasm32@0.35.3':
     resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-wasm32@0.35.4':
+    resolution: {integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==}
     engines: {node: '>=20.9.0'}
 
   '@img/sharp-webcontainers-wasm32@0.35.3':
@@ -1265,8 +1400,19 @@ packages:
     engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    resolution: {integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
   '@img/sharp-win32-arm64@0.35.3':
     resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-arm64@0.35.4':
+    resolution: {integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
@@ -1277,8 +1423,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.35.4':
+    resolution: {integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.35.3':
     resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.4':
+    resolution: {integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
@@ -1627,8 +1785,17 @@ packages:
   '@next/env@16.3.3':
     resolution: {integrity: sha512-U2eYQRwXj+dsqxV79zFqExDdatnNY/ZWc2nsJU1p/OgT7fd3dXwlF6OjYaFQCfMoeTA19PWq+wVmYgimVA+V+g==}
 
+  '@next/env@16.4.0-canary.17':
+    resolution: {integrity: sha512-RXOx4qvAJNlszQQAx84tmc55qbRoV/HTMoKdtiJNgmXgYZ7OLzREeqOlUL1FAHeI9GVenZil4xf3s+XwekxyTg==}
+
   '@next/swc-darwin-arm64@16.3.3':
     resolution: {integrity: sha512-8Hiv32QJPwdV6KYJ8meR9SBA061tQqnIKTJDocvOXlEQqib0xMFpzArosuffFUUc0sslbh7QQ8a3Yey1QV8EIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@16.4.0-canary.17':
+    resolution: {integrity: sha512-x9bHRz4A2u8ZAo2UnPSDTonEGyHI8QSerRGcyQJsiX4WWBcsm3ZllxDjw8NfsdtCQBnUUgumpGMS4/XJ/bOwAg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -1639,8 +1806,21 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-darwin-x64@16.4.0-canary.17':
+    resolution: {integrity: sha512-FeV250AQmXS4H7TzRFg4jB79poosuV8I/0zE91wMrMfLaRNktVeKdb3D3elpNjZ6G9SV5MXHmBKDbAyANgzWDQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@next/swc-linux-arm64-gnu@16.3.3':
     resolution: {integrity: sha512-bf0FIssMFueU2dm7vQEWWxk0c8UjKTdW0yzuh0sQsD8pf1+KCLDdaqhYZNMYGmXwEOiHAUzgBKudovIlcvvBjg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-gnu@16.4.0-canary.17':
+    resolution: {integrity: sha512-V/d6F3M9q7oK3Z0K3TC57C88TthDphnGjY9HsQiI4gh8wpKddo1fpESvrqom8xbLvTq9upPhUHvKpDyqfn/sqw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1653,8 +1833,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-arm64-musl@16.4.0-canary.17':
+    resolution: {integrity: sha512-3OUcGG6Xz5+E8mpCTURdu8IHrHS+gK/D+Ga1bXGd8iOHKEv8vVcP15wyKpdd6Se4O9YsjN80VuuX8FtWhLRQaQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-linux-x64-gnu@16.3.3':
     resolution: {integrity: sha512-0W46zw1N3ODpI6n0GeivHvvob1pooozgZVqy65k0mh4/7vr+FbY9+WpHzNVXjHipJf/A3FDheBG19H1s5A25rA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-gnu@16.4.0-canary.17':
+    resolution: {integrity: sha512-5QBatj9kVhP3jgfx0wDDpmXmy7+Q6wBQfilyC9M9fHtCDS5tDqR7EauFapFBoA9ELuOKgmm0qCc5Wa5/xqp8jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1667,14 +1861,33 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-x64-musl@16.4.0-canary.17':
+    resolution: {integrity: sha512-Too4WIubczcD72h6r790OfnKk1dC97h6IXD1i3bBlLdhnsYx2NvRKvslUOos9PzfXYr6q2vpw6E/i2hr6CIb3w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-win32-arm64-msvc@16.3.3':
     resolution: {integrity: sha512-cTMUJpcEGmeywofCUfhR+rSsoE33+rVPnPEYNTNdLNlsOeEg/vktOsKUSTb28vUGqD2jkm4Zaskcwn7OCI6FQg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
+  '@next/swc-win32-arm64-msvc@16.4.0-canary.17':
+    resolution: {integrity: sha512-l0NhK9gfzeSh4njGaxr9Zx6dpaJqXZSPvUXKAdCY5hPMlU5+lrJQRbD/VmmOchqOd3+i3QQ5Twwc7SzuHGDM5w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@next/swc-win32-x64-msvc@16.3.3':
     resolution: {integrity: sha512-2VR4cTBzHXaBjnGsuH6GyJjENzQOmHeAh11uY1iUhjm3j5dEUrVJuUj+VL78jaGi/Dik8xS76zEj18BsFhlVZQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.4.0-canary.17':
+    resolution: {integrity: sha512-LLhcvJRFqAtGL1yB4eA6F5e3H+x7LTGuPBMZqLnLp1GgHoBjJQZngdXdycEYfXLvn6FYnb1uoFBWhyh1S0qt6g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -5791,6 +6004,27 @@ packages:
       sass:
         optional: true
 
+  next@16.4.0-canary.17:
+    resolution: {integrity: sha512-sL70qK+pzcfJ5tzT7BB+TilUMt7X1Z/KoIyw49KpSjepKugnuXlAVjk11vx7+hTs3swWqYsPKBZrKlW8Y2oVmg==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
@@ -6231,6 +6465,15 @@ packages:
 
   sharp@0.35.3:
     resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  sharp@0.35.4:
+    resolution: {integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       '@types/node': '*'
@@ -7907,9 +8150,19 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.3.2
     optional: true
 
+  '@img/sharp-darwin-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+    optional: true
+
   '@img/sharp-darwin-x64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.3
     optional: true
 
   '@img/sharp-freebsd-wasm32@0.35.3':
@@ -7917,34 +8170,69 @@ snapshots:
       '@img/sharp-wasm32': 0.35.3
     optional: true
 
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.4
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.3.2':
     optional: true
 
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.3':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.3.2':
     optional: true
 
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linux-ppc64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.3.2':
     optional: true
 
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.3':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.3.2':
     optional: true
 
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
     optional: true
 
   '@img/sharp-linux-arm64@0.35.3':
@@ -7952,9 +8240,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.3.2
     optional: true
 
+  '@img/sharp-linux-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+    optional: true
+
   '@img/sharp-linux-arm@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.3
     optional: true
 
   '@img/sharp-linux-ppc64@0.35.3':
@@ -7962,9 +8260,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.3.2
     optional: true
 
+  '@img/sharp-linux-ppc64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+    optional: true
+
   '@img/sharp-linux-riscv64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
     optional: true
 
   '@img/sharp-linux-s390x@0.35.3':
@@ -7972,9 +8280,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.3.2
     optional: true
 
+  '@img/sharp-linux-s390x@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+    optional: true
+
   '@img/sharp-linux-x64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.3
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.35.3':
@@ -7982,12 +8300,27 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.3.2
     optional: true
 
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+    optional: true
+
   '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-wasm32@0.35.4':
     dependencies:
       '@emnapi/runtime': 1.11.3
     optional: true
@@ -7997,13 +8330,27 @@ snapshots:
       '@img/sharp-wasm32': 0.35.3
     optional: true
 
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.4
+    optional: true
+
   '@img/sharp-win32-arm64@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.4':
     optional: true
 
   '@img/sharp-win32-ia32@0.35.3':
     optional: true
 
+  '@img/sharp-win32-ia32@0.35.4':
+    optional: true
+
   '@img/sharp-win32-x64@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.4':
     optional: true
 
   '@inquirer/ansi@1.0.2': {}
@@ -8371,28 +8718,54 @@ snapshots:
 
   '@next/env@16.3.3': {}
 
+  '@next/env@16.4.0-canary.17': {}
+
   '@next/swc-darwin-arm64@16.3.3':
+    optional: true
+
+  '@next/swc-darwin-arm64@16.4.0-canary.17':
     optional: true
 
   '@next/swc-darwin-x64@16.3.3':
     optional: true
 
+  '@next/swc-darwin-x64@16.4.0-canary.17':
+    optional: true
+
   '@next/swc-linux-arm64-gnu@16.3.3':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.4.0-canary.17':
     optional: true
 
   '@next/swc-linux-arm64-musl@16.3.3':
     optional: true
 
+  '@next/swc-linux-arm64-musl@16.4.0-canary.17':
+    optional: true
+
   '@next/swc-linux-x64-gnu@16.3.3':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.4.0-canary.17':
     optional: true
 
   '@next/swc-linux-x64-musl@16.3.3':
     optional: true
 
+  '@next/swc-linux-x64-musl@16.4.0-canary.17':
+    optional: true
+
   '@next/swc-win32-arm64-msvc@16.3.3':
     optional: true
 
+  '@next/swc-win32-arm64-msvc@16.4.0-canary.17':
+    optional: true
+
   '@next/swc-win32-x64-msvc@16.3.3':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.4.0-canary.17':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -10642,6 +11015,11 @@ snapshots:
       next: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
+  '@vercel/analytics@2.0.1(next@16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    optionalDependencies:
+      next: 16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+
   '@vercel/cli-config@0.2.1':
     dependencies:
       xdg-app-paths: 5.5.1
@@ -10729,6 +11107,11 @@ snapshots:
   '@vercel/speed-insights@2.0.0(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
       next: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+
+  '@vercel/speed-insights@2.0.0(next@16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    optionalDependencies:
+      next: 16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
   '@vimeo/player@2.29.0':
@@ -10820,9 +11203,9 @@ snapshots:
 
   bcp-47-match@2.0.3: {}
 
-  botid@1.5.11(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
+  botid@1.5.11(next@16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
     optionalDependencies:
-      next: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
   brace-expansion@5.0.9:
@@ -12781,7 +13164,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.14.1: {}
 
-  next-intl@4.14.1(@swc/helpers@0.5.23)(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
+  next-intl@4.14.1(@swc/helpers@0.5.23)(next@16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
     dependencies:
       '@eloqnt/config': 0.0.2
       '@eloqnt/format-json': 0.0.3
@@ -12791,7 +13174,7 @@ snapshots:
       '@swc/core': 1.16.1(@swc/helpers@0.5.23)
       icu-minify: 4.14.1
       negotiator: 1.0.0
-      next: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl-swc-plugin-extractor: 4.14.1
       react: 19.2.8
       use-intl: 4.14.1(react@19.2.8)
@@ -12825,6 +13208,33 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.35.3(@types/node@26.4.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
+
+  next@16.4.0-canary.17(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@next/env': 16.4.0-canary.17
+      '@swc/helpers': 0.5.23
+      baseline-browser-mapping: 2.11.17
+      caniuse-lite: 1.0.30001809
+      postcss: 8.5.23
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.8)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.4.0-canary.17
+      '@next/swc-darwin-x64': 16.4.0-canary.17
+      '@next/swc-linux-arm64-gnu': 16.4.0-canary.17
+      '@next/swc-linux-arm64-musl': 16.4.0-canary.17
+      '@next/swc-linux-x64-gnu': 16.4.0-canary.17
+      '@next/swc-linux-x64-musl': 16.4.0-canary.17
+      '@next/swc-win32-arm64-msvc': 16.4.0-canary.17
+      '@next/swc-win32-x64-msvc': 16.4.0-canary.17
+      '@opentelemetry/api': 1.9.1
+      babel-plugin-react-compiler: 1.0.0
+      sharp: 0.35.4(@types/node@26.4.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
@@ -13478,6 +13888,40 @@ snapshots:
       '@img/sharp-win32-arm64': 0.35.3
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 26.4.0
+    optional: true
+
+  sharp@0.35.4(@types/node@26.4.0):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.4
+      '@img/sharp-darwin-x64': 0.35.4
+      '@img/sharp-freebsd-wasm32': 0.35.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+      '@img/sharp-libvips-linux-arm': 1.3.3
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+      '@img/sharp-libvips-linux-x64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+      '@img/sharp-linux-arm': 0.35.4
+      '@img/sharp-linux-arm64': 0.35.4
+      '@img/sharp-linux-ppc64': 0.35.4
+      '@img/sharp-linux-riscv64': 0.35.4
+      '@img/sharp-linux-s390x': 0.35.4
+      '@img/sharp-linux-x64': 0.35.4
+      '@img/sharp-linuxmusl-arm64': 0.35.4
+      '@img/sharp-linuxmusl-x64': 0.35.4
+      '@img/sharp-webcontainers-wasm32': 0.35.4
+      '@img/sharp-win32-arm64': 0.35.4
+      '@img/sharp-win32-ia32': 0.35.4
+      '@img/sharp-win32-x64': 0.35.4
       '@types/node': 26.4.0
     optional: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,8 @@ minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
   - "@vercel/agent-readability"
   - "@vercel/geistdocs"
+  - next
+  - "@next/*"
 
 packages:
   - "apps/*"


### PR DESCRIPTION
## Summary

Moves the template to Next `16.4.0-canary.17` and uses two of its features so product and collection links resolve on hover instead of on click:

- `experimental.dynamicOnHover` + `<Link unstable_dynamicOnHover>`: a new `components/ui/link` wrapper turns this on for `/products` and `/collections` hrefs, and every template link now goes through it. High-fan-out grids keep the shared App Shell prefetch in the viewport and only pay for a per-link runtime prefetch on intent.
- `unstable_navigation()`: the uncached collection results fetch now starts behind `await unstable_navigation()` inside the browse Suspense boundary. The hover prefetch carries the collection header and grid skeleton; the results themselves are rendered only on the actual navigation.

Both the PDP and the collection page drop `export const instant = false`. Each renders its static frame and reads `params`/`searchParams` under a single Suspense boundary with a matching skeleton (`ProductDetailSkeleton`, `CollectionDetailSkeleton`), so the routes have a prefetchable App Shell again.

`next` and `@next/*` are added to `minimumReleaseAgeExclude` so the canary installs.

## Measured (local production build, Playwright, 2.5s hover then click)

- `/collections/mens` -> `/products/arcgauge-jacket-mens-0811c3`: 0 RSC requests after click; first frame on the target already has the full PDP.
- `/collections` -> `/collections/mens`: first frame has the collection header and toolbar; 0 frames of the page skeleton; the grid streams in from one navigation request ~780ms later.
- Hover runtime prefetch for the collection page is 68 KB with the header and 80 card skeletons and no product links, confirming the results fetch stays out of the prefetch.

## Verification

- `tsc --noEmit`: clean (after `next typegen`; a stale `.next/types/cache-life.d.ts` from 16.3.3 shadowed `next/cache`)
- `oxlint app components lib`: 0 warnings, 0 errors; `oxfmt`: clean
- `next build`: succeeded, `/collections/[handle]` and `/products/[handle]` are Partial Prerender

## Follow-ups

- `packages/plugin/skills/build-shop/references/{plp-search,rendering-architecture}.md` still describe the `instant = false` pattern and need updating (and a docs sync).
- `global.ts` keeps the `LinkProps` augmentation: canary only types `unstable_dynamicOnHover` in `dist/client/app-dir/link.d.ts`, not on the `next/link` entry.
- `unstable_navigation()` is unstable; its error messages still carry `TODO(cache-stages)` docs links.
