### PR TITLE
Simplify Eve default-tool configuration

### DIFF
--- a/apps/template/agent/agent.ts
+++ b/apps/template/agent/agent.ts
@@ -4,6 +4,7 @@ import { defineAgent } from "eve";
 import { catalogMiddleware } from "./lib/catalog-middleware";
 
 export default defineAgent({
+  defaultTools: false,
   limits: {
     maxInputTokensPerSession: 100_000,
     maxOutputTokensPerSession: 10_000,

--- a/apps/template/agent/tools/agent.ts
+++ b/apps/template/agent/tools/agent.ts
@@ -1,3 +1,0 @@
-import { disableTool } from "eve/tools";
-
-export default disableTool();

--- a/apps/template/agent/tools/ask_question.ts
+++ b/apps/template/agent/tools/ask_question.ts
@@ -1,3 +1,0 @@
-import { disableTool } from "eve/tools";
-
-export default disableTool();

--- a/apps/template/agent/tools/bash.ts
+++ b/apps/template/agent/tools/bash.ts
@@ -1,3 +1,0 @@
-import { disableTool } from "eve/tools";
-
-export default disableTool();

--- a/apps/template/agent/tools/load_skill.ts
+++ b/apps/template/agent/tools/load_skill.ts
@@ -1,3 +1,0 @@
-import { disableTool } from "eve/tools";
-
-export default disableTool();

--- a/apps/template/agent/tools/read_file.ts
+++ b/apps/template/agent/tools/read_file.ts
@@ -1,3 +1,0 @@
-import { disableTool } from "eve/tools";
-
-export default disableTool();

--- a/apps/template/agent/tools/task_cancel.ts
+++ b/apps/template/agent/tools/task_cancel.ts
@@ -1,3 +1,0 @@
-import { disableTool } from "eve/tools";
-
-export default disableTool();

--- a/apps/template/agent/tools/task_update.ts
+++ b/apps/template/agent/tools/task_update.ts
@@ -1,3 +1,0 @@
-import { disableTool } from "eve/tools";
-
-export default disableTool();

--- a/apps/template/agent/tools/todo.ts
+++ b/apps/template/agent/tools/todo.ts
@@ -1,3 +1,0 @@
-import { disableTool } from "eve/tools";
-
-export default disableTool();

--- a/apps/template/agent/tools/web_fetch.ts
+++ b/apps/template/agent/tools/web_fetch.ts
@@ -1,3 +1,0 @@
-import { disableTool } from "eve/tools";
-
-export default disableTool();

--- a/apps/template/agent/tools/web_search.ts
+++ b/apps/template/agent/tools/web_search.ts
@@ -1,3 +1,0 @@
-import { disableTool } from "eve/tools";
-
-export default disableTool();

--- a/apps/template/agent/tools/write_file.ts
+++ b/apps/template/agent/tools/write_file.ts
@@ -1,3 +1,0 @@
-import { disableTool } from "eve/tools";
-
-export default disableTool();


### PR DESCRIPTION
Replace eleven disableTool() stubs with defaultTools: false. Keep the eleven shopping tools, connection_search, and the disabled home channel. The agent remains disabled by default.

Verification: eve info --json before/after confirmed identical compiled tool descriptors, schemas, connections, routes, instructions, and limits. pnpm --filter template typecheck, focused oxlint/oxfmt, and git diff HEAD --check passed. No live conversation check; docs and skills unchanged.