### PR TITLE
Add simple subscription purchase options

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -23,7 +23,7 @@ Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/do
 - **Variant picker** — shows available colors, sizes, and other options.
 - **Add to cart** — adds the selected variant without waiting for the full cart response.
 - **Quantity** — accepts values from 1 through 99.
-- **Subscriptions** — lets shoppers choose a recurring plan offered for the selected variant and check out through the cart. Configure plans in Shopify and enable the `unauthenticated_read_selling_plans` Storefront API permission.
+- **Subscriptions** — shows subscription options configured in Shopify.
 - **Gift cards** — collects recipient details and keeps gifts for different recipients separate in the cart.
 - **Buy with Shop** — starts Shopify checkout.
 - **Bundles** — shows included items and other bundles containing the product.

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -23,7 +23,7 @@ Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/do
 - **Variant picker** — shows available colors, sizes, and other options.
 - **Add to cart** — adds the selected variant without waiting for the full cart response.
 - **Quantity** — accepts values from 1 through 99.
-- **Subscriptions** — lets shoppers choose a recurring plan offered for the selected variant.
+- **Subscriptions** — lets shoppers choose a recurring plan offered for the selected variant and check out through the cart. Configure plans in Shopify and enable the `unauthenticated_read_selling_plans` Storefront API permission.
 - **Gift cards** — collects recipient details and keeps gifts for different recipients separate in the cart.
 - **Buy with Shop** — starts Shopify checkout.
 - **Bundles** — shows included items and other bundles containing the product.
@@ -32,16 +32,6 @@ Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/do
 - **Structured data** — describes the product and breadcrumbs to search engines.
 
 Quantity, Buy with Shop, bundles, complementary products, and related products are enabled by default. Disable sections that do not fit the catalog or purchase journey.
-
-## Offer subscriptions
-
-Create recurring selling plans in Shopify and assign them to product variants. Enable the `unauthenticated_read_selling_plans` Storefront API permission for your Headless channel. Products without plans keep the standard purchase controls.
-
-Shoppers can choose a one-time purchase or a named subscription plan. The purchase options show Shopify’s price for the first billing period; later pricing and subscription terms are confirmed at checkout. Products that require a subscription omit the one-time option and cannot be added without an eligible plan.
-
-The cart shows the selected plan and keeps one-time and subscription purchases separate. Subscription purchases use Add to Cart and the cart’s checkout button; the direct Buy with Shop link is hidden while a subscription is selected.
-
-This simple UI supports recurring plans among the first 100 allocations per variant. It does not provide subscription management, prepaid-plan scheduling, or non-recurring purchase options. Subscription management remains with your Shopify subscription app.
 
 ## What’s next
 

--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -23,6 +23,7 @@ Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/do
 - **Variant picker** — shows available colors, sizes, and other options.
 - **Add to cart** — adds the selected variant without waiting for the full cart response.
 - **Quantity** — accepts values from 1 through 99.
+- **Subscriptions** — lets shoppers choose a recurring plan offered for the selected variant.
 - **Gift cards** — collects recipient details and keeps gifts for different recipients separate in the cart.
 - **Buy with Shop** — starts Shopify checkout.
 - **Bundles** — shows included items and other bundles containing the product.
@@ -31,6 +32,16 @@ Product updates are cached and refreshed by Shopify webhooks. See [Webhooks](/do
 - **Structured data** — describes the product and breadcrumbs to search engines.
 
 Quantity, Buy with Shop, bundles, complementary products, and related products are enabled by default. Disable sections that do not fit the catalog or purchase journey.
+
+## Offer subscriptions
+
+Create recurring selling plans in Shopify and assign them to product variants. Enable the `unauthenticated_read_selling_plans` Storefront API permission for your Headless channel. Products without plans keep the standard purchase controls.
+
+Shoppers can choose a one-time purchase or a named subscription plan. The purchase options show Shopify’s price for the first billing period; later pricing and subscription terms are confirmed at checkout. Products that require a subscription omit the one-time option and cannot be added without an eligible plan.
+
+The cart shows the selected plan and keeps one-time and subscription purchases separate. Subscription purchases use Add to Cart and the cart’s checkout button; the direct Buy with Shop link is hidden while a subscription is selected.
+
+This simple UI supports recurring plans among the first 100 allocations per variant. It does not provide subscription management, prepaid-plan scheduling, or non-recurring purchase options. Subscription management remains with your Shopify subscription app.
 
 ## What’s next
 

--- a/apps/template/components/cart/overlay-item.tsx
+++ b/apps/template/components/cart/overlay-item.tsx
@@ -91,6 +91,11 @@ export function OverlayItem({ item }: OverlayItemProps) {
                 {merchandise.selectedOptions.map((option) => option.value).join(" / ")}
               </p>
             ) : null}
