### PR TITLE
Fix subscription purchase controls shifting after loading

### DIFF
--- a/apps/docs/content/docs/anatomy/pages/pdp.mdx
+++ b/apps/docs/content/docs/anatomy/pages/pdp.mdx
@@ -12,7 +12,7 @@ The Product Detail Page (PDP) gives shoppers the information and controls needed
 
 Product pages show the title, price, media, description, and available options. Option choices update the page URL, so shoppers can share a selected color, size, or other variant and use browser back and forward controls.
 
-While an option choice is being resolved, purchase controls temporarily block purchases without dimming or showing a loading indicator. They become available once the selected variant is confirmed; out-of-stock variants remain disabled.
+Subscription options can appear while a variant choice is being resolved, but purchase controls remain disabled until the selected variant is confirmed. Out-of-stock variants remain disabled.
 
 When colors have distinct media, the gallery leads with the selected color's image. Desktop shoppers get a grid and lightbox; mobile shoppers get a swipeable gallery.
 

--- a/apps/template/components/product-detail/buy-buttons.tsx
+++ b/apps/template/components/product-detail/buy-buttons.tsx
@@ -9,7 +9,9 @@ import { useCartDrawer } from "@/components/cart/context";
 import { useProductForm } from "@/components/product-detail/product-form";
 import { Button } from "@/components/ui/button";
 import { shopConfig } from "@/lib/config";
-import type { ProductFormVariant } from "@/lib/product/types";
+import type { Money } from "@/lib/money/types";
+import { getProductPurchaseOptions } from "@/lib/product";
+import type { ProductFormVariant, SellingPlanAllocation } from "@/lib/product/types";
 
 import { BuyWithShopLogo } from "./buy-with-shop-logo";
 
