### PR TITLE
refactor: refresh customer views

### DIFF
--- a/apps/docs/content/docs/anatomy/authentication.mdx
+++ b/apps/docs/content/docs/anatomy/authentication.mdx
@@ -66,7 +66,7 @@ Sessions use encrypted, HttpOnly cookies rather than browser-readable storage. E
 
 When authentication is enabled, the cart follows the customer session. Signing in attaches the browser cart when possible, and checkout can carry the customer's saved details. Cart synchronization is best-effort; an authentication redirect still completes if cart synchronization fails.
 
-Successful profile and address changes refresh the current account view automatically. Customer Account API data is personalized and is not publicly cached.
+Customer Account API data is personalized and is not publicly cached.
 
 > **Security requirements:** Never expose access, refresh, or ID tokens to browser-readable storage. Keep logout as a same-origin `POST`. Register callback and logout URIs exactly, and rotate `CUSTOMER_ACCOUNT_SESSION_SECRET` only when you intend to invalidate all sessions.
 

--- a/apps/docs/content/docs/anatomy/authentication.mdx
+++ b/apps/docs/content/docs/anatomy/authentication.mdx
@@ -66,7 +66,7 @@ Sessions use encrypted, HttpOnly cookies rather than browser-readable storage. E
 
 When authentication is enabled, the cart follows the customer session. Signing in attaches the browser cart when possible, and checkout can carry the customer's saved details. Cart synchronization is best-effort; an authentication redirect still completes if cart synchronization fails.
 
-Customer Account API data is personalized and is not publicly cached.
+Successful profile and address changes refresh the current account view automatically. Customer Account API data is personalized and is not publicly cached.
 
 > **Security requirements:** Never expose access, refresh, or ID tokens to browser-readable storage. Keep logout as a same-origin `POST`. Register callback and logout URIs exactly, and rotate `CUSTOMER_ACCOUNT_SESSION_SECRET` only when you intend to invalidate all sessions.
 

--- a/apps/template/lib/customer/action.ts
+++ b/apps/template/lib/customer/action.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { refresh } from "next/cache";
 import { unstable_rethrow } from "next/navigation";
 
 import type { CustomerAddressInput } from "@/lib/customer/types";
@@ -78,7 +78,7 @@ export async function createAddressAction(
 
   try {
     const result = mapUserErrors(await createCustomerAddress(input, isDefault));
-    if (result.success) revalidatePath("/account/addresses");
+    if (result.success) refresh();
     return result;
   } catch (error) {
     unstable_rethrow(error);
@@ -103,7 +103,7 @@ export async function updateAddressAction(
 
   try {
     const result = mapUserErrors(await updateCustomerAddress(addressId, input, isDefault));
-    if (result.success) revalidatePath("/account/addresses");
+    if (result.success) refresh();
     return result;
   } catch (error) {
     unstable_rethrow(error);
@@ -120,7 +120,7 @@ export async function deleteAddressAction(addressId: string): Promise<AccountAct
 
   try {
     const result = mapUserErrors(await deleteCustomerAddress(addressId));
-    if (result.success) revalidatePath("/account/addresses");
+    if (result.success) refresh();
     return result;
   } catch (error) {
     unstable_rethrow(error);
@@ -143,7 +143,7 @@ export async function updateProfileAction(raw: {
 
   try {
     const result = mapUserErrors(await updateCustomerProfile(input));
-    if (result.success) revalidatePath("/account/profile");
+    if (result.success) refresh();
     return result;
   } catch (error) {
     unstable_rethrow(error);


### PR DESCRIPTION
Use refresh() after successful customer mutations instead of revalidatePath(). Preserve validation and error handling. This is a code-only refactor; the existing account documentation remains unchanged.

Checks passed (exit 0):
- pnpm --dir apps/template exec tsc --noEmit --pretty false
- pnpm --dir apps/template exec oxlint lib/customer/action.ts
- pnpm --dir apps/template exec oxfmt --check lib/customer/action.ts
- git diff --check
- git diff --exit-code origin/main -- apps/docs/content/docs/anatomy/authentication.mdx

Signed-in browser flows not manually tested.