### PR TITLE
Fix assistant recovery and purchase flows

### DIFF
--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -29,13 +29,17 @@ Out of the box, shoppers can:
 - Ask about shipping, returns, payments, warranty, sizing, care, and other store policies
 - Open product, collection, search, cart, checkout, account, and order destinations
 
-Product, availability, and policy answers come from Shopify data rather than the model's memory. Searches with a required option can return fewer results, or none, instead of showing near matches.
+Product, availability, and policy answers come from Shopify data rather than the model's memory. If semantic search is unavailable, the assistant falls back to keyword search. Searches with a required option can return fewer results, or none, instead of showing near matches.
 
 Cart changes made in chat update the same cart used by the rest of the storefront. Product cards, variant choices, and cart summaries can appear directly in the conversation.
 
 The conversation and draft are saved in the shopper's browser and survive navigation and reloads. Sending a message also sends conversation history to the model provider. Clearing the chat removes the browser-local history, not data already sent to the provider.
 
-When the assistant reads the cart, it receives an item summary, not the full cart or gift-card recipient details. Cart changes return only an update confirmation; the cart shown in chat stays live. Personal details that shoppers type into chat are still sent to the model provider.
+When the assistant reads the cart, it receives an item summary, not the full cart or gift-card recipient details. Cart changes return an update confirmation and any Shopify warnings; the cart shown in chat stays live. Personal details that shoppers type into chat are still sent to the model provider.
+
+You can stop a response while it is loading or streaming and continue the conversation afterward. Stopping does not undo a cart change already sent to Shopify. If a change was interrupted, ask the assistant to check the cart before trying it again.
+
+The template enables request cancellation for chat on Vercel. Other hosts must propagate client disconnects to the server for Stop to cancel model generation.
 
 ## What’s next
 

--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -39,7 +39,7 @@ The conversation and draft are saved in the shopper's browser and survive naviga
 
 When the assistant reads the cart, it receives an item summary, not the full cart or gift-card recipient details. Cart changes return an update confirmation and any Shopify warnings; the cart shown in chat stays live. Personal details that shoppers type into chat are still sent to the model provider.
 
-You can stop a response while it is loading or streaming and continue the conversation afterward. Stopping does not undo a cart change already sent to Shopify. If a change was interrupted, ask the assistant to check the cart before trying it again.
+You can stop a response while it is loading or streaming and continue the conversation afterward. Stopping or clearing chat does not cancel a cart change already started: the cart keeps its pending state and updates when Shopify responds. Checkout stays unavailable while that change is pending. If a cart request fails or times out, check the cart before trying the change again.
 
 The template enables request cancellation for chat on Vercel. Other hosts must propagate client disconnects to the server for Stop to cancel model generation.
 

--- a/apps/docs/content/docs/anatomy/agent.mdx
+++ b/apps/docs/content/docs/anatomy/agent.mdx
@@ -31,7 +31,9 @@ Out of the box, shoppers can:
 
 Product, availability, and policy answers come from Shopify data rather than the model's memory. If semantic search is unavailable, the assistant falls back to keyword search. Searches with a required option can return fewer results, or none, instead of showing near matches.
 
-Cart changes made in chat update the same cart used by the rest of the storefront. Product cards, variant choices, and cart summaries can appear directly in the conversation.
+Cart changes made in chat update the same cart used by the rest of the storefront. When customer accounts are enabled, a cart created by the assistant is associated with the signed-in customer if their session is usable or can be refreshed. Product cards, variant choices, and cart summaries can appear directly in the conversation.
+
+Checkout from a cart summary waits until cart updates have finished and confirms the checkout destination before leaving the storefront. If checkout cannot start, the shopper can retry without losing the conversation.
 
 The conversation and draft are saved in the shopper's browser and survive navigation and reloads. Sending a message also sends conversation history to the model provider. Clearing the chat removes the browser-local history, not data already sent to the provider.
 

--- a/apps/docs/content/docs/anatomy/cart.mdx
+++ b/apps/docs/content/docs/anatomy/cart.mdx
@@ -22,7 +22,7 @@ The cart displays confirmed discounts and sale pricing. Shopify bundles remain g
 
 When customer authentication is enabled, sign-in can attach the existing browser cart to the customer. Checkout can then use the customer's saved details. See [Authentication](/docs/anatomy/authentication).
 
-The optional shopping assistant uses the same cart. After a successful change in chat, the storefront refreshes the cart from Shopify so the overlay, badge, and `/cart` show the latest contents. Restoring an old conversation does not replay its cart changes.
+The optional shopping assistant uses the same cart. Changes remain pending until Shopify responds, even if the shopper stops the response or clears chat. The overlay, badge, and `/cart` then show the confirmed contents. Restoring an old conversation does not replay its cart changes.
 
 If `NEXT_PUBLIC_SHOPIFY_STOREFRONT_ID` is set, server-side cart activity is attributed to the corresponding Headless storefront. See [Environment Variables](/docs/reference/env-vars).
 

--- a/apps/docs/content/docs/anatomy/cart.mdx
+++ b/apps/docs/content/docs/anatomy/cart.mdx
@@ -14,7 +14,9 @@ No additional setup is required for the standard cart. The cart ID is stored in 
 
 Shoppers can add products, change quantities, remove lines, apply discount codes, and proceed to checkout. The cart overlay is available throughout the storefront, and `/cart` provides the full cart.
 
-Updates are optimistic: quantities and badges change immediately, then reconcile with Shopify. If Shopify rejects a change, the cart returns to its confirmed state and shows the relevant error. Prices and totals show muted updating text while Shopify confirms the cost. Checkout remains unavailable until pending cart changes finish. Line-specific errors appear alongside the affected item.
+Updates are optimistic: quantities and badges change immediately, then reconcile with Shopify. If Shopify rejects a change, the cart returns to its confirmed state and shows the relevant error. Prices and totals show muted updating text while Shopify confirms the cost. Line-specific errors appear alongside the affected item.
+
+Checkout stays unavailable while cart changes or a cart refresh are pending, including changes to discounts, order notes, and cart attributes. The cart page and overlay confirm the checkout link before sending the shopper to Shopify. If checkout preparation fails or the cart changes during preparation, an inline message lets the shopper try again. Returning from checkout restores the checkout button.
 
 The cart displays confirmed discounts and sale pricing. Shopify bundles remain grouped so shoppers can understand which products belong together. Quantity and remove controls follow Shopify's rules for each line, so some bundle lines may not be editable individually.
 

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -12,6 +12,8 @@ The Product Detail Page (PDP) gives shoppers the information and controls needed
 
 Product pages show the title, price, media, description, and available options. Option choices update the page URL, so shoppers can share a selected color, size, or other variant and use browser back and forward controls.
 
+While an option choice is being resolved, purchase controls temporarily block purchases without dimming or showing a loading indicator. They become available once the selected variant is confirmed; out-of-stock variants remain disabled.
+
 When colors have distinct media, the gallery leads with the selected color's image. Desktop shoppers get a grid and lightbox; mobile shoppers get a swipeable gallery.
 
 Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/docs/anatomy/webhooks).

--- a/apps/template/AGENTS.md
+++ b/apps/template/AGENTS.md
@@ -193,7 +193,7 @@ Cart interactions use Hydrogen's client store and server handlers:
 
 - Use `useProductForm` for standard product purchases and `useCartForm` for cart forms. `proxy.ts` serves `/api/cart` through Hydrogen's registered handlers.
 - Gift-card purchases use `addGiftCardToCart` in `lib/cart/gift-card-client.ts` to preserve recipient and scheduling line attributes. The pinned preview's add-form bindings omit line attributes; preserve this adapter until the SDK forwards them.
