### PR TITLE
Unify PDP purchase state under Hydrogen

### DIFF
--- a/apps/template/components/product-detail/product-detail-section.tsx
+++ b/apps/template/components/product-detail/product-detail-section.tsx
@@ -1,6 +1,6 @@
 import { cn } from "cn";
 import { MinusIcon, PlusIcon } from "lucide-react";
-import { Suspense } from "react";
+import { type ReactNode, Suspense } from "react";
 
 import { BundleComponents, BundleParents } from "@/components/product-detail/bundle-components";
 import { BuyButtons, PurchaseOptions } from "@/components/product-detail/buy-buttons";
@@ -12,7 +12,6 @@ import {
   ProductForm,
   ProductFormOptions,
   ProductFormPrice,
-  ProductInfoShell,
 } from "@/components/product-detail/product-form";
 import {
   ProductInfoDescription,
@@ -36,7 +35,6 @@ import {
   getSharedImages,
   hasColorImagePartitioning,
   toProductFormInput,
-  toProductFormVariant,
   toStaticOptionGroups,
 } from "@/lib/product";
 import { type SelectedOptions } from "@/lib/product/types";
@@ -173,7 +171,10 @@ function ProductInfoArea({
   const hasOptions = options.some((option) => option.values.length > 1);
   return (
     <div className="grid gap-10 lg:sticky lg:top-20 lg:col-span-4">
-      <ProductInfoShell>
+      <div
+        className="grid data-[uniform-price=true]:gap-10"
+        data-uniform-price={product.hasUniformPricing}
+      >
         <div data-slot="product-info-header">
           <h1 className="text-foreground text-3xl">{product.title}</h1>
           {product.hasUniformPricing ? (
@@ -182,16 +183,21 @@ function ProductInfoArea({
               currencyCode={product.priceRange.minVariantPrice.currencyCode}
               compareAtAmount={product.compareAtPriceRange?.minVariantPrice.amount}
             />
-          ) : (
-            // h-7 matches the resolved price's text-xl line-height (1.75rem) — keep in sync to avoid CLS
-            <Suspense fallback={<div className="h-7" aria-hidden />}>
-              <ResolvedProductPrice variantPromise={variantPromise} />
-            </Suspense>
-          )}
+          ) : null}
         </div>
 
         {singleVariant ? (
-          <ProductInfoContent product={product} selectedVariant={product.defaultVariant} />
+          <ProductInfoContent
+            priceSlot={
+              !product.hasUniformPricing ? (
+                <Suspense fallback={<div className="h-7" aria-hidden />}>
+                  <ResolvedProductPrice variantPromise={variantPromise} />
+                </Suspense>
+              ) : undefined
+            }
+            product={product}
+            selectedVariant={product.defaultVariant}
+          />
         ) : (
           <Suspense
             fallback={
@@ -206,7 +212,7 @@ function ProductInfoArea({
             <ResolvedProductInfo product={product} variantPromise={variantPromise} />
           </Suspense>
         )}
-      </ProductInfoShell>
+      </div>
 
       {!product.isGiftCard && shopConfig.pdp.bundles.isEnabled ? (
         <BundleRelationships variant={product.defaultVariant} />
@@ -227,7 +233,13 @@ async function ResolvedProductPrice({
   variantPromise: Promise<ProductVariant | undefined>;
 }) {
   const variant = await variantPromise;
-  return <ProductFormPrice fallbackVariant={variant ? toProductFormVariant(variant) : undefined} />;
+  return (
+    <ProductFormPrice
+      fallbackVariant={
+        variant ? { compareAtPrice: variant.compareAtPrice, price: variant.price } : undefined
+      }
+    />
+  );
 }
 
 async function ResolvedProductInfo({
@@ -242,28 +254,38 @@ async function ResolvedProductInfo({
 
 // The store is seeded from the URL-resolved variant so server HTML and client state agree on first paint.
 function ProductInfoContent({
+  priceSlot,
   product,
   selectedVariant,
 }: {
+  priceSlot?: ReactNode;
   product: ProductDetails;
   selectedVariant: ProductVariant | undefined;
 }) {
-  const fallbackVariant = selectedVariant ? toProductFormVariant(selectedVariant) : undefined;
+  const formProduct = toProductFormInput(product, selectedVariant);
+  const fallbackVariant = formProduct.selectedOrFirstAvailableVariant ?? undefined;
   const hasOptions = product.options.some((option) => option.values.length > 1);
 
   return (
-    <ProductForm product={toProductFormInput(product, selectedVariant)}>
-      {hasOptions ? <ProductFormOptions /> : null}
-      {product.isGiftCard ? (
-        <GiftCardPurchaseForm />
-      ) : (
-        <BuyButtons
-          fallbackVariant={fallbackVariant}
-          availableForSale={product.availableForSale}
-          buyWithShop={shopConfig.pdp.buyWithShop.isEnabled}
-          quantityPicker={shopConfig.pdp.quantityPicker.isEnabled}
-        />
-      )}
+    <ProductForm product={formProduct}>
+      <div className="grid gap-10">
+        {!product.hasUniformPricing ? (
+          <div data-slot="product-info-price">
+            {priceSlot ?? <ProductFormPrice fallbackVariant={fallbackVariant} />}
+          </div>
+        ) : null}
+        {hasOptions ? <ProductFormOptions handle={product.handle} /> : null}
+        {product.isGiftCard ? (
+          <GiftCardPurchaseForm />
+        ) : (
+          <BuyButtons
+            fallbackVariant={fallbackVariant}
+            availableForSale={product.availableForSale}
+            buyWithShop={shopConfig.pdp.buyWithShop.isEnabled}
+            quantityPicker={shopConfig.pdp.quantityPicker.isEnabled}
+          />
+        )}
+      </div>
     </ProductForm>
   );
 }
@@ -280,7 +302,8 @@ function ProductInfoFallback({
   showLabel: boolean;
 }) {
   return (
-    <>
+    <div className="grid gap-10">
+      {!product.hasUniformPricing ? <div className="h-7" aria-hidden /> : null}
       {hasOptions ? (
         <ProductInfoOptions options={toStaticOptionGroups(product)} hideImages />
       ) : null}
@@ -293,7 +316,7 @@ function ProductInfoFallback({
           variant={product.defaultVariant}
         />
       )}
-    </>
+    </div>
   );
 }
 

--- a/apps/template/components/product-detail/product-form.tsx
+++ b/apps/template/components/product-detail/product-form.tsx
@@ -1,36 +1,18 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
+import type { ReactNode } from "react";
 
 import { ProductInfoOptions } from "@/components/product-detail/product-info";
 import { ProductPrice } from "@/components/product-detail/product-price";
 import { buildProductUrl } from "@/lib/product";
 import { ProductProvider, useProduct } from "@/lib/product/client";
-import {
-  type OptionGroupState,
-  type ProductFormInput,
-  type ProductFormSwatch,
-  type ProductFormVariant,
+import type {
+  OptionGroupState,
+  ProductFormInput,
+  ProductFormSwatch,
+  ProductFormVariant,
 } from "@/lib/product/types";
-
-const ProductHandleContext = createContext<string | null>(null);
-
-// The header price sits in the static shell above the form's Suspense boundary, so the
-// resolved form publishes its selection up through this bridge instead of owning the header.
-const SelectedVariantContext = createContext<{
-  publish: (variant: ProductFormVariant | null) => void;
-  variant: ProductFormVariant | null;
-} | null>(null);
-
-export function ProductInfoShell({ children }: { children: ReactNode }) {
-  const [variant, publish] = useState<ProductFormVariant | null>(null);
-  return (
-    <SelectedVariantContext.Provider value={{ publish, variant }}>
-      {children}
-    </SelectedVariantContext.Provider>
-  );
-}
 
 export function ProductForm({
   children,
@@ -42,73 +24,52 @@ export function ProductForm({
   const router = useRouter();
   const searchParams = useSearchParams();
   return (
-    <ProductHandleContext.Provider value={product.handle}>
-      <ProductProvider
-        product={product}
-        onSelect={(result) => {
-          const handle = result.selectedVariant?.product.handle ?? product.handle;
-          router.replace(buildProductUrl(handle, result.selectedOptions, searchParams), {
-            scroll: false,
-          });
-        }}
-      >
-        <SelectedVariantPublisher />
-        {children}
-      </ProductProvider>
-    </ProductHandleContext.Provider>
+    <ProductProvider
+      product={product}
+      onSelect={(result) => {
+        const handle = result.selectedVariant?.product.handle ?? product.handle;
+        router.replace(buildProductUrl(handle, result.selectedOptions, searchParams), {
+          scroll: false,
+        });
+      }}
+    >
+      {children}
+    </ProductProvider>
   );
 }
 
-function SelectedVariantPublisher() {
-  const bridge = useContext(SelectedVariantContext);
-  const { selectedVariant } = useProduct();
-  useEffect(() => {
-    bridge?.publish(selectedVariant);
-  }, [bridge, selectedVariant]);
-  return null;
+interface ProductFormOptionsProps {
+  handle: string;
 }
 
-function useProductFormState(): {
-  options: OptionGroupState[];
-  selectOption: (name: string, value: string) => void;
-  selectedVariant: ProductFormVariant | null;
-} {
-  const productHandle = useContext(ProductHandleContext);
-  const { options, selectOption, selectedVariant } = useProduct();
-  return {
-    options: options.map((option) => ({
-      name: option.name,
-      values: option.values.map((value) => {
-        const swatch = value.swatch as ProductFormSwatch | undefined;
-        return {
-          available: value.available,
-          crossProduct: value.handle !== productHandle,
-          exists: value.exists,
-          href: buildProductUrl(value.handle, value.selectedOptions),
-          image: swatch?.variantImage,
-          name: value.name,
-          selected: value.selected,
-          swatch: swatch ? { color: swatch.color, image: swatch.image } : undefined,
-        };
-      }),
-    })),
-    selectOption,
-    selectedVariant,
-  };
+export function ProductFormOptions({ handle }: ProductFormOptionsProps) {
+  const { options, selectOption } = useProduct();
+  const optionGroups: OptionGroupState[] = options.map((option) => ({
+    name: option.name,
+    values: option.values.map((value) => {
+      const swatch = value.swatch as ProductFormSwatch | undefined;
+      return {
+        available: value.available,
+        crossProduct: value.handle !== handle,
+        exists: value.exists,
+        href: buildProductUrl(value.handle, value.selectedOptions),
+        image: swatch?.variantImage,
+        name: value.name,
+        selected: value.selected,
+        swatch: swatch ? { color: swatch.color, image: swatch.image } : undefined,
+      };
+    }),
+  }));
+  return <ProductInfoOptions options={optionGroups} onSelectValue={selectOption} />;
 }
 
-export function ProductFormOptions() {
-  const { options, selectOption } = useProductFormState();
-  return <ProductInfoOptions options={options} onSelectValue={selectOption} />;
-}
-
-// Renders inside ProductInfoShell, not ProductForm; the server-resolved variant wins until the form publishes.
 export function ProductFormPrice({
   fallbackVariant,
 }: {
-  fallbackVariant: ProductFormVariant | undefined;
+  fallbackVariant: Pick<ProductFormVariant, "compareAtPrice" | "price"> | undefined;
 }) {
-  const variant = useContext(SelectedVariantContext)?.variant ?? fallbackVariant;
+  const { selectedVariant } = useProduct();
+  const variant = selectedVariant ?? fallbackVariant;
   if (!variant) return null;
   return (
     <ProductPrice

--- a/apps/template/lib/product/index.ts
+++ b/apps/template/lib/product/index.ts
@@ -67,7 +67,7 @@ export function getProductPurchaseOptions(
 }
 
 // Customized bundle parents have no fixed components; only their gating boolean crosses the client boundary.
-export function toProductFormVariant(variant: ProductVariant): ProductFormVariant {
+function toProductFormVariant(variant: ProductVariant): ProductFormVariant {
   return {
     availableForSale: variant.availableForSale,
     compareAtPrice: variant.compareAtPrice,


### PR DESCRIPTION
Put the variant-dependent price, options, and purchase controls under one Hydrogen provider. Remove the two custom contexts and selected-variant publisher effect, and reuse one projected purchase input for the provider and display fallbacks. Keep the thin projection that excludes bundle relationship payloads.

Preserve the static heading and uniform price, streamed fallback geometry, single-variant shortcut, URL behavior, and purchase safeguards. No GraphQL, cache policy, image, agent lifecycle, docs, or skills changes.

Verification: pnpm --filter template typecheck and pnpm --filter template build passed (34 pages), plus focused lint/format checks and 125 isolated React/Hydrogen assertions. Production-browser checks with real Shopify reads covered regular and gift-card variants, price/purchase-ID agreement, query preservation, reload, field retention through navigation, and deliberately delayed variant queries. Live color, sparse-selection, bundle, subscription, and combined-listing cases were not exercised; these remain fixture coverage where applicable. No live cart submissions or checkout.