@@ -30,14 +32,7 @@ export function BuyButtons({
   const [isBuyingNow, setIsBuyingNow] = useState(false);
   const [quantity, setQuantity] = useState(1);
   const [purchaseOption, setPurchaseOption] = useState("");
-  const purchaseOptionId = useId();
-  const plans =
-    selectedVariant?.sellingPlanAllocations.filter(
-      (allocation) => allocation.sellingPlan.recurringDeliveries,
-    ) ?? [];
-  const selectedPlan =
-    plans.find((allocation) => allocation.sellingPlan.id === purchaseOption) ??
-    (selectedVariant?.requiresSellingPlan ? plans[0] : undefined);
+  const { plans, selectedPlan } = getProductPurchaseOptions(selectedVariant, purchaseOption);
   const missingRequiredPlan = Boolean(selectedVariant?.requiresSellingPlan && !selectedPlan);
   const { openOverlay } = useCartDrawer();
 
@@ -85,51 +80,14 @@ export function BuyButtons({
       })}
       className="grid gap-2.5"
     >
-      {plans.length > 0 ? (
-        <fieldset className="grid gap-2.5" disabled={pending || isSelectionUnresolved}>
-          <legend className="pb-2.5 text-sm font-medium">Purchase options</legend>
-          {[
-            ...(!selectedVariant.requiresSellingPlan
-              ? [{ id: "", name: "One-time purchase", price: selectedVariant.price }]
-              : []),
-            ...plans.map((allocation) => ({
-              id: allocation.sellingPlan.id,
-              name: allocation.sellingPlan.name,
-              price: allocation.price,
-            })),
-          ].map((option) => (
-            <label
-              key={option.id}
-              className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-border p-4 has-checked:border-foreground has-disabled:cursor-not-allowed has-disabled:opacity-50"
-            >
-              <input
-                type="radio"
-                name={purchaseOptionId}
-                value={option.id}
-                checked={(selectedPlan?.sellingPlan.id ?? "") === option.id}
-                onChange={() => setPurchaseOption(option.id)}
-                className="size-4 cursor-pointer accent-foreground disabled:cursor-not-allowed"
-              />
-              <span className="flex flex-1 flex-wrap items-center justify-between gap-2.5 text-sm">
-                <span>{option.name}</span>
-                <span className="tabular-nums">
-                  {
-                    formatMoney(option.price, { locale: shopConfig.localization.locale })
-                      .localizedString
-                  }
-                </span>
-              </span>
-            </label>
-          ))}
-          {selectedPlan ? (
-            <p className="text-sm text-muted-foreground">
-              Recurring purchase.{" "}
-              {selectedPlan.sellingPlan.description ||
-                "Subscription details are shown at checkout."}
-            </p>
-          ) : null}
-        </fieldset>
-      ) : null}
+      <PurchaseOptions
+        disabled={pending || isSelectionUnresolved}
+        onSelect={setPurchaseOption}
+        plans={plans}
+        price={selectedVariant.price}
+        requiresSellingPlan={selectedVariant.requiresSellingPlan}
+        selectedPlan={selectedPlan}
+      />
       <input type="hidden" name="sellingPlanId" value={selectedPlan?.sellingPlan.id ?? ""} />
       <input type="hidden" {...register("merchandiseId", {})} />
       <input type="hidden" {...register("quantity", { value: quantity })} />
@@ -212,5 +170,70 @@ export function BuyButtons({
         </a>
       ) : null}
     </form>
+  );
+}
+
+interface PurchaseOptionsProps {
+  disabled?: boolean;
+  onSelect?: (id: string) => void;
+  plans: SellingPlanAllocation[];
+  price: Money;
+  requiresSellingPlan: boolean;
+  selectedPlan: SellingPlanAllocation | undefined;
+}
+
+export function PurchaseOptions({
+  disabled = false,
+  onSelect,
+  plans,
+  price,
+  requiresSellingPlan,
+  selectedPlan,
+}: PurchaseOptionsProps) {
+  const purchaseOptionId = useId();
+  if (plans.length === 0) return null;
+
+  return (
+    <fieldset className="grid gap-2.5" disabled={disabled}>
+      <legend className="pb-2.5 text-sm font-medium">Purchase options</legend>
+      {[
+        ...(!requiresSellingPlan ? [{ id: "", name: "One-time purchase", price }] : []),
+        ...plans.map((allocation) => ({
+          id: allocation.sellingPlan.id,
+          name: allocation.sellingPlan.name,
+          price: allocation.price,
+        })),
+      ].map((option) => (
+        <label
+          key={option.id}
+          className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-border p-4 has-checked:border-foreground has-disabled:cursor-not-allowed has-disabled:opacity-50"
+        >
+          <input
+            type="radio"
+            name={purchaseOptionId}
+            value={option.id}
+            checked={(selectedPlan?.sellingPlan.id ?? "") === option.id}
+            onChange={onSelect ? () => onSelect(option.id) : undefined}
+            readOnly={!onSelect}
+            className="size-4 cursor-pointer accent-foreground disabled:cursor-not-allowed"
+          />
+          <span className="flex flex-1 flex-wrap items-center justify-between gap-2.5 text-sm">
+            <span>{option.name}</span>
+            <span className="tabular-nums">
+              {
+                formatMoney(option.price, { locale: shopConfig.localization.locale })
+                  .localizedString
+              }
+            </span>
+          </span>
+        </label>
+      ))}
+      {selectedPlan ? (
+        <p className="text-sm text-muted-foreground">
+          Recurring purchase.{" "}
+          {selectedPlan.sellingPlan.description || "Subscription details are shown at checkout."}
+        </p>
+      ) : null}
+    </fieldset>
   );
 }

--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -3,7 +3,7 @@ import { MinusIcon, PlusIcon } from "lucide-react";
 import { Suspense } from "react";
 
 import { BundleComponents, BundleParents } from "@/components/product-detail/bundle-components";
-import { BuyButtons } from "@/components/product-detail/buy-buttons";
+import { BuyButtons, PurchaseOptions } from "@/components/product-detail/buy-buttons";
 import { BuyWithShopLogo } from "@/components/product-detail/buy-with-shop-logo";
 import { ComplementaryProducts } from "@/components/product-detail/complementary-products";
 import { ProductOpenGraph } from "@/components/product-detail/open-graph";