-- Assistant tools mutate through `runCartMutation` in `lib/cart/server.ts`. The client bridge refreshes Hydrogen's cart store after successful tool results without replaying mutations from restored conversations.
+- Assistant cart mutations are client tools dispatched from `onToolCall` through `lib/agent/cart-client.ts` and Hydrogen's standard cart events. Their requests and store reconciliation outlive chat Stop/Clear; never execute mutations by scanning restored messages or attach the chat abort signal. The cart bridge only refreshes after cart reads.
 - `seedCartData` shares a per-request promise, not a Next.js data-cache entry. Keep carts out of public caches; cart updates reconcile through Hydrogen's store rather than cache-tag invalidation.
 - `prepareCheckoutAction` reads the confirmed checkout URL; it does not mutate the cart.
 - Cart types are the deliberate domain-type exception: `lib/cart/index.ts` derives `Cart`, `CartLine`, and seed data from Hydrogen's handlers. Cart integration components may also use Hydrogen store/form types. Keep SDK and domain types out of `components/ui/`; wrappers pass primitive props.

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -23,13 +23,19 @@ export async function POST(request: Request) {
     const { isBot } = await checkBotId(botIdCheckOptions);
     if (isBot) return Response.json({ error: BOTID_DENIED_CODE }, { status: 403 });
   }
-  let body: { messages?: unknown };
+  let body: unknown;
   try {
-    body = (await request.json()) as { messages?: unknown };
+    body = await request.json();
   } catch {
     return Response.json({ error: "Invalid request body" }, { status: 400 });
   }
-  if (!Array.isArray(body.messages)) {
+  if (
+    !body ||
+    typeof body !== "object" ||
+    !("messages" in body) ||
+    !Array.isArray(body.messages) ||
+    body.messages.length === 0
+  ) {
     return Response.json({ error: "Invalid messages" }, { status: 400 });
   }
   const safeMessages = await safeValidateUIMessages({ messages: body.messages });
@@ -47,7 +53,11 @@ export async function POST(request: Request) {
   }
   const agent = createAgent({ cartId, page });
   const result = await agent.stream({
-    messages: await convertToModelMessages(safeMessages.data, { tools: agent.tools }),
+    abortSignal: request.signal,
+    messages: await convertToModelMessages(safeMessages.data, {
+      ignoreIncompleteToolCalls: true,
+      tools: agent.tools,
+    }),
   });
   const stream = createUIMessageStream({
     execute: ({ writer }) => {

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -11,6 +11,7 @@ import { checkBotId } from "botid/server";
 
 import { parsePageContext } from "@/lib/agent/routes";
 import { createAgent } from "@/lib/agent/server";
+import { createCustomerRequestContext, createCustomerSessionManager } from "@/lib/auth/server";
 import { BOTID_DENIED_CODE, botIdCheckOptions } from "@/lib/botid";
 import { createEmptyCart, getCartIdFromCookie } from "@/lib/cart/server";
 import { shopConfig } from "@/lib/config";
@@ -43,40 +44,61 @@ export async function POST(request: Request) {
     return Response.json({ error: "Invalid messages" }, { status: 400 });
   }
 
-  // Page context comes from the same-origin Referer rather than client-supplied product data.
-  const { page } = parsePageContext(request.headers.get("referer"));
-  let cartId = await getCartIdFromCookie();
+  const requestContext = createCustomerRequestContext(request);
+  const sessionManager = shopConfig.auth.isEnabled
+    ? createCustomerSessionManager(request)
+    : undefined;
   let newCartCookie: string | undefined;
-  if (!cartId) {
-    cartId = await createEmptyCart();
-    if (cartId) newCartCookie = createCartCookie(cartId);
-  }
-  const agent = createAgent({ cartId, page });
-  const result = await agent.stream({
-    abortSignal: request.signal,
-    messages: await convertToModelMessages(safeMessages.data, {
-      ignoreIncompleteToolCalls: true,
-      tools: agent.tools,
-    }),
-  });
-  const stream = createUIMessageStream({
-    execute: ({ writer }) => {
-      writer.merge(
-        pipeJsonRender(
-          toUIMessageStream({
-            originalMessages: safeMessages.data,
-            // pipeJsonRender only understands text deltas; reasoning parts would pass through unhandled.
-            sendReasoning: false,
-            stream: result.stream,
-            tools: agent.tools,
-          }),
-        ),
-      );
-    },
-  });
+  let response: Response;
 
-  return createUIMessageStreamResponse({
-    headers: newCartCookie ? { "Set-Cookie": newCartCookie } : undefined,
-    stream,
-  });
+  try {
+    // Page context comes from the same-origin Referer rather than client-supplied product data.
+    const { page } = parsePageContext(request.headers.get("referer"));
+    let cartId = await getCartIdFromCookie();
+    if (!cartId) {
+      cartId = await createEmptyCart(requestContext, sessionManager);
+      newCartCookie = createCartCookie(cartId);
+    }
+    const agent = createAgent({ cartId, page });
+    const result = await agent.stream({
+      abortSignal: request.signal,
+      messages: await convertToModelMessages(safeMessages.data, {
+        ignoreIncompleteToolCalls: true,
+        tools: agent.tools,
+      }),
+    });
+    const stream = createUIMessageStream({
+      execute: ({ writer }) => {
+        writer.merge(
+          pipeJsonRender(
+            toUIMessageStream({
+              originalMessages: safeMessages.data,
+              // pipeJsonRender only understands text deltas; reasoning parts would pass through unhandled.
+              sendReasoning: false,
+              stream: result.stream,
+              tools: agent.tools,
+            }),
+          ),
+        );
+      },
+    });
+
+    response = createUIMessageStreamResponse({ stream });
+  } catch {
+    response = Response.json(
+      { error: "Could not start the assistant. Please try again." },
+      { status: 500 },
+    );
+  }
+
+  // Preserve rotated session cookies even when cart creation or stream startup fails.
+  const sessionHeaders = await sessionManager?.commit?.();
+  if (sessionHeaders) {
+    for (const cookie of new Headers(sessionHeaders).getSetCookie()) {
+      response.headers.append("Set-Cookie", cookie);
+    }
+  }
+  if (newCartCookie) response.headers.append("Set-Cookie", newCartCookie);
+  requestContext.applyResponseHeaders(response.headers);
+  return response;
 }

--- a/apps/template/components/agent/agent-panel.tsx
+++ b/apps/template/components/agent/agent-panel.tsx
@@ -55,7 +55,7 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
   const panelRef = useRef<HTMLDivElement>(null);
   const [stored] = useState(readStoredChat);
   const [input, setInput] = useState(stored.input);
-  const { error, messages, setMessages, sendMessage, status, stop } = useChat({
+  const { clearError, error, messages, setMessages, sendMessage, status, stop } = useChat({
     messages: stored.messages,
     transport: new DefaultChatTransport({ api: "/api/chat" }),
   });
@@ -78,11 +78,34 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
     return () => observer.disconnect();
   }, []);
 
-  // Drafts change per keystroke, so debounce to avoid re-serializing the transcript each time.
+  const snapshot = useRef<StoredChat>({ input: stored.input, messages: stored.messages });
+  const checkpointTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flushChat = useCallback(() => {
+    if (checkpointTimer.current !== null) clearTimeout(checkpointTimer.current);
+    checkpointTimer.current = null;
+    writeStoredChat(snapshot.current);
+  }, []);
   useEffect(() => {
-    const timer = setTimeout(() => writeStoredChat({ input, messages }), DRAFT_DEBOUNCE_MS);
+    snapshot.current.input = input;
+    const timer = setTimeout(flushChat, DRAFT_DEBOUNCE_MS);
     return () => clearTimeout(timer);
-  }, [input, messages]);
+  }, [flushChat, input]);
+  useEffect(() => {
+    snapshot.current.messages = messages;
+    if (status !== "streaming" && status !== "submitted") {
+      flushChat();
+    } else if (checkpointTimer.current === null) {
+      // Streaming updates must not keep postponing the next transcript checkpoint.
+      checkpointTimer.current = setTimeout(flushChat, DRAFT_DEBOUNCE_MS);
+    }
+  }, [flushChat, messages, status]);
+  useEffect(() => {
+    window.addEventListener("pagehide", flushChat);
+    return () => {
+      window.removeEventListener("pagehide", flushChat);
+      flushChat();
+    };
+  }, [flushChat]);
   useEffect(() => {
     if (!open) return;
     function handleClickOutside(event: MouseEvent) {
@@ -118,8 +141,10 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
     stop();
     setMessages([]);
     setInput("");
-    writeStoredChat({ input: "", messages: [] });
-  }, [setMessages, stop]);
+    clearError();
+    snapshot.current = { input: "", messages: [] };
+    flushChat();
+  }, [clearError, flushChat, setMessages, stop]);
   const canClear = messages.length > 0 || input.trim().length > 0;
   return (
     <div

--- a/apps/template/components/agent/agent-panel.tsx
+++ b/apps/template/components/agent/agent-panel.tsx
@@ -2,11 +2,17 @@
 
 import { useChat } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
-import { DefaultChatTransport } from "ai";
+import {
+  DefaultChatTransport,
+  isToolUIPart,
+  lastAssistantMessageIsCompleteWithToolCalls,
+} from "ai";
 import { MinusIcon, Trash2Icon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useCartDrawer } from "@/components/cart/context";
 import { useScrollContain } from "@/hooks/use-scroll-contain";
+import { executeCartTool, isCartMutationTool } from "@/lib/agent/cart-client";
 import { BOTID_DENIED_CODE } from "@/lib/botid";
 
 import { AgentCartBridge } from "./cart-bridge";
@@ -55,10 +61,51 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
   const panelRef = useRef<HTMLDivElement>(null);
   const [stored] = useState(readStoredChat);
   const [input, setInput] = useState(stored.input);
-  const { clearError, error, messages, setMessages, sendMessage, status, stop } = useChat({
-    messages: stored.messages,
-    transport: new DefaultChatTransport({ api: "/api/chat" }),
-  });
+  const { openOverlay } = useCartDrawer();
+  const generation = useRef(0);
+  const continueAutomatically = useRef(false);
+  const executedTools = useRef(new Set<string>());
+  const { addToolOutput, clearError, error, messages, setMessages, sendMessage, status, stop } =
+    useChat({
+      messages: stored.messages,
+      onToolCall: ({ toolCall }) => {
+        if (
+          !isCartMutationTool(toolCall.toolName) ||
+          executedTools.current.has(toolCall.toolCallId)
+        )
+          return;
+        executedTools.current.add(toolCall.toolCallId);
+        const currentGeneration = generation.current;
+        // The cart request must settle independently of Stop or Clear cancelling the chat stream.
+        void executeCartTool(toolCall.toolName, toolCall.input).then((output) => {
+          if (generation.current !== currentGeneration) return;
+          if ("cartUpdated" in output) openOverlay();
+          void addToolOutput({ tool: toolCall.toolName, toolCallId: toolCall.toolCallId, output });
+        });
+      },
+      sendAutomaticallyWhen: (options) => {
+        const parts = options.messages.at(-1)?.parts ?? [];
+        const lastStep = parts.findLastIndex((part) => part.type === "step-start");
+        return (
+          continueAutomatically.current &&
+          parts
+            .slice(lastStep + 1)
+            .some(
+              (part) =>
+                isToolUIPart(part) &&
+                isCartMutationTool(
+                  part.type === "dynamic-tool" ? part.toolName : part.type.slice(5),
+                ),
+            ) &&
+          lastAssistantMessageIsCompleteWithToolCalls(options)
+        );
+      },
+      transport: new DefaultChatTransport({ api: "/api/chat" }),
+    });
+  const handleStop = useCallback(() => {
+    continueAutomatically.current = false;
+    void stop();
+  }, [stop]);
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const pinnedRef = useRef(true);
@@ -132,19 +179,22 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
   const handleSend = useCallback(
     (text: string) => {
       pinnedRef.current = true;
+      generation.current += 1;
+      continueAutomatically.current = true;
       void sendMessage({ text });
       setInput("");
     },
     [sendMessage],
   );
   const handleClear = useCallback(() => {
-    stop();
+    generation.current += 1;
+    handleStop();
     setMessages([]);
     setInput("");
     clearError();
     snapshot.current = { input: "", messages: [] };
     flushChat();
-  }, [clearError, flushChat, setMessages, stop]);
+  }, [clearError, flushChat, handleStop, setMessages]);
   const canClear = messages.length > 0 || input.trim().length > 0;
   return (
     <div
@@ -208,7 +258,7 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
       </div>
       <AgentComposer
         onChange={setInput}
-        onStop={stop}
+        onStop={handleStop}
         onSubmit={handleSend}
         placeholder="Ask anything…"
         status={status}

--- a/apps/template/components/agent/cart-bridge.tsx
+++ b/apps/template/components/agent/cart-bridge.tsx
@@ -24,23 +24,28 @@ export function AgentCartBridge({ messages }: { messages: readonly UIMessage[] }
     const isReplay = !hydrated.current;
     hydrated.current = true;
     let shouldRefresh = false;
+    let shouldOpen = false;
 
     for (const message of messages) {
       if (message.role !== "assistant") continue;
       for (const part of message.parts) {
-        if (!isToolUIPart(part) || !MUTATION_TOOLS.has(toolNameOf(part))) continue;
+        if (!isToolUIPart(part)) continue;
+        const toolName = toolNameOf(part);
+        if (toolName !== "getCart" && !MUTATION_TOOLS.has(toolName)) continue;
         if (part.state !== "output-available" || seen.current.has(part.toolCallId)) continue;
         seen.current.add(part.toolCallId);
         if (isReplay) continue;
-        const output = part.output as { cartUpdated?: boolean } | undefined;
-        if (output?.cartUpdated === true) shouldRefresh = true;
+        const output = part.output as { cartUpdated?: boolean; empty?: boolean } | undefined;
+        if (toolName === "getCart" && typeof output?.empty === "boolean") shouldRefresh = true;
+        if (MUTATION_TOOLS.has(toolName) && output?.cartUpdated === true) {
+          shouldRefresh = true;
+          shouldOpen = true;
+        }
       }
     }
 
-    if (shouldRefresh) {
-      void refresh();
-      openOverlay();
-    }
+    if (shouldRefresh) void refresh();
+    if (shouldOpen) openOverlay();
   }, [messages, openOverlay, refresh]);
 
   return null;