+            {item.sellingPlanAllocation ? (
+              <p className="text-xs text-muted-foreground">
+                {item.sellingPlanAllocation.sellingPlan.name || "Subscription"}
+              </p>
+            ) : null}
           </div>
           {components.length ? (
             <div className="grid gap-1">

--- a/apps/template/components/product-detail/buy-buttons.tsx
+++ b/apps/template/components/product-detail/buy-buttons.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { getShopPayButtonUrl } from "@shopify/hydrogen";
+import { formatMoney, getShopPayButtonUrl } from "@shopify/hydrogen";
 import { cn } from "cn";
 import { Loader2, MinusIcon, PlusIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 
 import { useCartDrawer } from "@/components/cart/context";
 import { useProductForm } from "@/components/product-detail/product-form";
 import { Button } from "@/components/ui/button";
+import { shopConfig } from "@/lib/config";
 import type { ProductFormVariant } from "@/lib/product/types";
 
 import { BuyWithShopLogo } from "./buy-with-shop-logo";
@@ -28,6 +29,16 @@ export function BuyButtons({
   const isSelectionUnresolved = !storeVariant;
   const [isBuyingNow, setIsBuyingNow] = useState(false);
   const [quantity, setQuantity] = useState(1);
+  const [purchaseOption, setPurchaseOption] = useState("");
+  const purchaseOptionId = useId();
+  const plans =
+    selectedVariant?.sellingPlanAllocations.filter(
+      (allocation) => allocation.sellingPlan.recurringDeliveries,
+    ) ?? [];
+  const selectedPlan =
+    plans.find((allocation) => allocation.sellingPlan.id === purchaseOption) ??
+    (selectedVariant?.requiresSellingPlan ? plans[0] : undefined);
+  const missingRequiredPlan = Boolean(selectedVariant?.requiresSellingPlan && !selectedPlan);
   const { openOverlay } = useCartDrawer();
 
   useEffect(() => {
@@ -51,6 +62,7 @@ export function BuyButtons({
     if (pending) return "Adding to Cart...";
     if (isSelectionUnresolved) return "Add to Cart";
     if (requiresBundleConfiguration) return "Choose bundle items";
+    if (missingRequiredPlan) return "Subscription unavailable";
     if (isOutOfStock) return "Out of Stock";
     return "Add to Cart";
   };
@@ -58,7 +70,13 @@ export function BuyButtons({
     <form
       {...formProps({
         beforeSubmit: (event) => {
-          if (isSelectionUnresolved || isOutOfStock || requiresBundleConfiguration || pending) {
+          if (
+            isSelectionUnresolved ||
+            isOutOfStock ||
+            requiresBundleConfiguration ||
+            missingRequiredPlan ||
+            pending
+          ) {
             event.preventDefault();
             return;
           }
@@ -67,6 +85,52 @@ export function BuyButtons({
       })}
       className="grid gap-2.5"
     >
+      {plans.length > 0 ? (
+        <fieldset className="grid gap-2.5" disabled={pending || isSelectionUnresolved}>
+          <legend className="pb-2.5 text-sm font-medium">Purchase options</legend>
+          {[
+            ...(!selectedVariant.requiresSellingPlan
+              ? [{ id: "", name: "One-time purchase", price: selectedVariant.price }]
+              : []),
+            ...plans.map((allocation) => ({
+              id: allocation.sellingPlan.id,
+              name: allocation.sellingPlan.name,
+              price: allocation.price,
+            })),
+          ].map((option) => (
+            <label
+              key={option.id}
+              className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-border p-4 has-checked:border-foreground has-disabled:cursor-not-allowed has-disabled:opacity-50"
+            >
+              <input
+                type="radio"
+                name={purchaseOptionId}
+                value={option.id}
+                checked={(selectedPlan?.sellingPlan.id ?? "") === option.id}
+                onChange={() => setPurchaseOption(option.id)}
+                className="size-4 cursor-pointer accent-foreground disabled:cursor-not-allowed"
+              />
+              <span className="flex flex-1 flex-wrap items-center justify-between gap-2.5 text-sm">
+                <span>{option.name}</span>
+                <span className="tabular-nums">
+                  {
+                    formatMoney(option.price, { locale: shopConfig.localization.locale })
+                      .localizedString
+                  }
+                </span>
+              </span>
+            </label>
+          ))}
+          {selectedPlan ? (
+            <p className="text-sm text-muted-foreground">
+              Recurring purchase.{" "}
+              {selectedPlan.sellingPlan.description ||
+                "Subscription details are shown at checkout."}
+            </p>
+          ) : null}
+        </fieldset>
+      ) : null}
+      <input type="hidden" name="sellingPlanId" value={selectedPlan?.sellingPlan.id ?? ""} />
       <input type="hidden" {...register("merchandiseId", {})} />
       <input type="hidden" {...register("quantity", { value: quantity })} />
       <div className="flex gap-2.5">
@@ -106,13 +170,19 @@ export function BuyButtons({
         <Button
           {...register("addToCart", {})}
           data-selection-unresolved={isSelectionUnresolved && !pending}
-          disabled={isSelectionUnresolved || isOutOfStock || requiresBundleConfiguration || pending}
+          disabled={
+            isSelectionUnresolved ||
+            isOutOfStock ||
+            requiresBundleConfiguration ||
+            missingRequiredPlan ||
+            pending
+          }
           className="h-12 min-w-0 flex-1 justify-center data-[selection-unresolved=true]:disabled:opacity-100"
         >
           {getButtonText()}
         </Button>
       </div>
-      {buyWithShop ? (
+      {buyWithShop && !selectedPlan && !selectedVariant.requiresSellingPlan ? (
         <a
           aria-busy={isBuyingNow || undefined}
           aria-disabled={buyNowUrl ? undefined : true}

--- a/apps/template/lib/cart/server.ts
+++ b/apps/template/lib/cart/server.ts
@@ -23,6 +23,11 @@ const CART_FRAGMENT = gql(/* GraphQL */ `
     updatedAt
     lines(first: 250) {
       nodes {
+        sellingPlanAllocation {
+          sellingPlan {
+            name
+          }
+        }
         discountAllocations {
           __typename
           discountedAmount {

--- a/apps/template/lib/product/index.ts
+++ b/apps/template/lib/product/index.ts
@@ -64,7 +64,9 @@ export function toProductFormVariant(variant: ProductVariant): ProductFormVarian
     price: variant.price,
     product: { handle: variant.productHandle, title: variant.productTitle },
     requiresBundleConfiguration: variant.requiresComponents && variant.components.length === 0,
+    requiresSellingPlan: variant.requiresSellingPlan,
     selectedOptions: variant.selectedOptions,
+    sellingPlanAllocations: variant.sellingPlanAllocations,
     title: variant.title,
   };
 }

--- a/apps/template/lib/product/types.ts
+++ b/apps/template/lib/product/types.ts
@@ -8,7 +8,15 @@ export type SelectedOptions = Record<string, string>;
 
 export type ProductFormVariant = Pick<
   ProductVariant,
-  "availableForSale" | "compareAtPrice" | "id" | "image" | "price" | "selectedOptions" | "title"
+  | "availableForSale"
+  | "compareAtPrice"
+  | "id"
+  | "image"
+  | "price"
+  | "requiresSellingPlan"
+  | "selectedOptions"
+  | "sellingPlanAllocations"
+  | "title"
 > & {
   product: { handle: string; title: string };
   requiresBundleConfiguration: boolean;
@@ -114,8 +122,22 @@ export interface ProductVariant {
   productHandle: string;
   productTitle: string;
   requiresComponents: boolean;
+  requiresSellingPlan: boolean;
   selectedOptions: SelectedOption[];
+  // Only the first 100 allocations are loaded, even when Shopify reports another page.
+  sellingPlanAllocations: SellingPlanAllocation[];
   title: string;
+}
+
+export interface SellingPlanAllocation {
+  compareAtPrice: Money;
+  price: Money;
+  sellingPlan: {
+    description?: string | null;
+    id: string;
+    name: string;
+    recurringDeliveries: boolean;
+  };
 }
 
 export interface ProductVariantComponent {

--- a/apps/template/lib/shopify/fragments/variant/index.ts
+++ b/apps/template/lib/shopify/fragments/variant/index.ts
@@ -30,7 +30,31 @@ export const PRODUCT_VARIANT_FRAGMENT = gql(
     }
     product {
       handle
+      requiresSellingPlan
       title
+    }
+    sellingPlanAllocations(first: 100) {
+      nodes {
+        priceAdjustments {
+          compareAtPrice {
+            amount
+            currencyCode
+          }
+          price {
+            amount
+            currencyCode
+          }
+        }
+        sellingPlan {
+          description
+          id
+          name
+          recurringDeliveries
+        }
+      }
+      pageInfo {
+        hasNextPage
+      }
     }
   }
 `,

--- a/apps/template/lib/shopify/transforms/product/index.ts
+++ b/apps/template/lib/shopify/transforms/product/index.ts
@@ -116,6 +116,18 @@ export function transformVariant(variant: ShopifyVariant): ProductVariant {
     bundleParents: variant.groupedBy?.nodes.map(transformVariantReference) ?? [],
     components: variant.components?.nodes.map(transformBundleComponent) ?? [],
     requiresComponents: variant.requiresComponents ?? false,
+    requiresSellingPlan: variant.product.requiresSellingPlan,
+    sellingPlanAllocations: variant.sellingPlanAllocations.nodes.map((allocation) => {
+      const adjustment = allocation.priceAdjustments[0];
+      if (!adjustment) {
+        throw new Error(`Missing selling plan price adjustment for variant ${variant.id}`);
+      }
+      return {
+        compareAtPrice: adjustment.compareAtPrice,
+        price: adjustment.price,
+        sellingPlan: allocation.sellingPlan,
+      };
+    }),
   };
 }
 

--- a/apps/template/lib/shopify/transforms/product/index.ts
+++ b/apps/template/lib/shopify/transforms/product/index.ts
@@ -119,12 +119,9 @@ export function transformVariant(variant: ShopifyVariant): ProductVariant {
     requiresSellingPlan: variant.product.requiresSellingPlan,
     sellingPlanAllocations: variant.sellingPlanAllocations.nodes.map((allocation) => {
       const adjustment = allocation.priceAdjustments[0];
-      if (!adjustment) {
-        throw new Error(`Missing selling plan price adjustment for variant ${variant.id}`);
-      }
       return {
-        compareAtPrice: adjustment.compareAtPrice,
-        price: adjustment.price,
+        compareAtPrice: adjustment?.compareAtPrice ?? variant.compareAtPrice ?? variant.price,
+        price: adjustment?.price ?? variant.price,
         sellingPlan: allocation.sellingPlan,
       };
     }),


### PR DESCRIPTION
## Summary
- Show one-time and recurring selling-plan options on product pages using Shopify allocation prices.
- Send the selected sellingPlanId through the existing Hydrogen cart form; show the plan name in cart and hide direct Shop Pay for subscription purchases.
- Handle subscription-required products, preserve variant selection, and document setup and limits.

## Verification
- pnpm typecheck: passed, including Storefront and Customer Account GraphQL validation.
- pnpm build: passed on Next.js 16.3.4.
- Focused oxfmt --check and oxlint: passed with zero warnings/errors; git diff --check passed.
- node /tmp/shop-navigation-FjHDrW/subscriptions-check.mjs: passed against local production server and the live climbmode-sweatshirt-unisex-d97d9e product. Verified monthly $84.60 purchase, plan name in cart, separate one-time/subscription lines, and variant change. No browser errors.

## Limits
- First 100 selling-plan allocations per variant; recurring plans only.
- No subscription management or prepaid scheduling UI.
- Checkout payment/order completion was not performed; subscription-only and unavailable-plan cases have not been verified against live products.
- Existing untracked lib/i18n files were left untouched and excluded.