@@ -31,6 +31,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { shopConfig } from "@/lib/config";
 import {
+  getProductPurchaseOptions,
   getSelectedColorImage,
   getSharedImages,
   hasColorImagePartitioning,
@@ -291,7 +292,11 @@ function ProductInfoFallback({
       {product.isGiftCard ? (
         <GiftCardPurchaseFormFallback />
       ) : (
-        <BuyButtonsFallback showLabel={showLabel} allInStock={allInStock} />
+        <BuyButtonsFallback
+          allInStock={allInStock}
+          showLabel={showLabel}
+          variant={product.defaultVariant}
+        />
       )}
     </>
   );
@@ -360,21 +365,33 @@ function QuantityPickerFallback() {
 }
 
 function BuyButtonsFallback({
-  showLabel,
   allInStock,
+  showLabel,
+  variant,
 }: {
   allInStock: boolean;
   showLabel: boolean;
+  variant: ProductVariant | undefined;
 }) {
+  const { plans, selectedPlan } = getProductPurchaseOptions(variant);
   return (
     <div className="grid gap-2.5">
+      {variant ? (
+        <PurchaseOptions
+          disabled
+          plans={plans}
+          price={variant.price}
+          requiresSellingPlan={variant.requiresSellingPlan}
+          selectedPlan={selectedPlan}
+        />
+      ) : null}
       <div className="flex gap-2.5">
         {shopConfig.pdp.quantityPicker.isEnabled ? <QuantityPickerFallback /> : null}
         <div className="flex h-12 min-w-0 flex-1 items-center justify-center rounded-lg bg-primary text-sm font-medium text-primary-foreground">
           {showLabel ? (allInStock ? "Add to Cart" : "Out of Stock") : null}
         </div>
       </div>
-      {shopConfig.pdp.buyWithShop.isEnabled ? (
+      {shopConfig.pdp.buyWithShop.isEnabled && !selectedPlan && !variant?.requiresSellingPlan ? (
         <div
           className={cn(
             "flex h-12 items-center justify-center rounded-lg bg-shop px-4 text-white",

--- a/apps/template/lib/product/index.ts
+++ b/apps/template/lib/product/index.ts
@@ -54,6 +54,20 @@ export function toStaticOptionGroups(product: ProductDetails): OptionGroupState[
   }));
 }
 
+export function getProductPurchaseOptions(
+  variant: Pick<ProductVariant, "requiresSellingPlan" | "sellingPlanAllocations"> | undefined,
+  purchaseOption = "",
+) {
+  const plans =
+    variant?.sellingPlanAllocations.filter(
+      (allocation) => allocation.sellingPlan.recurringDeliveries,
+    ) ?? [];
+  const selectedPlan =
+    plans.find((allocation) => allocation.sellingPlan.id === purchaseOption) ??
+    (variant?.requiresSellingPlan ? plans[0] : undefined);
+  return { plans, selectedPlan };
+}
+
 // Customized bundle parents have no fixed components; only their gating boolean crosses the client boundary.
 export function toProductFormVariant(variant: ProductVariant): ProductFormVariant {
   return {


### PR DESCRIPTION
## Summary

The multi-variant PDP fallback rendered quantity, Add to Cart, and Buy with Shop without any subscription controls. Resolving the form then inserted the purchase-option rows and recurring disclosure, and removed Buy with Shop for subscription-only products.

- Render the known default variant's subscription choices and prices immediately in the purchase fallback, using data already in the cached product response.
- Share `PurchaseOptions` markup and recurring-plan selection logic between the fallback and interactive form.
- Keep fallback options disabled/read-only, with inert purchase placeholders until variant resolution completes.
- Match Buy with Shop visibility for subscription-only products, including missing required plans.
- Keep the PDP documentation concise and describe the disabled loading state.

No Shopify queries, cache contracts, URL selection, cart submission behavior, or dependencies changed.

## Limits

This fixes the missing subscription UI in the default-variant fallback. A URL-selected variant with different plan counts, descriptions, or prices can still change the layout when it resolves; the fallback does not claim to know that variant yet. Browser CLS/hydration measurements and live checkout have not been performed.

## Verification

Passed, exit 0:

- `pnpm --filter template typecheck` (route types, TypeScript, both GraphQL projects)
- `pnpm --filter template build` (Next 16.3.4, 33 pages generated)
- `pnpm --filter template exec oxlint components/product-detail/buy-buttons.tsx components/product-detail/product-detail-section.tsx lib/product/index.ts` (0 warnings/errors)
- `pnpm --filter template exec oxfmt --check components/product-detail/buy-buttons.tsx components/product-detail/product-detail-section.tsx lib/product/index.ts`
- `pnpm --filter docs exec oxfmt --check content/docs/anatomy/pages/pdp.mdx`
- `git diff --check`
- Ephemeral inline `node` SSR probe using actual source transpiled through Next SWC and ReactDOMServer: 566 renders, 270 normalized comparisons against the original implementation, and 270 submit-guard checks; no React warnings. Covered optional/required subscriptions, one/multiple plans, missing/nonrecurring plans, stale selections, pending/unresolved/out-of-stock/bundle states, and configuration toggles. Hydrogen hooks and unrelated imports were mocked; this does not establish browser geometry or live checkout correctness.

No test files, suites, or dependencies added. Existing untracked `apps/template/lib/i18n/` files were left untouched.