### PR TITLE
Defer PDP recommendations

### DIFF
--- a/apps/template/components/product-detail/complementary-products.tsx
+++ b/apps/template/components/product-detail/complementary-products.tsx
@@ -1,22 +1,51 @@
+import { unstable_navigation } from "next/cache";
 import Image from "next/image";
+import { Suspense } from "react";
 
 import { Price } from "@/components/product/price";
 import { ImagePlaceholder } from "@/components/ui/image-placeholder";
 import Link from "@/components/ui/link";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { ProductCard } from "@/lib/product/types";
 import { getComplementaryProducts } from "@/lib/shopify/operations/products/server";
 
-export async function ComplementaryProducts({
-  handle,
-  limit,
-  locale,
-  title,
-}: {
+interface ComplementaryProductsProps {
   handle: string;
   limit: number;
   locale: string;
   title: string;
-}) {
+}
+
+export function ComplementaryProducts(props: ComplementaryProductsProps) {
+  return (
+    <Suspense fallback={<ComplementaryProductsSkeleton limit={props.limit} title={props.title} />}>
+      <Render {...props} />
+    </Suspense>
+  );
+}
+
+function ComplementaryProductsSkeleton({ limit, title }: { limit: number; title: string }) {
+  return (
+    <div className="grid gap-2.5" data-slot="complementary-products">
+      <h2 className="font-medium text-foreground/70 text-sm">{title}</h2>
+      <div className="grid gap-2.5" aria-hidden="true">
+        {Array.from({ length: limit }, (_, index) => (
+          <div
+            key={index}
+            className="flex items-center gap-2.5 rounded-lg border border-border p-2.5"
+          >
+            <Skeleton className="size-12 shrink-0 rounded-md" />
+            <Skeleton className="h-4 min-w-0 flex-1" />
+            <Skeleton className="h-4 w-12 shrink-0" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+async function Render({ handle, limit, locale, title }: ComplementaryProductsProps) {
+  await unstable_navigation();
   const complementary = await getComplementaryProducts({ handle, locale });
   if (complementary.length === 0) return null;
 

--- a/apps/template/components/product/related-products-section.tsx
+++ b/apps/template/components/product/related-products-section.tsx
@@ -1,4 +1,5 @@
 import { getTranslations } from "next-intl/server";
+import { unstable_navigation } from "next/cache";
 import { Suspense } from "react";
 
 import { ProductCard, ProductCardSkeleton } from "@/components/product-card/product-card";
@@ -27,6 +28,7 @@ async function Render({
   limit: number;
   locale: Locale;
 }) {
+  await unstable_navigation();
   const resolvedHandle = await handle;
   const [t, related] = await Promise.all([
     getTranslations("product"),


### PR DESCRIPTION
Give complementary products their own Suspense boundary and defer both recommendation fetches until navigation. Keep existing data caches and core PDP prefetching unchanged.

Typecheck, GraphQL checks, focused lint/format, and 12 mocked streaming scenarios pass. Browser performance and a production build remain unverified.