### PR TITLE
Wire desktop PDP gallery preview to Vercel flag

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -16,7 +16,7 @@ While an option choice is being resolved, purchase controls temporarily block pu
 
 When colors have distinct media, the gallery leads with the selected color's image. Virtual try-on also uses the active variant's image, with the product image as a fallback. Desktop shoppers get a grid and lightbox; mobile shoppers get a swipeable gallery.
 
-In the enterprise demo, turn on the Vercel `pdp-gallery` flag to use a desktop gallery with thumbnails on the left and one large image or video. A border marks the active thumbnail. Selecting a different color returns the gallery to that color's image. Images still open in a lightbox, and virtual try-on uses the selected variant. The flag defaults to off, and the mobile gallery stays unchanged. Reload the product page after toggling the flag.
+In the enterprise demo, turn on the Vercel `pdp-gallery` flag to use a desktop gallery with thumbnails on the left and one large image or video. A border marks the active thumbnail. Selecting a different color returns the gallery to that color's image. Images still open in a lightbox. Virtual try-on appears only on the leading variant image, with the product image as a fallback. Leaving and returning to the page resets the gallery to its first image. The flag defaults to off, and the mobile gallery stays unchanged. Reload the product page after toggling the flag.
 
 Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/docs/anatomy/webhooks).
 

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -16,7 +16,7 @@ While an option choice is being resolved, purchase controls temporarily block pu
 
 When colors have distinct media, the gallery leads with the selected color's image. Virtual try-on also uses the active variant's image, with the product image as a fallback. Desktop shoppers get a grid and lightbox; mobile shoppers get a swipeable gallery.
 
-In the enterprise demo, the Vercel `pdp-gallery` flag controls a desktop-only preview marker. It defaults to off. Turning it on shows “pdp-gallery enabled” over the existing desktop grid; the mobile gallery stays unchanged. Reload the product page after toggling the flag to see the selected state. The preview does not include a thumbnail-sidebar layout.
+In the enterprise demo, turn on the Vercel `pdp-gallery` flag to use a desktop gallery with thumbnails on the left and one large image or video. A border marks the active thumbnail. Selecting a different color returns the gallery to that color's image. Images still open in a lightbox, and virtual try-on uses the selected variant. The flag defaults to off, and the mobile gallery stays unchanged. Reload the product page after toggling the flag.
 
 Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/docs/anatomy/webhooks).
 

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -16,6 +16,8 @@ While an option choice is being resolved, purchase controls temporarily block pu
 
 When colors have distinct media, the gallery leads with the selected color's image. Virtual try-on also uses the active variant's image, with the product image as a fallback. Desktop shoppers get a grid and lightbox; mobile shoppers get a swipeable gallery.
 
+In the enterprise demo, the Vercel `pdp-gallery` flag controls a desktop-only preview marker. It defaults to off. Turning it on shows “pdp-gallery enabled” over the existing desktop grid; the mobile gallery stays unchanged. Reload the product page after toggling the flag to see the selected state. The preview does not include a thumbnail-sidebar layout.
+
 Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/docs/anatomy/webhooks).
 
 ## Included purchase features

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -16,7 +16,7 @@ While an option choice is being resolved, purchase controls temporarily block pu
 
 When colors have distinct media, the gallery leads with the selected color's image. Virtual try-on also uses the active variant's image, with the product image as a fallback. Desktop shoppers get a grid and lightbox; mobile shoppers get a swipeable gallery.
 
-In the enterprise demo, turn on the Vercel `pdp-gallery` flag to use a desktop gallery with thumbnails on the left and one large image or video. A border marks the active thumbnail. Selecting a different color returns the gallery to that color's image. Images still open in a lightbox. Virtual try-on appears only on the leading variant image, with the product image as a fallback. Leaving and returning to the page resets the gallery to its first image. The flag defaults to off, and the mobile gallery stays unchanged. Reload the product page after toggling the flag.
+In the enterprise demo, turn on the Vercel `pdp-gallery` flag to use a desktop gallery with thumbnails on the left and one large image or video. A border marks the active thumbnail. The desktop gallery stays pinned below the navigation while the product information scrolls, then scrolls away at the end of the product section. Selecting a different color returns the gallery to that color's image. Images still open in a lightbox. Virtual try-on appears only on the leading variant image, with the product image as a fallback. Leaving and returning to the page resets the gallery to its first image. The flag defaults to off, and the mobile gallery stays unchanged. Reload the product page after toggling the flag.
 
 Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/docs/anatomy/webhooks).
 

