### PR TITLE
Preserve carts when lookup fails

### DIFF
--- a/apps/template/lib/cart/server.ts
+++ b/apps/template/lib/cart/server.ts
@@ -77,6 +77,7 @@ export async function getCartById(cartId: string): Promise<Cart | undefined> {
   const url = new URL("/api/cart", shopConfig.site.url);
   url.searchParams.set("cartId", cartId);
   const { data } = await handlers.get({ ...context, request: new Request(url) } as never);
+  if (data.errors?.length) throw new Error(data.errors[0].message);
   return data.cart ?? undefined;
 }
 


### PR DESCRIPTION
Keep cart lookup errors distinct from missing carts. Agent setup returns 503 instead of creating a replacement cart after a failed lookup.

Verified typecheck and mocked-upstream checks for existing, missing, and failed lookups. No docs or skills changes.