### PR TITLE
Wait for agent settlement and cart confirmation

### DIFF
--- a/apps/template/components/agent/agent-panel.tsx
+++ b/apps/template/components/agent/agent-panel.tsx
@@ -5,7 +5,7 @@ import { MinusIcon, Trash2Icon } from "lucide-react";
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
 
 import { useScrollContain } from "@/hooks/use-scroll-contain";
-import { setAgentCartPending } from "@/lib/agent/cart/client";
+import { setAgentCartStatus, useAgentCartPending } from "@/lib/agent/cart/client";
 import { readStoredChat, writeStoredChat } from "@/lib/agent/chat/client";
 
 import { AgentCartBridge } from "./cart-bridge";
@@ -26,9 +26,21 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
   const [input, setInput] = useState(stored.input);
   const snapshot = useRef(stored);
   const [clearing, setClearing] = useState(false);
+  const clearAttempt = useRef<{
+    reject: (error: Error) => void;
+    resolve: () => void;
+  } | null>(null);
+  const cartPending = useAgentCartPending();
   const [controlError, setControlError] = useState<string | null>(null);
   const agent = useEveAgent({
     initialSession: stored.session,
+    onError(cause) {
+      clearAttempt.current?.reject(cause);
+    },
+    onFinish(finished) {
+      if (finished.error) clearAttempt.current?.reject(finished.error);
+      else clearAttempt.current?.resolve();
+    },
     onSessionChange(session) {
       snapshot.current.session = session ? { ...session, streamIndex: 0 } : undefined;
       writeStoredChat(snapshot.current);
@@ -91,9 +103,12 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
     return () => {
       window.removeEventListener("pagehide", flush);
       flush();
+      clearAttempt.current?.reject(new Error("Conversation closed"));
+      clearAttempt.current = null;
     };
   }, []);
   function clearChat() {
+    setAgentCartStatus("pending");
     agent.reset();
     setInput("");
     setClearing(false);
@@ -131,9 +146,9 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
     });
   };
   const handleSend = (text: string) => {
-    if (busy || clearing || hasReachedLimit) return;
+    if (busy || clearing || cartPending || hasReachedLimit) return;
     pinnedRef.current = true;
-    setAgentCartPending(true);
+    setAgentCartStatus("pending");
     setControlError(null);
     void agent
       .send(text)
@@ -145,30 +160,38 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
     setInput("");
   };
   const handleClear = async () => {
-    if (clearing) return;
+    if (clearAttempt.current) return;
     setClearing(true);
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    let couldNotStop = false;
+    setControlError(null);
+    const attempt = Promise.withResolvers<void>();
+    clearAttempt.current = attempt;
+    const timeout = setTimeout(
+      () => attempt.reject(new Error("Cancellation timed out")),
+      CANCEL_TIMEOUT_MS,
+    );
     try {
-      await Promise.race([
-        agent.cancel(),
-        new Promise<never>((_, reject) => {
-          timeout = setTimeout(
-            () => reject(new Error("Cancellation timed out")),
-            CANCEL_TIMEOUT_MS,
-          );
-        }),
-      ]);
+      void agent.cancel().then((result) => {
+        if (result.status === "no_active_turn") attempt.resolve();
+      }, attempt.reject);
+      await attempt.promise;
+      if (clearAttempt.current !== attempt) return;
+      clearChat();
+      if (busy || status === "error")
+        setControlError(
+          "Started a new chat. Check your cart before repeating an interrupted change.",
+        );
     } catch {
-      couldNotStop = true;
+      if (clearAttempt.current === attempt)
+        setControlError(
+          "Could not confirm the response stopped. Your conversation was kept. Try Stop or Clear again.",
+        );
     } finally {
       clearTimeout(timeout);
-      clearChat();
+      if (clearAttempt.current === attempt) {
+        clearAttempt.current = null;
+        setClearing(false);
+      }
     }
-    if (couldNotStop)
-      setControlError(
-        "Started a new chat, but the previous response may still finish. Check your cart before requesting another change.",
-      );
   };
   return (
     <div
@@ -234,7 +257,7 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
       {(clearing || (status === "resuming" && messages.length > 0)) && (
         <p role="status" className="px-5 py-2 text-muted-foreground text-xs">
           {clearing
-            ? "Starting a new conversation…"
+            ? "Waiting for the response to stop…"
             : "Restoring your conversation… Clear chat to start fresh."}
         </p>
       )}
@@ -245,7 +268,7 @@ export function AgentPanel({ onOpenChange, open, triggerRef }: AgentPanelProps) 
       )}
       <AgentCartBridge messages={messages} status={status} />
       <AgentComposer
-        disabled={clearing || hasReachedLimit}
+        disabled={!busy && (clearing || cartPending || hasReachedLimit)}
         onChange={setInput}
         onStop={handleStop}
         onSubmit={handleSend}