--- a/apps/template/components/product-detail/desktop-gallery.tsx
+++ b/apps/template/components/product-detail/desktop-gallery.tsx
@@ -78,7 +78,7 @@ export function DesktopGallery({ images, overlay, title, videos }: DesktopGaller
                 key={item.type === "image" ? item.image.url : item.video.url}
                 aria-label={t("goToImage", { number: String(index + 1) })}
                 aria-pressed={index === activeIndex}
-                className="relative aspect-square w-full shrink-0 cursor-pointer overflow-hidden outline-none after:pointer-events-none after:absolute after:inset-0 after:border-2 after:border-transparent hover:after:border-muted-foreground focus-visible:after:border-foreground data-[active=true]:after:border-foreground"
+                className="relative aspect-square w-full shrink-0 cursor-pointer overflow-hidden outline-none after:pointer-events-none after:absolute after:inset-0 after:border after:border-transparent hover:after:border-muted-foreground focus-visible:after:border-foreground data-[active=true]:after:border-foreground"
                 data-active={index === activeIndex}
                 onClick={() => setSelectedIndex(index)}
                 type="button"

--- a/apps/template/components/product-detail/desktop-gallery.tsx
+++ b/apps/template/components/product-detail/desktop-gallery.tsx
@@ -12,7 +12,7 @@ import type { Image as ImageType, Video } from "@/lib/media/types";
 
 import { LightboxTrigger } from "./lightbox";
 
-const IMAGE_SIZES = "(min-width: 1536px) 776px, (min-width: 1024px) calc(60vw - 146px), 100vw";
+const IMAGE_SIZES = "(min-width: 1536px) 696px, (min-width: 1024px) calc(60vw - 226px), 100vw";
 
 type GalleryItem = { image: ImageType; type: "image" } | { type: "video"; video: Video };
 
@@ -63,7 +63,7 @@ export function DesktopGallery({ images, overlay, title, videos }: DesktopGaller
 
   return (
     <div
-      className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-2.5"
+      className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-2.5 pr-20"
       data-pdp-gallery="enabled"
     >
       <div className="relative h-full min-h-0">

--- a/apps/template/components/product-detail/desktop-gallery.tsx
+++ b/apps/template/components/product-detail/desktop-gallery.tsx
@@ -3,7 +3,7 @@
 import { PlayIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image, { getImageProps } from "next/image";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useLayoutEffect, useRef, useState } from "react";
 import { preload } from "react-dom";
 
 import { AutoPlayVideo } from "@/components/ui/auto-play-video";
@@ -12,7 +12,7 @@ import type { Image as ImageType, Video } from "@/lib/media/types";
 
 import { LightboxTrigger } from "./lightbox";
 
-const IMAGE_SIZES = "(min-width: 1536px) 766px, (min-width: 1024px) calc(60vw - 156px), 100vw";
+const IMAGE_SIZES = "(min-width: 1536px) 776px, (min-width: 1024px) calc(60vw - 146px), 100vw";
 
 type GalleryItem = { image: ImageType; type: "image" } | { type: "video"; video: Video };
 
@@ -25,7 +25,17 @@ interface DesktopGalleryProps {
 
 export function DesktopGallery({ images, overlay, title, videos }: DesktopGalleryProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const thumbnailsRef = useRef<HTMLDivElement>(null);
   const t = useTranslations("product");
+
+  // Activity keeps state on navigation but runs layout-effect cleanup when hiding the gallery.
+  useLayoutEffect(() => {
+    const thumbnails = thumbnailsRef.current;
+    return () => {
+      setSelectedIndex(0);
+      if (thumbnails) thumbnails.scrollTop = 0;
+    };
+  }, []);
   const items: GalleryItem[] = [
     ...images.map((image): GalleryItem => ({ image, type: "image" })),
     ...videos.map((video): GalleryItem => ({ type: "video", video })),
@@ -53,11 +63,14 @@ export function DesktopGallery({ images, overlay, title, videos }: DesktopGaller
 
   return (
     <div
-      className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-5"
+      className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-2.5"
       data-pdp-gallery="enabled"
     >
       <div className="relative h-full min-h-0">
-        <div className="absolute inset-0 flex flex-col gap-2.5 overflow-y-auto overscroll-contain">
+        <div
+          ref={thumbnailsRef}
+          className="absolute inset-0 flex flex-col gap-2.5 overflow-y-auto overscroll-contain"
+        >
           {items.map((item, index) => {
             const image = item.type === "image" ? item.image : item.video.previewImage;
             return (
@@ -65,14 +78,14 @@ export function DesktopGallery({ images, overlay, title, videos }: DesktopGaller
                 key={item.type === "image" ? item.image.url : item.video.url}
                 aria-label={t("goToImage", { number: String(index + 1) })}
                 aria-pressed={index === activeIndex}
-                className="relative aspect-square w-full shrink-0 cursor-pointer overflow-hidden border-2 border-transparent p-1 outline-none hover:border-muted-foreground focus-visible:border-foreground data-[active=true]:border-foreground"
+                className="relative aspect-square w-full shrink-0 cursor-pointer overflow-hidden outline-none after:pointer-events-none after:absolute after:inset-0 after:border-2 after:border-transparent hover:after:border-muted-foreground focus-visible:after:border-foreground data-[active=true]:after:border-foreground"
                 data-active={index === activeIndex}
                 onClick={() => setSelectedIndex(index)}
                 type="button"
               >
                 <span className="relative block size-full">
                   {image ? (
-                    <Image alt="" className="object-contain" fill sizes="68px" src={image.url} />
+                    <Image alt="" className="object-cover" fill sizes="80px" src={image.url} />
                   ) : (
                     <ImagePlaceholder className="size-full" />
                   )}
@@ -108,7 +121,7 @@ export function DesktopGallery({ images, overlay, title, videos }: DesktopGaller
                 src={activeItem.image.url}
               />
             </LightboxTrigger>
-            {overlay}
+            {activeIndex === 0 ? overlay : null}
           </>
         ) : activeItem?.type === "video" ? (
           <AutoPlayVideo

--- a/apps/template/components/product-detail/desktop-gallery.tsx
+++ b/apps/template/components/product-detail/desktop-gallery.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { PlayIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import Image, { getImageProps } from "next/image";
+import { type ReactNode, useState } from "react";
+import { preload } from "react-dom";
+
+import { AutoPlayVideo } from "@/components/ui/auto-play-video";
+import { ImagePlaceholder } from "@/components/ui/image-placeholder";
+import type { Image as ImageType, Video } from "@/lib/media/types";
+
+import { LightboxTrigger } from "./lightbox";
+
+const IMAGE_SIZES = "(min-width: 1536px) 766px, (min-width: 1024px) calc(60vw - 156px), 100vw";
+
+type GalleryItem = { image: ImageType; type: "image" } | { type: "video"; video: Video };
+
+interface DesktopGalleryProps {
+  images: ImageType[];
+  overlay?: ReactNode;
+  title: string;
+  videos: Video[];
+}
+
+export function DesktopGallery({ images, overlay, title, videos }: DesktopGalleryProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const t = useTranslations("product");
+  const items: GalleryItem[] = [
+    ...images.map((image): GalleryItem => ({ image, type: "image" })),
+    ...videos.map((video): GalleryItem => ({ type: "video", video })),
+  ];
+  const activeIndex = Math.min(selectedIndex, Math.max(0, items.length - 1));
+  const activeItem = items[activeIndex];
+  const firstImage = images[0];
+
+  // Scope the hero preload to desktop so the hidden gallery doesn't compete with the mobile carousel.
+  if (firstImage) {
+    const { props } = getImageProps({
+      alt: "",
+      fill: true,
+      sizes: IMAGE_SIZES,
+      src: firstImage.url,
+    });
+    preload(props.src, {
+      as: "image",
+      fetchPriority: "high",
+      imageSizes: props.sizes,
+      imageSrcSet: props.srcSet,
+      media: "(min-width: 1024px)",
+    });
+  }
+
+  return (
+    <div
+      className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-5"
+      data-pdp-gallery="enabled"
+    >
+      <div className="relative h-full min-h-0">
+        <div className="absolute inset-0 flex flex-col gap-2.5 overflow-y-auto overscroll-contain">
+          {items.map((item, index) => {
+            const image = item.type === "image" ? item.image : item.video.previewImage;
+            return (
+              <button
+                key={item.type === "image" ? item.image.url : item.video.url}
+                aria-label={t("goToImage", { number: String(index + 1) })}
+                aria-pressed={index === activeIndex}
+                className="relative aspect-square w-full shrink-0 cursor-pointer overflow-hidden border-2 border-transparent p-1 outline-none hover:border-muted-foreground focus-visible:border-foreground data-[active=true]:border-foreground"
+                data-active={index === activeIndex}
+                onClick={() => setSelectedIndex(index)}
+                type="button"
+              >
+                <span className="relative block size-full">
+                  {image ? (
+                    <Image alt="" className="object-contain" fill sizes="68px" src={image.url} />
+                  ) : (
+                    <ImagePlaceholder className="size-full" />
+                  )}
+                </span>
+                {item.type === "video" ? (
+                  <PlayIcon
+                    aria-hidden
+                    className="absolute bottom-2 right-2 size-4 fill-background"
+                  />
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div
+        className="relative aspect-square min-w-0 overflow-hidden"
+        data-slot="gallery-active-media"
+      >
+        {activeItem?.type === "image" ? (
+          <>
+            <LightboxTrigger item={activeItem}>
+              <Image
+                key={activeItem.image.url}
+                alt={activeItem.image.altText || title}
+                blurDataURL={activeItem.image.blurDataURL}
+                className="object-contain"
+                draggable={false}
+                fetchPriority={activeIndex === 0 ? "high" : "auto"}
+                fill
+                placeholder={activeItem.image.blurDataURL ? "blur" : "empty"}
+                sizes={IMAGE_SIZES}
+                src={activeItem.image.url}
+              />
+            </LightboxTrigger>
+            {overlay}
+          </>
+        ) : activeItem?.type === "video" ? (
+          <AutoPlayVideo
+            key={activeItem.video.url}
+            className="size-full object-contain"
+            previewImage={
+              activeItem.video.previewImage
+                ? {
+                    alt: activeItem.video.previewImage.altText || title,
+                    src: activeItem.video.previewImage.url,
+                  }
+                : null
+            }
+            previewImageLoading="lazy"
+            sizes={IMAGE_SIZES}
+            src={activeItem.video.url}
+          />
+        ) : (
+          <ImagePlaceholder className="size-full" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -147,7 +147,7 @@ async function ProductMediaArea({
         galleryEnabled ? (
           <Suspense
             fallback={
-              <div className="grid grid-cols-[5rem_minmax(0,1fr)] gap-5">
+              <div className="grid grid-cols-[5rem_minmax(0,1fr)] gap-2.5">
                 <div />
                 <div className="aspect-square" />
               </div>
@@ -214,7 +214,7 @@ async function ResolvedDesktopGallery({
     <DesktopGallery
       key={`${product.id}:${image?.url ?? "default"}`}
       images={images}
-      overlay={overlay}
+      overlay={image ? overlay : undefined}
       title={product.title}
       videos={product.videos}
     />

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -8,6 +8,7 @@ import { BundleComponents, BundleParents } from "@/components/product-detail/bun
 import { BuyButtons } from "@/components/product-detail/buy-buttons";
 import { BuyWithShopLogo } from "@/components/product-detail/buy-with-shop-logo";
 import { ComplementaryProducts } from "@/components/product-detail/complementary-products";
+import { DesktopGallery } from "@/components/product-detail/desktop-gallery";
 import { ProductOpenGraph } from "@/components/product-detail/open-graph";
 import {
   ProductForm,
@@ -120,7 +121,17 @@ async function ProductMediaArea({
   if (!hasColorImagePartitioning(product.options)) {
     return (
       <ProductMedia
-        galleryEnabled={galleryEnabled}
+        desktopGallery={
+          galleryEnabled ? (
+            <DesktopGallery
+              key={product.id}
+              images={product.images}
+              overlay={tryOnOverlay}
+              title={product.title}
+              videos={product.videos}
+            />
+          ) : undefined
+        }
         otherImages={product.images}
         videos={product.videos}
         title={product.title}
@@ -132,7 +143,24 @@ async function ProductMediaArea({
 
   return (
     <ProductMedia
-      galleryEnabled={galleryEnabled}
+      desktopGallery={
+        galleryEnabled ? (
+          <Suspense
+            fallback={
+              <div className="grid grid-cols-[5rem_minmax(0,1fr)] gap-5">
+                <div />
+                <div className="aspect-square" />
+              </div>
+            }
+          >
+            <ResolvedDesktopGallery
+              overlay={tryOnOverlay}
+              product={product}
+              selectedOptionsPromise={selectedOptionsPromise}
+            />
+          </Suspense>
+        ) : undefined
+      }
       otherImages={getSharedImages(product.images, product.options)}
       videos={product.videos}
       title={product.title}
@@ -161,6 +189,34 @@ async function ProductMediaArea({
           />
         </Suspense>
       }
+    />
+  );
+}
+
+interface ResolvedDesktopGalleryProps {
+  overlay?: ReactNode;
+  product: ProductDetails;
+  selectedOptionsPromise: Promise<SelectedOptions>;
+}
+
+async function ResolvedDesktopGallery({
+  overlay,
+  product,
+  selectedOptionsPromise,
+}: ResolvedDesktopGalleryProps) {
+  const image = getSelectedColorImage(product, await selectedOptionsPromise);
+  const sharedImages = getSharedImages(product.images, product.options);
+  const images = image
+    ? [image, ...sharedImages.filter((shared) => shared.url !== image.url)]
+    : sharedImages;
+
+  return (
+    <DesktopGallery
+      key={`${product.id}:${image?.url ?? "default"}`}
+      images={images}
+      overlay={overlay}
+      title={product.title}
+      videos={product.videos}
     />
   );
 }

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -147,7 +147,7 @@ async function ProductMediaArea({
         galleryEnabled ? (
           <Suspense
             fallback={
-              <div className="grid grid-cols-[5rem_minmax(0,1fr)] gap-2.5">
+              <div className="grid grid-cols-[5rem_minmax(0,1fr)] gap-2.5 pr-20">
                 <div />
                 <div className="aspect-square" />
               </div>
@@ -276,14 +276,21 @@ async function ProductInfoArea({
   const t = await getTranslations("product");
   // Read the precomputed value so the button color varies per [flags] cache entry
   // instead of re-deciding (and splitting the cache) at render time.
-  const ctaColored = await ctaColor(await getFlagsCode(), precomputedFlags);
+  const flagsCode = await getFlagsCode();
+  const [ctaColored, galleryEnabled] = await Promise.all([
+    ctaColor(flagsCode, precomputedFlags),
+    pdpGallery(flagsCode, precomputedFlags),
+  ]);
   const buyFallbackT = uniformStock && !singleVariant ? t : null;
   const allInStock = product.defaultVariant?.availableForSale ?? product.availableForSale;
   const hasOptions = options.some((option) => option.values.length > 1);
   const reviewSummary = product.rating;
 
   return (
-    <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
+    <div
+      className="grid gap-10 lg:col-span-4 lg:data-[gallery=false]:sticky lg:data-[gallery=false]:top-20"
+      data-gallery={galleryEnabled}
+    >
       <ProductInfoShell>
         <div data-slot="product-info-header" className="grid gap-2.5">
           {reviewSummary ? (

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -35,7 +35,7 @@ import { Label } from "@/components/ui/label";
 import { RatingStars } from "@/components/ui/rating-stars";
 import { Textarea } from "@/components/ui/textarea";
 import { shopConfig } from "@/lib/config";
-import { ctaColor, precomputedFlags } from "@/lib/flags";
+import { ctaColor, pdpGallery, precomputedFlags } from "@/lib/flags";
 import type { Locale } from "@/lib/i18n";
 import { getFlagsCode } from "@/lib/params";
 import {
@@ -100,7 +100,7 @@ export async function ProductDetailSection({
   );
 }
 
-function ProductMediaArea({
+async function ProductMediaArea({
   product,
   selectedOptionsPromise,
   variantPromise,
@@ -109,6 +109,7 @@ function ProductMediaArea({
   selectedOptionsPromise: Promise<SelectedOptions>;
   variantPromise: Promise<ProductVariant | undefined>;
 }) {
+  const galleryEnabled = await pdpGallery(await getFlagsCode(), precomputedFlags);
   const fallbackImageUrl = product.featuredImage?.url ?? product.images[0]?.url;
   const tryOnOverlay = (
     <Suspense fallback={null}>
@@ -119,6 +120,7 @@ function ProductMediaArea({
   if (!hasColorImagePartitioning(product.options)) {
     return (
       <ProductMedia
+        galleryEnabled={galleryEnabled}
         otherImages={product.images}
         videos={product.videos}
         title={product.title}
@@ -130,6 +132,7 @@ function ProductMediaArea({
 
   return (
     <ProductMedia
+      galleryEnabled={galleryEnabled}
       otherImages={getSharedImages(product.images, product.options)}
       videos={product.videos}
       title={product.title}

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -344,23 +344,8 @@ export function ColorImageCarouselItems({
   });
 }
 
-interface DesktopGalleryPreviewProps {
-  children: ReactNode;
-}
-
-function DesktopGalleryPreview({ children }: DesktopGalleryPreviewProps) {
-  return (
-    <div className="relative" data-pdp-gallery="enabled">
-      {children}
-      <div className="pointer-events-none absolute top-4 left-4 z-10 rounded-md bg-background px-4 py-2 text-sm text-foreground shadow-sm">
-        pdp-gallery enabled
-      </div>
-    </div>
-  );
-}
-
 export function ProductMedia({
-  galleryEnabled = false,
+  desktopGallery,
   otherImages,
   videos,
   title,
@@ -369,7 +354,7 @@ export function ProductMedia({
   mobileSlot,
   overlay,
 }: {
-  galleryEnabled?: boolean;
+  desktopGallery?: ReactNode;
   otherImages: ImageType[];
   videos: Video[];
   title: string;
@@ -407,13 +392,7 @@ export function ProductMedia({
           {mobileSlot}
         </Carousel>
       </div>
-      <div className="hidden lg:block">
-        {galleryEnabled ? (
-          <DesktopGalleryPreview>{desktopGrid}</DesktopGalleryPreview>
-        ) : (
-          desktopGrid
-        )}
-      </div>
+      <div className="hidden lg:block">{desktopGallery ?? desktopGrid}</div>
     </div>
   );
 

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -380,7 +380,7 @@ export function ProductMedia({
   );
 
   const content = (
-    <div className={className}>
+    <div className={cn(className, desktopGallery && "lg:sticky lg:top-20")}>
       <div className="lg:hidden">
         <Carousel
           key={mediaItems.map(mediaKey).join(",")}

--- a/apps/template/components/product-detail/product-media.tsx
+++ b/apps/template/components/product-detail/product-media.tsx
@@ -344,7 +344,23 @@ export function ColorImageCarouselItems({
   });
 }
 
+interface DesktopGalleryPreviewProps {
+  children: ReactNode;
+}
+
+function DesktopGalleryPreview({ children }: DesktopGalleryPreviewProps) {
+  return (
+    <div className="relative" data-pdp-gallery="enabled">
+      {children}
+      <div className="pointer-events-none absolute top-4 left-4 z-10 rounded-md bg-background px-4 py-2 text-sm text-foreground shadow-sm">
+        pdp-gallery enabled
+      </div>
+    </div>
+  );
+}
+
 export function ProductMedia({
+  galleryEnabled = false,
   otherImages,
   videos,
   title,
@@ -353,6 +369,7 @@ export function ProductMedia({
   mobileSlot,
   overlay,
 }: {
+  galleryEnabled?: boolean;
   otherImages: ImageType[];
   videos: Video[];
   title: string;
@@ -371,6 +388,12 @@ export function ProductMedia({
   const isEmpty = sharedMediaItems.length === 0 && !hasColorSlot;
   const mediaItems: MediaItem[] = isEmpty ? [{ type: "placeholder" }] : sharedMediaItems;
 
+  const desktopGrid = (
+    <Grid mediaItems={mediaItems} title={title} hasColorSlot={hasColorSlot} overlay={overlay}>
+      {desktopSlot}
+    </Grid>
+  );
+
   const content = (
     <div className={className}>
       <div className="lg:hidden">
@@ -385,9 +408,11 @@ export function ProductMedia({
         </Carousel>
       </div>
       <div className="hidden lg:block">
-        <Grid mediaItems={mediaItems} title={title} hasColorSlot={hasColorSlot} overlay={overlay}>
-          {desktopSlot}
-        </Grid>
+        {galleryEnabled ? (
+          <DesktopGalleryPreview>{desktopGrid}</DesktopGalleryPreview>
+        ) : (
+          desktopGrid
+        )}
       </div>
     </div>
   );

--- a/apps/template/lib/flags.ts
+++ b/apps/template/lib/flags.ts
@@ -16,11 +16,11 @@ export const ctaColor = flag<boolean>({
 export const pdpGallery = flag<boolean>({
   adapter: vercelAdapter<boolean, unknown>(),
   defaultValue: false,
-  description: "Enable the desktop PDP gallery preview",
+  description: "Use the desktop PDP thumbnail gallery",
   key: "pdp-gallery",
   options: [
     { label: "Default", value: false },
-    { label: "Gallery preview", value: true },
+    { label: "Thumbnail gallery", value: true },
   ],
 });
 

--- a/apps/template/lib/flags.ts
+++ b/apps/template/lib/flags.ts
@@ -13,5 +13,16 @@ export const ctaColor = flag<boolean>({
   adapter: vercelAdapter<boolean, unknown>(),
 });
 
+export const pdpGallery = flag<boolean>({
+  adapter: vercelAdapter<boolean, unknown>(),
+  defaultValue: false,
+  description: "Enable the desktop PDP gallery preview",
+  key: "pdp-gallery",
+  options: [
+    { label: "Default", value: false },
+    { label: "Gallery preview", value: true },
+  ],
+});
+
 // Precomputed in proxy.ts and encoded into the hidden [flags] segment.
-export const precomputedFlags = [ctaColor] as const;
+export const precomputedFlags = [ctaColor, pdpGallery] as const;


### PR DESCRIPTION
## Summary
- Register the boolean `pdp-gallery` Vercel flag (default off) alongside `cta-color` in the existing precomputed flag group.
- Read the precomputed value on the server and switch the desktop gallery into a preview component that displays `pdp-gallery enabled` over the existing grid.
- Preserve mobile, color-image slots, lightbox, videos, and virtual try-on; no thumbnail-sidebar design in this draft.
- Document the enterprise-only preview behavior.

## Verification
- `pnpm install --frozen-lockfile` (repo root): passed, exit 0.
- `./node_modules/.bin/oxfmt --check lib/flags.ts components/product-detail/product-detail-section.tsx components/product-detail/product-media.tsx` (template): passed, exit 0.
- `./node_modules/.bin/oxlint lib/flags.ts components/product-detail/product-detail-section.tsx components/product-detail/product-media.tsx` (template): passed, exit 0; zero warnings/errors.
- `./apps/docs/node_modules/.bin/oxfmt --check apps/docs/content/docs/anatomy/pages/pdp.mdx`: passed.
- `git diff --check`: passed.
- Direct Node HTTP assertions against `next dev --port 3100`, using the SDK's signed `vercel-flag-overrides` cookie: all four `cta-color`/`pdp-gallery` combinations returned HTTP 200; marker matched the gallery flag and remained inside `hidden lg:block`; mobile carousel retained.
- `./apps/template/node_modules/.bin/tsc --noEmit --project apps/template/tsconfig.json`: blocked (exit 1) by generated `.next/dev/types/validator.ts(270,31)` TS2559 for unchanged `app/robots.ts` versus `RouteHandlerConfig<"/robots.txt">`.
- No full build or browser interaction check performed.

## Preview confirmation
Local `FLAGS` credentials are missing, so live dashboard evaluation is not yet verified. The local runtime checks prove override → proxy → precomputed route → rendered gallery wiring.

1. Open a product on the Vercel preview at desktop width (1024px or wider).
2. Ensure the preview deployment has its Vercel Flags connection and clear any Toolbar overrides.
3. Toggle `pdp-gallery` off for the Preview environment and reload: existing grid, no marker.
4. Toggle it on and reload: `pdp-gallery enabled` appears over the grid.
5. At mobile width, the existing swipeable gallery remains, with no visible marker.

The thumbnail sidebar and single-large-image component are follow-up design work.