### PR TITLE
Align browse and search orchestration

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/plp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/plp.mdx
@@ -20,7 +20,7 @@ Filters, sorting, and pagination state are reflected in the URL using the same `
 - **Swatches** — color or image choices when Shopify provides swatch presentation data.
 - **Sorting** — Shopify's supported collection sorts. Search omits name and date because Shopify search does not support them.
 - **Infinite scroll** — loads up to 40 products at a time as the shopper moves down the page and guards against duplicates when rankings change. To change the batch size for collection and search listings, set `PRODUCTS_PER_PAGE` in `lib/collections/index.ts`.
-- **Toolbar** — provides filter access, result count, and sorting.
+- **Toolbar** — collection and search pages share filter access, sorting, and a matching loading layout. Search also shows a result count.
 - **Predictive search** — shows suggestions and products from the navigation search dialog.
 - **Structured data** — describes collection pages to search engines.
 

--- a/apps/template/app/search/page.tsx
+++ b/apps/template/app/search/page.tsx
@@ -1,32 +1,19 @@
-import { SlidersHorizontalIcon } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Suspense } from "react";
 
 import { SearchViewedTracker } from "@/components/analytics/trackers";
-import {
-  CollectionActiveFilterCountBadge,
-  CollectionBrowseProvider,
-} from "@/components/collections/collection-browse-provider";
-import { FilterPendingScope } from "@/components/collections/filter-pending-context";
-import { FilterSidebarSheet } from "@/components/collections/filter-sidebar-sheet";
-import { CollectionFilters } from "@/components/collections/filters";
-import { CollectionsSortSelect, SEARCH_SORT_EXCLUDE } from "@/components/collections/sort-select";
-import { SortSelectFallback } from "@/components/collections/sort-select-fallback";
-import { CollectionToolbar } from "@/components/collections/toolbar";
-import { ProductsGridSkeleton } from "@/components/product/products-grid";
-import {
-  type SearchResultsData,
-  SearchResultsGrid,
-  getSearchResultsData,
-} from "@/components/search/results";
+import { CollectionBrowseProvider } from "@/components/collections/collection-browse-provider";
+import { SEARCH_SORT_EXCLUDE } from "@/components/collections/sort-select";
+import { BrowseFallback, BrowseToolbar } from "@/components/collections/toolbar";
+import { SearchResultsGrid } from "@/components/search/results";
 import { Container } from "@/components/ui/container";
 import { Page } from "@/components/ui/page";
 import { Sections } from "@/components/ui/sections";
 import { Skeleton } from "@/components/ui/skeleton";
-import { PRODUCTS_PER_PAGE } from "@/lib/collections";
 import { getCollectionSearchState } from "@/lib/collections/server";
 import { formatCount } from "@/lib/content";
+import { getSearchResultsData, type SearchResultsData } from "@/lib/search/server";
 import { buildAlternates, buildOpenGraph } from "@/lib/seo";
 
 type SearchParams = Record<string, string | string[] | undefined>;
@@ -81,8 +68,6 @@ export default function SearchPage({ searchParams }: PageProps<"/search">) {
       searchStatePromise,
     });
   })();
-  const filtersLabel = "Filters";
-  const sortByLabel = "Sort";
   return (
     <Page className="pt-2.5 md:pt-10">
       <Container>
@@ -98,13 +83,8 @@ export default function SearchPage({ searchParams }: PageProps<"/search">) {
               </Suspense>
             </h1>
           </div>
-          <Suspense
-            fallback={
-              <SearchBrowseFallback filtersLabel={filtersLabel} sortByLabel={sortByLabel} />
-            }
-          >
+          <Suspense fallback={<BrowseFallback resultCount={<Skeleton className="h-4 w-20" />} />}>
             <SearchBrowse
-              filtersLabel={filtersLabel}
               searchParamsPromise={searchParams}
               searchResultsDataPromise={searchResultsDataPromise}
               searchStatePromise={searchStatePromise}
@@ -117,12 +97,10 @@ export default function SearchPage({ searchParams }: PageProps<"/search">) {
 }
 
 async function SearchBrowse({
-  filtersLabel,
   searchParamsPromise,
   searchResultsDataPromise,
   searchStatePromise,
 }: {
-  filtersLabel: string;
   searchParamsPromise: PageProps<"/search">["searchParams"];
   searchResultsDataPromise: Promise<SearchResultsData>;
   searchStatePromise: Promise<Awaited<ReturnType<typeof getCollectionSearchState>>>;
@@ -132,61 +110,17 @@ async function SearchBrowse({
   // A new term rebuilds the browse store so stale filters never carry across searches.
   return (
     <CollectionBrowseProvider handle={`search:${query}`} searchStatePromise={searchStatePromise}>
-      <CollectionToolbar
+      <BrowseToolbar
+        facetsPromise={searchResultsDataPromise.then((data) => data.transformedFilters)}
         resultCount={
           <Suspense fallback={<Skeleton className="h-4 w-20" />}>
             <SearchResultCount dataPromise={searchResultsDataPromise} />
           </Suspense>
         }
-        filterSheet={
-          <FilterSidebarSheet
-            label={filtersLabel}
-            trigger={
-              <button type="button" className="flex items-center gap-2 text-sm font-medium">
-                <SlidersHorizontalIcon className="size-4" />
-                <span>{filtersLabel}</span>
-                <CollectionActiveFilterCountBadge />
-              </button>
-            }
-          >
-            <FilterPendingScope>
-              <CollectionFilters
-                facetsPromise={searchResultsDataPromise.then((data) => data.transformedFilters)}
-              />
-            </FilterPendingScope>
-          </FilterSidebarSheet>
-        }
-        sortSelect={<CollectionsSortSelect exclude={SEARCH_SORT_EXCLUDE} />}
+        sortExclude={SEARCH_SORT_EXCLUDE}
       />
       <SearchResultsGrid searchResultsDataPromise={searchResultsDataPromise} />
     </CollectionBrowseProvider>
-  );
-}
-
-function SearchBrowseFallback({
-  filtersLabel,
-  sortByLabel,
-}: {
-  filtersLabel: string;
-  sortByLabel: string;
-}) {
-  return (
-    <>
-      <CollectionToolbar
-        resultCount={<Skeleton className="h-4 w-20" />}
-        filterSheet={
-          <button type="button" className="flex items-center gap-2 text-sm font-medium">
-            <SlidersHorizontalIcon className="size-4" />
-            <span>{filtersLabel}</span>
-          </button>
-        }
-        sortSelect={<SortSelectFallback label={sortByLabel} />}
-      />
-      <ProductsGridSkeleton
-        count={PRODUCTS_PER_PAGE}
-        className="sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
-      />
-    </>
   );
 }
 

--- a/apps/template/components/collections/collection-page.tsx
+++ b/apps/template/components/collections/collection-page.tsx
@@ -1,15 +1,9 @@
-import { SlidersHorizontalIcon } from "lucide-react";
 import Link from "next/link";
 import { Suspense } from "react";
 
 import { CollectionViewedTracker } from "@/components/analytics/trackers";
-import { FilterSidebarSheet } from "@/components/collections/filter-sidebar-sheet";
-import { CollectionFilters } from "@/components/collections/filters";
 import { CollectionResultsGrid } from "@/components/collections/results-grid";
-import { CollectionsSortSelect } from "@/components/collections/sort-select";
-import { SortSelectFallback } from "@/components/collections/sort-select-fallback";
-import { CollectionToolbar } from "@/components/collections/toolbar";
-import { ProductsGridSkeleton } from "@/components/product/products-grid";
+import { BrowseFallback, BrowseToolbar } from "@/components/collections/toolbar";
 import { BreadcrumbSchema } from "@/components/schema/breadcrumb-schema";
 import { CollectionSchema } from "@/components/schema/collection-schema";
 import { Container } from "@/components/ui/container";
@@ -18,10 +12,7 @@ import { Sections } from "@/components/ui/sections";
 import type { CollectionResultsData, CollectionSearchState } from "@/lib/collections/server";
 import type { Collection } from "@/lib/types";
 
-import {
-  CollectionActiveFilterCountBadge,
-  CollectionBrowseProvider,
-} from "./collection-browse-provider";
+import { CollectionBrowseProvider } from "./collection-browse-provider";
 import { FilterPendingScope } from "./filter-pending-context";
 
 export function CollectionDetailPage({
@@ -37,8 +28,6 @@ export function CollectionDetailPage({
   searchStatePromise: Promise<CollectionSearchState>;
   sortExclude?: string[];
 }) {
-  const filtersLabel = "Filters";
-  const sortByLabel = "Sort";
   return (
     <>
       {collection.id ? (
@@ -49,37 +38,13 @@ export function CollectionDetailPage({
           <Sections className="gap-5">
             <CollectionHeader collection={collection} handle={handle} homeLabel="Home" />
 
-            <Suspense
-              fallback={
-                <CollectionBrowseFallback filtersLabel={filtersLabel} sortByLabel={sortByLabel} />
-              }
-            >
+            <Suspense fallback={<BrowseFallback />}>
               <CollectionBrowseProvider handle={handle} searchStatePromise={searchStatePromise}>
-                <CollectionToolbar
-                  filterSheet={
-                    <FilterSidebarSheet
-                      label={filtersLabel}
-                      trigger={
-                        <button
-                          type="button"
-                          className="flex items-center gap-2 text-sm font-medium"
-                        >
-                          <SlidersHorizontalIcon className="size-4" />
-                          <span>{filtersLabel}</span>
-                          <CollectionActiveFilterCountBadge />
-                        </button>
-                      }
-                    >
-                      <FilterPendingScope>
-                        <CollectionFilters
-                          facetsPromise={collectionResultsDataPromise.then(
-                            (data) => data.transformedFilters,
-                          )}
-                        />
-                      </FilterPendingScope>
-                    </FilterSidebarSheet>
-                  }
-                  sortSelect={<CollectionsSortSelect exclude={sortExclude} />}
+                <BrowseToolbar
+                  facetsPromise={collectionResultsDataPromise.then(
+                    (data) => data.transformedFilters,
+                  )}
+                  sortExclude={sortExclude}
                 />
 
                 <FilterPendingScope>
@@ -92,29 +57,6 @@ export function CollectionDetailPage({
           </Sections>
         </Container>
       </Page>
-    </>
-  );
-}
-
-function CollectionBrowseFallback({
-  filtersLabel,
-  sortByLabel,
-}: {
-  filtersLabel: string;
-  sortByLabel: string;
-}) {
-  return (
-    <>
-      <CollectionToolbar
-        filterSheet={
-          <button type="button" className="flex items-center gap-2 text-sm font-medium">
-            <SlidersHorizontalIcon className="size-4" />
-            <span>{filtersLabel}</span>
-          </button>
-        }
-        sortSelect={<SortSelectFallback label={sortByLabel} />}
-      />
-      <ProductsGridSkeleton count={40} className="sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5" />
     </>
   );
 }

--- a/apps/template/components/collections/toolbar.tsx
+++ b/apps/template/components/collections/toolbar.tsx
@@ -1,16 +1,86 @@
+import { SlidersHorizontalIcon } from "lucide-react";
 import type * as React from "react";
 
-interface CollectionToolbarProps {
-  filterSheet: React.ReactNode;
-  sortSelect: React.ReactNode;
+import { ProductsGridSkeleton } from "@/components/product/products-grid";
+import { PRODUCTS_PER_PAGE } from "@/lib/collections";
+import type { Filter, PriceRange } from "@/lib/types";
+
+import { CollectionActiveFilterCountBadge } from "./collection-browse-provider";
+import { FilterPendingScope } from "./filter-pending-context";
+import { FilterSidebarSheet } from "./filter-sidebar-sheet";
+import { CollectionFilters } from "./filters";
+import { CollectionsSortSelect } from "./sort-select";
+import { SortSelectFallback } from "./sort-select-fallback";
+
+interface BrowseToolbarProps {
+  facetsPromise: Promise<{ filters: Filter[]; priceRange?: PriceRange }>;
+  resultCount?: React.ReactNode;
+  sortExclude?: string[];
+}
+
+export function BrowseToolbar({ facetsPromise, resultCount, sortExclude }: BrowseToolbarProps) {
+  return (
+    <ToolbarLayout
+      filterSheet={
+        <FilterSidebarSheet
+          label="Filters"
+          trigger={
+            <button
+              type="button"
+              className="flex cursor-pointer items-center gap-2 text-sm font-medium"
+            >
+              <SlidersHorizontalIcon className="size-4" />
+              <span>Filters</span>
+              <CollectionActiveFilterCountBadge />
+            </button>
+          }
+        >
+          <FilterPendingScope>
+            <CollectionFilters facetsPromise={facetsPromise} />
+          </FilterPendingScope>
+        </FilterSidebarSheet>
+      }
+      resultCount={resultCount}
+      sortSelect={<CollectionsSortSelect exclude={sortExclude} />}
+    />
+  );
+}
+
+interface BrowseFallbackProps {
   resultCount?: React.ReactNode;
 }
 
-export function CollectionToolbar({
-  filterSheet,
-  sortSelect,
-  resultCount,
-}: CollectionToolbarProps) {
+export function BrowseFallback({ resultCount }: BrowseFallbackProps) {
+  return (
+    <>
+      <ToolbarLayout
+        filterSheet={
+          <button
+            type="button"
+            className="flex cursor-pointer items-center gap-2 text-sm font-medium"
+          >
+            <SlidersHorizontalIcon className="size-4" />
+            <span>Filters</span>
+          </button>
+        }
+        resultCount={resultCount}
+        sortSelect={<SortSelectFallback label="Sort" />}
+      />
+      <ProductsGridSkeleton
+        count={PRODUCTS_PER_PAGE}
+        className="sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+      />
+    </>
+  );
+}
+
+interface ToolbarLayoutProps {
+  filterSheet: React.ReactNode;
+  resultCount?: React.ReactNode;
+  sortSelect: React.ReactNode;
+}
+
+function ToolbarLayout({ filterSheet, resultCount, sortSelect }: ToolbarLayoutProps) {
   return (
     <div className="flex items-center gap-5">
       {filterSheet}

--- a/apps/template/components/search/results.tsx
+++ b/apps/template/components/search/results.tsx
@@ -8,57 +8,8 @@ import { InfiniteProductGrid } from "@/components/collections/infinite-product-g
 import { ProductCard } from "@/components/product-card/product-card";
 import { ProductsGridSkeleton } from "@/components/product/products-grid";
 import { PRODUCTS_PER_PAGE } from "@/lib/collections";
-import type { CollectionSearchState } from "@/lib/collections/server";
 import { loadMoreSearchProductsAction } from "@/lib/search/action";
-import { fetchSearchFacets, fetchSearchIndexProducts } from "@/lib/shopify/operations/products";
-import type { Filter, PageInfo, PriceRange, ProductCard as ProductCardType } from "@/lib/types";
-
-export interface SearchResultsData {
-  collection?: string;
-  dataSearch: string;
-  pageInfo: PageInfo;
-  products: ProductCardType[];
-  query?: string;
-  total: number;
-  transformedFilters: { filters: Filter[]; priceRange?: PriceRange };
-}
-
-export async function getSearchResultsData({
-  collection,
-  query,
-  searchStatePromise,
-}: {
-  collection?: string;
-  query?: string;
-  searchStatePromise: Promise<CollectionSearchState>;
-}): Promise<SearchResultsData> {
-  const { activeFilters, dataSearch, filters, sort } = await searchStatePromise;
-  const [results, facets] = await Promise.all([
-    fetchSearchIndexProducts({
-      activeFilters,
-      query,
-      collection,
-      sortKey: sort,
-      limit: PRODUCTS_PER_PAGE,
-      filters,
-    }),
-    fetchSearchFacets({
-      activeFilters,
-      query,
-      collection,
-      filters,
-    }),
-  ]);
-  return {
-    collection,
-    dataSearch,
-    pageInfo: results.pageInfo,
-    products: results.products,
-    query,
-    total: facets.total,
-    transformedFilters: { filters: facets.filters, priceRange: facets.priceRange },
-  };
-}
+import type { SearchResultsData } from "@/lib/search/server";
 
 export function SearchResultsGrid({
   searchResultsDataPromise,

--- a/apps/template/lib/search/server.ts
+++ b/apps/template/lib/search/server.ts
@@ -1,6 +1,58 @@
 import "server-only";
 import { createPredictiveSearchServerHandlers, gql } from "@shopify/hydrogen";
 
+import { PRODUCTS_PER_PAGE } from "@/lib/collections";
+import type { CollectionSearchState } from "@/lib/collections/server";
+import { fetchSearchFacets, fetchSearchIndexProducts } from "@/lib/shopify/operations/products";
+import type { Filter, PageInfo, PriceRange, ProductCard } from "@/lib/types";
+
+export interface SearchResultsData {
+  collection?: string;
+  dataSearch: string;
+  pageInfo: PageInfo;
+  products: ProductCard[];
+  query?: string;
+  total: number;
+  transformedFilters: { filters: Filter[]; priceRange?: PriceRange };
+}
+
+export async function getSearchResultsData({
+  collection,
+  query,
+  searchStatePromise,
+}: {
+  collection?: string;
+  query?: string;
+  searchStatePromise: Promise<CollectionSearchState>;
+}): Promise<SearchResultsData> {
+  const { activeFilters, dataSearch, filters, sort } = await searchStatePromise;
+  const [results, facets] = await Promise.all([
+    fetchSearchIndexProducts({
+      activeFilters,
+      collection,
+      filters,
+      limit: PRODUCTS_PER_PAGE,
+      query,
+      sortKey: sort,
+    }),
+    fetchSearchFacets({
+      activeFilters,
+      collection,
+      filters,
+      query,
+    }),
+  ]);
+  return {
+    collection,
+    dataSearch,
+    pageInfo: results.pageInfo,
+    products: results.products,
+    query,
+    total: facets.total,
+    transformedFilters: { filters: facets.filters, priceRange: facets.priceRange },
+  };
+}
+
 const PRODUCT_FRAGMENT = gql(/* GraphQL */ `
   fragment PredictiveSearchProductFragment on Product {
     availableForSale


### PR DESCRIPTION
## Summary
- Move search result data loading and its result type into `lib/search/server.ts`, alongside the existing search handlers.
- Share browse toolbar and loading composition across collection and search pages without introducing a new framework.
- Preserve provider and Suspense boundaries, parallel product/facet loading, sort exclusions, search result counts, and pagination behavior.
- Clarify the shared toolbar behavior in the PLP guide.

## Verification
- `pnpm --filter template lint` — passed, zero lint warnings/errors and formatting clean.
- `pnpm --filter template exec next typegen` — passed.
- `pnpm --filter template exec tsc --noEmit` — passed.
- `pnpm --filter template build` — passed, including GraphQL codegen and production build; search and collection routes remain partially prerendered.
- `pnpm --filter docs exec oxfmt --check content/docs/anatomy/pages/plp.mdx` — passed.
- `git diff --check` — passed.
- Independent source review found no introduced issues.

All verification commands exited 0. Local Node was 26.7.0; the template targets Node 24, so pnpm emitted an engine warning. Browser interaction testing was not performed.