--- a/apps/template/components/agent/cart-bridge.tsx
+++ b/apps/template/components/agent/cart-bridge.tsx
@@ -5,17 +5,12 @@ import type { UIMessage } from "ai";
 import { isToolUIPart } from "ai";
 import { useEffect, useRef } from "react";
 
-import { useCartDrawer } from "@/components/cart/context";
-
-const MUTATION_TOOLS = new Set(["addCartNote", "addToCart", "updateCartItem"]);
-
 function toolNameOf(part: { toolName?: string; type: string }): string {
   return part.type === "dynamic-tool" ? (part.toolName ?? "") : part.type.slice(5);
 }
 
 export function AgentCartBridge({ messages }: { messages: readonly UIMessage[] }) {
   const { refresh } = useCartActions();
-  const { openOverlay } = useCartDrawer();
   const seen = useRef<Set<string>>(new Set());
   const hydrated = useRef(false);
 
@@ -24,29 +19,23 @@ export function AgentCartBridge({ messages }: { messages: readonly UIMessage[] }
     const isReplay = !hydrated.current;
     hydrated.current = true;
     let shouldRefresh = false;
-    let shouldOpen = false;
 
     for (const message of messages) {
       if (message.role !== "assistant") continue;
       for (const part of message.parts) {
         if (!isToolUIPart(part)) continue;
         const toolName = toolNameOf(part);
-        if (toolName !== "getCart" && !MUTATION_TOOLS.has(toolName)) continue;
+        if (toolName !== "getCart") continue;
         if (part.state !== "output-available" || seen.current.has(part.toolCallId)) continue;
         seen.current.add(part.toolCallId);
         if (isReplay) continue;
-        const output = part.output as { cartUpdated?: boolean; empty?: boolean } | undefined;
-        if (toolName === "getCart" && typeof output?.empty === "boolean") shouldRefresh = true;
-        if (MUTATION_TOOLS.has(toolName) && output?.cartUpdated === true) {
-          shouldRefresh = true;
-          shouldOpen = true;
-        }
+        const output = part.output as { empty?: boolean } | undefined;
+        if (typeof output?.empty === "boolean") shouldRefresh = true;
       }
     }
 
     if (shouldRefresh) void refresh();
-    if (shouldOpen) openOverlay();
-  }, [messages, openOverlay, refresh]);
+  }, [messages, refresh]);
 
   return null;
 }

