### PR TITLE
Simplify BotID errors and library-backed config types

### DIFF
--- a/apps/docs/content/docs/reference/shop-config.mdx
+++ b/apps/docs/content/docs/reference/shop-config.mdx
@@ -36,6 +36,8 @@ Before enabling `auth.isEnabled`, set `CUSTOMER_ACCOUNT_SESSION_SECRET`, `SHOPIF
 
 Enable `botid.isEnabled` with `agent.isEnabled`. BotID verification runs only on Vercel, so leave it disabled when self-hosting. Check [BotID pricing](https://vercel.com/docs/botid#pricing) before selecting `deepAnalysis`.
 
+Blocked assistant requests return `403` before any cart or AI work starts. The assistant shows the same generic error message as other request failures.
+
 `site.url` resolves from the Vercel production URL and falls back to `http://localhost:3000` during local development. Set `site.url` directly when deploying elsewhere.
 
 ## Shopify consent modes

--- a/apps/docs/content/docs/reference/shop-config.mdx
+++ b/apps/docs/content/docs/reference/shop-config.mdx
@@ -36,8 +36,6 @@ Before enabling `auth.isEnabled`, set `CUSTOMER_ACCOUNT_SESSION_SECRET`, `SHOPIF
 
 Enable `botid.isEnabled` with `agent.isEnabled`. BotID verification runs only on Vercel, so leave it disabled when self-hosting. Check [BotID pricing](https://vercel.com/docs/botid#pricing) before selecting `deepAnalysis`.
 
-Blocked assistant requests return `403` before any cart or AI work starts. The assistant shows the same generic error message as other request failures.
-
 `site.url` resolves from the Vercel production URL and falls back to `http://localhost:3000` during local development. Set `site.url` directly when deploying elsewhere.
 
 ## Shopify consent modes

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -12,7 +12,6 @@ import { checkBotId } from "botid/server";
 import { parsePageContext } from "@/lib/agent/routes";
 import { createAgent } from "@/lib/agent/server";
 import { createCustomerRequestContext, createCustomerSessionManager } from "@/lib/auth/server";
-import { botIdCheckOptions } from "@/lib/botid";
 import { createEmptyCart, getCartIdFromCookie } from "@/lib/cart/server";
 import { shopConfig } from "@/lib/config";
 