--- a/apps/template/components/agent/cart-bridge.tsx
+++ b/apps/template/components/agent/cart-bridge.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef } from "react";
 
 import { useCartDrawer } from "@/components/cart/context";
 import { getCartMutationResult } from "@/lib/agent/cart";
-import { setAgentCartPending, useAgentCartPending } from "@/lib/agent/cart/client";
+import { setAgentCartStatus, useAgentCartStatus } from "@/lib/agent/cart/client";
 
 export function AgentCartBridge({
   messages,
@@ -24,11 +24,10 @@ export function AgentCartBridge({
   const observedLoading = useRef(false);
   const previousNetworkErrorAt = useRef(0);
   const shouldOpen = useRef(false);
-  const agentPending = useAgentCartPending();
+  const cartStatus = useAgentCartStatus();
   const busy = status === "submitted" || status === "streaming" || status === "resuming";
-  const refreshFailed = !busy && agentPending && cart.errors.network.length > 0;
   useEffect(() => {
-    setAgentCartPending(true);
+    setAgentCartStatus("pending");
     let cartChanged = false;
     for (const message of messages)
       for (const part of message.parts) {
@@ -52,24 +51,34 @@ export function AgentCartBridge({
   useEffect(() => {
     if (!refreshing.current) return;
     if (cart.loading || cart.revalidating) {
+      setAgentCartStatus("pending");
       observedLoading.current = true;
       previousNetworkErrorAt.current = cart.errors.networkUpdatedAt;
       return;
     }
+    if (!observedLoading.current) return;
     // Hydrogen retains network errors from unrelated mutations across refreshes.
     if (
-      !observedLoading.current ||
-      (cart.errors.network.length && cart.errors.networkUpdatedAt > previousNetworkErrorAt.current)
-    )
+      cart.errors.network.length &&
+      cart.errors.networkUpdatedAt > previousNetworkErrorAt.current
+    ) {
+      setAgentCartStatus("failed");
       return;
+    }
     refreshing.current = false;
-    if (!busy) setAgentCartPending(false);
+    if (!busy) setAgentCartStatus("ready");
     if (shouldOpen.current) {
       shouldOpen.current = false;
       openOverlay();
     }
   }, [busy, cart, openOverlay]);
-  if (!refreshFailed) return null;
+  if (busy || cartStatus === "ready") return null;
+  if (cartStatus === "pending" || cart.loading || cart.revalidating)
+    return (
+      <p role="status" className="px-5 py-2 text-muted-foreground text-xs">
+        Confirming your cart…
+      </p>
+    );
   return (
     <div role="alert" className="grid gap-2.5 px-5 py-2 text-red-500 text-xs">
       <p>
@@ -79,7 +88,7 @@ export function AgentCartBridge({
         className="w-fit cursor-pointer underline underline-offset-4 disabled:cursor-not-allowed disabled:opacity-40"
         disabled={cart.loading || cart.revalidating}
         onClick={() => {
-          setAgentCartPending(true);
+          setAgentCartStatus("pending");
           refreshing.current = true;
           observedLoading.current = false;
           refresh();

--- a/apps/template/lib/agent/cart/client.ts
+++ b/apps/template/lib/agent/cart/client.ts
@@ -2,16 +2,18 @@
 
 import { useSyncExternalStore } from "react";
 
-let pending = false;
+type AgentCartStatus = "failed" | "pending" | "ready";
+
+let status: AgentCartStatus = "ready";
 const listeners = new Set<() => void>();
 
-export function setAgentCartPending(value: boolean) {
-  if (pending === value) return;
-  pending = value;
+export function setAgentCartStatus(value: AgentCartStatus) {
+  if (status === value) return;
+  status = value;
   for (const listener of listeners) listener();
 }
 
-export function useAgentCartPending() {
+export function useAgentCartStatus() {
   return useSyncExternalStore(
     (listener) => {
       listeners.add(listener);
@@ -19,7 +21,11 @@ export function useAgentCartPending() {
         listeners.delete(listener);
       };
     },
-    () => pending,
-    () => false,
+    () => status,
+    (): AgentCartStatus => "ready",
   );
+}
+
+export function useAgentCartPending() {
+  return useAgentCartStatus() !== "ready";
 }


### PR DESCRIPTION
Clear chat waits for Eve to finish the turn rather than treating cancellation acceptance as completion. Cancellation failures/timeouts retain the conversation for retry, and late callbacks cannot reset a newer attempt or storage after unmount. Interrupted-change inspection guidance remains.

New sends wait for cart confirmation. Stop, Clear, and refresh recovery stay usable. The existing cart-confirmation signal distinguishes pending from failed, so retained older errors do not report a new refresh failure. Checkout safeguards and agent defaults are unchanged.

Verification: focused lint/format, pnpm --filter template typecheck, and pnpm --filter template build passed. Reused the original reproduction harness for 11 targeted scenarios with real React/Eve/Hydrogen and mocked local transport, covering cancellation/settlement, failure/timeout recovery, restoration, session limits, late callbacks, and cart gating. No live model calls or Shopify writes.