### PR TITLE
Keep full cart payloads out of chat history

### DIFF
--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -33,7 +33,9 @@ Product, availability, and policy answers come from Shopify data rather than the
 
 Cart changes made in chat update the same cart used by the rest of the storefront. Product cards, variant choices, and cart summaries can appear directly in the conversation.
 
-The current conversation and draft are stored only in the shopper's browser. They survive navigation and reloads, but not clearing site data or moving to another device. Clearing the chat removes that browser-local history.
+The conversation and draft are saved in the shopper's browser and survive navigation and reloads. Sending a message also sends conversation history to the model provider. Clearing the chat removes the browser-local history, not data already sent to the provider.
+
+When the assistant reads the cart, it receives an item summary, not the full cart or gift-card recipient details. Cart changes return only an update confirmation; the cart shown in chat stays live. Personal details that shoppers type into chat are still sent to the model provider.
 
 ## What’s next
 

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: Request) {
   return withAgentContext({ cart: cartId, page, user }, async () => {
     const agent = createAgent();
     const result = await agent.stream({
-      messages: await convertToModelMessages(safeMessages.data),
+      messages: await convertToModelMessages(safeMessages.data, { tools: agent.tools }),
     });
     const stream = createUIMessageStream({
       execute: ({ writer }) => {

--- a/apps/template/components/agent/cart-bridge.tsx
+++ b/apps/template/components/agent/cart-bridge.tsx
@@ -32,8 +32,8 @@ export function AgentCartBridge({ messages }: { messages: readonly UIMessage[] }
         if (part.state !== "output-available" || seen.current.has(part.toolCallId)) continue;
         seen.current.add(part.toolCallId);
         if (isReplay) continue;
-        const output = part.output as { cart?: unknown } | undefined;
-        if (output?.cart) shouldRefresh = true;
+        const output = part.output as { cartUpdated?: boolean } | undefined;
+        if (output?.cartUpdated === true) shouldRefresh = true;
       }
     }
 

--- a/apps/template/lib/agent/tools/cart.ts
+++ b/apps/template/lib/agent/tools/cart.ts
@@ -7,9 +7,8 @@ import { getCartById, runCartMutation } from "@/lib/cart/server";
 import { getAgentContext } from "../server";
 
 function cartSummary(cart: Cart | undefined) {
-  if (!cart) return { cart: null, empty: true as const };
+  if (!cart) return { empty: true as const };
   return {
-    cart,
     empty: cart.lines.nodes.length === 0,
     lines: cart.lines.nodes.map((line) => ({
       lineId: line.id,
@@ -22,7 +21,7 @@ function cartSummary(cart: Cart | undefined) {
   };
 }
 
-// Keep the native cart for client reconciliation without sending its full payload to the model.
+// Older browser histories still contain full carts, including gift-card recipient details.
 function cartModelOutput({ output }: { output: unknown }) {
   if (output && typeof output === "object" && "cart" in output) {
     const { cart: _cart, ...summary } = output;
@@ -38,7 +37,7 @@ export const getCartTool = tool({
   toModelOutput: cartModelOutput,
   execute: async () => {
     const { cart: cartId } = getAgentContext();
-    if (!cartId) return { cart: null, empty: true };
+    if (!cartId) return { empty: true };
 
     try {
       return cartSummary(await getCartById(cartId));
@@ -67,7 +66,7 @@ export const addToCartTool = tool({
         { lines: [{ merchandiseId: variantId, quantity }] },
         cartId,
       );
-      return { added: true, ...cartSummary(cart) };
+      return { cartUpdated: Boolean(cart) };
     } catch (error) {
       console.error("Failed to add to cart:", error);
       return { error: "Could not add that item to the cart." };
@@ -89,7 +88,7 @@ export const updateCartItemTool = tool({
 
     try {
       const { cart } = await runCartMutation({ lines: [{ id: lineId, quantity }] }, cartId);
-      return { removed: quantity === 0, updated: true, ...cartSummary(cart) };
+      return { cartUpdated: Boolean(cart) };
     } catch (error) {
       console.error("Failed to update cart line:", error);
       return { error: "Could not update that cart line." };
@@ -107,7 +106,7 @@ export const addCartNoteTool = tool({
 
     try {
       const { cart } = await runCartMutation({ note }, cartId);
-      return { noteUpdated: true, ...cartSummary(cart) };
+      return { cartUpdated: Boolean(cart) };
     } catch (error) {
       console.error("Failed to update cart note:", error);
       return { error: "Could not update the cart note." };


### PR DESCRIPTION
## Summary
- Remove full carts from chat tool results; keep item context in getCart only.
- Return minimal cartUpdated acknowledgments from mutations and refresh the shared cart provider.
- Apply tool output filtering when replaying older conversation history.
- Clarify chat storage and model-provider data sharing in the docs.

## Verification
- PASS: inline Node assertions covering getCart summaries, add/update/remove/note acknowledgments, missing carts, errors, and all four legacy-history filters.
- PASS: pnpm exec tsc --noEmit --incremental false
- PASS: focused oxlint and oxfmt checks on changed files.
- PASS: git diff --check
- No live Shopify/model or browser integration test.