@@ -21,7 +20,9 @@ export async function POST(request: Request) {
 
   // Runs before body parsing and cart creation so rejected traffic costs no Shopify or gateway work.
   if (shopConfig.botid.isEnabled) {
-    const { isBot } = await checkBotId(botIdCheckOptions);
+    const { isBot } = await checkBotId({
+      advancedOptions: { checkLevel: shopConfig.botid.checkLevel },
+    });
     if (isBot) return new Response(null, { status: 403 });
   }
   let body: unknown;

--- a/apps/template/app/api/chat/route.ts
+++ b/apps/template/app/api/chat/route.ts
@@ -12,7 +12,7 @@ import { checkBotId } from "botid/server";
 import { parsePageContext } from "@/lib/agent/routes";
 import { createAgent } from "@/lib/agent/server";
 import { createCustomerRequestContext, createCustomerSessionManager } from "@/lib/auth/server";
-import { BOTID_DENIED_CODE, botIdCheckOptions } from "@/lib/botid";
+import { botIdCheckOptions } from "@/lib/botid";
 import { createEmptyCart, getCartIdFromCookie } from "@/lib/cart/server";
 import { shopConfig } from "@/lib/config";
 
@@ -22,7 +22,7 @@ export async function POST(request: Request) {
   // Runs before body parsing and cart creation so rejected traffic costs no Shopify or gateway work.
   if (shopConfig.botid.isEnabled) {
     const { isBot } = await checkBotId(botIdCheckOptions);
-    if (isBot) return Response.json({ error: BOTID_DENIED_CODE }, { status: 403 });
+    if (isBot) return new Response(null, { status: 403 });
   }
   let body: unknown;
   try {

--- a/apps/template/components/agent/agent-panel.tsx
+++ b/apps/template/components/agent/agent-panel.tsx
@@ -13,7 +13,6 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from "react"
 import { useCartDrawer } from "@/components/cart/context";
 import { useScrollContain } from "@/hooks/use-scroll-contain";
 import { executeCartTool, isCartMutationTool } from "@/lib/agent/cart-client";
-import { BOTID_DENIED_CODE } from "@/lib/botid";
 
 import { AgentCartBridge } from "./cart-bridge";
 import { ChatMessage } from "./chat-message";
@@ -264,13 +263,7 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
         status={status}
         value={input}
       />
-      {error && (
-        <p className="px-5 pb-2 text-red-500 text-xs">
-          {error.message.includes(BOTID_DENIED_CODE)
-            ? "We couldn't verify this request. Reload the page and try again."
-            : "Something went wrong. Try again."}
-        </p>
-      )}
+      {error && <p className="px-5 pb-2 text-red-500 text-xs">Something went wrong. Try again.</p>}
     </div>
   );
 }

--- a/apps/template/lib/botid/index.ts
+++ b/apps/template/lib/botid/index.ts
@@ -1,19 +1,11 @@
-import { type BotIdCheckLevel, shopConfig } from "@/lib/config";
-
-export interface BotIdProtectedRoute {
-  advancedOptions: { checkLevel: BotIdCheckLevel };
-  method: string;
-  path: string;
-}
-
-export const BOTID_DENIED_CODE = "botid_denied";
+import { shopConfig } from "@/lib/config";
 
 // The client `protect` entry and the server `checkBotId()` call must declare the same checkLevel or verification fails.
 export const botIdCheckOptions = {
   advancedOptions: { checkLevel: shopConfig.botid.checkLevel },
 };
 
-export const botIdProtectedRoutes: BotIdProtectedRoute[] = [
+export const botIdProtectedRoutes = [
   ...(shopConfig.agent.isEnabled
     ? [
         {

--- a/apps/template/lib/botid/index.ts
+++ b/apps/template/lib/botid/index.ts
@@ -1,10 +1,5 @@
 import { shopConfig } from "@/lib/config";
 
-// The client `protect` entry and the server `checkBotId()` call must declare the same checkLevel or verification fails.
-export const botIdCheckOptions = {
-  advancedOptions: { checkLevel: shopConfig.botid.checkLevel },
-};
-
 export const botIdProtectedRoutes = [
   ...(shopConfig.agent.isEnabled
     ? [

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -83,7 +83,6 @@ export const shopConfig = {
     isEnabled: false,
   },
   botid: {
-    // Client protection and server verification must use the same check level.
     checkLevel: "basic",
     isEnabled: false,
   },

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -83,6 +83,7 @@ export const shopConfig = {
     isEnabled: false,
   },
   botid: {
+    // Client protection and server verification must use the same check level.
     checkLevel: "basic",
     isEnabled: false,
   },

--- a/apps/template/lib/config.ts
+++ b/apps/template/lib/config.ts
@@ -1,10 +1,7 @@
-import type { I18nConfig } from "@shopify/hydrogen";
+import type { ConsentConfig, I18nConfig } from "@shopify/hydrogen";
+import type { initBotId } from "botid/client/core";
 
 export type CommerceLocale = Pick<I18nConfig, "country" | "language">;
-
-export type BotIdCheckLevel = "basic" | "deepAnalysis";
-
-type ShopifyConsentMode = "custom-banner" | "default-banner" | "no-banner";
 
 export interface ShopConfig {
   agent: {
@@ -12,7 +9,7 @@ export interface ShopConfig {
   };
   analytics: {
     shopify: {
-      consentMode: ShopifyConsentMode;
+      consentMode: NonNullable<ConsentConfig["mode"]>;
       isEnabled: boolean;
     };
     speedInsights: {
@@ -26,7 +23,11 @@ export interface ShopConfig {
     isEnabled: boolean;
   };
   botid: {
-    checkLevel: BotIdCheckLevel;
+    checkLevel: NonNullable<
+      NonNullable<
+        Parameters<typeof initBotId>[0]["protect"][number]["advancedOptions"]
+      >["checkLevel"]
+    >;
     isEnabled: boolean;
   };
   localization: CommerceLocale & {


### PR DESCRIPTION
## Summary
- Remove the custom BotID denial code and chat error-message matching. Blocked requests return an empty 403 and use the existing generic error UI.
- Infer protected-route types at the BotID consumer and derive the required check level from the public initBotId API.
- Derive the required Shopify consent mode from Hydrogen's ConsentConfig; retain CommerceLocale and shared client/server check-level configuration.
- Document the blocked-request behavior in the shop configuration reference.

## Verification
All final checks passed (exit 0):
- In apps/template: `pnpm exec oxlint lib/config.ts lib/botid/index.ts app/api/chat/route.ts components/agent/agent-panel.tsx` — zero warnings/errors.
- In apps/template: `pnpm exec oxfmt --check lib/config.ts lib/botid/index.ts app/api/chat/route.ts components/agent/agent-panel.tsx`.
- In apps/template: `pnpm exec tsc --noEmit`.
- In apps/docs: `pnpm exec oxfmt --check content/docs/reference/shop-config.mdx`.
- `git diff --check`.
- Direct `node --input-type=module` check using AI SDK DefaultChatTransport and a mocked empty 403 response confirmed sendMessages rejects, enabling the existing generic error UI.

Initial formatting check found two files; formatted them and reran successfully. No tests added. No full build, live Shopify codegen, browser check, or production BotID verification run.