--- a/apps/template/components/agent/composer.tsx
+++ b/apps/template/components/agent/composer.tsx
@@ -29,12 +29,12 @@ export function AgentComposer({
 }: AgentComposerProps) {
   const isBusy = status === "submitted" || status === "streaming";
   const submit = () => {
-    if (status === "streaming") {
+    if (isBusy) {
       onStop();
       return;
     }
     const text = value.trim();
-    if (!text || isBusy) return;
+    if (!text) return;
     onSubmit(text);
   };
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -46,7 +46,7 @@ export function AgentComposer({
   if (status === "submitted") icon = <Loader2Icon className="size-4 animate-spin" />;
   else if (status === "streaming") icon = <SquareIcon className="size-4" />;
   else if (status === "error") icon = <XIcon className="size-4" />;
-  const isStopping = status === "streaming";
+  const isStopping = isBusy;
   return (
     <form
       onSubmit={(e) => {

--- a/apps/template/components/agent/registry.tsx
+++ b/apps/template/components/agent/registry.tsx
@@ -72,8 +72,8 @@ export const { registry } = defineRegistry(catalog, {
           </div>
           {!isPending && cart.checkoutUrl && (
             <div className="border-t px-2.5 py-2">
-              <Button asChild className="w-full" size="sm">
-                <a href={cart.checkoutUrl}>Checkout</a>
+              <Button className="h-12 w-full justify-center" render={<a href={cart.checkoutUrl} />}>
+                Checkout
               </Button>
             </div>
           )}

--- a/apps/template/components/agent/registry.tsx
+++ b/apps/template/components/agent/registry.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { defineRegistry } from "@json-render/react";
-import type { CartState } from "@shopify/hydrogen";
 import { useCart, useCartForm } from "@shopify/hydrogen/react";
 import { cn } from "cn";
+import { Loader2 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
@@ -21,6 +21,7 @@ import {
 import { Price } from "@/components/product/price";
 import { Button } from "@/components/ui/button";
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
+import { useCheckout } from "@/hooks/use-checkout";
 import { catalog } from "@/lib/agent";
 import type { AgentVariant } from "@/lib/agent/products";
 import type { Cart } from "@/lib/cart";
@@ -38,13 +39,15 @@ function variantLabel(variant: AgentVariant): string {
 export const { registry } = defineRegistry(catalog, {
   components: {
     AgentCartSummary: () => {
+      const cart = useCart<Cart, Cart>((state) => state.data);
       const {
-        data: cart,
-        loading,
-        pending,
-        revalidating,
-      } = useCart<Cart, CartState<Cart>>((state) => state);
-      const isPending = loading || revalidating || pending.cost || pending.lines.size > 0;
+        checkoutError,
+        checkoutErrorId,
+        handleCheckout,
+        isCheckingOut,
+        isCheckoutDisabled,
+        isUpdatingCart,
+      } = useCheckout();
       if (cart.lines.nodes.length === 0) return <MissingData>Your cart is empty</MissingData>;
       return (
         <div className="my-2 overflow-hidden rounded-lg border">
@@ -70,13 +73,26 @@ export const { registry } = defineRegistry(catalog, {
               Taxes and shipping calculated at checkout.
             </p>
           </div>
-          {!isPending && cart.checkoutUrl && (
-            <div className="border-t px-2.5 py-2">
-              <Button className="h-12 w-full justify-center" render={<a href={cart.checkoutUrl} />}>
-                Checkout
-              </Button>
-            </div>
-          )}
+          <div className="grid gap-2.5 border-t px-2.5 py-2">
+            <Button
+              aria-busy={isCheckingOut || isUpdatingCart || undefined}
+              aria-describedby={checkoutError ? checkoutErrorId : undefined}
+              className="h-12 w-full justify-center"
+              disabled={isCheckoutDisabled}
+              onClick={handleCheckout}
+              type="button"
+            >
+              {isCheckingOut || isUpdatingCart ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              ) : null}
+              {isCheckingOut ? "Redirecting..." : isUpdatingCart ? "Updating cart..." : "Checkout"}
+            </Button>
+            {checkoutError ? (
+              <p className="text-xs text-destructive" id={checkoutErrorId} role="alert">
+                {checkoutError}
+              </p>
+            ) : null}
+          </div>
           <span className="sr-only">This cart updates as you change it.</span>
         </div>
       );

--- a/apps/template/components/cart-page/summary.tsx
+++ b/apps/template/components/cart-page/summary.tsx
@@ -4,35 +4,26 @@ import { formatMoney } from "@shopify/hydrogen";
 import { useCart } from "@shopify/hydrogen/react";
 import { cn } from "cn";
 import { Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
 
 import { DiscountForm } from "@/components/cart/discount-form";
+import { useCheckout } from "@/hooks/use-checkout";
 import type { Cart } from "@/lib/cart";
-import { prepareCheckoutAction } from "@/lib/cart/action";
 import { shopConfig } from "@/lib/config";
 
-function CheckoutLink({
-  checkoutUrl,
-  isUpdatingCart,
-  updatingText,
-  checkoutText,
-}: {
-  checkoutUrl: string;
-  isUpdatingCart: boolean;
-  updatingText: string;
+interface CheckoutButtonProps {
   checkoutText: string;
-}) {
-  const [isCheckingOut, setIsCheckingOut] = useState(false);
-  const [checkoutError, setCheckoutError] = useState<string | null>(null);
+  updatingText: string;
+}
 
-  // Reset pending state when returning from checkout (bfcache / back navigation)
-  useEffect(() => {
-    const handlePageShow = (e: PageTransitionEvent) => {
-      if (e.persisted) setIsCheckingOut(false);
-    };
-    window.addEventListener("pageshow", handlePageShow);
-    return () => window.removeEventListener("pageshow", handlePageShow);
-  }, []);
+function CheckoutButton({ checkoutText, updatingText }: CheckoutButtonProps) {
+  const {
+    checkoutError,
+    checkoutErrorId,
+    handleCheckout,
+    isCheckingOut,
+    isCheckoutDisabled,
+    isUpdatingCart,
+  } = useCheckout();
 
   const baseClassName =
     "flex items-center justify-center w-full h-12 rounded-lg text-sm font-medium bg-primary text-primary-foreground transition-colors";
@@ -45,25 +36,10 @@ function CheckoutLink({
           baseClassName,
           "cursor-pointer hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50",
         )}
-        disabled={isUpdatingCart || isCheckingOut || !checkoutUrl}
+        disabled={isCheckoutDisabled}
         aria-busy={isCheckingOut || isUpdatingCart || undefined}
-        onClick={async () => {
-          if (isUpdatingCart || isCheckingOut || !checkoutUrl) return;
-          setCheckoutError(null);
-          setIsCheckingOut(true);
-          try {
-            const { checkoutUrl: url } = await prepareCheckoutAction();
-            if (!url) {
-              setIsCheckingOut(false);
-              setCheckoutError("Checkout is unavailable. Refresh your cart and try again.");
-              return;
-            }
-            window.location.href = url;
-          } catch {
-            setIsCheckingOut(false);
-            setCheckoutError("We couldn't start checkout. Please try again.");
-          }
-        }}
+        aria-describedby={checkoutError ? checkoutErrorId : undefined}
+        onClick={handleCheckout}
       >
         <span className="flex items-center gap-2.5">
           {isCheckingOut || isUpdatingCart ? (
@@ -73,7 +49,7 @@ function CheckoutLink({
         </span>
       </button>
       {checkoutError ? (
-        <p className="text-xs text-destructive" role="alert">
+        <p className="text-xs text-destructive" id={checkoutErrorId} role="alert">
           {checkoutError}
         </p>
       ) : null}
@@ -95,17 +71,6 @@ export function Summary({
   updatingCartLabel,
 }: SummaryProps) {
   const cart = useCart<Cart, Cart>((state) => state.data);
-  const isUpdatingCart = useCart((state) =>
-    Boolean(
-      state.loading ||
-      state.revalidating ||
-      state.pending.cost ||
-      state.pending.lines.size ||
-      state.pending.discountCodes.size ||
-      state.pending.attributes ||
-      state.pending.note,
-    ),
-  );
   const isCostPending = useCart((state) => Boolean(state.pending.cost || state.revalidating));
   if (!cart.lines.nodes.length) return null;
   const { amount, currencyCode } = cart.cost.totalAmount;
@@ -135,12 +100,7 @@ export function Summary({
         <p className="text-xs text-muted-foreground mt-1">{taxesAndShippingNote}</p>
       </div>
 
-      <CheckoutLink
-        checkoutUrl={cart.checkoutUrl ?? ""}
-        isUpdatingCart={isUpdatingCart}
-        updatingText={updatingCartLabel}
-        checkoutText={completeCheckoutLabel}
-      />
+      <CheckoutButton checkoutText={completeCheckoutLabel} updatingText={updatingCartLabel} />
     </div>
   );
 }

--- a/apps/template/components/cart/overlay-content.tsx
+++ b/apps/template/components/cart/overlay-content.tsx
@@ -3,9 +3,9 @@
 import { useCart } from "@shopify/hydrogen/react";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { useCheckout } from "@/hooks/use-checkout";
 import type { Cart } from "@/lib/cart";
 
 import { useCartDrawer } from "./context";
@@ -43,32 +43,15 @@ export function OverlayContent() {
   const router = useRouter();
   const displayCart = useCart<Cart, Cart>((state) => state.data);
   const isLoading = useCart((state) => state.loading);
-  const isUpdatingCart = useCart((state) =>
-    Boolean(
-      state.loading ||
-      state.revalidating ||
-      state.pending.cost ||
-      state.pending.lines.size ||
-      state.pending.discountCodes.size ||
-      state.pending.attributes ||
-      state.pending.note,
-    ),
-  );
+  const {
+    checkoutError,
+    checkoutErrorId,
+    handleCheckout,
+    isCheckingOut,
+    isCheckoutDisabled,
+    isUpdatingCart,
+  } = useCheckout();
   const { setOverlayOpen } = useCartDrawer();
-  const [isCheckingOut, setIsCheckingOut] = useState(false);
-  // Reset pending state when returning from checkout (bfcache / back navigation)
-  useEffect(() => {
-    const handlePageShow = (e: PageTransitionEvent) => {
-      if (e.persisted) setIsCheckingOut(false);
-    };
-    window.addEventListener("pageshow", handlePageShow);
-    return () => window.removeEventListener("pageshow", handlePageShow);
-  }, []);
-  const handleCheckout = () => {
-    if (isCheckingOut || isUpdatingCart || !displayCart.checkoutUrl) return;
-    setIsCheckingOut(true);
-    window.location.href = displayCart.checkoutUrl;
-  };
   if (isLoading && displayCart.lines.nodes.length === 0) {
     return (
       <div className="flex h-full items-center justify-center gap-2.5" role="status">
@@ -110,14 +93,24 @@ export function OverlayContent() {
       <footer className="px-5 py-5 space-y-5">
         <OverlaySummary cart={displayCart} />
 
-        <Button
-          onClick={handleCheckout}
-          className="w-full h-12 justify-center"
-          disabled={isCheckingOut || isUpdatingCart || !displayCart.checkoutUrl}
-          aria-label="Proceed to Checkout"
-        >
-          <CheckoutButtonContent isCheckingOut={isCheckingOut} isUpdatingCart={isUpdatingCart} />
-        </Button>
+        <div className="grid gap-2.5">
+          <Button
+            onClick={handleCheckout}
+            className="w-full h-12 justify-center"
+            disabled={isCheckoutDisabled}
+            aria-busy={isCheckingOut || isUpdatingCart || undefined}
+            aria-describedby={checkoutError ? checkoutErrorId : undefined}
+            aria-label="Proceed to Checkout"
+            type="button"
+          >
+            <CheckoutButtonContent isCheckingOut={isCheckingOut} isUpdatingCart={isUpdatingCart} />
+          </Button>
+          {checkoutError ? (
+            <p className="text-xs text-destructive" id={checkoutErrorId} role="alert">
+              {checkoutError}
+            </p>
+          ) : null}
+        </div>
       </footer>
     </div>
   );

--- a/apps/template/components/product-detail/buy-buttons.tsx
+++ b/apps/template/components/product-detail/buy-buttons.tsx
@@ -25,6 +25,7 @@ export function BuyButtons({
 }) {
   const { formProps, pending, register, selectedVariant: storeVariant } = useProductForm();
   const selectedVariant = storeVariant ?? fallbackVariant;
+  const isSelectionUnresolved = !storeVariant;
   const [isBuyingNow, setIsBuyingNow] = useState(false);
   const [quantity, setQuantity] = useState(1);
   const { openOverlay } = useCartDrawer();
@@ -43,17 +44,29 @@ export function BuyButtons({
   const isOutOfStock = !selectedVariant.availableForSale;
   // Keep href while buying: removing it during the click cancels the anchor's navigation.
   const buyNowUrl = getShopPayButtonUrl({
-    disabled: isOutOfStock || requiresBundleConfiguration,
+    disabled: isSelectionUnresolved || isOutOfStock || requiresBundleConfiguration,
     variants: [{ id: selectedVariant.id, quantity }],
   });
   const getButtonText = () => {
     if (pending) return "Adding to Cart...";
+    if (isSelectionUnresolved) return "Add to Cart";
     if (requiresBundleConfiguration) return "Choose bundle items";
     if (isOutOfStock) return "Out of Stock";
     return "Add to Cart";
   };
   return (
-    <form {...formProps({ beforeSubmit: openOverlay })} className="grid gap-2.5">
+    <form
+      {...formProps({
+        beforeSubmit: (event) => {
+          if (isSelectionUnresolved || isOutOfStock || requiresBundleConfiguration || pending) {
+            event.preventDefault();
+            return;
+          }
+          openOverlay();
+        },
+      })}
+      className="grid gap-2.5"
+    >
       <input type="hidden" {...register("merchandiseId", {})} />
       <input type="hidden" {...register("quantity", { value: quantity })} />
       <div className="flex gap-2.5">
@@ -92,8 +105,9 @@ export function BuyButtons({
         ) : null}
         <Button
           {...register("addToCart", {})}
-          disabled={isOutOfStock || requiresBundleConfiguration || pending}
-          className="h-12 min-w-0 flex-1 justify-center"
+          data-selection-unresolved={isSelectionUnresolved && !pending}
+          disabled={isSelectionUnresolved || isOutOfStock || requiresBundleConfiguration || pending}
+          className="h-12 min-w-0 flex-1 justify-center data-[selection-unresolved=true]:disabled:opacity-100"
         >
           {getButtonText()}
         </Button>
@@ -103,11 +117,18 @@ export function BuyButtons({
           aria-busy={isBuyingNow || undefined}
           aria-disabled={buyNowUrl ? undefined : true}
           className={cn(
-            "flex h-12 w-full cursor-pointer items-center justify-center rounded-lg bg-shop px-4 text-white transition-colors hover:bg-shop/85 aria-busy:pointer-events-none aria-disabled:pointer-events-none aria-disabled:opacity-50",
+            "flex h-12 w-full cursor-pointer items-center justify-center rounded-lg bg-shop px-4 text-white transition-colors hover:bg-shop/85 aria-busy:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50 data-[selection-unresolved=true]:aria-disabled:opacity-100",
             !availableForSale && "invisible",
           )}
+          data-selection-unresolved={isSelectionUnresolved}
           href={buyNowUrl ?? undefined}
-          onClick={() => setIsBuyingNow(true)}
+          onClick={(event) => {
+            if (!buyNowUrl || isBuyingNow) {
+              event.preventDefault();
+              return;
+            }
+            setIsBuyingNow(true);
+          }}
           rel="nofollow"
         >
           {isBuyingNow ? (

--- a/apps/template/components/product-detail/gift-card-purchase-form.tsx
+++ b/apps/template/components/product-detail/gift-card-purchase-form.tsx
@@ -13,7 +13,7 @@ import { addGiftCardToCart } from "@/lib/cart/gift-card-client";
 import type { OptimisticProductInfo } from "@/lib/product";
 
 interface GiftCardPurchaseFormProps {
-  merchandiseId: string;
+  merchandiseId: string | undefined;
   productInfo?: OptimisticProductInfo;
 }
 
@@ -48,7 +48,7 @@ export function GiftCardPurchaseForm({ merchandiseId, productInfo }: GiftCardPur
   const [sendOnEnabled, setSendOnEnabled] = useState(false);
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (isPending) return;
+    if (isPending || !merchandiseId) return;
     setError(null);
     const formData = new FormData(event.currentTarget);
     const email = String(formData.get("email") ?? "").trim();
@@ -158,9 +158,10 @@ export function GiftCardPurchaseForm({ merchandiseId, productInfo }: GiftCardPur
 
       <Button
         type="submit"
-        disabled={isPending}
+        data-selection-unresolved={!merchandiseId && !isPending}
+        disabled={isPending || !merchandiseId}
         className={cn(
-          "h-12 w-full justify-center",
+          "h-12 w-full justify-center group-valid:data-[selection-unresolved=true]:disabled:opacity-100",
           "group-invalid:cursor-not-allowed group-invalid:opacity-50",
         )}
       >

--- a/apps/template/components/product-detail/product-form.tsx
+++ b/apps/template/components/product-detail/product-form.tsx
@@ -137,11 +137,12 @@ export function ProductFormGiftCard({
   handle: string;
   title: string;
 }) {
-  const variant = useProductFormState().selectedVariant ?? fallbackVariant;
+  const { selectedVariant } = useProductFormState();
+  const variant = selectedVariant ?? fallbackVariant;
   if (!variant) return null;
   return (
     <GiftCardPurchaseForm
-      merchandiseId={variant.id}
+      merchandiseId={selectedVariant?.id}
       productInfo={variantToOptimisticInfo(variant, { title, handle, featuredImage })}
     />
   );

--- a/apps/template/hooks/use-checkout.ts
+++ b/apps/template/hooks/use-checkout.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { useCart } from "@shopify/hydrogen/react";
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+
+import { prepareCheckoutAction } from "@/lib/cart/action";
+
+export function useCheckout() {
+  const cartState = useCart((state) => state);
+  const { data: cart, loading, pending, revalidating } = cartState;
+  const isUpdatingCart = Boolean(
+    loading ||
+    revalidating ||
+    pending.attributes ||
+    pending.cost ||
+    pending.discountCodes.size ||
+    pending.lines.size ||
+    pending.note,
+  );
+  const [checkoutError, setCheckoutError] = useState<string | null>(null);
+  const [isCheckingOut, setIsCheckingOut] = useState(false);
+  const checkoutErrorId = useId();
+  const attempt = useRef<object | null>(null);
+  const latestCartState = useRef(cartState);
+  const isCheckoutDisabled = isUpdatingCart || isCheckingOut || !cart.lines.nodes.length;
+
+  useLayoutEffect(() => {
+    latestCartState.current = cartState;
+    if (attempt.current && isUpdatingCart) {
+      attempt.current = null;
+      setIsCheckingOut(false);
+      setCheckoutError(
+        "Your cart changed. Wait for it to finish updating, then try checkout again.",
+      );
+    }
+  }, [cartState, isUpdatingCart]);
+
+  useEffect(() => {
+    const resetCheckout = () => {
+      attempt.current = null;
+      setIsCheckingOut(false);
+      setCheckoutError(null);
+    };
+    window.addEventListener("pageshow", resetCheckout);
+    return () => {
+      attempt.current = null;
+      window.removeEventListener("pageshow", resetCheckout);
+    };
+  }, []);
+
+  async function handleCheckout() {
+    if (isCheckoutDisabled || attempt.current) return;
+    const currentAttempt = {};
+    attempt.current = currentAttempt;
+    setCheckoutError(null);
+    setIsCheckingOut(true);
+
+    try {
+      const { checkoutUrl } = await prepareCheckoutAction();
+      if (attempt.current !== currentAttempt) return;
+      if (latestCartState.current.data !== cart) {
+        setCheckoutError("Your cart changed. Please try checkout again.");
+      } else if (!checkoutUrl) {
+        setCheckoutError("Checkout is unavailable. Refresh your cart and try again.");
+      } else {
+        window.location.href = checkoutUrl;
+        return;
+      }
+    } catch {
+      if (attempt.current !== currentAttempt) return;
+      setCheckoutError("We couldn't start checkout. Please try again.");
+    }
+
+    attempt.current = null;
+    setIsCheckingOut(false);
+  }
+
+  return {
+    checkoutError,
+    checkoutErrorId,
+    handleCheckout,
+    isCheckingOut,
+    isCheckoutDisabled,
+    isUpdatingCart,
+  };
+}

--- a/apps/template/lib/agent/cart-client.ts
+++ b/apps/template/lib/agent/cart-client.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import type { CartUserError } from "@shopify/hydrogen";
+
+import type { Cart, CartWarning } from "@/lib/cart";
+
+import { addCartNoteInputSchema, addToCartInputSchema, updateCartItemInputSchema } from "./cart";
+
+const ENDPOINT = "/api/cart";
+const TIMEOUT_MS = 10_000;
+const UNCONFIRMED_MESSAGE =
+  "The cart update could not be confirmed. Read the cart before trying again; the change may have been applied.";
+
+interface CartMutationResponse {
+  cart: Cart | null;
+  userErrors?: CartUserError[];
+  warnings?: CartWarning[];
+}
+
+type CartToolResult = { cartUpdated: true; warnings: string[] } | { error: string };
+
+type CartMutation =
+  | {
+      action: "add";
+      lines: { merchandiseId: string; quantity: number }[];
+    }
+  | {
+      action: "remove" | "update";
+      lines: { id: string; quantity: number }[];
+    }
+  | { note: string };
+
+export function isCartMutationTool(name: string): boolean {
+  return name === "addToCart" || name === "updateCartItem" || name === "addCartNote";
+}
+
+function parseMutation(toolName: string, input: unknown): CartMutation {
+  switch (toolName) {
+    case "addToCart": {
+      const { quantity, variantId } = addToCartInputSchema.parse(input);
+      return { action: "add", lines: [{ merchandiseId: variantId, quantity }] };
+    }
+    case "updateCartItem": {
+      const { lineId, quantity } = updateCartItemInputSchema.parse(input);
+      return {
+        action: quantity === 0 ? "remove" : "update",
+        lines: [{ id: lineId, quantity }],
+      };
+    }
+    case "addCartNote":
+      return addCartNoteInputSchema.parse(input);
+    default:
+      throw new Error("Unsupported cart tool.");
+  }
+}
+
+async function postCart(mutation: CartMutation) {
+  const payload = "lines" in mutation ? { lines: mutation.lines } : { note: mutation.note };
+  const response = await fetch(ENDPOINT, {
+    body: JSON.stringify(payload),
+    credentials: "same-origin",
+    headers: { "content-type": "application/json" },
+    method: "POST",
+    redirect: "error",
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(UNCONFIRMED_MESSAGE);
+
+  const { cart, userErrors, warnings } = (await response.json()) as CartMutationResponse;
+  if (!cart) {
+    return {
+      cart: null,
+      userErrors: userErrors?.length ? userErrors : [{ message: UNCONFIRMED_MESSAGE }],
+      warnings,
+    };
+  }
+  if (!cart.id || !Array.isArray(cart.lines?.nodes)) throw new Error(UNCONFIRMED_MESSAGE);
+
+  const { lines, ...cartData } = cart;
+  return { cart: { ...cartData, lines: lines.nodes }, userErrors, warnings };
+}
+
+function dispatchMutation(mutation: CartMutation, promise: ReturnType<typeof postCart>) {
+  const eventName = "lines" in mutation ? "shopify:cart:lines-update" : "shopify:cart:note-update";
+  const event = Object.assign(new Event(eventName, { bubbles: true, cancelable: true }), {
+    ...mutation,
+    context: "cart" as const,
+    promise,
+  });
+  document.dispatchEvent(event);
+}
+
+export async function executeCartTool(toolName: string, input: unknown): Promise<CartToolResult> {
+  if (!isCartMutationTool(toolName)) return { error: "Unsupported cart tool." };
+
+  let mutation: CartMutation;
+  try {
+    mutation = parseMutation(toolName, input);
+  } catch {
+    return { error: "Invalid cart tool input. Check the item ID, quantity, or note." };
+  }
+
+  if (typeof document === "undefined") return { error: "Cart updates require the storefront." };
+
+  try {
+    const promise = postCart(mutation);
+    // Hydrogen registers synchronous settlement handlers during dispatch, before our await continuation.
+    dispatchMutation(mutation, promise);
+    const result = await promise;
+    if (result.userErrors?.length) {
+      return { error: result.userErrors.map(({ message }) => message).join("; ") };
+    }
+    if (!result.cart) return { error: UNCONFIRMED_MESSAGE };
+    return {
+      cartUpdated: true,
+      warnings: result.warnings?.map(({ message }) => message) ?? [],
+    };
+  } catch {
+    return { error: UNCONFIRMED_MESSAGE };
+  }
+}

--- a/apps/template/lib/agent/cart.ts
+++ b/apps/template/lib/agent/cart.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const addCartNoteInputSchema = z.strictObject({ note: z.string() });
+
+export const addToCartInputSchema = z.strictObject({
+  quantity: z.number().int().min(1).max(99).default(1),
+  variantId: z.string().regex(/^gid:\/\/shopify\/ProductVariant\/[0-9]+$/),
+});
+
+export const updateCartItemInputSchema = z.strictObject({
+  lineId: z.string().regex(/^gid:\/\/shopify\/CartLine\/[^\s]+$/),
+  quantity: z.number().int().min(0).max(99),
+});

--- a/apps/template/lib/agent/server.ts
+++ b/apps/template/lib/agent/server.ts
@@ -46,6 +46,7 @@ function createSystemPrompt(page: PageContext): string {
     `The storefront display locale is ${shopConfig.localization.locale}; its commerce country is ${shopConfig.localization.country} and catalog language is ${shopConfig.localization.language}.`,
     "You can search products, browse collections, recommend products, answer store policy questions, manage the cart, and build on-site links.",
     "Never guess policy, shipping, returns, payment, warranty, sizing, or care answers; use searchShopPolicies.",
+    "Only change the cart when the shopper asks. Read the current cart before retrying an interrupted cart change; it may already have succeeded. Explain any warnings returned by a cart tool, and never claim a failed change succeeded.",
     'When the shopper names a required product option such as a colour or size, pass it to searchProducts as options (e.g. [{"name":"Color","value":"Orange"}]) and keep the query focused on the product itself ("jackets"). Fewer results than expected is the correct outcome; state how many matched.',
     "Only describe results as matching a colour, size, or other option when the tool returned them under that option. If searchProducts reports unmatchedOptions, tell the shopper nothing matched and offer to drop or change the constraint — never present other products as if they satisfied it.",
     describePage(page),

--- a/apps/template/lib/agent/tools/cart.ts
+++ b/apps/template/lib/agent/tools/cart.ts
@@ -1,8 +1,13 @@
 import { tool } from "ai";
 import { z } from "zod";
 
+import {
+  addCartNoteInputSchema,
+  addToCartInputSchema,
+  updateCartItemInputSchema,
+} from "@/lib/agent/cart";
 import type { Cart } from "@/lib/cart";
-import { getCartById, runCartMutation } from "@/lib/cart/server";
+import { getCartById } from "@/lib/cart/server";
 
 interface CartToolsOptions {
   cartId: string | undefined;
@@ -54,66 +59,21 @@ export function createCartTools({ cartId }: CartToolsOptions) {
     description:
       "Add a product variant to the cart using a ProductVariant ID from getProductDetails. " +
       "Never pass a product ID. Confirm the variant first when a product has several.",
-    inputSchema: z.object({
-      quantity: z.number().int().min(1).max(99).default(1),
-      variantId: z.string(),
-    }),
+    inputSchema: addToCartInputSchema,
     toModelOutput: cartModelOutput,
-    execute: async ({ quantity, variantId }, { abortSignal }) => {
-      abortSignal?.throwIfAborted();
-      if (!cartId) return { error: "The cart is not ready yet. Ask the shopper to try again." };
-
-      try {
-        const { warnings } = await runCartMutation(
-          { lines: [{ merchandiseId: variantId, quantity }] },
-          cartId,
-        );
-        return { cartUpdated: true, warnings: warnings.map(({ message }) => message) };
-      } catch (error) {
-        console.error("Failed to add to cart:", error);
-        return { error: "Could not add that item to the cart." };
-      }
-    },
   });
 
   const updateCartItem = tool({
     description:
       "Change a cart line's quantity, or remove it by passing 0. Call getCart first to get the lineId.",
-    inputSchema: z.object({
-      lineId: z.string(),
-      quantity: z.number().int().min(0).max(99),
-    }),
+    inputSchema: updateCartItemInputSchema,
     toModelOutput: cartModelOutput,
-    execute: async ({ lineId, quantity }, { abortSignal }) => {
-      abortSignal?.throwIfAborted();
-      if (!cartId) return { error: "The cart is not ready yet. Ask the shopper to try again." };
-
-      try {
-        const { warnings } = await runCartMutation({ lines: [{ id: lineId, quantity }] }, cartId);
-        return { cartUpdated: true, warnings: warnings.map(({ message }) => message) };
-      } catch (error) {
-        console.error("Failed to update cart line:", error);
-        return { error: "Could not update that cart line." };
-      }
-    },
   });
 
   const addCartNote = tool({
     description: "Attach a note to the cart for gift messages, delivery, or special instructions.",
-    inputSchema: z.object({ note: z.string() }),
+    inputSchema: addCartNoteInputSchema,
     toModelOutput: cartModelOutput,
-    execute: async ({ note }, { abortSignal }) => {
-      abortSignal?.throwIfAborted();
-      if (!cartId) return { error: "The cart is not ready yet. Ask the shopper to try again." };
-
-      try {
-        const { warnings } = await runCartMutation({ note }, cartId);
-        return { cartUpdated: true, warnings: warnings.map(({ message }) => message) };
-      } catch (error) {
-        console.error("Failed to update cart note:", error);
-        return { error: "Could not update the cart note." };
-      }
-    },
   });
 
   return { addCartNote, addToCart, getCart, updateCartItem };

--- a/apps/template/lib/agent/tools/cart.ts
+++ b/apps/template/lib/agent/tools/cart.ts
@@ -55,19 +55,20 @@ export function createCartTools({ cartId }: CartToolsOptions) {
       "Add a product variant to the cart using a ProductVariant ID from getProductDetails. " +
       "Never pass a product ID. Confirm the variant first when a product has several.",
     inputSchema: z.object({
-      quantity: z.number().min(1).max(99).default(1),
+      quantity: z.number().int().min(1).max(99).default(1),
       variantId: z.string(),
     }),
     toModelOutput: cartModelOutput,
-    execute: async ({ quantity, variantId }) => {
+    execute: async ({ quantity, variantId }, { abortSignal }) => {
+      abortSignal?.throwIfAborted();
       if (!cartId) return { error: "The cart is not ready yet. Ask the shopper to try again." };
 
       try {
-        const { cart } = await runCartMutation(
+        const { warnings } = await runCartMutation(
           { lines: [{ merchandiseId: variantId, quantity }] },
           cartId,
         );
-        return { cartUpdated: Boolean(cart) };
+        return { cartUpdated: true, warnings: warnings.map(({ message }) => message) };
       } catch (error) {
         console.error("Failed to add to cart:", error);
         return { error: "Could not add that item to the cart." };
@@ -80,15 +81,16 @@ export function createCartTools({ cartId }: CartToolsOptions) {
       "Change a cart line's quantity, or remove it by passing 0. Call getCart first to get the lineId.",
     inputSchema: z.object({
       lineId: z.string(),
-      quantity: z.number().min(0).max(99),
+      quantity: z.number().int().min(0).max(99),
     }),
     toModelOutput: cartModelOutput,
-    execute: async ({ lineId, quantity }) => {
+    execute: async ({ lineId, quantity }, { abortSignal }) => {
+      abortSignal?.throwIfAborted();
       if (!cartId) return { error: "The cart is not ready yet. Ask the shopper to try again." };
 
       try {
-        const { cart } = await runCartMutation({ lines: [{ id: lineId, quantity }] }, cartId);
-        return { cartUpdated: Boolean(cart) };
+        const { warnings } = await runCartMutation({ lines: [{ id: lineId, quantity }] }, cartId);
+        return { cartUpdated: true, warnings: warnings.map(({ message }) => message) };
       } catch (error) {
         console.error("Failed to update cart line:", error);
         return { error: "Could not update that cart line." };
@@ -100,12 +102,13 @@ export function createCartTools({ cartId }: CartToolsOptions) {
     description: "Attach a note to the cart for gift messages, delivery, or special instructions.",
     inputSchema: z.object({ note: z.string() }),
     toModelOutput: cartModelOutput,
-    execute: async ({ note }) => {
+    execute: async ({ note }, { abortSignal }) => {
+      abortSignal?.throwIfAborted();
       if (!cartId) return { error: "The cart is not ready yet. Ask the shopper to try again." };
 
       try {
-        const { cart } = await runCartMutation({ note }, cartId);
-        return { cartUpdated: Boolean(cart) };
+        const { warnings } = await runCartMutation({ note }, cartId);
+        return { cartUpdated: true, warnings: warnings.map(({ message }) => message) };
       } catch (error) {
         console.error("Failed to update cart note:", error);
         return { error: "Could not update the cart note." };

--- a/apps/template/lib/agent/tools/products.ts
+++ b/apps/template/lib/agent/tools/products.ts
@@ -110,7 +110,11 @@ export const searchProductsTool = tool({
     try {
       let pool: ProductCard[] = [];
       if (mode === "semantic") {
-        pool = await semanticProducts(searchQuery, intent, poolSize);
+        try {
+          pool = await semanticProducts(searchQuery, intent, poolSize);
+        } catch (error) {
+          console.error("Semantic search failed; falling back to keyword search:", error);
+        }
       }
       if (pool.length === 0) {
         const { products } = await searchIndexProducts({

--- a/apps/template/lib/cart/server.ts
+++ b/apps/template/lib/cart/server.ts
@@ -5,7 +5,9 @@ import {
   createShopifyRequestContext,
   getCartId,
   gql,
+  type ShopifyRequestContext,
 } from "@shopify/hydrogen";
+import type { WritableCustomerSessionManager } from "@shopify/hydrogen/customer-account";
 import { io } from "next/cache";
 import { headers } from "next/headers";
 import { cache } from "react";
@@ -118,14 +120,23 @@ export async function getCartById(cartId: string): Promise<Cart | undefined> {
   return data.cart ?? undefined;
 }
 
-/** Creates an empty cart so a streaming response can set the cookie before any line is added. */
-export async function createEmptyCart(): Promise<string | undefined> {
-  const { storefrontClient } = await getHandlerContext();
+// Streaming tools need a cart cookie before adding the first line; Hydrogen's POST rejects empty lines.
+export async function createEmptyCart(
+  requestContext: ShopifyRequestContext,
+  sessionManager?: WritableCustomerSessionManager,
+): Promise<string> {
+  const storefrontClient = createRequestStorefrontClient(requestContext);
+  const customerAccessToken = sessionManager
+    ? await (
+        await getHydrogenCustomerSession()
+      ).getOrRefreshAccessToken(sessionManager, requestContext)
+    : undefined;
   const { data, errors } = await storefrontClient.graphql(cartQueries.cartCreate, {
     variables: {
       input: {
         buyerIdentity: {
           countryCode: shopConfig.localization.country,
+          ...(customerAccessToken ? { customerAccessToken } : {}),
         },
       },
     },
@@ -133,7 +144,9 @@ export async function createEmptyCart(): Promise<string | undefined> {
   if (errors?.length) throw new Error(errors[0].message);
   const userErrors = data?.cartCreate?.userErrors ?? [];
   if (userErrors.length) throw new Error(userErrors.map((e) => e.message).join("; "));
-  return data?.cartCreate?.cart?.id;
+  const cartId = data?.cartCreate?.cart?.id;
+  if (!cartId) throw new Error("Cart creation returned no cart");
+  return cartId;
 }
 
 export type CartMutationInput =

--- a/apps/template/lib/cart/server.ts
+++ b/apps/template/lib/cart/server.ts
@@ -13,7 +13,7 @@ import { headers } from "next/headers";
 import { cache } from "react";
 
 import { getHydrogenCustomerSession, getReadonlyCustomerSessionManager } from "@/lib/auth/server";
-import type { Cart, CartSeedData, CartWarning } from "@/lib/cart";
+import type { Cart, CartSeedData } from "@/lib/cart";
 import { shopConfig } from "@/lib/config";
 import { createRequestStorefrontClient } from "@/lib/shopify/storefront";
 
@@ -147,60 +147,4 @@ export async function createEmptyCart(
   const cartId = data?.cartCreate?.cart?.id;
   if (!cartId) throw new Error("Cart creation returned no cart");
   return cartId;
-}
-
-export type CartMutationInput =
-  | {
-      lines: {
-        attributes?: { key: string; value: string }[];
-        merchandiseId: string;
-        quantity: number;
-      }[];
-    }
-  | { lines: { id: string; quantity: number }[] }
-  | { note: string };
-
-export type CartMutationResult = { cart: Cart; warnings: CartWarning[] };
-
-/**
- * Runs a cart mutation through Hydrogen's `/api/cart` handler without an HTTP round trip.
- * Callers that create a cart must persist `cart.id` with `createCartCookie` on their own response.
- */
-export async function runCartMutation(
-  input: CartMutationInput,
-  cartId?: string,
-): Promise<CartMutationResult> {
-  const { handlers, requestContext: sharedContext, ...context } = await getHandlerContext();
-  const requestContext = sharedContext ?? (await getRequestContext());
-  const request = new Request(new URL("/api/cart", shopConfig.site.url), {
-    body: JSON.stringify({ ...input, ...(cartId ? { cartId } : {}) }),
-    headers: {
-      "content-type": "application/json",
-      cookie: (await headers()).get("cookie") ?? "",
-    },
-    method: "POST",
-  });
-  // Cookies can't be committed from a tool call, so pass a read-only session and let refreshes fall through.
-  const result = await handlers.post({
-    ...context,
-    request,
-    requestContext,
-    sessionManager: {
-      ...("sessionManager" in context ? context.sessionManager : {}),
-      commit: undefined,
-    },
-  } as never);
-
-  if (result.type === "error") throw new Error(result.error.message);
-  if (result.type !== "json") throw new Error("Cart mutation returned an unexpected response");
-
-  // Hydrogen's POST result erases the cart fragment type even though it uses the same query as GET.
-  const data = result.data as {
-    cart?: Cart | null;
-    userErrors?: { message: string }[];
-    warnings?: CartWarning[];
-  };
-  if (data.userErrors?.length) throw new Error(data.userErrors.map((e) => e.message).join("; "));
-  if (!data.cart) throw new Error("Cart mutation returned no cart");
-  return { cart: data.cart, warnings: data.warnings ?? [] };
 }

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -64,7 +64,7 @@ const defaultUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
 
 export const shopConfig = {
   agent: {
-    isEnabled: false,
+    isEnabled: true,
   },
   analytics: {
     shopify: {

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -64,7 +64,7 @@ const defaultUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
 
 export const shopConfig = {
   agent: {
-    isEnabled: true,
+    isEnabled: false,
   },
   analytics: {
     shopify: {

--- a/apps/template/vercel.json
+++ b/apps/template/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "app/api/chat/route.ts": {
+      "supportsCancellation": true
+    }
+  }
+}


### PR DESCRIPTION
Improve chat recovery and cart sync, preserve customer identity in assistant-created carts, and share checkout preparation across cart surfaces. Block unresolved variant purchases without visual flicker. Update docs; assistant remains opt-in.

Verified: production build, codegen, typecheck, focused lint/format, and mocked runtime checks. Live signed-in checkout and deployed cancellation remain unverified.